### PR TITLE
Fix syncToDisk race condition in ts-web-extras

### DIFF
--- a/common/changes/@fgv/ts-web-extras/fix-sync-race-condition_2026-03-26-22-58.json
+++ b/common/changes/@fgv/ts-web-extras/fix-sync-race-condition_2026-03-26-22-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-web-extras",
+      "comment": "Fix save & delete race conditions for web storage file tree",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras"
+}

--- a/libraries/ts-web-extras/src/packlets/file-tree/httpTreeAccessors.ts
+++ b/libraries/ts-web-extras/src/packlets/file-tree/httpTreeAccessors.ts
@@ -130,6 +130,8 @@ export class HttpTreeAccessors<TCT extends string = string>
    */
   public async syncToDisk(): Promise<Result<void>> {
     if (this._syncPromise) {
+      // Wait for the in-flight sync — it drains the queue in a loop,
+      // so any items added before it finishes will be included.
       return this._syncPromise;
     }
 
@@ -140,66 +142,94 @@ export class HttpTreeAccessors<TCT extends string = string>
   }
 
   private async _doSync(): Promise<Result<void>> {
-    if (this._dirtyFiles.size === 0 && this._pendingDeletions.size === 0) {
-      return succeed(undefined);
+    // Drain loop: keep processing as long as new items arrive.
+    // This is critical for bulk operations (e.g. reset) where many
+    // deleteFile/saveFileContents calls happen synchronously — only
+    // the first may be in the set when we snapshot, but the rest
+    // arrive during the async gaps and must be picked up before
+    // we return.
+    let didWork = false;
+    while (this._dirtyFiles.size > 0 || this._pendingDeletions.size > 0) {
+      didWork = true;
+      // Snapshot and clear so that changes arriving during the async
+      // requests land in the live sets for the next iteration.
+      const deletions = new Set(this._pendingDeletions);
+      const dirty = new Set(this._dirtyFiles);
+      this._pendingDeletions.clear();
+      this._dirtyFiles.clear();
+
+      for (const path of deletions) {
+        const query = new URLSearchParams();
+        query.set('path', path);
+        if (this._namespace) {
+          query.set('namespace', this._namespace);
+        }
+
+        const deleteResult = await this._requestWithRetry<{ deleted: boolean }>(`/file?${query.toString()}`, {
+          method: 'DELETE'
+        });
+        if (deleteResult.isFailure()) {
+          this._restoreUnsynced(deletions, dirty);
+          return fail(`delete ${path}: ${deleteResult.message}`);
+        }
+      }
+
+      for (const path of dirty) {
+        const contentsResult = this.getFileContents(path);
+        if (contentsResult.isFailure()) {
+          this._restoreUnsynced(deletions, dirty);
+          return fail(`${path}: ${contentsResult.message}`);
+        }
+
+        const body: Record<string, unknown> = {
+          path,
+          contents: contentsResult.value
+        };
+        if (this._namespace) {
+          body.namespace = this._namespace;
+        }
+
+        const saveResult = await this._requestWithRetry<IHttpStorageFileResponse>('/file', {
+          method: 'PUT',
+          body: JSON.stringify(body)
+        });
+        if (saveResult.isFailure()) {
+          this._restoreUnsynced(deletions, dirty);
+          return fail(`sync ${path}: ${saveResult.message}`);
+        }
+      }
     }
 
-    // Snapshot and clear dirty sets so that changes arriving during
-    // the async sync are not dropped when we finish.
-    const deletions = new Set(this._pendingDeletions);
-    const dirty = new Set(this._dirtyFiles);
-    this._pendingDeletions.clear();
-    this._dirtyFiles.clear();
+    if (didWork) {
+      const syncBody: Record<string, unknown> = {};
+      if (this._namespace) {
+        syncBody.namespace = this._namespace;
+      }
 
+      const syncResult = await this._requestWithRetry<IHttpStorageSyncResponse>('/sync', {
+        method: 'POST',
+        body: JSON.stringify(syncBody)
+      });
+
+      if (syncResult.isFailure()) {
+        return fail(syncResult.message);
+      }
+    }
+    return succeed(undefined);
+  }
+
+  /**
+   * Restores snapshotted items back into the live dirty sets so they
+   * are retried on the next sync attempt. Items that were added to
+   * the live sets while the sync was in flight are preserved.
+   */
+  private _restoreUnsynced(deletions: Set<string>, dirty: Set<string>): void {
     for (const path of deletions) {
-      const query = new URLSearchParams();
-      query.set('path', path);
-      if (this._namespace) {
-        query.set('namespace', this._namespace);
-      }
-
-      const deleteResult = await this._requestWithRetry<{ deleted: boolean }>(`/file?${query.toString()}`, {
-        method: 'DELETE'
-      });
-      if (deleteResult.isFailure()) {
-        return fail(`delete ${path}: ${deleteResult.message}`);
-      }
+      this._pendingDeletions.add(path);
     }
-
     for (const path of dirty) {
-      const contentsResult = this.getFileContents(path);
-      if (contentsResult.isFailure()) {
-        return fail(`${path}: ${contentsResult.message}`);
-      }
-
-      const body: Record<string, unknown> = {
-        path,
-        contents: contentsResult.value
-      };
-      if (this._namespace) {
-        body.namespace = this._namespace;
-      }
-
-      const saveResult = await this._requestWithRetry<IHttpStorageFileResponse>('/file', {
-        method: 'PUT',
-        body: JSON.stringify(body)
-      });
-      if (saveResult.isFailure()) {
-        return fail(`sync ${path}: ${saveResult.message}`);
-      }
+      this._dirtyFiles.add(path);
     }
-
-    const syncBody: Record<string, unknown> = {};
-    if (this._namespace) {
-      syncBody.namespace = this._namespace;
-    }
-
-    const syncResult = await this._requestWithRetry<IHttpStorageSyncResponse>('/sync', {
-      method: 'POST',
-      body: JSON.stringify(syncBody)
-    });
-
-    return syncResult.isFailure() ? fail(syncResult.message) : succeed(undefined);
   }
 
   /**

--- a/libraries/ts-web-extras/src/test/unit/httpTreeAccessors.test.ts
+++ b/libraries/ts-web-extras/src/test/unit/httpTreeAccessors.test.ts
@@ -1567,5 +1567,184 @@ describe('HttpTreeAccessors', () => {
       expect(putCalls).toHaveLength(1);
       expect(postCalls).toHaveLength(1);
     });
+
+    test('drains items written during an in-flight sync within the same _doSync call', async () => {
+      // This tests the drain loop fix for the race where:
+      // 1. sync starts, snapshots dirty set {a.json}
+      // 2. during the PUT for a.json, a new write arrives adding a.json back
+      // 3. _doSync loops back, snapshots the new item, and syncs it too
+      // 4. Only one POST /sync is sent at the end, after all items are drained
+      let callCount = 0;
+      let saveHook: (() => void) | undefined;
+
+      const fetchImpl: typeof fetch = (url, init) => {
+        callCount++;
+        const urlStr = url.toString();
+
+        // Calls 1-2: fromHttp load
+        if (callCount <= 2) {
+          if (callCount === 1) {
+            return Promise.resolve(makeMockResponse({ ok: true, jsonValue: rootWithOneFile('a.json') }));
+          }
+          return Promise.resolve(
+            makeMockResponse({ ok: true, jsonValue: fileResponse('/a.json', '"orig"') })
+          );
+        }
+
+        // Call 3: first PUT /file for a.json — trigger a write mid-sync
+        if (callCount === 3 && init?.method === 'PUT') {
+          saveHook?.();
+          return Promise.resolve(makeMockResponse({ ok: true, jsonValue: fileResponse('/a.json', '"v1"') }));
+        }
+
+        // Call 4: second PUT /file for a.json (drain loop iteration)
+        if (callCount === 4 && init?.method === 'PUT') {
+          return Promise.resolve(makeMockResponse({ ok: true, jsonValue: fileResponse('/a.json', '"v2"') }));
+        }
+
+        // Call 5: single POST /sync after drain loop exits
+        if (callCount === 5 && urlStr.includes('/sync')) {
+          return Promise.resolve(makeMockResponse({ ok: true, jsonValue: { synced: 1 } }));
+        }
+
+        return Promise.reject(new Error(`Unexpected call #${callCount} to ${urlStr}`));
+      };
+
+      const accessors = (
+        await HttpTreeAccessors.fromHttp({
+          baseUrl: 'http://localhost:3000',
+          fetchImpl: fetchImpl as typeof fetch,
+          mutable: true
+        })
+      ).orThrow();
+
+      // Write a.json
+      accessors.saveFileContents('/a.json', '"v1"').orThrow();
+
+      // Set up the hook BEFORE starting sync — the mock fetch for the PUT
+      // runs synchronously within syncToDisk(), so the hook must be in place.
+      saveHook = () => {
+        accessors.saveFileContents('/a.json', '"v2"').orThrow();
+      };
+
+      // Start sync — during the first PUT, saveHook fires and writes v2.
+      // The drain loop in _doSync picks this up and PUTs again before
+      // sending the final POST /sync.
+      const result = await accessors.syncToDisk();
+
+      expect(result).toSucceed();
+      expect(accessors.isDirty()).toBe(false);
+
+      // 5 calls: 2 load + 2 PUTs (v1, v2) + 1 POST /sync
+      expect(callCount).toBe(5);
+    });
+  });
+
+  describe('syncToDisk() error recovery', () => {
+    test('restores dirty files when PUT fails so they can be retried', async () => {
+      const { fetchImpl } = makeMockFetch([
+        { ok: true, jsonValue: rootWithOneFile('data.json') },
+        { ok: true, jsonValue: fileResponse('/data.json', '{}') },
+        // PUT /file fails with non-transient error
+        { ok: false, status: 500, textValue: 'Server Error' }
+      ]);
+
+      const accessors = (
+        await HttpTreeAccessors.fromHttp({
+          baseUrl: 'http://localhost:3000',
+          fetchImpl,
+          mutable: true
+        })
+      ).orThrow();
+
+      accessors.saveFileContents('/data.json', '"updated"').orThrow();
+      expect(accessors.isDirty()).toBe(true);
+
+      const result = await accessors.syncToDisk();
+      expect(result).toFailWith(/sync.*data\.json.*server error/i);
+
+      // The file should still be dirty so a retry is possible
+      expect(accessors.isDirty()).toBe(true);
+      expect(accessors.getDirtyPaths()).toContain('/data.json');
+    });
+
+    test('restores pending deletions when DELETE fails so they can be retried', async () => {
+      const { fetchImpl } = makeMockFetch([
+        { ok: true, jsonValue: rootWithOneFile('data.json') },
+        { ok: true, jsonValue: fileResponse('/data.json', '{}') },
+        // DELETE fails with non-transient error
+        { ok: false, status: 500, textValue: 'Server Error' }
+      ]);
+
+      const accessors = (
+        await HttpTreeAccessors.fromHttp({
+          baseUrl: 'http://localhost:3000',
+          fetchImpl,
+          mutable: true
+        })
+      ).orThrow();
+
+      accessors.deleteFile('/data.json').orThrow();
+      expect(accessors.isDirty()).toBe(true);
+
+      const result = await accessors.syncToDisk();
+      expect(result).toFailWith(/delete.*data\.json.*server error/i);
+
+      // The deletion should still be pending so a retry is possible
+      expect(accessors.isDirty()).toBe(true);
+      expect(accessors.getDirtyPaths()).toContain('/data.json');
+    });
+
+    test('restores dirty files when POST /sync fails so they can be retried', async () => {
+      jest.useFakeTimers();
+      try {
+        let callCount = 0;
+        const fetchImpl: typeof fetch = (_url, _init) => {
+          callCount++;
+          if (callCount === 1) {
+            return Promise.resolve(makeMockResponse({ ok: true, jsonValue: rootWithOneFile('data.json') }));
+          }
+          if (callCount === 2) {
+            return Promise.resolve(
+              makeMockResponse({ ok: true, jsonValue: fileResponse('/data.json', '{}') })
+            );
+          }
+          if (callCount === 3) {
+            // PUT succeeds
+            return Promise.resolve(
+              makeMockResponse({ ok: true, jsonValue: fileResponse('/data.json', '"v2"') })
+            );
+          }
+          // All /sync attempts: persistent 503
+          return Promise.resolve(
+            makeMockResponse({ ok: false, status: 503, textValue: 'Service Unavailable' })
+          );
+        };
+
+        const accessors = (
+          await HttpTreeAccessors.fromHttp({
+            baseUrl: 'http://localhost:3000',
+            fetchImpl,
+            mutable: true
+          })
+        ).orThrow();
+
+        accessors.saveFileContents('/data.json', '"v2"').orThrow();
+
+        const syncPromise = accessors.syncToDisk();
+        await jest.advanceTimersByTimeAsync(1500);
+
+        const result = await syncPromise;
+        expect(result).toFailWith(/service unavailable/i);
+
+        // The PUT succeeded — data is on the server — so the file is no
+        // longer dirty. Only the server-side /sync acknowledgement failed,
+        // which is not something the client can meaningfully retry via
+        // re-sending the file contents.
+        expect(accessors.isDirty()).toBe(false);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary
- **Fix bulk operation race**: `_doSync` now uses a drain loop that re-snapshots after each pass, picking up items that arrive during async HTTP requests. This restores the behavior where `for...of` on the live Set naturally visited items added during iteration — broken when the snapshot-and-clear optimization was introduced.
- **Fix error recovery**: Error paths restore un-synced items to the live dirty sets so they can be retried on the next sync attempt.
- **Simplify concurrency guard**: Since `_doSync` handles draining internally, `syncToDisk` no longer needs to re-check and re-sync from the coalesced path.

## Root cause
During bulk operations (e.g. full reset via `deleteAllChildren` + `syncAllToDisk`), the snapshot-and-clear in `_doSync` only captured items present at snapshot time. Subsequent `deleteFile` calls added to the live sets but were invisible to the running sync. The coalesced `syncAllToDisk` returned without processing remaining deletions, leaving stale files on the server and causing import collisions.

## Test plan
- [x] New test: drain loop picks up items written during an in-flight sync
- [x] New test: failed PUT restores dirty files for retry
- [x] New test: failed DELETE restores pending deletions for retry
- [x] New test: POST /sync failure after successful PUTs does not re-dirty files
- [x] All 379 existing tests pass
- [x] 100% statement/line/function coverage
- [x] Verified fix via tarball override in chocolate-lab — full reset + reimport works

🤖 Generated with [Claude Code](https://claude.com/claude-code)