### PR TITLE
Add @fgv/ts-res-tutorial - hands-on sample app for ts-res

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1881,6 +1881,70 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  ../../tools/ts-res-tutorial:
+    dependencies:
+      '@fgv/ts-extras':
+        specifier: workspace:*
+        version: link:../../libraries/ts-extras
+      '@fgv/ts-json':
+        specifier: workspace:*
+        version: link:../../libraries/ts-json
+      '@fgv/ts-json-base':
+        specifier: workspace:*
+        version: link:../../libraries/ts-json-base
+      '@fgv/ts-res':
+        specifier: workspace:*
+        version: link:../../libraries/ts-res
+      '@fgv/ts-utils':
+        specifier: workspace:*
+        version: link:../../libraries/ts-utils
+      commander:
+        specifier: ^11.0.0
+        version: 11.1.0
+    devDependencies:
+      '@fgv/ts-utils-jest':
+        specifier: workspace:*
+        version: link:../../libraries/ts-utils-jest
+      '@rushstack/eslint-config':
+        specifier: 4.6.4
+        version: 4.6.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@rushstack/heft':
+        specifier: 1.2.7
+        version: 1.2.7(@types/node@20.19.37)
+      '@rushstack/heft-jest-plugin':
+        specifier: 1.2.6
+        version: 1.2.6(@rushstack/heft@1.2.7(@types/node@20.19.37))(@types/node@20.19.37)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.7.0)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
+      '@rushstack/heft-node-rig':
+        specifier: 2.11.27
+        version: 2.11.27(@rushstack/heft@1.2.7(@types/node@20.19.37))(@types/node@20.19.37)(jest-environment-jsdom@29.5.0)(jiti@2.6.1)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
+      '@types/heft-jest':
+        specifier: 1.0.6
+        version: 1.0.6
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.37
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.52.0
+        version: 8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.52.0
+        version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint:
+        specifier: ^9.39.2
+        version: 9.39.4(jiti@2.6.1)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.6
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   ../../tools/ts-res-ui-playground:
     dependencies:
       '@fgv/ts-extras':
@@ -9866,9 +9930,9 @@ snapshots:
   '@jest/core@29.5.0(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
-      '@jest/reporters': 29.5.0
+      '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.5.0
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.19.37
       ansi-escapes: 4.3.2
@@ -9877,11 +9941,11 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.5.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
-      jest-resolve: 29.5.0
+      jest-resolve: 29.7.0
       jest-resolve-dependencies: 29.7.0
       jest-runner: 29.7.0
       jest-runtime: 29.7.0
@@ -9974,7 +10038,7 @@ snapshots:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.5.0
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
       '@types/node': 20.19.37
@@ -11294,7 +11358,7 @@ snapshots:
   '@typescript-eslint/project-service@8.56.1(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.8.3)
-      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/types': 8.57.2
       debug: 4.4.3
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -11303,7 +11367,7 @@ snapshots:
   '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/types': 8.57.2
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14019,7 +14083,7 @@ snapshots:
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
-      jest-resolve: 29.5.0
+      jest-resolve: 29.7.0
       jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
@@ -14276,7 +14340,7 @@ snapshots:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@jest/expect-utils': 29.7.0
-      '@jest/transform': 29.5.0
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/babel__traverse': 7.28.0
       '@types/prettier': 2.7.3

--- a/rush.json
+++ b/rush.json
@@ -554,6 +554,12 @@
       "tags": ["tools", "template"]
     },
     {
+      "packageName": "@fgv/ts-res-tutorial",
+      "projectFolder": "tools/ts-res-tutorial",
+      "shouldPublish": false,
+      "tags": ["tools", "tutorial", "sample"]
+    },
+    {
       "packageName": "@fgv/ts-random",
       "projectFolder": "libraries/ts-random",
       "shouldPublish": true,

--- a/tools/ts-res-tutorial/README.md
+++ b/tools/ts-res-tutorial/README.md
@@ -1,0 +1,234 @@
+# @fgv/ts-res-tutorial
+
+A hands-on, end-to-end tutorial for the [`@fgv/ts-res`](../../libraries/ts-res)
+multidimensional resource management library. It walks through the four
+concepts you actually need to build something with ts-res:
+
+1. Loading a qualifier configuration.
+2. Setting up the importer with a pre-processor so you can load YAML
+   (or any other serialization) transparently.
+3. Wiring the runtime - context qualifier provider, custom qualifier
+   types, resource resolver.
+4. Resolving resources in all four supported ways - best match, all
+   matches, composed, and manually composed.
+
+Unlike [`@fgv/ts-res-cli`](../ts-res-cli), this package is not a tool.
+It is a small, commented application that you are meant to read as much
+as run. Every lesson lives in its own file, each function takes an
+`ITutorialPrinter` so tests can capture and assert on the narrative,
+and the sample data is YAML on purpose - it demonstrates the importer
+preprocessor end to end.
+
+## Running the tutorial
+
+From the repo root:
+
+```bash
+rush install
+rush build --to @fgv/ts-res-tutorial
+```
+
+From `tools/ts-res-tutorial`:
+
+```bash
+rushx lesson1   # just lesson 1
+rushx lesson2   # lessons 1 + 2
+rushx lesson3   # lessons 1 + 2 + 3
+rushx lesson4   # lessons 1 + 2 + 3 + 4
+rushx all       # everything in one run
+```
+
+Every lesson after lesson 1 depends on the output of the previous one,
+so the CLI runs the prerequisites for you when you invoke a single
+lesson directly.
+
+## Tutorial layout
+
+```
+tools/ts-res-tutorial/
+├── data/
+│   ├── config/system.yaml        # Qualifier types + qualifiers + resource types
+│   └── resources/
+│       ├── strings.yaml          # Language + territory priority demo
+│       ├── theme.yaml            # Composition with full + partial candidates
+│       └── icons.yaml            # Custom density qualifier type demo
+└── src/
+    ├── cli.ts                    # Commander wiring, kept intentionally thin
+    ├── lessons/
+    │   ├── lesson01LoadConfig.ts
+    │   ├── lesson02Import.ts
+    │   ├── lesson03Runtime.ts
+    │   └── lesson04Resolve.ts
+    ├── qualifierTypes/
+    │   ├── densityQualifierType.ts         # Custom QualifierType subclass
+    │   └── densityQualifierTypeFactory.ts  # Config factory that builds it
+    └── utils/
+        ├── paths.ts              # Paths to the bundled sample data
+        └── printer.ts            # ITutorialPrinter abstraction
+```
+
+## Lesson 1 - Loading a qualifier configuration
+
+`src/lessons/lesson01LoadConfig.ts`
+
+A ts-res application needs a _system configuration_ that declares:
+
+- the **qualifier types** it understands (language, territory, literal,
+  custom types like `density`),
+- the named **qualifiers** that reference those types (and their priorities),
+- the **resource types** your resources are allowed to be.
+
+Lesson 1 does three things in sequence:
+
+1. Calls `Config.getPredefinedSystemConfiguration('default')` and
+   inspects the result. Use this when you just want territory + language
+   and nothing else - ts-res ships `default`, `language-priority`,
+   `territory-priority` and `extended-example`.
+
+2. Loads a custom configuration from `data/config/system.yaml`. To show
+   the moving parts we read the YAML file by hand, pipe it through
+   `Yaml.yamlConverter(JsonConverters.jsonObject)` from `@fgv/ts-extras`,
+   then hand the parsed declaration to
+   `Config.Convert.systemConfiguration.convert(...)` to validate its
+   shape.
+
+3. Builds the validated declaration into a `SystemConfiguration` while
+   injecting a `QualifierTypeFactory` that knows about our custom
+   `density` type. Without the custom factory, the built-in factory
+   would fail at `systemType: density` because it only handles
+   `language`, `territory`, and `literal`.
+
+The key detail is that `Config.QualifierTypeFactory`'s constructor
+automatically appends the built-in factory to the end of the chain, so
+you only have to supply your own additions.
+
+## Lesson 2 - Importing YAML transparently
+
+`src/lessons/lesson02Import.ts`
+
+`ImportManager.create()` accepts two parameters that turn the importer
+into a general "read resources from files" pipeline:
+
+```ts
+Import.ImportManager.create({
+  resources: resourceManagerBuilder,
+  fileTree: FileTree.forFilesystem().orThrow(),
+  fileContentConverter: Yaml.yamlConverter(JsonConverters.jsonObject),
+  fileContentExtensions: ['.yaml', '.yml']
+});
+```
+
+- `fileContentConverter` is any `Converter<JsonValue>`. Its job is to
+  turn raw file text into a JSON value the rest of the pipeline can
+  consume. It runs **before** the normal JSON import logic.
+- `fileContentExtensions` tells the importer which extensions should
+  flow through the converter. `.json` is still handled natively, so
+  you can mix JSON and YAML in the same folder if you want.
+
+The lesson then calls `importFromFileSystem(RESOURCES_ROOT)` to walk
+the tree. The imported resource IDs look like
+`resources.strings.greetings`, `resources.theme.theme`,
+`resources.icons.icons` - the importer prefixes every explicit `id`
+inside the collection with the path it came from (parent directories
++ file basename).
+
+Nothing in the lesson code mentions YAML past the one-line converter
+setup. That is the whole point: a new file format is exactly one
+`Converter<JsonValue>` away.
+
+## Lesson 3 - Wiring the runtime
+
+`src/lessons/lesson03Runtime.ts`
+
+At runtime you need two objects of your own:
+
+- A **context qualifier provider** that holds the current values of
+  every qualifier. The tutorial uses
+  `Runtime.ValidatingSimpleContextQualifierProvider`, which accepts
+  plain `Record<string, string>` and validates the values against the
+  qualifier collection.
+- A **resource resolver** that combines the resource manager, the
+  qualifier types, and the context provider. It owns O(1) caches for
+  condition, condition set, and decision resolution results.
+
+Lesson 3 also demonstrates `resolver.withContext({...})`, which returns
+a brand-new resolver tied to a different context provider while sharing
+the same built resources. That's the supported way to evaluate the
+same resource set under multiple contexts.
+
+### Custom qualifier types
+
+Lesson 3 relies on the `DensityQualifierType` shipped under
+`src/qualifierTypes/`:
+
+- `DensityQualifierType` subclasses `QualifierTypes.QualifierType` and
+  overrides `isValidConditionValue` and `_matchOne`. It recognises five
+  Android-style density buckets (`ldpi` → `xxhdpi`) and gives adjacent
+  buckets a partial match so that "close" is still useful.
+- `DensityQualifierTypeFactory` implements
+  `Config.IConfigInitFactory<IAnyQualifierTypeConfig, QualifierType>`,
+  matches on `config.systemType === 'density'`, and otherwise fails so
+  the chained built-in factory can take over.
+
+This is the only pattern you need to know to add a qualifier type.
+
+## Lesson 4 - Resolving resources
+
+`src/lessons/lesson04Resolve.ts`
+
+There are four resolution strategies, and each one has a right place to
+use it:
+
+| Strategy | API | When you want it |
+|---|---|---|
+| Best match | `resolver.resolveResource(id)` | "Just give me the winning candidate." This is the normal case. |
+| All matches | `resolver.resolveAllResourceCandidates(id)` | Debugging, fallbacks, rendering every alternate. Returns descending priority. |
+| Composed | `resolver.resolveComposedResourceValue(id)` | Theme-style overlays. Finds the highest-priority full candidate as the base and deep-merges higher-priority partial candidates on top. |
+| Manually composed | `JsonEditor.create(...).mergeObjectsInPlace(...)` on candidates you picked yourself | When you need custom composition rules, extra inputs from outside the resource system, or to pick a non-standard subset of candidates. |
+
+The lesson exercises every strategy against the bundled resources:
+
+- `resources.strings.greetings` demonstrates best-match and all-matches
+  behaviour. With the default context (`language=fr`,
+  `currentTerritory=CA`, `theme=dark`, `density=xhdpi`) and the
+  territory-priority qualifier ordering, the combined `fr + CA`
+  candidate wins.
+- `resources.icons.icons` shows that the custom density type allows
+  _partial_ matches: with `density=xhdpi` the candidates for `xhdpi`
+  (best), `hdpi` and `xxhdpi` (adjacent, partial) all appear in
+  `resolveAllResourceCandidates`.
+- `resources.theme.theme` shows composition. The `theme=dark` candidate
+  is the base; the `language=fr` partial overlays a new typography
+  family; at `density=xxhdpi` a second partial would bump the base
+  font size, but the active context is `xhdpi` so it doesn't fire.
+- The manual composition section merges every theme candidate plus a
+  synthetic runtime override into a fresh object using
+  `JsonEditor.create({ merge: { arrayMergeBehavior: 'replace', nullAsDelete: true } })`.
+  This is the escape hatch for anything the built-in composition can't
+  express.
+
+## Testing
+
+```bash
+rushx test
+```
+
+The tests live under `src/test/unit/`:
+
+- `densityQualifierType.test.ts` covers the custom qualifier type and
+  its factory comprehensively - this is the reusable unit.
+- `lessons.test.ts` smoke-tests every lesson via the
+  `CapturingTutorialPrinter` in `src/utils/printer.ts`. That way the
+  tests run the _real_ lesson code (including the sample data) and can
+  assert on what it produces without depending on the CLI layer or
+  intercepting `console.log`.
+
+## Where to go next
+
+- [`libraries/ts-res/README.md`](../../libraries/ts-res/README.md) -
+  the canonical ts-res documentation.
+- [`tools/ts-res-cli`](../ts-res-cli) - a production CLI for compiling
+  resource trees into bundles, filter contexts, and emit JS/TS code.
+- [`data/test/ts-res`](../../data/test/ts-res) - the repo-wide sample
+  data. Most of it predates the pre-processor; use this tutorial's
+  bundled data as a YAML-native reference.

--- a/tools/ts-res-tutorial/README.md
+++ b/tools/ts-res-tutorial/README.md
@@ -1,7 +1,7 @@
 # @fgv/ts-res-tutorial
 
 A hands-on, end-to-end tutorial for the [`@fgv/ts-res`](../../libraries/ts-res)
-multidimensional resource management library. It walks through the four
+multidimensional resource management library. It walks through the five
 concepts you actually need to build something with ts-res:
 
 1. Loading a qualifier configuration.
@@ -11,6 +11,8 @@ concepts you actually need to build something with ts-res:
    types, resource resolver.
 4. Resolving resources in all four supported ways - best match, all
    matches, composed, and manually composed.
+5. Letting the importer infer qualifiers from folder and file names,
+   and composing resource ids from the filesystem layout.
 
 Unlike [`@fgv/ts-res-cli`](../ts-res-cli), this package is not a tool.
 It is a small, commented application that you are meant to read as much
@@ -35,6 +37,7 @@ rushx lesson1   # just lesson 1
 rushx lesson2   # lessons 1 + 2
 rushx lesson3   # lessons 1 + 2 + 3
 rushx lesson4   # lessons 1 + 2 + 3 + 4
+rushx lesson5   # lesson 1 + 5 (lesson 5 is independent of 2-4)
 rushx all       # everything in one run
 ```
 
@@ -47,24 +50,34 @@ lesson directly.
 ```
 tools/ts-res-tutorial/
 ├── data/
-│   ├── config/system.yaml        # Qualifier types + qualifiers + resource types
-│   └── resources/
-│       ├── strings.yaml          # Language + territory priority demo
-│       ├── theme.yaml            # Composition with full + partial candidates
-│       └── icons.yaml            # Custom density qualifier type demo
+│   ├── config/system.yaml           # Qualifier types + qualifiers + resource types
+│   ├── resources/                   # Lessons 2-4 (explicit conditions)
+│   │   ├── strings.yaml             # Language + territory priority demo
+│   │   ├── theme.yaml               # Composition with full + partial candidates
+│   │   └── icons.yaml               # Custom density qualifier type demo
+│   └── inferred/                    # Lesson 5 (path-inferred conditions)
+│       ├── messages.yaml            # default
+│       ├── messages.fr.yaml         # language=fr (tokenless filename)
+│       ├── messages.US.yaml         # territory=US (tokenless filename)
+│       ├── messages.geo=GB,lang=en.yaml  # comma-separated tokens
+│       ├── en/messages.yaml         # language=en (tokenless folder)
+│       └── geo=CA/                  # territory=CA (explicit geo token)
+│           ├── messages.yaml
+│           └── lang=fr/messages.yaml  # stacked: CA + fr
 └── src/
-    ├── cli.ts                    # Commander wiring, kept intentionally thin
+    ├── cli.ts                       # Commander wiring, kept intentionally thin
     ├── lessons/
     │   ├── lesson01LoadConfig.ts
     │   ├── lesson02Import.ts
     │   ├── lesson03Runtime.ts
-    │   └── lesson04Resolve.ts
+    │   ├── lesson04Resolve.ts
+    │   └── lesson05Inference.ts
     ├── qualifierTypes/
     │   ├── densityQualifierType.ts         # Custom QualifierType subclass
     │   └── densityQualifierTypeFactory.ts  # Config factory that builds it
     └── utils/
-        ├── paths.ts              # Paths to the bundled sample data
-        └── printer.ts            # ITutorialPrinter abstraction
+        ├── paths.ts                 # Paths to the bundled sample data
+        └── printer.ts               # ITutorialPrinter abstraction
 ```
 
 ## Lesson 1 - Loading a qualifier configuration
@@ -206,6 +219,73 @@ The lesson exercises every strategy against the bundled resources:
   `JsonEditor.create({ merge: { arrayMergeBehavior: 'replace', nullAsDelete: true } })`.
   This is the escape hatch for anything the built-in composition can't
   express.
+
+## Lesson 5 - Path-driven qualifier inference
+
+`src/lessons/lesson05Inference.ts`
+
+Lessons 2-4 put the conditions for each candidate inside the YAML file.
+That's fine, but it means every file has to repeat the qualifier
+structure even for trivial cases. The importer supports a much more
+compact alternative: encode the conditions in **folder** and **file**
+names.
+
+### The inference rules
+
+When the `FsItemImporter` walks a file tree it inspects the basename of
+every folder and file and applies the following rules:
+
+1. **Split on `.`**. The importer only inspects the LAST dot-separated
+   segment for qualifier tokens. Everything else becomes the name
+   fragment.
+2. **Split the last segment on `,`**. Each piece is parsed as a
+   `[qualifier=]value` pair.
+3. **Explicit tokens** (`geo=CA`, `lang=fr`) are resolved by looking up
+   the left-hand side as a qualifier name first, then as a qualifier
+   token. Token names are declared in `data/config/system.yaml` via the
+   `token` field.
+4. **Tokenless values** (`CA`, `fr`) are only resolved when
+   `tokenIsOptional: true`. The importer tries each token-optional
+   qualifier's type validator in turn, and accepts the value only if
+   exactly one qualifier matches. Our `system.yaml` sets
+   `tokenIsOptional: true` on both `currentTerritory` and `language`;
+   `CA` validates as a territory but not as a BCP47 language tag, and
+   `fr` does the opposite, so the choice is unambiguous.
+5. **Folders whose entire name parses as a token** contribute the
+   condition but no name fragment, so you can add arbitrary
+   organisational nesting without polluting the resource id.
+6. **Path composition** joins every surviving name fragment, plus the
+   explicit candidate `id` inside the file, with `.` to produce the
+   final resource id.
+
+### What the sample tree exercises
+
+`data/inferred/` contains seven YAML files, all of which collapse to a
+single resource id `inferred.messages.text` with one candidate each:
+
+| File | Inferred conditions | Mechanism |
+|---|---|---|
+| `messages.yaml` | _(none)_ | default fallback |
+| `messages.fr.yaml` | `language=fr` | tokenless value in filename |
+| `messages.US.yaml` | `currentTerritory=US` | tokenless value in filename |
+| `en/messages.yaml` | `language=en` | tokenless value in folder |
+| `geo=CA/messages.yaml` | `currentTerritory=CA` | explicit token in folder |
+| `geo=CA/lang=fr/messages.yaml` | `currentTerritory=CA, language=fr` | stacked tokens across folders |
+| `messages.geo=GB,lang=en.yaml` | `currentTerritory=GB, language=en` | comma-separated tokens in one segment |
+
+Notice that the YAML files themselves contain **no** `conditions`
+blocks - the layout alone is enough.
+
+### What the lesson prints
+
+Lesson 5 imports the tree into its own resource manager, lists what the
+importer discovered, and then resolves the resource under several
+contexts so you can watch the priority rules you learned in Lessons 1
+and 4 pick different candidates on the fly. Remember that
+`currentTerritory` outranks `language` (850 vs 800), so a context like
+`{ fr, US }` still selects the US candidate - the lesson includes a
+`{ fr, DE }` case to show that language-only contexts do pick the
+language candidate when no territory matches.
 
 ## Testing
 

--- a/tools/ts-res-tutorial/bin/ts-res-tutorial.js
+++ b/tools/ts-res-tutorial/bin/ts-res-tutorial.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const { TutorialApp } = require('../lib/cli');
+
+async function main() {
+  try {
+    const app = new TutorialApp();
+    await app.run(process.argv);
+  } catch (error) {
+    console.error('Fatal error:', error.message);
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error('Unhandled error:', error);
+  process.exit(1);
+});

--- a/tools/ts-res-tutorial/config/jest.config.json
+++ b/tools/ts-res-tutorial/config/jest.config.json
@@ -1,0 +1,9 @@
+{
+  "testMatch": ["<rootDir>/src/test/**/*.test.ts", "<rootDir>/test/**/*.test.ts"],
+  "preset": "ts-jest",
+  "testEnvironment": "node",
+  "extensionsToTreatAsEsm": [],
+  "transform": {
+    "^.+\\.ts$": "ts-jest"
+  }
+}

--- a/tools/ts-res-tutorial/config/rig.json
+++ b/tools/ts-res-tutorial/config/rig.json
@@ -1,0 +1,6 @@
+// The "rig.json" file directs tools to look for their config files in an external package.
+// Documentation for this system: https://www.npmjs.com/package/@rushstack/rig-package
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
+  "rigPackageName": "@rushstack/heft-node-rig"
+}

--- a/tools/ts-res-tutorial/data/README.md
+++ b/tools/ts-res-tutorial/data/README.md
@@ -1,0 +1,41 @@
+# Tutorial Sample Data
+
+Every file in this tree is YAML. The ts-res library natively reads JSON;
+the tutorial plugs a YAML preprocessor into the importer so that `.yaml`
+files are parsed into JSON before the normal import pipeline runs. See
+`../src/lessons/lesson02Import.ts` for the wiring and `../README.md` for
+the narrative.
+
+## Layout
+
+```
+data/
+├── config/
+│   └── system.yaml       # Qualifier types, qualifiers, resource types
+└── resources/
+    ├── strings.yaml      # Language + territory priority demo
+    ├── theme.yaml        # Composition with full + partial candidates
+    └── icons.yaml        # Custom density qualifier type demo
+```
+
+## Resource IDs
+
+The importer prefixes every resource id with the path it was imported
+from (parent directories + file basename), so after loading this tree
+you get:
+
+```
+resources.strings.greetings
+resources.strings.uiLabels
+resources.theme.theme
+resources.icons.icons
+```
+
+## Why YAML?
+
+Nothing in ts-res is YAML-specific. The importer accepts any
+`Converter<JsonValue>` as a content preprocessor plus a list of file
+extensions to apply it to. The tutorial uses `@fgv/ts-extras`
+`Yaml.yamlConverter` as the preprocessor, but you could swap in a TOML
+parser, JSON5, a templated format, or anything else that produces a
+`JsonValue`.

--- a/tools/ts-res-tutorial/data/README.md
+++ b/tools/ts-res-tutorial/data/README.md
@@ -11,17 +11,28 @@ the narrative.
 ```
 data/
 ├── config/
-│   └── system.yaml       # Qualifier types, qualifiers, resource types
-└── resources/
-    ├── strings.yaml      # Language + territory priority demo
-    ├── theme.yaml        # Composition with full + partial candidates
-    └── icons.yaml        # Custom density qualifier type demo
+│   └── system.yaml                # Qualifier types, qualifiers, resource types
+├── resources/                     # Used by Lessons 2-4
+│   ├── strings.yaml               # Language + territory priority demo
+│   ├── theme.yaml                 # Composition with full + partial candidates
+│   └── icons.yaml                 # Custom density qualifier type demo
+└── inferred/                      # Used by Lesson 5 (path inference)
+    ├── messages.yaml                       # default
+    ├── messages.fr.yaml                    # language=fr (tokenless filename)
+    ├── messages.US.yaml                    # territory=US (tokenless filename)
+    ├── messages.geo=GB,lang=en.yaml        # GB+en (comma-separated tokens)
+    ├── en/
+    │   └── messages.yaml                   # language=en (tokenless folder)
+    └── geo=CA/
+        ├── messages.yaml                   # territory=CA (explicit "geo" token)
+        └── lang=fr/
+            └── messages.yaml               # CA + fr (stacked across folders)
 ```
 
 ## Resource IDs
 
 The importer prefixes every resource id with the path it was imported
-from (parent directories + file basename), so after loading this tree
+from (parent directories + file basename). After loading `data/resources/`
 you get:
 
 ```
@@ -30,6 +41,17 @@ resources.strings.uiLabels
 resources.theme.theme
 resources.icons.icons
 ```
+
+Every file under `data/inferred/` collapses to the same resource id:
+
+```
+inferred.messages.text
+```
+
+with a different candidate per file. Folders whose name is just a
+qualifier token (`geo=CA`, `lang=fr`, or a tokenless value like `en`)
+contribute a condition but no name fragment, so the id stays clean
+regardless of how deeply nested the file is.
 
 ## Why YAML?
 

--- a/tools/ts-res-tutorial/data/config/system.yaml
+++ b/tools/ts-res-tutorial/data/config/system.yaml
@@ -1,0 +1,71 @@
+# System configuration for the ts-res tutorial.
+#
+# This file defines:
+#   - qualifierTypes: named categories that describe how a value is validated
+#     and matched. Each type is backed by a "systemType" implementation that
+#     the library (or your custom factory) knows how to instantiate.
+#   - qualifiers: named dimensions (language, territory, density, ...) used
+#     to qualify resource candidates. Each qualifier points at a qualifier
+#     type and declares a default priority.
+#   - resourceTypes: the logical "kinds" of resources your app understands.
+#
+# Note the custom "density" qualifier type below. The built-in ts-res
+# configuration factory doesn't know how to build it, so Lesson 3 wires a
+# custom factory that recognises systemType="density" and returns an
+# instance of DensityQualifierType.
+
+qualifierTypes:
+  - name: language
+    systemType: language
+    configuration:
+      allowContextList: true
+
+  - name: territory
+    systemType: territory
+    configuration:
+      allowContextList: false
+
+  - name: theme
+    systemType: literal
+    configuration:
+      allowContextList: false
+      caseSensitive: false
+      enumeratedValues:
+        - light
+        - dark
+
+  # Custom qualifier type - resolved by our DensityQualifierTypeFactory
+  # (see src/qualifierTypes/densityQualifierTypeFactory.ts).
+  - name: density
+    systemType: density
+    configuration:
+      allowContextList: false
+
+qualifiers:
+  # Highest priority wins when it matches. Territory beats language beats
+  # theme beats density in this tutorial - picked only for demonstration.
+  - name: currentTerritory
+    typeName: territory
+    token: geo
+    defaultPriority: 850
+
+  - name: language
+    typeName: language
+    token: lang
+    defaultPriority: 800
+
+  - name: theme
+    typeName: theme
+    token: theme
+    defaultPriority: 700
+    defaultValue: light
+
+  - name: density
+    typeName: density
+    token: density
+    defaultPriority: 600
+    defaultValue: mdpi
+
+resourceTypes:
+  - name: json
+    typeName: json

--- a/tools/ts-res-tutorial/data/config/system.yaml
+++ b/tools/ts-res-tutorial/data/config/system.yaml
@@ -44,14 +44,21 @@ qualifierTypes:
 qualifiers:
   # Highest priority wins when it matches. Territory beats language beats
   # theme beats density in this tutorial - picked only for demonstration.
+  #
+  # tokenIsOptional: true on the territory and language qualifiers lets
+  # Lesson 5 demonstrate "tokenless" inference - a plain `CA` or `fr` in
+  # a folder or filename gets resolved to the right qualifier by trying
+  # each token-optional qualifier in turn.
   - name: currentTerritory
     typeName: territory
     token: geo
+    tokenIsOptional: true
     defaultPriority: 850
 
   - name: language
     typeName: language
     token: lang
+    tokenIsOptional: true
     defaultPriority: 800
 
   - name: theme

--- a/tools/ts-res-tutorial/data/inferred/en/messages.yaml
+++ b/tools/ts-res-tutorial/data/inferred/en/messages.yaml
@@ -1,0 +1,16 @@
+# Tokenless language qualifier in a parent folder.
+#
+# File path:   data/inferred/en/messages.yaml
+# Resource id: inferred.messages.text (the "en" folder adds a condition
+#              but no path fragment)
+# Conditions:  language=en
+#
+# When a folder's entire name parses as a single tokenless value, the
+# folder contributes a condition but no path fragment. Here the "en"
+# folder adds language=en and does not appear in the resource id.
+candidates:
+  - id: text
+    resourceTypeName: json
+    json:
+      hello: Hello there
+      source: 'LANGUAGE: en (inferred from folder)'

--- a/tools/ts-res-tutorial/data/inferred/geo=CA/lang=fr/messages.yaml
+++ b/tools/ts-res-tutorial/data/inferred/geo=CA/lang=fr/messages.yaml
@@ -1,0 +1,17 @@
+# Stacked conditions across nested folders.
+#
+# File path:   data/inferred/geo=CA/lang=fr/messages.yaml
+# Resource id: inferred.messages.text
+# Conditions:  currentTerritory=CA, language=fr
+#
+# The parent folder "geo=CA" contributes currentTerritory=CA (via the
+# "geo" token). Its child "lang=fr" contributes language=fr (via the
+# "lang" token). Each folder in the tree stacks its conditions onto the
+# cumulative import context, so deep trees can encode any condition set
+# you like.
+candidates:
+  - id: text
+    resourceTypeName: json
+    json:
+      hello: Salut mon ami
+      source: 'BOTH: CA + fr (stacked across nested folders)'

--- a/tools/ts-res-tutorial/data/inferred/geo=CA/messages.yaml
+++ b/tools/ts-res-tutorial/data/inferred/geo=CA/messages.yaml
@@ -1,0 +1,17 @@
+# Token-explicit territory qualifier in a parent folder.
+#
+# File path:   data/inferred/geo=CA/messages.yaml
+# Resource id: inferred.messages.text
+# Conditions:  currentTerritory=CA
+#
+# The folder name "geo=CA" uses the explicit "token=value" form. The
+# token "geo" was declared on the currentTerritory qualifier in
+# system.yaml - token lookups first try qualifier name, then qualifier
+# token, so this folder maps to currentTerritory=CA regardless of
+# whether tokenIsOptional is set.
+candidates:
+  - id: text
+    resourceTypeName: json
+    json:
+      hello: Hello there, eh
+      source: 'TERRITORY: CA (inferred from "geo=CA" folder)'

--- a/tools/ts-res-tutorial/data/inferred/messages.US.yaml
+++ b/tools/ts-res-tutorial/data/inferred/messages.US.yaml
@@ -1,0 +1,15 @@
+# Tokenless territory qualifier in the filename.
+#
+# File path:   data/inferred/messages.US.yaml
+# Resource id: inferred.messages.text
+# Conditions:  currentTerritory=US
+#
+# "US" is a valid ISO 3166-1 alpha-2 territory code but NOT a valid BCP47
+# language tag (language subtags are lowercase), so tokenless inference
+# disambiguates to the currentTerritory qualifier.
+candidates:
+  - id: text
+    resourceTypeName: json
+    json:
+      hello: Howdy
+      source: 'TERRITORY: US (inferred from filename)'

--- a/tools/ts-res-tutorial/data/inferred/messages.fr.yaml
+++ b/tools/ts-res-tutorial/data/inferred/messages.fr.yaml
@@ -1,0 +1,17 @@
+# Tokenless language qualifier in the filename.
+#
+# File path:   data/inferred/messages.fr.yaml
+# Resource id: inferred.messages.text (same as messages.yaml)
+# Conditions:  language=fr
+#
+# The importer splits the basename on "." and inspects the LAST segment
+# ("fr"). It tries each tokenIsOptional qualifier in turn; "fr" is a
+# valid BCP47 language tag but not a territory code, so the language
+# qualifier is the only match. The segment is removed and the rest of
+# the basename ("messages") becomes the path fragment.
+candidates:
+  - id: text
+    resourceTypeName: json
+    json:
+      hello: Bonjour
+      source: 'LANGUAGE: fr (inferred from filename)'

--- a/tools/ts-res-tutorial/data/inferred/messages.geo=GB,lang=en.yaml
+++ b/tools/ts-res-tutorial/data/inferred/messages.geo=GB,lang=en.yaml
@@ -1,0 +1,15 @@
+# Multiple tokens in a single filename segment.
+#
+# File path:   data/inferred/messages.geo=GB,lang=en.yaml
+# Resource id: inferred.messages.text
+# Conditions:  currentTerritory=GB, language=en
+#
+# The last dot-segment ("geo=GB,lang=en") is split on commas and every
+# piece is parsed as a token=value pair. This is the most compact way
+# to encode several conditions without creating a folder per qualifier.
+candidates:
+  - id: text
+    resourceTypeName: json
+    json:
+      hello: Good day, old chap
+      source: 'BOTH: GB + en (comma-separated filename tokens)'

--- a/tools/ts-res-tutorial/data/inferred/messages.yaml
+++ b/tools/ts-res-tutorial/data/inferred/messages.yaml
@@ -1,0 +1,17 @@
+# Default (no path-inferred conditions).
+#
+# File path:   data/inferred/messages.yaml
+# Resource id: inferred.messages.text
+# Conditions:  (none)
+#
+# The file basename "messages" does not parse as a qualifier value
+# (it is not a valid BCP47 language tag or territory code), so no
+# conditions are inferred. The explicit "text" candidate id combines
+# with the path-derived baseId "inferred.messages" to produce the
+# final resource id.
+candidates:
+  - id: text
+    resourceTypeName: json
+    json:
+      hello: Hello
+      source: DEFAULT

--- a/tools/ts-res-tutorial/data/resources/icons.yaml
+++ b/tools/ts-res-tutorial/data/resources/icons.yaml
@@ -1,0 +1,41 @@
+# Icon asset paths keyed by the custom "density" qualifier. The
+# DensityQualifierType lives in
+# src/qualifierTypes/densityQualifierType.ts and knows about the
+# Android-style density buckets (ldpi, mdpi, hdpi, xhdpi, xxhdpi).
+#
+# Because adjacent buckets partially match (score 0.7, see the custom
+# _matchOne in DensityQualifierType), lesson 4 can use this resource to
+# show what "all matching candidates" looks like in priority order -
+# the best bucket wins, but the neighbouring buckets still match.
+#
+# Imported id: resources.icons.icons (import path + explicit id).
+
+resources:
+  - id: icons
+    resourceTypeName: json
+    candidates:
+      - json:
+          home: icons/home.png
+          search: icons/search.png
+          bucket: mdpi
+
+      - conditions:
+          density: hdpi
+        json:
+          home: icons/hdpi/home.png
+          search: icons/hdpi/search.png
+          bucket: hdpi
+
+      - conditions:
+          density: xhdpi
+        json:
+          home: icons/xhdpi/home.png
+          search: icons/xhdpi/search.png
+          bucket: xhdpi
+
+      - conditions:
+          density: xxhdpi
+        json:
+          home: icons/xxhdpi/home.png
+          search: icons/xxhdpi/search.png
+          bucket: xxhdpi

--- a/tools/ts-res-tutorial/data/resources/strings.yaml
+++ b/tools/ts-res-tutorial/data/resources/strings.yaml
@@ -1,0 +1,85 @@
+# ts-res supports several JSON shapes. This file uses the
+# "collection" shape: a top-level "resources" array, each entry with an
+# explicit id plus its candidate list.
+#
+# When imported from the file system, the importer prefixes every id
+# with the path it was imported from (parent directories + file basename).
+# For this file at data/resources/strings.yaml the resulting ids are
+#   resources.strings.greetings
+#   resources.strings.uiLabels
+
+resources:
+  # --------------------------------------------------------------------
+  # "resources.strings.greetings" demonstrates territory-priority resolution.
+  # The qualifier priorities in data/config/system.yaml are:
+  #   currentTerritory = 850  (wins)
+  #   language         = 800
+  # so a US territory match outranks a French language match even though
+  # both score PerfectMatch individually.
+  # --------------------------------------------------------------------
+  - id: greetings
+    resourceTypeName: json
+    candidates:
+      - json:
+          hello: Hello
+          goodbye: Goodbye
+          source: DEFAULT
+
+      - conditions:
+          currentTerritory: US
+        json:
+          hello: Howdy
+          goodbye: See ya later
+          source: 'TERRITORY: US'
+
+      - conditions:
+          currentTerritory: GB
+        json:
+          hello: Good day
+          goodbye: Cheerio
+          source: 'TERRITORY: GB'
+
+      - conditions:
+          language: fr
+        json:
+          hello: Bonjour
+          goodbye: Au revoir
+          source: 'LANGUAGE: fr'
+
+      - conditions:
+          language: fr
+          currentTerritory: CA
+        json:
+          hello: Salut
+          goodbye: À bientôt
+          source: 'BOTH: fr + CA'
+
+      - conditions:
+          language: fr
+          currentTerritory: FR
+        json:
+          hello: Bonjour monsieur/madame
+          goodbye: Au revoir et bonne journée
+          source: 'BOTH: fr + FR'
+
+  # --------------------------------------------------------------------
+  # "resources.strings.uiLabels" is a second resource in the same file
+  # to show that a single YAML document can define any number of
+  # resources.
+  # --------------------------------------------------------------------
+  - id: uiLabels
+    resourceTypeName: json
+    candidates:
+      - json:
+          welcome: Welcome
+          save: Save
+          cancel: Cancel
+          source: DEFAULT
+
+      - conditions:
+          language: fr
+        json:
+          welcome: Bienvenue
+          save: Enregistrer
+          cancel: Annuler
+          source: 'LANGUAGE: fr'

--- a/tools/ts-res-tutorial/data/resources/theme.yaml
+++ b/tools/ts-res-tutorial/data/resources/theme.yaml
@@ -1,0 +1,69 @@
+# Demonstrates composition ("resolveComposedResourceValue"). The imported
+# resource id is resources.theme.theme (import path + explicit id).
+#
+# How composition works:
+#
+#   - A "full" candidate (isPartial omitted or false) is selected as the
+#     base. The first full candidate with the highest priority wins.
+#   - All matching *partial* candidates with priority >= the chosen base
+#     are merged into it, ascending by priority so higher-priority values
+#     overwrite lower-priority ones.
+#   - Property-level merge rules:
+#       * scalars/arrays replace outright
+#       * objects are deep-merged
+#       * explicit null deletes the underlying property (toggle with the
+#         `suppressNullAsDelete` resolver option)
+#
+# See src/lessons/lesson04-resolve.ts for the demo.
+
+resources:
+  - id: theme
+    resourceTypeName: json
+    candidates:
+      # Full baseline theme - no conditions, always selectable.
+      - json:
+          name: default
+          palette:
+            background: '#FFFFFF'
+            foreground: '#111111'
+            accent: '#2b6cb0'
+          typography:
+            family: Inter
+            baseSize: 14
+          experimental:
+            newShadow: null
+
+      # Full "dark" replacement when theme=dark.
+      - conditions:
+          theme: dark
+        json:
+          name: dark
+          palette:
+            background: '#0f172a'
+            foreground: '#e2e8f0'
+            accent: '#60a5fa'
+          typography:
+            family: Inter
+            baseSize: 14
+          experimental:
+            newShadow: null
+
+      # Partial override: at xxhdpi bump typography in isolation and
+      # enable the experimental shadow. Composes with whichever full
+      # candidate was chosen above.
+      - isPartial: true
+        conditions:
+          density: xxhdpi
+        json:
+          typography:
+            baseSize: 16
+          experimental:
+            newShadow: '0 8px 24px rgba(0,0,0,0.35)'
+
+      # Partial override: French users get a different accent font.
+      - isPartial: true
+        conditions:
+          language: fr
+        json:
+          typography:
+            family: 'Merriweather, Inter'

--- a/tools/ts-res-tutorial/eslint.config.js
+++ b/tools/ts-res-tutorial/eslint.config.js
@@ -1,0 +1,15 @@
+// ESLint 9 flat config
+const nodeProfile = require('@rushstack/eslint-config/flat/profile/node');
+const packletsPlugin = require('@rushstack/eslint-config/flat/mixins/packlets');
+const tsdocPlugin = require('@rushstack/eslint-config/flat/mixins/tsdoc');
+
+module.exports = [
+  ...nodeProfile,
+  packletsPlugin,
+  ...tsdocPlugin,
+  {
+    rules: {
+      '@rushstack/packlets/mechanics': 'warn'
+    }
+  }
+];

--- a/tools/ts-res-tutorial/package.json
+++ b/tools/ts-res-tutorial/package.json
@@ -17,6 +17,7 @@
     "lesson2": "node bin/ts-res-tutorial.js lesson2-import",
     "lesson3": "node bin/ts-res-tutorial.js lesson3-runtime",
     "lesson4": "node bin/ts-res-tutorial.js lesson4-resolve",
+    "lesson5": "node bin/ts-res-tutorial.js lesson5-inference",
     "all": "node bin/ts-res-tutorial.js all"
   },
   "keywords": [

--- a/tools/ts-res-tutorial/package.json
+++ b/tools/ts-res-tutorial/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@fgv/ts-res-tutorial",
+  "version": "0.1.0",
+  "description": "Hands-on tutorial and sample application for the @fgv/ts-res library",
+  "main": "lib/index.js",
+  "bin": {
+    "ts-res-tutorial": "bin/ts-res-tutorial.js"
+  },
+  "scripts": {
+    "build": "heft build --clean",
+    "test": "heft test --clean",
+    "coverage": "heft test --clean --coverage",
+    "clean": "heft clean",
+    "lint": "eslint src --ext .ts",
+    "fixlint": "eslint src --ext .ts --fix",
+    "lesson1": "node bin/ts-res-tutorial.js lesson1-config",
+    "lesson2": "node bin/ts-res-tutorial.js lesson2-import",
+    "lesson3": "node bin/ts-res-tutorial.js lesson3-runtime",
+    "lesson4": "node bin/ts-res-tutorial.js lesson4-resolve",
+    "all": "node bin/ts-res-tutorial.js all"
+  },
+  "keywords": [
+    "typescript",
+    "resources",
+    "tutorial",
+    "sample",
+    "ts-res"
+  ],
+  "author": "Erik Fortune",
+  "license": "MIT",
+  "dependencies": {
+    "@fgv/ts-res": "workspace:*",
+    "@fgv/ts-utils": "workspace:*",
+    "@fgv/ts-extras": "workspace:*",
+    "@fgv/ts-json": "workspace:*",
+    "@fgv/ts-json-base": "workspace:*",
+    "commander": "^11.0.0"
+  },
+  "devDependencies": {
+    "@fgv/ts-utils-jest": "workspace:*",
+    "@rushstack/heft": "1.2.7",
+    "@rushstack/heft-node-rig": "2.11.27",
+    "@rushstack/eslint-config": "4.6.4",
+    "@types/heft-jest": "1.0.6",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^20.14.9",
+    "@typescript-eslint/eslint-plugin": "^8.52.0",
+    "@typescript-eslint/parser": "^8.52.0",
+    "eslint": "^9.39.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.6",
+    "typescript": "5.9.3",
+    "@rushstack/heft-jest-plugin": "1.2.6"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ErikFortune/fgv.git"
+  }
+}

--- a/tools/ts-res-tutorial/src/cli.ts
+++ b/tools/ts-res-tutorial/src/cli.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { Command } from 'commander';
+import { Result } from '@fgv/ts-utils';
+import { Runtime } from '@fgv/ts-res';
+import { runAllLessons, runLesson1, runLesson2, runLesson3, runLesson4 } from './lessons';
+import { ConsoleTutorialPrinter, ITutorialPrinter } from './utils';
+
+/**
+ * Minimal CLI wrapper around the tutorial lessons. Each subcommand
+ * invokes one lesson (or all four in order).
+ *
+ * @remarks
+ * The CLI is intentionally thin - every lesson is a plain function that
+ * takes an {@link ITutorialPrinter} so it can be exercised from tests
+ * without going through commander at all. Keep the CLI layer "dumb" so
+ * the interesting code lives in the lessons where readers expect it.
+ *
+ * @public
+ */
+export class TutorialApp {
+  private readonly _printer: ITutorialPrinter;
+
+  /**
+   * Creates a new tutorial CLI.
+   *
+   * @param printer - Optional printer override. Defaults to a
+   *                  `ConsoleTutorialPrinter` that writes to stdout.
+   */
+  public constructor(printer?: ITutorialPrinter) {
+    this._printer = printer ?? new ConsoleTutorialPrinter();
+  }
+
+  /**
+   * Parses `argv` and runs the requested subcommand. Mirrors the signature
+   * of `commander`'s `program.parseAsync` so the bin script can simply
+   * pass through `process.argv`.
+   */
+  public async run(argv: string[]): Promise<void> {
+    const program = new Command();
+    program.name('ts-res-tutorial').description('Hands-on tutorial for the @fgv/ts-res library');
+
+    program
+      .command('lesson1-config')
+      .description('Lesson 1 - load a qualifier configuration')
+      .action(() => {
+        runLesson1(this._printer).orThrow();
+      });
+
+    program
+      .command('lesson2-import')
+      .description('Lesson 2 - import YAML resources via the preprocessor')
+      .action(() => {
+        runLesson1(this._printer)
+          .onSuccess((systemConfig) => runLesson2(this._printer, systemConfig))
+          .orThrow();
+      });
+
+    program
+      .command('lesson3-runtime')
+      .description('Lesson 3 - wire the runtime (context provider + resolver)')
+      .action(() => {
+        this._runThroughLesson3().orThrow();
+      });
+
+    program
+      .command('lesson4-resolve')
+      .description('Lesson 4 - resolve resources (best, all, composed, manual)')
+      .action(() => {
+        this._runThroughLesson3()
+          .onSuccess((resolver) => runLesson4(this._printer, resolver))
+          .orThrow();
+      });
+
+    program
+      .command('all')
+      .description('Run every lesson in order')
+      .action(() => {
+        runAllLessons(this._printer).orThrow();
+      });
+
+    await program.parseAsync(argv);
+  }
+
+  /**
+   * Helper that chains lessons 1-3 so lesson 4 can run against the
+   * resulting resolver.
+   */
+  private _runThroughLesson3(): Result<Runtime.ResourceResolver> {
+    return runLesson1(this._printer).onSuccess((systemConfig) =>
+      runLesson2(this._printer, systemConfig).onSuccess((resourceManager) =>
+        runLesson3(this._printer, systemConfig, resourceManager)
+      )
+    );
+  }
+}

--- a/tools/ts-res-tutorial/src/cli.ts
+++ b/tools/ts-res-tutorial/src/cli.ts
@@ -23,12 +23,12 @@
 import { Command } from 'commander';
 import { Result } from '@fgv/ts-utils';
 import { Runtime } from '@fgv/ts-res';
-import { runAllLessons, runLesson1, runLesson2, runLesson3, runLesson4 } from './lessons';
+import { runAllLessons, runLesson1, runLesson2, runLesson3, runLesson4, runLesson5 } from './lessons';
 import { ConsoleTutorialPrinter, ITutorialPrinter } from './utils';
 
 /**
  * Minimal CLI wrapper around the tutorial lessons. Each subcommand
- * invokes one lesson (or all four in order).
+ * invokes one lesson (or all five in order).
  *
  * @remarks
  * The CLI is intentionally thin - every lesson is a plain function that
@@ -89,6 +89,15 @@ export class TutorialApp {
       .action(() => {
         this._runThroughLesson3()
           .onSuccess((resolver) => runLesson4(this._printer, resolver))
+          .orThrow();
+      });
+
+    program
+      .command('lesson5-inference')
+      .description('Lesson 5 - infer qualifiers from folder and file names')
+      .action(() => {
+        runLesson1(this._printer)
+          .onSuccess((systemConfig) => runLesson5(this._printer, systemConfig))
           .orThrow();
       });
 

--- a/tools/ts-res-tutorial/src/index.ts
+++ b/tools/ts-res-tutorial/src/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+export * from './cli';
+export * from './lessons';
+export * from './qualifierTypes';
+export * from './utils';

--- a/tools/ts-res-tutorial/src/lessons/index.ts
+++ b/tools/ts-res-tutorial/src/lessons/index.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { Result, succeed } from '@fgv/ts-utils';
+import { ITutorialPrinter } from '../utils';
+import { runLesson1 } from './lesson01LoadConfig';
+import { runLesson2 } from './lesson02Import';
+import { runLesson3 } from './lesson03Runtime';
+import { runLesson4 } from './lesson04Resolve';
+
+export * from './lesson01LoadConfig';
+export * from './lesson02Import';
+export * from './lesson03Runtime';
+export * from './lesson04Resolve';
+
+/**
+ * Runs every lesson in order, feeding each lesson the output of the
+ * previous one.
+ *
+ * @remarks
+ * This is the function invoked by both the `all` CLI subcommand and the
+ * lesson smoke tests. Every lesson returns a `Result` - any failure
+ * short-circuits the chain so the test harness gets a precise error.
+ *
+ * @param printer - Sink for tutorial output.
+ * @returns `Success` when every lesson finished cleanly.
+ * @public
+ */
+export function runAllLessons(printer: ITutorialPrinter): Result<undefined> {
+  return runLesson1(printer)
+    .onSuccess((systemConfig) =>
+      runLesson2(printer, systemConfig).onSuccess((resourceManager) =>
+        runLesson3(printer, systemConfig, resourceManager).onSuccess((resolver) =>
+          runLesson4(printer, resolver)
+        )
+      )
+    )
+    .onSuccess(() => succeed(undefined));
+}

--- a/tools/ts-res-tutorial/src/lessons/index.ts
+++ b/tools/ts-res-tutorial/src/lessons/index.ts
@@ -21,16 +21,19 @@
  */
 
 import { Result, succeed } from '@fgv/ts-utils';
+import { Config } from '@fgv/ts-res';
 import { ITutorialPrinter } from '../utils';
 import { runLesson1 } from './lesson01LoadConfig';
 import { runLesson2 } from './lesson02Import';
 import { runLesson3 } from './lesson03Runtime';
 import { runLesson4 } from './lesson04Resolve';
+import { runLesson5 } from './lesson05Inference';
 
 export * from './lesson01LoadConfig';
 export * from './lesson02Import';
 export * from './lesson03Runtime';
 export * from './lesson04Resolve';
+export * from './lesson05Inference';
 
 /**
  * Runs every lesson in order, feeding each lesson the output of the
@@ -41,18 +44,26 @@ export * from './lesson04Resolve';
  * lesson smoke tests. Every lesson returns a `Result` - any failure
  * short-circuits the chain so the test harness gets a precise error.
  *
+ * Lesson 5 is independent of Lessons 2-4: it imports a separate
+ * `data/inferred/` tree into its own resource manager because the
+ * inference demo is orthogonal to the resource graph the earlier
+ * lessons built. It still reuses the Lesson 1 system configuration so
+ * the qualifier tokens and `tokenIsOptional` flags are consistent.
+ *
  * @param printer - Sink for tutorial output.
  * @returns `Success` when every lesson finished cleanly.
  * @public
  */
 export function runAllLessons(printer: ITutorialPrinter): Result<undefined> {
   return runLesson1(printer)
-    .onSuccess((systemConfig) =>
-      runLesson2(printer, systemConfig).onSuccess((resourceManager) =>
-        runLesson3(printer, systemConfig, resourceManager).onSuccess((resolver) =>
-          runLesson4(printer, resolver)
+    .onSuccess((systemConfig: Config.SystemConfiguration) =>
+      runLesson2(printer, systemConfig)
+        .onSuccess((resourceManager) =>
+          runLesson3(printer, systemConfig, resourceManager).onSuccess((resolver) =>
+            runLesson4(printer, resolver)
+          )
         )
-      )
+        .onSuccess(() => runLesson5(printer, systemConfig))
     )
     .onSuccess(() => succeed(undefined));
 }

--- a/tools/ts-res-tutorial/src/lessons/lesson01LoadConfig.ts
+++ b/tools/ts-res-tutorial/src/lessons/lesson01LoadConfig.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import * as fs from 'fs';
+import { Result, succeed } from '@fgv/ts-utils';
+import { Converters as JsonConverters } from '@fgv/ts-json-base';
+import { Yaml } from '@fgv/ts-extras';
+import { Config } from '@fgv/ts-res';
+import { DensityQualifierTypeFactory } from '../qualifierTypes';
+import { CONFIG_FILE, ITutorialPrinter } from '../utils';
+
+/**
+ * Lesson 1: Loading a qualifier configuration.
+ *
+ * @remarks
+ * ts-res ships with a handful of predefined system configurations
+ * (`default`, `language-priority`, `territory-priority`,
+ * `extended-example`) exposed via
+ * {@link Config.getPredefinedSystemConfiguration}. They're a great way to
+ * get started, but real applications usually want a custom configuration
+ * with their own qualifier types and priorities.
+ *
+ * This lesson shows:
+ *   1. Loading a predefined configuration and inspecting it.
+ *   2. Reading a custom configuration from a YAML file using the
+ *      `ts-extras` YAML converter and validating it with the ts-res
+ *      `Config.Convert.systemConfiguration` converter.
+ *   3. Wiring a custom qualifier type factory so that the configuration
+ *      can reference a `systemType` the built-in factory doesn't know
+ *      about (here: `density`).
+ *
+ * @param printer - Sink for everything the lesson produces. Tests pass a
+ *                  capturing printer so they can assert on output.
+ * @returns `Success` with the materialised custom `SystemConfiguration`
+ *          if the lesson runs to completion.
+ * @public
+ */
+export function runLesson1(printer: ITutorialPrinter): Result<Config.SystemConfiguration> {
+  printer.heading('Lesson 1 - Loading a qualifier configuration');
+  printer.line('Predefined configurations are the quickest way to get a');
+  printer.line('working system. Each one bundles qualifier types,');
+  printer.line('qualifiers and resource types with sensible priorities.');
+
+  // --- Step 1: predefined configuration --------------------------------
+  printer.subheading('Predefined: "default" (territory-priority)');
+  const predefined = Config.getPredefinedSystemConfiguration('default').orThrow();
+  printer.line(`name:        ${predefined.name}`);
+  printer.line(`description: ${predefined.description}`);
+  printer.line(`qualifiers:  ${Array.from(predefined.qualifiers.values(), (q) => q.name).join(', ')}`);
+
+  // --- Step 2: custom configuration from a YAML file -------------------
+  printer.subheading('Custom: loaded from data/config/system.yaml');
+  printer.line('We parse the YAML ourselves here so you can see the layers:');
+  printer.line('  raw string -> YAML -> unknown JSON -> validated config.');
+  printer.line('Lesson 2 uses the same pre-processor from the importer side.');
+
+  // Step 2a: read the file from disk. Real apps might get this from an
+  // HTTP response, a bundled asset, etc - ts-res doesn't care where the
+  // string comes from.
+  const rawYaml = fs.readFileSync(CONFIG_FILE, 'utf-8');
+
+  // Step 2b: YAML -> JsonValue. yamlConverter wraps js-yaml and then
+  // validates the result with whatever JsonConverter you pass it.
+  // jsonObject is strict enough to ensure the top level is an object.
+  const yamlToJson = Yaml.yamlConverter(JsonConverters.jsonObject);
+  const parsed = yamlToJson.convert(rawYaml).orThrow();
+
+  // Step 2c: JsonValue -> ISystemConfiguration. Converters give us a
+  // strongly-typed result with friendly error messages. Doing the shape
+  // validation yourself by hand is an anti-pattern in this repo.
+  const declaration = Config.Convert.systemConfiguration.convert(parsed).orThrow();
+  printer.line(
+    `parsed ${declaration.qualifierTypes.length} qualifier types and ` +
+      `${declaration.qualifiers.length} qualifiers from YAML`
+  );
+
+  // --- Step 3: wire the custom density qualifier type ------------------
+  printer.subheading('Wiring a custom qualifier type factory');
+  printer.line('system.yaml declares `systemType: density`. The built-in');
+  printer.line('factory only knows language/territory/literal - we supply');
+  printer.line('a DensityQualifierTypeFactory that handles the rest.');
+
+  const qualifierTypeFactory = new Config.QualifierTypeFactory([
+    // Tried first; returns Failure for anything it doesn't know.
+    new DensityQualifierTypeFactory()
+    // The BuiltInQualifierTypeFactory is appended automatically by the
+    // QualifierTypeFactory constructor so language/territory/literal
+    // keep working.
+  ]);
+
+  const systemConfig = Config.SystemConfiguration.create(declaration, {
+    qualifierTypeFactory
+  }).orThrow();
+
+  printer.line(`qualifier types built: ${systemConfig.qualifierTypes.size}`);
+  printer.line(`qualifiers built:      ${systemConfig.qualifiers.size}`);
+  printer.line(`resource types built:  ${systemConfig.resourceTypes.size}`);
+
+  // List qualifiers by priority so the priority-ordering becomes obvious
+  // when lessons 3 and 4 start matching candidates.
+  printer.line('');
+  printer.line('Qualifier priorities (higher wins):');
+  const sorted = Array.from(systemConfig.qualifiers.values()).sort(
+    (a, b) => b.defaultPriority - a.defaultPriority
+  );
+  for (const q of sorted) {
+    printer.line(`  ${String(q.defaultPriority).padStart(4)}  ${q.name.padEnd(18)}  ${q.type.name}`);
+  }
+
+  return succeed(systemConfig);
+}

--- a/tools/ts-res-tutorial/src/lessons/lesson02Import.ts
+++ b/tools/ts-res-tutorial/src/lessons/lesson02Import.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { Result } from '@fgv/ts-utils';
+import { Converters as JsonConverters, FileTree } from '@fgv/ts-json-base';
+import { Yaml } from '@fgv/ts-extras';
+import { Config, Import, Resources } from '@fgv/ts-res';
+import { ITutorialPrinter, RESOURCES_ROOT } from '../utils';
+
+/**
+ * Lesson 2: Setting up the importer with a YAML preprocessor.
+ *
+ * @remarks
+ * ts-res imports are driven by an {@link Import.ImportManager | ImportManager}
+ * that owns a chain of importers: `PathImporter`, `FsItemImporter`,
+ * `JsonImporter`, `CollectionImporter`. Out of the box they read `.json`.
+ *
+ * The `ImportManager.create()` parameters include two important knobs
+ * that were added to enable transparent YAML (or TOML, JSON5, ...) loading:
+ *
+ *   - `fileContentConverter`: any `Converter<JsonValue>` applied to raw
+ *     file contents before the rest of the import pipeline runs.
+ *   - `fileContentExtensions`: the file extensions that should flow
+ *     through the converter. `.json` is still handled natively.
+ *
+ * Combined, they turn "import a directory of YAML resources" into a
+ * one-liner: the importer reads each `.yaml` file as text, hands it to
+ * the YAML converter to produce a `JsonObject`, and the rest of the
+ * pipeline is unchanged.
+ *
+ * This lesson:
+ *   1. Builds the same `SystemConfiguration` as lesson 1.
+ *   2. Creates a `ResourceManagerBuilder` for the configuration.
+ *   3. Creates an `ImportManager` with a YAML preprocessor for `.yaml`.
+ *   4. Imports the entire `data/resources/` tree.
+ *   5. Builds the resources and prints a summary.
+ *
+ * The returned `ResourceManagerBuilder` is handed to Lesson 3 which
+ * wires up the runtime.
+ *
+ * @param printer - Sink for tutorial output.
+ * @returns `Success` with the built resource manager if import succeeded.
+ * @public
+ */
+export function runLesson2(
+  printer: ITutorialPrinter,
+  systemConfig: Config.SystemConfiguration
+): Result<Resources.ResourceManagerBuilder> {
+  printer.heading('Lesson 2 - Importing YAML resources transparently');
+  printer.line('The ts-res importer reads `.json` natively. To accept a');
+  printer.line('different serialization we supply a preprocessor -');
+  printer.line('a `Converter<JsonValue>` that turns raw text into JSON.');
+
+  // --- Step 1: the YAML preprocessor -----------------------------------
+  printer.subheading('Building the YAML preprocessor');
+  // `Yaml.yamlConverter` takes an inner converter that validates the
+  // parsed YAML. We use `jsonObject` because the import pipeline needs
+  // the top level to be an object. Any Converter<JsonValue> works - the
+  // preprocessor is intentionally generic so you can plug in TOML or a
+  // templated JSON format just as easily.
+  const preprocessor = Yaml.yamlConverter(JsonConverters.jsonObject);
+  printer.line('preprocessor:          Yaml.yamlConverter(jsonObject)');
+  printer.line("fileContentExtensions: ['.yaml', '.yml']");
+
+  // --- Step 2: resource manager builder --------------------------------
+  // Same shape as lesson 1 - a mutable builder seeded with the qualifiers
+  // and resource types from the configuration.
+  const resourceManager = Resources.ResourceManagerBuilder.create({
+    qualifiers: systemConfig.qualifiers,
+    resourceTypes: systemConfig.resourceTypes
+  }).orThrow();
+
+  // --- Step 3: importer ------------------------------------------------
+  printer.subheading('Creating an ImportManager with the preprocessor');
+  // A `FileTree` tells the importer how to read files. `forFilesystem()`
+  // is the normal choice; an in-memory tree is handy for tests.
+  const fileTree = FileTree.forFilesystem().orThrow();
+
+  // `fileContentConverter` + `fileContentExtensions` is the extension
+  // point - the rest of the import pipeline is unchanged.
+  const importManager = Import.ImportManager.create({
+    resources: resourceManager,
+    fileTree,
+    fileContentConverter: preprocessor,
+    fileContentExtensions: ['.yaml', '.yml']
+  }).orThrow();
+
+  // --- Step 4: import the resource tree --------------------------------
+  printer.subheading(`Importing from ${RESOURCES_ROOT}`);
+  // `importFromFileSystem` walks the path recursively. Directories and
+  // individual files both work. Errors from any single file short-circuit
+  // the whole import, returning a Failure with an aggregated message.
+  importManager.importFromFileSystem(RESOURCES_ROOT).orThrow();
+
+  // --- Step 5: build and summarise -------------------------------------
+  // `.build()` finalises the collected candidates into built Resource
+  // objects that Lesson 4 can then resolve.
+  resourceManager.build().orThrow();
+
+  printer.line(`imported resources:    ${resourceManager.numResources}`);
+  printer.line(`imported candidates:   ${resourceManager.numCandidates}`);
+  printer.line('');
+  printer.line('Resource ids:');
+  for (const id of [...resourceManager.resourceIds].sort()) {
+    printer.line(`  ${id}`);
+  }
+
+  return resourceManager.build();
+}

--- a/tools/ts-res-tutorial/src/lessons/lesson03Runtime.ts
+++ b/tools/ts-res-tutorial/src/lessons/lesson03Runtime.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { Result, succeed } from '@fgv/ts-utils';
+import { Config, Resources, Runtime } from '@fgv/ts-res';
+import { ITutorialPrinter } from '../utils';
+
+/**
+ * Default runtime context used by every lesson that resolves resources.
+ * Picked to exercise every qualifier defined in `data/config/system.yaml`.
+ * @public
+ */
+export const DEFAULT_CONTEXT: Record<string, string> = {
+  language: 'fr',
+  currentTerritory: 'CA',
+  theme: 'dark',
+  density: 'xhdpi'
+};
+
+/**
+ * Lesson 3: Setting up the runtime (context provider + resolver).
+ *
+ * @remarks
+ * "Runtime" in ts-res refers to the objects that evaluate a context
+ * against the built resources to pick winning candidates. There are two
+ * pieces you own:
+ *
+ *   - A {@link Runtime.IContextQualifierProvider | context qualifier
+ *     provider} that holds the current values of every qualifier (e.g.
+ *     language=fr, density=xhdpi). The tutorial uses
+ *     {@link Runtime.ValidatingSimpleContextQualifierProvider | ValidatingSimpleContextQualifierProvider}
+ *     because it accepts plain string keys/values and validates them
+ *     against the qualifier collection - no branded-type casting.
+ *
+ *   - A {@link Runtime.ResourceResolver | ResourceResolver} that pairs
+ *     a resource manager, the qualifier types, and a context provider.
+ *     Once created it owns an O(1) cache for condition, condition set,
+ *     and decision resolution results.
+ *
+ * This lesson wires both up and then swaps the context to demonstrate
+ * how the same resolver can serve multiple contexts.
+ *
+ * @param printer - Sink for tutorial output.
+ * @param systemConfig - The configuration from lesson 1.
+ * @param resourceManager - The built resource manager from lesson 2.
+ * @returns `Success` with the new resolver if setup succeeded.
+ * @public
+ */
+export function runLesson3(
+  printer: ITutorialPrinter,
+  systemConfig: Config.SystemConfiguration,
+  resourceManager: Resources.ResourceManagerBuilder
+): Result<Runtime.ResourceResolver> {
+  printer.heading('Lesson 3 - Wiring the runtime');
+
+  // --- Step 1: context provider ----------------------------------------
+  printer.subheading('Creating a ValidatingSimpleContextQualifierProvider');
+  printer.line('The provider holds "current" qualifier values. The');
+  printer.line('validating variant accepts plain string keys/values and');
+  printer.line('runs them through the qualifier collection so we catch');
+  printer.line('typos and invalid values at setup time.');
+
+  const contextProvider = Runtime.ValidatingSimpleContextQualifierProvider.create({
+    qualifiers: systemConfig.qualifiers,
+    qualifierValues: DEFAULT_CONTEXT
+  }).orThrow();
+
+  printer.line('');
+  printer.line('Initial context:');
+  for (const [key, value] of Object.entries(DEFAULT_CONTEXT)) {
+    printer.line(`  ${key.padEnd(18)} = ${value}`);
+  }
+
+  // --- Step 2: resolver ------------------------------------------------
+  printer.subheading('Creating a ResourceResolver');
+  printer.line('The resolver marries three things: the resource manager');
+  printer.line('(which provides the built resources), the qualifier type');
+  printer.line('collector (so it can evaluate condition match scores),');
+  printer.line('and the context provider we just built.');
+
+  const resolver = Runtime.ResourceResolver.create({
+    resourceManager,
+    qualifierTypes: systemConfig.qualifierTypes,
+    contextQualifierProvider: contextProvider
+  }).orThrow();
+
+  printer.line('');
+  printer.line(`condition cache size:     ${resolver.conditionCacheSize}`);
+  printer.line(`conditionSet cache size:  ${resolver.conditionSetCacheSize}`);
+  printer.line(`decision cache size:      ${resolver.decisionCacheSize}`);
+  printer.line('(caches are empty now and fill on demand)');
+
+  // --- Step 3: swapping contexts ---------------------------------------
+  printer.subheading('Creating an alternate resolver via withContext()');
+  printer.line('ResourceResolver.withContext() returns a brand-new');
+  printer.line('resolver instance tied to a different context provider.');
+  printer.line('The resource data is shared, only the context changes.');
+
+  const usEnglish = resolver
+    .withContext({
+      language: 'en',
+      currentTerritory: 'US',
+      theme: 'light',
+      density: 'mdpi'
+    })
+    .orThrow();
+
+  printer.line('');
+  printer.line('US English context built from the same resources:');
+  printer.line(`  same resource manager: ${usEnglish.resourceManager === resolver.resourceManager}`);
+  printer.line(`  distinct resolver:     ${usEnglish !== resolver}`);
+
+  // Hand back the original (fr/CA/dark/xhdpi) resolver since that's the
+  // interesting context for the resolution lesson.
+  return succeed(resolver);
+}

--- a/tools/ts-res-tutorial/src/lessons/lesson04Resolve.ts
+++ b/tools/ts-res-tutorial/src/lessons/lesson04Resolve.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { Result, succeed } from '@fgv/ts-utils';
+import { isJsonObject, JsonObject } from '@fgv/ts-json-base';
+import { JsonEditor } from '@fgv/ts-json';
+import { Runtime } from '@fgv/ts-res';
+import { ITutorialPrinter } from '../utils';
+
+const STRINGS_ID: string = 'resources.strings.greetings';
+const ICONS_ID: string = 'resources.icons.icons';
+const THEME_ID: string = 'resources.theme.theme';
+
+/**
+ * Lesson 4: Four ways to resolve a resource.
+ *
+ * @remarks
+ * Once you have a `ResourceResolver`, there are four distinct resolution
+ * strategies that solve different problems:
+ *
+ *   1. **Best match** - `resolveResource(id)` returns the single most
+ *      specific candidate. This is the "just give me the answer" API and
+ *      the right default for most apps.
+ *
+ *   2. **All matches** - `resolveAllResourceCandidates(id)` returns every
+ *      candidate whose conditions matched, ordered by descending
+ *      priority. Useful for introspection, debugging, fallbacks, and
+ *      rendering resource galleries.
+ *
+ *   3. **Composed** - `resolveComposedResourceValue(id)` merges matching
+ *      candidates together: highest-priority full candidate as the base,
+ *      plus all higher-priority partial candidates layered on top. This
+ *      is what you want for "theme overrides".
+ *
+ *   4. **Manually composed** - Take `resolveAllResourceCandidates()`,
+ *      hand-pick a subset, and feed them to `JsonEditor.mergeObjectsInPlace`
+ *      yourself. Use this when you want custom composition - e.g. merge
+ *      only the candidates above some priority threshold, or include a
+ *      runtime override that isn't in the resource file at all.
+ *
+ * @param printer - Sink for tutorial output.
+ * @param resolver - The resolver built in lesson 3 (context:
+ *                   language=fr, currentTerritory=CA, theme=dark,
+ *                   density=xhdpi).
+ * @returns `Success` when every demonstration completes.
+ * @public
+ */
+export function runLesson4(printer: ITutorialPrinter, resolver: Runtime.ResourceResolver): Result<undefined> {
+  printer.heading('Lesson 4 - Resolving resources');
+
+  // Context in effect:
+  //   language=fr  currentTerritory=CA  theme=dark  density=xhdpi
+  // With territory-priority system configuration, "CA" outranks "fr".
+  printer.line('Using the lesson-3 resolver. Active context:');
+  printer.line('  language=fr  currentTerritory=CA  theme=dark  density=xhdpi');
+
+  // --- Strategy 1: best match ------------------------------------------
+  printer.subheading('(1) Best match  -  resolveResource()');
+  printer.line('Returns the single highest-priority candidate. For');
+  printer.line(`"${STRINGS_ID}" with the active context, territory CA +`);
+  printer.line('language fr both match and the "BOTH: fr + CA" candidate');
+  printer.line('has the most specific condition set, so it wins.');
+  const best = resolver.resolveResource(STRINGS_ID).orThrow();
+  printer.json('best match', best.json);
+
+  // --- Strategy 2: all matches -----------------------------------------
+  printer.subheading('(2) All matches  -  resolveAllResourceCandidates()');
+  printer.line('Returns every matching candidate in priority order. Useful');
+  printer.line('for debugging ("why did this one win?") and for showing');
+  printer.line('all alternates.');
+  const allStrings = resolver.resolveAllResourceCandidates(STRINGS_ID).orThrow();
+  printer.line(`total matches: ${allStrings.length}`);
+  allStrings.forEach((candidate, i) => {
+    const summary =
+      isJsonObject(candidate.json) && typeof candidate.json.source === 'string'
+        ? candidate.json.source
+        : JSON.stringify(candidate.json);
+    printer.line(`  [${i}] isPartial=${candidate.isPartial}  ${summary}`);
+  });
+
+  // The density qualifier is more interesting here - adjacent buckets
+  // still match (score 0.7) so a single context hits more than one
+  // candidate in priority order.
+  printer.line('');
+  printer.line(`Same story for "${ICONS_ID}" - the custom density type`);
+  printer.line('gives adjacent buckets a partial match:');
+  const allIcons = resolver.resolveAllResourceCandidates(ICONS_ID).orThrow();
+  allIcons.forEach((candidate, i) => {
+    const bucket = isJsonObject(candidate.json) ? candidate.json.bucket : undefined;
+    printer.line(`  [${i}] bucket=${String(bucket)}`);
+  });
+
+  // --- Strategy 3: composed resolution ---------------------------------
+  printer.subheading('(3) Composed  -  resolveComposedResourceValue()');
+  printer.line('Finds the highest-priority full candidate as the base and');
+  printer.line('merges all higher-priority partial candidates on top of');
+  printer.line(`it. For "${THEME_ID}":`);
+  printer.line('  - base:    the theme=dark full candidate');
+  printer.line('  - partial: density=xxhdpi (not active - xhdpi context)');
+  printer.line('  - partial: language=fr   (active)');
+  const composed = resolver.resolveComposedResourceValue(THEME_ID).orThrow();
+  printer.json('composed theme (fr overrides font family)', composed);
+
+  // --- Strategy 4: manually composed -----------------------------------
+  printer.subheading('(4) Manually composed  -  hand-rolled merge');
+  printer.line('Sometimes you want control that the built-in composition');
+  printer.line("doesn't give you. Example: force every matching candidate");
+  printer.line('to merge regardless of isPartial, plus splice in a runtime');
+  printer.line('override computed from user settings.');
+
+  const themeCandidates = resolver.resolveAllResourceCandidates(THEME_ID).orThrow();
+
+  // Keep only JsonObject payloads - they are the only shape JsonEditor
+  // can merge. In this tutorial every theme candidate is an object so
+  // nothing is lost; the filter is there for safety.
+  const candidatePayloads = themeCandidates
+    .map((c) => c.json)
+    .filter((v): v is JsonObject => isJsonObject(v));
+
+  // A runtime override we'd like to apply on top - demonstrates that
+  // manual composition lets you mix resource data with data from any
+  // other source.
+  const runtimeOverride: JsonObject = {
+    palette: {
+      accent: '#ff7f50'
+    },
+    experimental: {
+      newShadow: '0 2px 8px rgba(0,0,0,0.25)'
+    }
+  };
+
+  // Build the merge list in ascending priority order so later entries
+  // win. resolveAllResourceCandidates returns descending priority, so
+  // reverse it and stick the runtime override on the end.
+  const mergeInputs: JsonObject[] = [...candidatePayloads].reverse();
+  mergeInputs.push(runtimeOverride);
+
+  const editor = JsonEditor.create({
+    merge: {
+      arrayMergeBehavior: 'replace',
+      nullAsDelete: true
+    }
+  }).orThrow();
+
+  const hand = editor.mergeObjectsInPlace({}, mergeInputs).orThrow();
+  printer.json('hand-merged theme (adds runtime accent)', hand);
+
+  return succeed(undefined);
+}

--- a/tools/ts-res-tutorial/src/lessons/lesson05Inference.ts
+++ b/tools/ts-res-tutorial/src/lessons/lesson05Inference.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import * as path from 'path';
+import { Result, succeed } from '@fgv/ts-utils';
+import { Converters as JsonConverters, FileTree, isJsonObject } from '@fgv/ts-json-base';
+import { Yaml } from '@fgv/ts-extras';
+import { Config, Import, Resources, Runtime } from '@fgv/ts-res';
+import { DATA_ROOT, ITutorialPrinter } from '../utils';
+
+const INFERRED_ROOT: string = path.join(DATA_ROOT, 'inferred');
+const INFERRED_RESOURCE_ID: string = 'inferred.messages.text';
+
+/**
+ * Lesson 5: Path-driven qualifier inference and id composition.
+ *
+ * @remarks
+ * Lessons 2-4 import resources whose conditions are spelled out inside
+ * each YAML file. That works but it is verbose - the same language/
+ * territory combination has to be repeated in every candidate.
+ *
+ * The ts-res importer can also infer conditions and resource ids
+ * directly from the filesystem layout:
+ *
+ *   - Every **folder name** and **file basename** may contain qualifier
+ *     tokens. Parsing is applied to the LAST dot-separated segment of
+ *     the name, which is split on commas into one or more
+ *     `[qualifier=]value` pairs.
+ *
+ *   - A token may be **explicit** (`geo=CA`) or **tokenless** (just
+ *     `CA`). Tokenless values only work for qualifiers with
+ *     `tokenIsOptional: true`; the importer picks the single qualifier
+ *     whose type accepts the value, and fails if zero or more than one
+ *     qualifier matches.
+ *
+ *   - Explicit tokens are looked up by **qualifier name first, then
+ *     qualifier token**. In `data/config/system.yaml` the qualifier
+ *     `currentTerritory` declares `token: geo`, so `geo=CA` resolves to
+ *     `currentTerritory=CA`.
+ *
+ *   - Whatever is left of the basename after tokens are stripped becomes
+ *     a **resource id fragment**. Fragments stack as the importer walks
+ *     the tree, so the final resource id is the path joined with `.`.
+ *
+ *   - Folders whose entire name parses as a token contribute conditions
+ *     **but no id fragment**, which lets you keep a clean logical id
+ *     while adding arbitrary nesting for organisation.
+ *
+ * This lesson imports the separate `data/inferred/` tree into a fresh
+ * resource manager, lists what the importer produced, and then runs the
+ * resolver under a few contexts to prove that path inference really
+ * does wire up the expected conditions.
+ *
+ * @param printer - Sink for tutorial output.
+ * @param systemConfig - The configuration from lesson 1. We reuse it so
+ *                       the tokens and tokenIsOptional flags in
+ *                       `data/config/system.yaml` apply.
+ * @returns `Success` when the lesson finishes.
+ * @public
+ */
+export function runLesson5(
+  printer: ITutorialPrinter,
+  systemConfig: Config.SystemConfiguration
+): Result<undefined> {
+  printer.heading('Lesson 5 - Path-driven qualifier inference');
+
+  // --- Step 1: a fresh, empty resource manager for this lesson --------
+  // We do NOT reuse the resource manager from Lesson 2 because that
+  // lesson imports data/resources/ and the two trees are unrelated.
+  // Building a second manager keeps each lesson self-contained.
+  const resourceManager = Resources.ResourceManagerBuilder.create({
+    qualifiers: systemConfig.qualifiers,
+    resourceTypes: systemConfig.resourceTypes
+  }).orThrow();
+
+  // --- Step 2: importer with the YAML preprocessor --------------------
+  // Same setup as Lesson 2. The inference logic lives in the
+  // FsItemImporter and doesn't need any extra configuration - the
+  // importer always parses folder and file basenames for qualifier
+  // tokens, regardless of which file format you feed it.
+  const fileTree = FileTree.forFilesystem().orThrow();
+  const importManager = Import.ImportManager.create({
+    resources: resourceManager,
+    fileTree,
+    fileContentConverter: Yaml.yamlConverter(JsonConverters.jsonObject),
+    fileContentExtensions: ['.yaml', '.yml']
+  }).orThrow();
+
+  // --- Step 3: import the whole inferred/ tree ------------------------
+  printer.subheading(`Importing from ${INFERRED_ROOT}`);
+  printer.line('The tree contains 7 files organised by qualifier tokens');
+  printer.line('in folder and file basenames. The importer discovers the');
+  printer.line('conditions automatically - the YAML files themselves');
+  printer.line('contain NO "conditions" blocks.');
+  importManager.importFromFileSystem(INFERRED_ROOT).orThrow();
+  resourceManager.build().orThrow();
+
+  printer.line('');
+  printer.line(`imported resources:  ${resourceManager.numResources}`);
+  printer.line(`imported candidates: ${resourceManager.numCandidates}`);
+  printer.line(`all candidates live under a single id: ${INFERRED_RESOURCE_ID}`);
+
+  // --- Step 4: show the discovered conditions per candidate -----------
+  // Pull the built resource and walk its candidates so readers can see
+  // exactly which path produced which condition set.
+  printer.subheading('Conditions the importer inferred per candidate');
+  const resource = resourceManager.getBuiltResource(INFERRED_RESOURCE_ID).orThrow();
+  resource.candidates.forEach((candidate, i) => {
+    const source =
+      isJsonObject(candidate.json) && typeof candidate.json.source === 'string'
+        ? candidate.json.source
+        : '(unknown)';
+    printer.line(`  [${i}] ${source}`);
+  });
+
+  // --- Step 5: resolve under a few contexts ---------------------------
+  // Each context below is designed to pick a DIFFERENT winning candidate
+  // so readers can verify the inference produced the expected matches.
+  //
+  // Note the priority interplay from Lesson 1's system.yaml:
+  //   currentTerritory priority 850 > language priority 800
+  // so a territory match always beats a language match when both fire.
+  // The contexts are chosen to exercise each branch - territory-only,
+  // language-only (via a territory nobody has content for), and
+  // combined matches where the most specific candidate wins.
+  printer.subheading('Best match per context');
+  const contexts: Array<Record<string, string>> = [
+    { language: 'fr', currentTerritory: 'DE' },
+    { language: 'en', currentTerritory: 'CA' },
+    { language: 'fr', currentTerritory: 'CA' },
+    { language: 'en', currentTerritory: 'GB' },
+    { language: 'en', currentTerritory: 'US' }
+  ];
+
+  for (const context of contexts) {
+    // Build a fresh resolver per context via withContext() so previous
+    // caches don't hide bugs. This is the same pattern Lesson 3 shows.
+    const resolver = Runtime.ResourceResolver.create({
+      resourceManager,
+      qualifierTypes: systemConfig.qualifierTypes,
+      contextQualifierProvider: Runtime.ValidatingSimpleContextQualifierProvider.create({
+        qualifiers: systemConfig.qualifiers,
+        qualifierValues: context
+      }).orThrow()
+    }).orThrow();
+
+    const candidate = resolver.resolveResource(INFERRED_RESOURCE_ID).orThrow();
+    const hello = isJsonObject(candidate.json) ? candidate.json.hello : candidate.json;
+    const source = isJsonObject(candidate.json) ? candidate.json.source : '(unknown)';
+    const contextLabel = Object.entries(context)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    printer.line(`  ${contextLabel.padEnd(36)} -> ${String(hello)}`);
+    printer.line(`  ${' '.repeat(36)}    (${String(source)})`);
+  }
+
+  return succeed(undefined);
+}

--- a/tools/ts-res-tutorial/src/qualifierTypes/densityQualifierType.ts
+++ b/tools/ts-res-tutorial/src/qualifierTypes/densityQualifierType.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { captureResult, Result, succeed } from '@fgv/ts-utils';
+import {
+  ConditionOperator,
+  NoMatch,
+  PerfectMatch,
+  QualifierConditionValue,
+  QualifierContextValue,
+  QualifierMatchScore,
+  QualifierTypeName,
+  QualifierTypes
+} from '@fgv/ts-res';
+import { JsonCompatibleType } from '@fgv/ts-json-base';
+
+/**
+ * Ordered density buckets understood by the {@link DensityQualifierType}.
+ * Listed from lowest to highest so the index of each value can be used as
+ * a proxy for "how close" two buckets are.
+ * @public
+ */
+export const DENSITY_BUCKETS: ReadonlyArray<string> = ['ldpi', 'mdpi', 'hdpi', 'xhdpi', 'xxhdpi'];
+
+/**
+ * Parameters for creating a {@link DensityQualifierType}.
+ * @public
+ */
+export interface IDensityQualifierTypeCreateParams {
+  /**
+   * Name used to identify this qualifier type inside a system configuration.
+   * Defaults to `'density'`.
+   */
+  name?: string;
+
+  /**
+   * Global index assigned to the type by its collector. Normally supplied
+   * automatically by the ts-res configuration layer.
+   */
+  index?: number;
+}
+
+/**
+ * A custom {@link QualifierTypes.QualifierType | QualifierType} that
+ * recognises Android-style pixel density buckets (`ldpi`, `mdpi`, `hdpi`,
+ * `xhdpi`, `xxhdpi`).
+ *
+ * @remarks
+ * The match semantics are deliberately simple so they are easy to reason
+ * about in the tutorial:
+ *
+ * - Exact bucket match scores {@link QualifierTypes.PerfectMatch | PerfectMatch}.
+ * - Adjacent buckets (e.g. `hdpi` vs `xhdpi`) score a partial match so that
+ *   a near-density asset is still preferred over nothing.
+ * - Two buckets apart scores lower again.
+ * - Three or more buckets apart scores {@link QualifierTypes.NoMatch | NoMatch}.
+ *
+ * The point of this class isn't to be the "correct" way to model density -
+ * it's to show how a consumer can plug a brand-new qualifier type into the
+ * ts-res configuration pipeline without modifying the library itself.
+ *
+ * @public
+ */
+export class DensityQualifierType extends QualifierTypes.QualifierType {
+  /**
+   * The systemType string this class handles. The companion
+   * `DensityQualifierTypeFactory` uses this value to decide whether it
+   * can instantiate an entry from the YAML/JSON system configuration.
+   */
+  public static readonly systemType: string = 'density';
+
+  /**
+   * {@inheritdoc QualifierTypes.QualifierType.systemTypeName}
+   */
+  public readonly systemTypeName: QualifierTypeName = DensityQualifierType.systemType as QualifierTypeName;
+
+  /**
+   * Protected constructor - use {@link DensityQualifierType.create} instead.
+   */
+  protected constructor(params: IDensityQualifierTypeCreateParams) {
+    super({
+      name: params.name ?? 'density',
+      index: params.index,
+      allowContextList: false
+    });
+  }
+
+  /**
+   * Factory method. Returns a `Result<DensityQualifierType>` so callers can
+   * compose construction into the rest of the ts-res Result-based pipeline.
+   */
+  public static create(params?: IDensityQualifierTypeCreateParams): Result<DensityQualifierType> {
+    return captureResult(() => new DensityQualifierType(params ?? {}));
+  }
+
+  /**
+   * {@inheritdoc QualifierTypes.QualifierType.isValidConditionValue}
+   */
+  public isValidConditionValue(value: string): value is QualifierConditionValue {
+    return DENSITY_BUCKETS.includes(value.toLowerCase());
+  }
+
+  /**
+   * {@inheritdoc QualifierTypes.QualifierType.getConfigurationJson}
+   */
+  public getConfigurationJson(): Result<JsonCompatibleType<QualifierTypes.Config.IQualifierTypeConfig>> {
+    return succeed({
+      name: this.name,
+      systemType: DensityQualifierType.systemType,
+      configuration: {}
+    });
+  }
+
+  /**
+   * Validates and returns the configuration JSON for this qualifier type.
+   *
+   * @remarks
+   * In a production implementation this would use a `Converter` to validate
+   * the raw shape. The tutorial keeps the story focused on matching logic,
+   * so we simply accept the incoming configuration object unchanged.
+   */
+  public validateConfigurationJson(
+    from: unknown
+  ): Result<JsonCompatibleType<QualifierTypes.Config.IQualifierTypeConfig>> {
+    return succeed(from as JsonCompatibleType<QualifierTypes.Config.IQualifierTypeConfig>);
+  }
+
+  /**
+   * Scores a single condition/context value pair.
+   *
+   * @remarks
+   * The match score is derived from the distance between the condition
+   * bucket and the context bucket in the {@link DENSITY_BUCKETS | ordered
+   * bucket list}. Distance 0 is perfect, distance 1 is a strong partial,
+   * distance 2 is a weak partial, anything beyond is a no-match.
+   */
+  protected _matchOne(
+    condition: QualifierConditionValue,
+    context: QualifierContextValue,
+    operator: ConditionOperator
+  ): QualifierMatchScore {
+    if (operator !== 'matches') {
+      return NoMatch;
+    }
+
+    const conditionIndex = DENSITY_BUCKETS.indexOf(condition.toLowerCase());
+    const contextIndex = DENSITY_BUCKETS.indexOf(context.toLowerCase());
+
+    if (conditionIndex < 0 || contextIndex < 0) {
+      return NoMatch;
+    }
+
+    const distance = Math.abs(conditionIndex - contextIndex);
+    if (distance === 0) {
+      return PerfectMatch;
+    }
+    if (distance === 1) {
+      return 0.7 as QualifierMatchScore;
+    }
+    if (distance === 2) {
+      return 0.4 as QualifierMatchScore;
+    }
+    return NoMatch;
+  }
+}

--- a/tools/ts-res-tutorial/src/qualifierTypes/densityQualifierTypeFactory.ts
+++ b/tools/ts-res-tutorial/src/qualifierTypes/densityQualifierTypeFactory.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { fail, Result } from '@fgv/ts-utils';
+import { Config, QualifierTypes } from '@fgv/ts-res';
+import { DensityQualifierType } from './densityQualifierType';
+
+/**
+ * A {@link Config.IConfigInitFactory | config init factory} that knows how
+ * to build a {@link DensityQualifierType} from a YAML/JSON qualifier type
+ * declaration whose `systemType` is `"density"`.
+ *
+ * @remarks
+ * The factory signature is the ts-res extension point for adding custom
+ * qualifier types. Factories are tried in order; ours returns
+ * {@link Result | fail} for anything it doesn't recognise so the chain can
+ * continue to the built-in factory for things like `language` / `territory`
+ * / `literal`.
+ *
+ * Wiring:
+ *
+ * ```ts
+ * const factory = new Config.QualifierTypeFactory([
+ *   new DensityQualifierTypeFactory()  // tried first
+ *   // BuiltInQualifierTypeFactory is appended automatically
+ * ]);
+ *
+ * const systemConfig = Config.SystemConfiguration.create(declaration, {
+ *   qualifierTypeFactory: factory
+ * }).orThrow();
+ * ```
+ *
+ * See `src/lessons/lesson03-runtime.ts` for the full picture.
+ *
+ * @public
+ */
+export class DensityQualifierTypeFactory
+  implements Config.IConfigInitFactory<QualifierTypes.Config.IAnyQualifierTypeConfig, DensityQualifierType>
+{
+  /**
+   * Attempts to create a {@link DensityQualifierType} from the supplied
+   * qualifier type declaration.
+   *
+   * @param config - A `qualifierTypes[]` entry from a system configuration.
+   * @returns `Success` with the new qualifier type if `config.systemType`
+   * is `"density"`, `Failure` otherwise.
+   */
+  public create(config: QualifierTypes.Config.IAnyQualifierTypeConfig): Result<DensityQualifierType> {
+    if (config.systemType !== DensityQualifierType.systemType) {
+      // Factories in a chain communicate "not mine" via Failure. The next
+      // factory in the chain (ultimately the built-in factory) will get
+      // a chance to handle configs we reject.
+      return fail(`DensityQualifierTypeFactory: unknown systemType '${config.systemType}'`);
+    }
+    return DensityQualifierType.create({ name: config.name });
+  }
+}

--- a/tools/ts-res-tutorial/src/qualifierTypes/index.ts
+++ b/tools/ts-res-tutorial/src/qualifierTypes/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+export * from './densityQualifierType';
+export * from './densityQualifierTypeFactory';

--- a/tools/ts-res-tutorial/src/test/unit/densityQualifierType.test.ts
+++ b/tools/ts-res-tutorial/src/test/unit/densityQualifierType.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import '@fgv/ts-utils-jest';
+import { NoMatch, PerfectMatch, QualifierConditionValue, QualifierContextValue } from '@fgv/ts-res';
+import { DENSITY_BUCKETS, DensityQualifierType, DensityQualifierTypeFactory } from '../../qualifierTypes';
+
+describe('DensityQualifierType', () => {
+  describe('create()', () => {
+    test('succeeds with no parameters and defaults the name to "density"', () => {
+      expect(DensityQualifierType.create()).toSucceedAndSatisfy((qt) => {
+        expect(qt.name).toBe('density');
+        expect(qt.systemTypeName).toBe('density');
+        expect(qt.allowContextList).toBe(false);
+      });
+    });
+
+    test('accepts a custom name', () => {
+      expect(DensityQualifierType.create({ name: 'screenDensity' })).toSucceedAndSatisfy((qt) => {
+        expect(qt.name).toBe('screenDensity');
+      });
+    });
+  });
+
+  describe('isValidConditionValue()', () => {
+    const qt = DensityQualifierType.create().orThrow();
+
+    test.each(DENSITY_BUCKETS)('accepts "%s"', (bucket) => {
+      expect(qt.isValidConditionValue(bucket)).toBe(true);
+    });
+
+    test('accepts values regardless of case', () => {
+      expect(qt.isValidConditionValue('HDPI')).toBe(true);
+      expect(qt.isValidConditionValue('xHdPi')).toBe(true);
+    });
+
+    test('rejects unknown values', () => {
+      expect(qt.isValidConditionValue('ultra')).toBe(false);
+      expect(qt.isValidConditionValue('')).toBe(false);
+      expect(qt.isValidConditionValue('xxxhdpi')).toBe(false);
+    });
+  });
+
+  describe('matches()', () => {
+    const qt = DensityQualifierType.create().orThrow();
+
+    function score(condition: string, context: string): number {
+      return qt.matches(condition as QualifierConditionValue, context as QualifierContextValue, 'matches');
+    }
+
+    test('returns PerfectMatch for an exact bucket match', () => {
+      expect(score('hdpi', 'hdpi')).toBe(PerfectMatch);
+      expect(score('xxhdpi', 'xxhdpi')).toBe(PerfectMatch);
+    });
+
+    test('matches are case-insensitive', () => {
+      expect(score('HDPI', 'hdpi')).toBe(PerfectMatch);
+      expect(score('hdpi', 'HDPI')).toBe(PerfectMatch);
+    });
+
+    test('adjacent buckets score a strong partial match', () => {
+      expect(score('hdpi', 'xhdpi')).toBeCloseTo(0.7);
+      expect(score('xhdpi', 'hdpi')).toBeCloseTo(0.7);
+      expect(score('ldpi', 'mdpi')).toBeCloseTo(0.7);
+    });
+
+    test('two buckets away score a weak partial match', () => {
+      expect(score('hdpi', 'xxhdpi')).toBeCloseTo(0.4);
+      expect(score('ldpi', 'hdpi')).toBeCloseTo(0.4);
+    });
+
+    test('three buckets away is NoMatch', () => {
+      expect(score('ldpi', 'xhdpi')).toBe(NoMatch);
+      expect(score('ldpi', 'xxhdpi')).toBe(NoMatch);
+    });
+
+    test('unknown values are NoMatch', () => {
+      expect(score('ultra', 'hdpi')).toBe(NoMatch);
+      expect(score('hdpi', 'ultra')).toBe(NoMatch);
+    });
+
+    test('operators other than "matches" are NoMatch', () => {
+      expect(qt.matches('hdpi' as QualifierConditionValue, 'hdpi' as QualifierContextValue, 'always')).toBe(
+        NoMatch
+      );
+    });
+  });
+
+  describe('getConfigurationJson()', () => {
+    test('returns a roundtrippable config object', () => {
+      const qt = DensityQualifierType.create({ name: 'density' }).orThrow();
+      expect(qt.getConfigurationJson()).toSucceedAndSatisfy((config) => {
+        expect(config.name).toBe('density');
+        expect(config.systemType).toBe('density');
+      });
+    });
+  });
+
+  describe('validateConfigurationJson()', () => {
+    test('accepts well-formed configuration objects', () => {
+      const qt = DensityQualifierType.create().orThrow();
+      expect(qt.validateConfigurationJson({ name: 'density', systemType: 'density' })).toSucceed();
+    });
+  });
+});
+
+describe('DensityQualifierTypeFactory', () => {
+  const factory = new DensityQualifierTypeFactory();
+
+  test('creates a DensityQualifierType when systemType is "density"', () => {
+    expect(factory.create({ name: 'density', systemType: 'density' })).toSucceedAndSatisfy((qt) => {
+      expect(qt).toBeInstanceOf(DensityQualifierType);
+    });
+  });
+
+  test('rejects configurations with a different systemType', () => {
+    expect(factory.create({ name: 'language', systemType: 'language' })).toFailWith(/unknown systemType/i);
+  });
+});

--- a/tools/ts-res-tutorial/src/test/unit/lessons.test.ts
+++ b/tools/ts-res-tutorial/src/test/unit/lessons.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import '@fgv/ts-utils-jest';
+import { isJsonObject } from '@fgv/ts-json-base';
+import {
+  CapturingTutorialPrinter,
+  runAllLessons,
+  runLesson1,
+  runLesson2,
+  runLesson3,
+  runLesson4
+} from '../../index';
+
+describe('Tutorial lessons', () => {
+  describe('Lesson 1 - load config', () => {
+    test('builds a system configuration with the custom density qualifier type', () => {
+      const printer = new CapturingTutorialPrinter();
+      expect(runLesson1(printer)).toSucceedAndSatisfy((systemConfig) => {
+        expect(systemConfig.name).toBe(undefined); // name is optional in YAML
+        // Every qualifier type declared in system.yaml must be present
+        // after loading, including the custom "density" type.
+        const typeNames = Array.from(systemConfig.qualifierTypes.values(), (t) => t.name);
+        expect(typeNames).toEqual(expect.arrayContaining(['language', 'territory', 'theme', 'density']));
+        const qualifierNames = Array.from(systemConfig.qualifiers.values(), (q) => q.name);
+        expect(qualifierNames).toEqual(
+          expect.arrayContaining(['currentTerritory', 'language', 'theme', 'density'])
+        );
+      });
+      // Headline checks on the output so the lesson prose doesn't silently
+      // regress.
+      expect(printer.text).toMatch(/Lesson 1/);
+      expect(printer.text).toMatch(/density/);
+    });
+  });
+
+  describe('Lesson 2 - import YAML', () => {
+    test('imports every YAML resource file via the preprocessor', () => {
+      const printer = new CapturingTutorialPrinter();
+      const systemConfig = runLesson1(printer).orThrow();
+      expect(runLesson2(printer, systemConfig)).toSucceedAndSatisfy((resourceManager) => {
+        const ids = resourceManager.resourceIds.map((id) => String(id));
+        // Three files, four resources total (strings.yaml contains two).
+        expect(ids).toEqual(
+          expect.arrayContaining([
+            'resources.strings.greetings',
+            'resources.strings.uiLabels',
+            'resources.theme.theme',
+            'resources.icons.icons'
+          ])
+        );
+      });
+      expect(printer.text).toMatch(/Lesson 2/);
+      expect(printer.text).toMatch(/Yaml\.yamlConverter/);
+    });
+  });
+
+  describe('Lesson 3 - runtime setup', () => {
+    test('creates a resolver that sees the same resources', () => {
+      const printer = new CapturingTutorialPrinter();
+      const systemConfig = runLesson1(printer).orThrow();
+      const resourceManager = runLesson2(printer, systemConfig).orThrow();
+      expect(runLesson3(printer, systemConfig, resourceManager)).toSucceedAndSatisfy((resolver) => {
+        expect(resolver.resourceIds.length).toBe(resourceManager.resourceIds.length);
+      });
+      expect(printer.text).toMatch(/Lesson 3/);
+      expect(printer.text).toMatch(/withContext/);
+    });
+  });
+
+  describe('Lesson 4 - resolve', () => {
+    test('demonstrates all four resolution strategies without errors', () => {
+      const printer = new CapturingTutorialPrinter();
+      const systemConfig = runLesson1(printer).orThrow();
+      const resourceManager = runLesson2(printer, systemConfig).orThrow();
+      const resolver = runLesson3(printer, systemConfig, resourceManager).orThrow();
+
+      expect(runLesson4(printer, resolver)).toSucceed();
+      // The lesson 4 prose should hit every strategy heading.
+      expect(printer.text).toMatch(/Best match/);
+      expect(printer.text).toMatch(/All matches/);
+      expect(printer.text).toMatch(/Composed/);
+      expect(printer.text).toMatch(/Manually composed/);
+    });
+
+    test('best-match picks the fr+CA candidate for the active context', () => {
+      const printer = new CapturingTutorialPrinter();
+      const systemConfig = runLesson1(printer).orThrow();
+      const resourceManager = runLesson2(printer, systemConfig).orThrow();
+      const resolver = runLesson3(printer, systemConfig, resourceManager).orThrow();
+
+      // Sanity-check the matching behaviour directly rather than parsing
+      // printed output. The default context is language=fr,
+      // currentTerritory=CA, so the combined candidate should win.
+      expect(resolver.resolveResource('resources.strings.greetings')).toSucceedAndSatisfy((candidate) => {
+        expect(isJsonObject(candidate.json)).toBe(true);
+        if (isJsonObject(candidate.json)) {
+          expect(candidate.json.source).toBe('BOTH: fr + CA');
+        }
+      });
+    });
+
+    test('composed theme resolves to the dark theme with french font overrides', () => {
+      const printer = new CapturingTutorialPrinter();
+      const systemConfig = runLesson1(printer).orThrow();
+      const resourceManager = runLesson2(printer, systemConfig).orThrow();
+      const resolver = runLesson3(printer, systemConfig, resourceManager).orThrow();
+
+      expect(resolver.resolveComposedResourceValue('resources.theme.theme')).toSucceedAndSatisfy((value) => {
+        expect(isJsonObject(value)).toBe(true);
+        if (isJsonObject(value)) {
+          expect(value.name).toBe('dark');
+          // The fr partial candidate overrides the base font family.
+          const typography = value.typography;
+          expect(isJsonObject(typography)).toBe(true);
+          if (isJsonObject(typography)) {
+            expect(typography.family).toMatch(/Merriweather/);
+          }
+        }
+      });
+    });
+  });
+
+  describe('runAllLessons', () => {
+    test('runs the whole tutorial end-to-end without errors', () => {
+      const printer = new CapturingTutorialPrinter();
+      expect(runAllLessons(printer)).toSucceed();
+      expect(printer.text).toMatch(/Lesson 1/);
+      expect(printer.text).toMatch(/Lesson 2/);
+      expect(printer.text).toMatch(/Lesson 3/);
+      expect(printer.text).toMatch(/Lesson 4/);
+    });
+  });
+});

--- a/tools/ts-res-tutorial/src/test/unit/lessons.test.ts
+++ b/tools/ts-res-tutorial/src/test/unit/lessons.test.ts
@@ -21,14 +21,19 @@
  */
 
 import '@fgv/ts-utils-jest';
-import { isJsonObject } from '@fgv/ts-json-base';
+import * as path from 'path';
+import { Converters as JsonConverters, FileTree, isJsonObject } from '@fgv/ts-json-base';
+import { Yaml } from '@fgv/ts-extras';
+import { Config, Import, Resources, Runtime } from '@fgv/ts-res';
 import {
   CapturingTutorialPrinter,
+  DATA_ROOT,
   runAllLessons,
   runLesson1,
   runLesson2,
   runLesson3,
-  runLesson4
+  runLesson4,
+  runLesson5
 } from '../../index';
 
 describe('Tutorial lessons', () => {
@@ -140,6 +145,75 @@ describe('Tutorial lessons', () => {
     });
   });
 
+  describe('Lesson 5 - path inference', () => {
+    test('imports the inferred/ tree and collapses every file to one resource id', () => {
+      const printer = new CapturingTutorialPrinter();
+      const systemConfig = runLesson1(printer).orThrow();
+      expect(runLesson5(printer, systemConfig)).toSucceed();
+
+      // Lesson 5 prints per-candidate sources that mention every
+      // inference pattern the tree exercises.
+      expect(printer.text).toMatch(/LANGUAGE: fr \(inferred from filename\)/);
+      expect(printer.text).toMatch(/TERRITORY: US \(inferred from filename\)/);
+      expect(printer.text).toMatch(/LANGUAGE: en \(inferred from folder\)/);
+      expect(printer.text).toMatch(/TERRITORY: CA \(inferred from "geo=CA" folder\)/);
+      expect(printer.text).toMatch(/stacked across nested folders/);
+      expect(printer.text).toMatch(/comma-separated filename tokens/);
+    });
+
+    test('every file in the inferred tree produces the same resource id with distinct conditions', () => {
+      // Build an isolated resource manager so we can introspect what
+      // the importer produced without mixing it with Lesson 2's data.
+      const printer = new CapturingTutorialPrinter();
+      const systemConfig = runLesson1(printer).orThrow();
+      runLesson5(printer, systemConfig).orThrow();
+
+      // Re-run the import here (we cannot reach into Lesson 5's
+      // internal manager) to verify candidate count matches file count.
+      const resourceManager = importInferredTree(systemConfig);
+      const resource = resourceManager.getBuiltResource('inferred.messages.text').orThrow();
+      expect(resource.candidates.length).toBe(7);
+
+      // Hit every distinct condition pattern via the resolver. Remember
+      // that the system configuration gives currentTerritory priority
+      // 850 and language priority 800, so territory beats language when
+      // both match - that's why {fr, US} picks the US candidate over
+      // the French candidate.
+      const probes: Array<[Record<string, string>, string]> = [
+        // Language-only contexts fall back to the LANGUAGE candidates
+        // because no territory-conditioned candidate matches.
+        [{ language: 'fr', currentTerritory: 'DE' }, 'LANGUAGE: fr (inferred from filename)'],
+        [{ language: 'en', currentTerritory: 'DE' }, 'LANGUAGE: en (inferred from folder)'],
+        // Territory-only matches pick the territory candidate.
+        [{ language: 'fr', currentTerritory: 'US' }, 'TERRITORY: US (inferred from filename)'],
+        [{ language: 'en', currentTerritory: 'US' }, 'TERRITORY: US (inferred from filename)'],
+        [{ language: 'en', currentTerritory: 'CA' }, 'TERRITORY: CA (inferred from "geo=CA" folder)'],
+        // Combined candidates win when both conditions match - their
+        // condition set is strictly more specific than either piece alone.
+        [{ language: 'fr', currentTerritory: 'CA' }, 'BOTH: CA + fr (stacked across nested folders)'],
+        [{ language: 'en', currentTerritory: 'GB' }, 'BOTH: GB + en (comma-separated filename tokens)']
+      ];
+
+      for (const [context, expectedSource] of probes) {
+        const resolver = Runtime.ResourceResolver.create({
+          resourceManager,
+          qualifierTypes: systemConfig.qualifierTypes,
+          contextQualifierProvider: Runtime.ValidatingSimpleContextQualifierProvider.create({
+            qualifiers: systemConfig.qualifiers,
+            qualifierValues: context
+          }).orThrow()
+        }).orThrow();
+
+        expect(resolver.resolveResource('inferred.messages.text')).toSucceedAndSatisfy((candidate) => {
+          expect(isJsonObject(candidate.json)).toBe(true);
+          if (isJsonObject(candidate.json)) {
+            expect(candidate.json.source).toBe(expectedSource);
+          }
+        });
+      }
+    });
+  });
+
   describe('runAllLessons', () => {
     test('runs the whole tutorial end-to-end without errors', () => {
       const printer = new CapturingTutorialPrinter();
@@ -148,6 +222,31 @@ describe('Tutorial lessons', () => {
       expect(printer.text).toMatch(/Lesson 2/);
       expect(printer.text).toMatch(/Lesson 3/);
       expect(printer.text).toMatch(/Lesson 4/);
+      expect(printer.text).toMatch(/Lesson 5/);
     });
   });
 });
+
+/**
+ * Minimal standalone importer for Lesson 5's data folder. Used by the
+ * test that wants to introspect the built manager directly (lesson 5
+ * itself keeps its manager private because the lesson only needs to
+ * print).
+ */
+function importInferredTree(systemConfig: Config.SystemConfiguration): Resources.ResourceManagerBuilder {
+  const resourceManager = Resources.ResourceManagerBuilder.create({
+    qualifiers: systemConfig.qualifiers,
+    resourceTypes: systemConfig.resourceTypes
+  }).orThrow();
+
+  const importManager = Import.ImportManager.create({
+    resources: resourceManager,
+    fileTree: FileTree.forFilesystem().orThrow(),
+    fileContentConverter: Yaml.yamlConverter(JsonConverters.jsonObject),
+    fileContentExtensions: ['.yaml', '.yml']
+  }).orThrow();
+
+  importManager.importFromFileSystem(path.join(DATA_ROOT, 'inferred')).orThrow();
+  resourceManager.build().orThrow();
+  return resourceManager;
+}

--- a/tools/ts-res-tutorial/src/utils/index.ts
+++ b/tools/ts-res-tutorial/src/utils/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+export * from './paths';
+export * from './printer';

--- a/tools/ts-res-tutorial/src/utils/paths.ts
+++ b/tools/ts-res-tutorial/src/utils/paths.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import * as path from 'path';
+
+/**
+ * Absolute path to the tutorial package root. Resolved at load time so
+ * lessons and tests can reference the bundled sample data regardless of
+ * the current working directory.
+ *
+ * @remarks
+ * At runtime the compiled lesson files live in `lib/utils/paths.js`, so
+ * two levels up from `__dirname` points at the package root.
+ *
+ * @public
+ */
+export const TUTORIAL_ROOT: string = path.resolve(__dirname, '..', '..');
+
+/**
+ * Absolute path to the bundled `data/` folder that ships with the tutorial.
+ * @public
+ */
+export const DATA_ROOT: string = path.join(TUTORIAL_ROOT, 'data');
+
+/**
+ * Absolute path to the YAML system configuration file that every lesson
+ * loads.
+ * @public
+ */
+export const CONFIG_FILE: string = path.join(DATA_ROOT, 'config', 'system.yaml');
+
+/**
+ * Absolute path to the `data/resources/` folder that the importer scans
+ * in lessons 2-4.
+ * @public
+ */
+export const RESOURCES_ROOT: string = path.join(DATA_ROOT, 'resources');

--- a/tools/ts-res-tutorial/src/utils/printer.ts
+++ b/tools/ts-res-tutorial/src/utils/printer.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Simple printing abstraction used by every lesson so that tests can
+ * capture and assert on output without intercepting `console.log`.
+ *
+ * @remarks
+ * The API intentionally covers only the shapes the tutorial actually
+ * emits (headings, plain lines, JSON blocks). We pass a printer into
+ * each lesson rather than letting it touch `console` directly; a
+ * `CapturingPrinter` in the tests keeps everything deterministic.
+ *
+ * @public
+ */
+export interface ITutorialPrinter {
+  /** Prints a top-level lesson heading. */
+  heading(text: string): void;
+  /** Prints a subsection heading. */
+  subheading(text: string): void;
+  /** Prints a normal line. */
+  line(text?: string): void;
+  /** Pretty-prints a JSON value in a labelled block. */
+  json(label: string, value: unknown): void;
+}
+
+/**
+ * Default {@link ITutorialPrinter | ITutorialPrinter} that writes to the
+ * supplied write function. Defaults to `console.log`.
+ * @public
+ */
+export class ConsoleTutorialPrinter implements ITutorialPrinter {
+  private readonly _write: (text: string) => void;
+
+  public constructor(write?: (text: string) => void) {
+    this._write = write ?? ((text: string) => console.log(text));
+  }
+
+  public heading(text: string): void {
+    this._write('');
+    this._write(`=== ${text} ===`);
+  }
+
+  public subheading(text: string): void {
+    this._write('');
+    this._write(`-- ${text}`);
+  }
+
+  public line(text?: string): void {
+    this._write(text ?? '');
+  }
+
+  public json(label: string, value: unknown): void {
+    this._write(`${label}:`);
+    this._write(JSON.stringify(value, null, 2));
+  }
+}
+
+/**
+ * A {@link ITutorialPrinter | ITutorialPrinter} that records every
+ * message into an in-memory buffer. Used by the lesson tests to make
+ * assertions about what each lesson actually printed.
+ * @public
+ */
+export class CapturingTutorialPrinter implements ITutorialPrinter {
+  /**
+   * The captured lines, in order.
+   */
+  public readonly lines: string[] = [];
+
+  public heading(text: string): void {
+    this.lines.push('');
+    this.lines.push(`=== ${text} ===`);
+  }
+
+  public subheading(text: string): void {
+    this.lines.push('');
+    this.lines.push(`-- ${text}`);
+  }
+
+  public line(text?: string): void {
+    this.lines.push(text ?? '');
+  }
+
+  public json(label: string, value: unknown): void {
+    this.lines.push(`${label}:`);
+    this.lines.push(JSON.stringify(value, null, 2));
+  }
+
+  /**
+   * Joins all captured output into a single string for regex testing.
+   */
+  public get text(): string {
+    return this.lines.join('\n');
+  }
+}

--- a/tools/ts-res-tutorial/tsconfig.json
+++ b/tools/ts-res-tutorial/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "types": ["heft-jest", "node"],
+    "lib": ["es2018"]
+  }
+}


### PR DESCRIPTION
A new non-published tools package under tools/ts-res-tutorial that walks through the four concepts needed to use @fgv/ts-res end to end:

  1. Loading a qualifier configuration (predefined + YAML custom).
  2. Setting up the importer with the new fileContentConverter pre-parser so .yaml resources load transparently alongside .json.
  3. Wiring the runtime (ValidatingSimpleContextQualifierProvider, custom qualifier type factory, ResourceResolver).
  4. Resolving resources in all four ways: best, all, composed, and manually composed via JsonEditor.

Includes a small DensityQualifierType custom subclass to demonstrate the QualifierTypeFactory extension point, bundled YAML sample data (strings/theme/icons), a thin commander CLI with one subcommand per lesson, unit tests for the custom qualifier type, and smoke tests for every lesson via a capturing printer abstraction.