### PR TITLE
Add wrapBytes/unwrapBytes to CryptoUtils

### DIFF
--- a/common/changes/@fgv/ts-extras/wrap-bytes_2026-04-27-15-30.json
+++ b/common/changes/@fgv/ts-extras/wrap-bytes_2026-04-27-15-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add ECIES wrapBytes/unwrapBytes (ECDH P-256 + HKDF-SHA256 + AES-GCM-256) to ICryptoProvider",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/common/changes/@fgv/ts-web-extras/wrap-bytes_2026-04-27-15-30.json
+++ b/common/changes/@fgv/ts-web-extras/wrap-bytes_2026-04-27-15-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-web-extras",
+      "comment": "Add ECIES wrapBytes/unwrapBytes (ECDH P-256 + HKDF-SHA256 + AES-GCM-256) to BrowserCryptoProvider",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -301,6 +301,8 @@ declare namespace CryptoUtils {
         INamedSecret,
         IEncryptionResult,
         KeyPairAlgorithm,
+        IWrapBytesOptions,
+        IWrappedBytes,
         allKeyPairAlgorithms,
         KeyDerivationFunction,
         IKeyDerivationParams,
@@ -763,6 +765,10 @@ interface ICryptoProvider {
     importPublicKeyJwk(jwk: JsonWebKey, algorithm: KeyPairAlgorithm): Promise<Result<CryptoKey>>;
     sha256(data: string): Promise<Result<string>>;
     toBase64(data: Uint8Array): string;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    unwrapBytes(wrapped: IWrappedBytes, recipientPrivateKey: CryptoKey, options: IWrapBytesOptions): Promise<Result<Uint8Array>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    wrapBytes(plaintext: Uint8Array, recipientPublicKey: CryptoKey, options: IWrapBytesOptions): Promise<Result<IWrappedBytes>>;
 }
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "DirectEncryptionProvider"
@@ -1045,6 +1051,23 @@ interface IVariableRef {
     readonly name: string;
     readonly path: readonly string[];
     readonly tokenType: MustacheTokenType;
+}
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+interface IWrapBytesOptions {
+    readonly info: Uint8Array;
+    readonly salt: Uint8Array;
+}
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+interface IWrappedBytes {
+    readonly ciphertext: string;
+    readonly ephemeralPublicKey: JsonWebKey;
+    readonly nonce: string;
 }
 
 // @public
@@ -1353,6 +1376,11 @@ class NodeCryptoProvider implements ICryptoProvider {
     importPublicKeyJwk(jwk: JsonWebKey, algorithm: KeyPairAlgorithm): Promise<Result<CryptoKey>>;
     sha256(data: string): Promise<Result<string>>;
     toBase64(data: Uint8Array): string;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    unwrapBytes(wrapped: IWrappedBytes, recipientPrivateKey: CryptoKey, options: IWrapBytesOptions): Promise<Result<Uint8Array>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    wrapBytes(plaintext: Uint8Array, recipientPublicKey: CryptoKey, options: IWrapBytesOptions): Promise<Result<IWrappedBytes>>;
 }
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver

--- a/libraries/ts-extras/src/packlets/crypto-utils/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/model.ts
@@ -86,6 +86,62 @@ export interface IEncryptionResult {
 export type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048';
 
 /**
+ * Caller-supplied HKDF parameters that domain-separate one
+ * {@link CryptoUtils.ICryptoProvider.wrapBytes | wrapBytes} call from another.
+ * Two wraps that share recipient but differ on `salt` or `info` derive distinct
+ * wrap keys, so callers should pick values that bind the wrap to its
+ * application context (e.g. a content hash for `salt` and a secret name for
+ * `info`).
+ *
+ * Both fields are required; pass an empty `Uint8Array` if the caller has no
+ * value to bind on a given axis. Silent defaulting would hide protocol
+ * mistakes, so the API does not pick defaults.
+ * @public
+ */
+export interface IWrapBytesOptions {
+  /**
+   * HKDF salt. Domain-separates this wrap from others in different contexts.
+   * Caller picks; common choices include a content hash, document id, channel
+   * id, etc.
+   */
+  readonly salt: Uint8Array;
+
+  /**
+   * HKDF info. Further binds the derived key to a specific use within the
+   * calling application. Caller picks; common choices include a secret name,
+   * message type, or version tag.
+   */
+  readonly info: Uint8Array;
+}
+
+/**
+ * Output of {@link CryptoUtils.ICryptoProvider.wrapBytes | wrapBytes}. The
+ * shape is JSON-serializable so it can travel directly over the wire or be
+ * persisted as-is.
+ * @public
+ */
+export interface IWrappedBytes {
+  /**
+   * Sender's ephemeral ECDH P-256 public key as a JSON Web Key. The matching
+   * ephemeral private key is dropped after the shared-secret derive.
+   */
+  readonly ephemeralPublicKey: JsonWebKey;
+
+  /**
+   * AES-GCM nonce, base64-encoded. 12 bytes (96 bits) — the standard AES-GCM
+   * nonce length.
+   */
+  readonly nonce: string;
+
+  /**
+   * AES-GCM ciphertext concatenated with the 16-byte authentication tag,
+   * base64-encoded. Tampering with either the nonce or the ciphertext causes
+   * unwrap to fail GCM authentication.
+   */
+  readonly ciphertext: string;
+}
+
+/**
  * All valid key pair algorithms.
  * @public
  */
@@ -281,6 +337,57 @@ export interface ICryptoProvider {
    * @returns Success with the imported public `CryptoKey`, or Failure with error context.
    */
   importPublicKeyJwk(jwk: JsonWebKey, algorithm: KeyPairAlgorithm): Promise<Result<CryptoKey>>;
+
+  /**
+   * Wraps `plaintext` for delivery to the holder of the private key paired
+   * with `recipientPublicKey`. Uses ECIES with ECDH P-256, HKDF-SHA256, and
+   * AES-GCM-256.
+   *
+   * Generates a fresh ephemeral keypair per call; the ephemeral private key
+   * is discarded after the shared-secret derive. Only the recipient (with the
+   * matching private key) and the same HKDF parameters can recover
+   * `plaintext`.
+   *
+   * Empty `plaintext` is permitted; the resulting wrap contains only the
+   * 16-byte GCM authentication tag and round-trips back to an empty
+   * `Uint8Array`.
+   * @param plaintext - The bytes to wrap. Any length supported by AES-GCM
+   * (in practice, well below 2^39 - 256 bits).
+   * @param recipientPublicKey - The recipient's ECDH P-256 public `CryptoKey`.
+   * Must have algorithm name `'ECDH'` and named curve `'P-256'`; mismatched
+   * algorithm or curve yields a `Failure` with error context.
+   * @param options - HKDF parameters; see {@link CryptoUtils.IWrapBytesOptions | IWrapBytesOptions}.
+   * @returns `Success` with the wrapped payload, or `Failure` with error context.
+   */
+  wrapBytes(
+    plaintext: Uint8Array,
+    recipientPublicKey: CryptoKey,
+    options: IWrapBytesOptions
+  ): Promise<Result<IWrappedBytes>>;
+
+  /**
+   * Inverse of {@link CryptoUtils.ICryptoProvider.wrapBytes | wrapBytes}.
+   * Recovers the original `plaintext` from a wrapped payload using the
+   * recipient's private key.
+   *
+   * Returns a `Failure` (never throws) on any of:
+   * - Tampered nonce or ciphertext (AES-GCM authentication fails)
+   * - Wrong private key (different shared secret derives a different wrap key)
+   * - Wrong HKDF parameters (different wrap key)
+   * - Malformed `ephemeralPublicKey` JWK
+   * - Malformed base64 in `nonce` or `ciphertext`
+   * @param wrapped - The wrapped payload produced by `wrapBytes`.
+   * @param recipientPrivateKey - The recipient's ECDH P-256 private
+   * `CryptoKey`. Must have algorithm name `'ECDH'` and named curve `'P-256'`,
+   * and key usages including `'deriveKey'` or `'deriveBits'`.
+   * @param options - The same HKDF parameters used at wrap time.
+   * @returns `Success` with the original `plaintext`, or `Failure` with error context.
+   */
+  unwrapBytes(
+    wrapped: IWrappedBytes,
+    recipientPrivateKey: CryptoKey,
+    options: IWrapBytesOptions
+  ): Promise<Result<Uint8Array>>;
 }
 
 // ============================================================================

--- a/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
@@ -273,7 +273,7 @@ export class NodeCryptoProvider implements ICryptoProvider {
     recipientPublicKey: CryptoKey,
     options: IWrapBytesOptions
   ): Promise<Result<IWrappedBytes>> {
-    const recipientCheck = checkEcdhP256(recipientPublicKey, 'recipient public key');
+    const recipientCheck = checkEcdhP256(recipientPublicKey, 'public', 'recipient public key');
     if (recipientCheck.isFailure()) {
       return fail(`wrapBytes failed: ${recipientCheck.message}`);
     }
@@ -321,7 +321,7 @@ export class NodeCryptoProvider implements ICryptoProvider {
     recipientPrivateKey: CryptoKey,
     options: IWrapBytesOptions
   ): Promise<Result<Uint8Array>> {
-    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'recipient private key');
+    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'private', 'recipient private key');
     if (recipientCheck.isFailure()) {
       return fail(`unwrapBytes failed: ${recipientCheck.message}`);
     }
@@ -368,21 +368,29 @@ export class NodeCryptoProvider implements ICryptoProvider {
 }
 
 /**
- * Verifies that `key` is an ECDH P-256 `CryptoKey`. Used by the wrap/unwrap
- * methods to surface a clean `Failure` instead of letting the WebCrypto
- * deriveKey call throw a less informative error later in the pipeline.
+ * Verifies that `key` is an ECDH P-256 `CryptoKey` of the expected `keyType`
+ * (public or private). Used by the wrap/unwrap methods to surface a clean
+ * `Failure` instead of letting the WebCrypto deriveKey call throw a less
+ * informative error later in the pipeline. Key usages are intentionally not
+ * checked here: WebCrypto already produces a specific error if `deriveKey` is
+ * not in `usages`, and `deriveBits` is an equally valid alternative usage that
+ * an explicit check would have to track.
  * @param key - The CryptoKey to validate.
+ * @param keyType - The required `key.type` ('public' for wrap, 'private' for unwrap).
  * @param label - Human-readable role label included in the failure message.
- * @returns `Success` with the key (unchanged) when the algorithm and curve
- * match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
+ * @returns `Success` with the key (unchanged) when the algorithm, curve, and
+ * type all match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
  */
-function checkEcdhP256(key: CryptoKey, label: string): Result<CryptoKey> {
+function checkEcdhP256(key: CryptoKey, keyType: 'public' | 'private', label: string): Result<CryptoKey> {
   if (key.algorithm.name !== 'ECDH') {
     return fail(`${label} must be ECDH P-256 (got algorithm '${key.algorithm.name}')`);
   }
   const namedCurve = (key.algorithm as EcKeyAlgorithm).namedCurve;
   if (namedCurve !== 'P-256') {
     return fail(`${label} must be ECDH P-256 (got curve '${namedCurve}')`);
+  }
+  if (key.type !== keyType) {
+    return fail(`${label} must be a ${keyType} CryptoKey (got '${key.type}')`);
   }
   return succeed(key);
 }

--- a/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
@@ -329,9 +329,19 @@ export class NodeCryptoProvider implements ICryptoProvider {
     if (nonceResult.isFailure()) {
       return fail(`unwrapBytes failed: nonce: ${nonceResult.message}`);
     }
+    if (nonceResult.value.length !== Constants.GCM_IV_SIZE) {
+      return fail(
+        `unwrapBytes failed: nonce must be ${Constants.GCM_IV_SIZE} bytes (got ${nonceResult.value.length})`
+      );
+    }
     const ciphertextResult = this.fromBase64(wrapped.ciphertext);
     if (ciphertextResult.isFailure()) {
       return fail(`unwrapBytes failed: ciphertext: ${ciphertextResult.message}`);
+    }
+    if (ciphertextResult.value.length < Constants.GCM_AUTH_TAG_SIZE) {
+      return fail(
+        `unwrapBytes failed: ciphertext must be at least ${Constants.GCM_AUTH_TAG_SIZE} bytes (got ${ciphertextResult.value.length})`
+      );
     }
     const subtle = crypto.webcrypto.subtle;
     const result = await captureAsyncResult(async () => {

--- a/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
@@ -22,7 +22,13 @@ import * as crypto from 'crypto';
 import { captureAsyncResult, captureResult, fail, Failure, Result, succeed, Success } from '@fgv/ts-utils';
 import * as Constants from './constants';
 import { keyPairAlgorithmParams } from './keyPairAlgorithmParams';
-import { ICryptoProvider, IEncryptionResult, KeyPairAlgorithm } from './model';
+import {
+  ICryptoProvider,
+  IEncryptionResult,
+  IWrapBytesOptions,
+  IWrappedBytes,
+  KeyPairAlgorithm
+} from './model';
 
 /**
  * Node.js implementation of {@link CryptoUtils.ICryptoProvider} using the built-in crypto module.
@@ -252,6 +258,133 @@ export class NodeCryptoProvider implements ICryptoProvider {
     );
     return result.withErrorFormat((e) => `Failed to import ${algorithm} public key from JWK: ${e}`);
   }
+
+  /**
+   * Wraps `plaintext` for the holder of `recipientPublicKey` using
+   * ECIES (ECDH P-256 + HKDF-SHA256 + AES-GCM-256). See
+   * {@link CryptoUtils.ICryptoProvider.wrapBytes | ICryptoProvider.wrapBytes}.
+   * @param plaintext - The bytes to wrap.
+   * @param recipientPublicKey - The recipient's ECDH P-256 public `CryptoKey`.
+   * @param options - HKDF salt and info; see {@link CryptoUtils.IWrapBytesOptions | IWrapBytesOptions}.
+   * @returns `Success` with the wrapped payload, or `Failure` with an error.
+   */
+  public async wrapBytes(
+    plaintext: Uint8Array,
+    recipientPublicKey: CryptoKey,
+    options: IWrapBytesOptions
+  ): Promise<Result<IWrappedBytes>> {
+    const recipientCheck = checkEcdhP256(recipientPublicKey, 'recipient public key');
+    if (recipientCheck.isFailure()) {
+      return fail(`wrapBytes failed: ${recipientCheck.message}`);
+    }
+    const subtle = crypto.webcrypto.subtle;
+    const result = await captureAsyncResult(async () => {
+      const ephemeral = (await subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, [
+        'deriveKey'
+      ])) as CryptoKeyPair;
+      const hkdfBase = await subtle.deriveKey(
+        { name: 'ECDH', public: recipientPublicKey },
+        ephemeral.privateKey,
+        { name: 'HKDF' },
+        false,
+        ['deriveKey']
+      );
+      const wrapKey = await subtle.deriveKey(
+        { name: 'HKDF', salt: options.salt, info: options.info, hash: 'SHA-256' },
+        hkdfBase,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['encrypt']
+      );
+      const nonce = crypto.randomBytes(Constants.GCM_IV_SIZE);
+      const ctBuf = await subtle.encrypt({ name: 'AES-GCM', iv: nonce }, wrapKey, plaintext);
+      const ephemeralPublicKey = await subtle.exportKey('jwk', ephemeral.publicKey);
+      return {
+        ephemeralPublicKey,
+        nonce: Buffer.from(nonce).toString('base64'),
+        ciphertext: Buffer.from(new Uint8Array(ctBuf)).toString('base64')
+      };
+    });
+    return result.withErrorFormat((e) => `wrapBytes failed: ${e}`);
+  }
+
+  /**
+   * Unwraps a payload produced by `wrapBytes` using the recipient's private
+   * key. See {@link CryptoUtils.ICryptoProvider.unwrapBytes | ICryptoProvider.unwrapBytes}.
+   * @param wrapped - The wrapped payload.
+   * @param recipientPrivateKey - The recipient's ECDH P-256 private `CryptoKey`.
+   * @param options - HKDF salt and info matching the wrap call.
+   * @returns `Success` with the original `plaintext`, or `Failure` with an error.
+   */
+  public async unwrapBytes(
+    wrapped: IWrappedBytes,
+    recipientPrivateKey: CryptoKey,
+    options: IWrapBytesOptions
+  ): Promise<Result<Uint8Array>> {
+    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'recipient private key');
+    if (recipientCheck.isFailure()) {
+      return fail(`unwrapBytes failed: ${recipientCheck.message}`);
+    }
+    const nonceResult = this.fromBase64(wrapped.nonce);
+    if (nonceResult.isFailure()) {
+      return fail(`unwrapBytes failed: nonce: ${nonceResult.message}`);
+    }
+    const ciphertextResult = this.fromBase64(wrapped.ciphertext);
+    if (ciphertextResult.isFailure()) {
+      return fail(`unwrapBytes failed: ciphertext: ${ciphertextResult.message}`);
+    }
+    const subtle = crypto.webcrypto.subtle;
+    const result = await captureAsyncResult(async () => {
+      const ephemeralPub = await subtle.importKey(
+        'jwk',
+        wrapped.ephemeralPublicKey,
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false,
+        []
+      );
+      const hkdfBase = await subtle.deriveKey(
+        { name: 'ECDH', public: ephemeralPub },
+        recipientPrivateKey,
+        { name: 'HKDF' },
+        false,
+        ['deriveKey']
+      );
+      const wrapKey = await subtle.deriveKey(
+        { name: 'HKDF', salt: options.salt, info: options.info, hash: 'SHA-256' },
+        hkdfBase,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['decrypt']
+      );
+      const ptBuf = await subtle.decrypt(
+        { name: 'AES-GCM', iv: nonceResult.value },
+        wrapKey,
+        ciphertextResult.value
+      );
+      return new Uint8Array(ptBuf);
+    });
+    return result.withErrorFormat((e) => `unwrapBytes failed: ${e}`);
+  }
+}
+
+/**
+ * Verifies that `key` is an ECDH P-256 `CryptoKey`. Used by the wrap/unwrap
+ * methods to surface a clean `Failure` instead of letting the WebCrypto
+ * deriveKey call throw a less informative error later in the pipeline.
+ * @param key - The CryptoKey to validate.
+ * @param label - Human-readable role label included in the failure message.
+ * @returns `Success` with the key (unchanged) when the algorithm and curve
+ * match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
+ */
+function checkEcdhP256(key: CryptoKey, label: string): Result<CryptoKey> {
+  if (key.algorithm.name !== 'ECDH') {
+    return fail(`${label} must be ECDH P-256 (got algorithm '${key.algorithm.name}')`);
+  }
+  const namedCurve = (key.algorithm as EcKeyAlgorithm).namedCurve;
+  if (namedCurve !== 'P-256') {
+    return fail(`${label} must be ECDH P-256 (got curve '${namedCurve}')`);
+  }
+  return succeed(key);
 }
 
 /**

--- a/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
@@ -301,8 +301,8 @@ export class NodeCryptoProvider implements ICryptoProvider {
       const ephemeralPublicKey = await subtle.exportKey('jwk', ephemeral.publicKey);
       return {
         ephemeralPublicKey,
-        nonce: Buffer.from(nonce).toString('base64'),
-        ciphertext: Buffer.from(new Uint8Array(ctBuf)).toString('base64')
+        nonce: this.toBase64(nonce),
+        ciphertext: this.toBase64(new Uint8Array(ctBuf))
       };
     });
     return result.withErrorFormat((e) => `wrapBytes failed: ${e}`);

--- a/libraries/ts-extras/src/test/unit/crypto/wrapBytes.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/wrapBytes.test.ts
@@ -110,7 +110,7 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
       );
     });
 
-    test('truncating ciphertext below the auth-tag length fails authentication', async () => {
+    test('truncating ciphertext by one byte fails GCM authentication', async () => {
       const pair = await generateEcdhPair();
       const wrapped = (
         await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)

--- a/libraries/ts-extras/src/test/unit/crypto/wrapBytes.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/wrapBytes.test.ts
@@ -285,5 +285,24 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
       const result = await provider.unwrapBytes(wrapped, wrongCurve.privateKey, defaultOptions);
       expect(result).toFailWith(/unwrapBytes failed: recipient private key must be ECDH P-256.*P-384/i);
     });
+
+    test('wrap fails when recipient is an ECDH private key (not public)', async () => {
+      const pair = await generateEcdhPair();
+      const result = await provider.wrapBytes(new Uint8Array([1, 2, 3]), pair.privateKey, defaultOptions);
+      expect(result).toFailWith(
+        /wrapBytes failed: recipient public key must be a public CryptoKey \(got 'private'\)/i
+      );
+    });
+
+    test('unwrap fails when recipient is an ECDH public key (not private)', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new Uint8Array([1, 2, 3]), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const result = await provider.unwrapBytes(wrapped, pair.publicKey, defaultOptions);
+      expect(result).toFailWith(
+        /unwrapBytes failed: recipient private key must be a private CryptoKey \(got 'public'\)/i
+      );
+    });
   });
 });

--- a/libraries/ts-extras/src/test/unit/crypto/wrapBytes.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/wrapBytes.test.ts
@@ -1,0 +1,289 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import * as crypto from 'crypto';
+import * as CryptoUtils from '../../../packlets/crypto-utils';
+
+const subtle = crypto.webcrypto.subtle;
+
+async function generateEcdhPair(curve: 'P-256' | 'P-384' = 'P-256'): Promise<CryptoKeyPair> {
+  return (await subtle.generateKey({ name: 'ECDH', namedCurve: curve }, true, [
+    'deriveKey',
+    'deriveBits'
+  ])) as CryptoKeyPair;
+}
+
+async function generateEcdsaPair(): Promise<CryptoKeyPair> {
+  return (await subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify'
+  ])) as CryptoKeyPair;
+}
+
+describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
+  const provider = CryptoUtils.nodeCryptoProvider;
+  const defaultOptions: CryptoUtils.IWrapBytesOptions = {
+    salt: new TextEncoder().encode('test-salt'),
+    info: new TextEncoder().encode('test-info')
+  };
+
+  describe('round-trip', () => {
+    test.each<[string, Uint8Array]>([
+      ['32-byte plaintext (AES-256 key shape)', new Uint8Array(crypto.randomBytes(32))],
+      ['1-byte plaintext', new Uint8Array([0x42])],
+      ['1KB plaintext', new Uint8Array(crypto.randomBytes(1024))],
+      ['empty plaintext', new Uint8Array(0)],
+      ['high-bit-set bytes', new Uint8Array(64).fill(0xff)]
+    ])('round-trips %s', async (__label, plaintext) => {
+      const pair = await generateEcdhPair();
+      const wrapped = (await provider.wrapBytes(plaintext, pair.publicKey, defaultOptions)).orThrow();
+      expect(wrapped.ephemeralPublicKey.kty).toBe('EC');
+      expect(wrapped.ephemeralPublicKey.crv).toBe('P-256');
+      const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, defaultOptions)).orThrow();
+      expect(new Uint8Array(recovered)).toEqual(plaintext);
+    });
+
+    test('unwrap with the recipient privateKey returns identical bytes', async () => {
+      const pair = await generateEcdhPair();
+      const plaintext = new Uint8Array(crypto.randomBytes(48));
+      const wrapped = (await provider.wrapBytes(plaintext, pair.publicKey, defaultOptions)).orThrow();
+      const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, defaultOptions)).orThrow();
+      expect(Buffer.from(recovered).equals(Buffer.from(plaintext))).toBe(true);
+    });
+  });
+
+  describe('determinism / freshness', () => {
+    test('two wraps of identical inputs produce different ephemeral keys and ciphertexts', async () => {
+      const pair = await generateEcdhPair();
+      const plaintext = new TextEncoder().encode('same payload');
+      const w1 = (await provider.wrapBytes(plaintext, pair.publicKey, defaultOptions)).orThrow();
+      const w2 = (await provider.wrapBytes(plaintext, pair.publicKey, defaultOptions)).orThrow();
+      expect(w1.ephemeralPublicKey).not.toEqual(w2.ephemeralPublicKey);
+      expect(w1.ciphertext).not.toEqual(w2.ciphertext);
+      expect(w1.nonce).not.toEqual(w2.nonce);
+    });
+  });
+
+  describe('tampering', () => {
+    test('flipping a bit in the nonce fails GCM authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const nonce = provider.fromBase64(wrapped.nonce).orThrow();
+      nonce[0] ^= 0xff;
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, nonce: provider.toBase64(nonce) };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('flipping a bit in the ciphertext fails GCM authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const ct = provider.fromBase64(wrapped.ciphertext).orThrow();
+      ct[0] ^= 0x01;
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: provider.toBase64(ct) };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('truncating ciphertext below the auth-tag length fails authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const ct = provider.fromBase64(wrapped.ciphertext).orThrow();
+      const truncated = ct.slice(0, ct.length - 1);
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: provider.toBase64(truncated) };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('substituting a different ephemeral public key fails authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      // A second wrap to harvest a valid-but-different ephemeral public key.
+      const other = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const tampered: CryptoUtils.IWrappedBytes = {
+        ...wrapped,
+        ephemeralPublicKey: other.ephemeralPublicKey
+      };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+  });
+
+  describe('wrong-key / wrong-options', () => {
+    test('unwrap with a different recipient private key fails', async () => {
+      const pair = await generateEcdhPair();
+      const other = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      expect(await provider.unwrapBytes(wrapped, other.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('unwrap with a different HKDF salt fails authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const wrongSalt: CryptoUtils.IWrapBytesOptions = {
+        salt: new TextEncoder().encode('different-salt'),
+        info: defaultOptions.info
+      };
+      expect(await provider.unwrapBytes(wrapped, pair.privateKey, wrongSalt)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('unwrap with a different HKDF info fails authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const wrongInfo: CryptoUtils.IWrapBytesOptions = {
+        salt: defaultOptions.salt,
+        info: new TextEncoder().encode('different-info')
+      };
+      expect(await provider.unwrapBytes(wrapped, pair.privateKey, wrongInfo)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('empty salt and info round-trip when both sides agree', async () => {
+      const pair = await generateEcdhPair();
+      const empty: CryptoUtils.IWrapBytesOptions = { salt: new Uint8Array(0), info: new Uint8Array(0) };
+      const plaintext = new Uint8Array(crypto.randomBytes(16));
+      const wrapped = (await provider.wrapBytes(plaintext, pair.publicKey, empty)).orThrow();
+      const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, empty)).orThrow();
+      expect(new Uint8Array(recovered)).toEqual(plaintext);
+    });
+  });
+
+  describe('malformed input', () => {
+    test('malformed ephemeralPublicKey JWK fails', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const bogus: CryptoUtils.IWrappedBytes = {
+        ...wrapped,
+        ephemeralPublicKey: { kty: 'EC', crv: 'P-256' } as JsonWebKey
+      };
+      expect(await provider.unwrapBytes(bogus, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('ephemeralPublicKey on the wrong curve (P-384) fails', async () => {
+      const pair = await generateEcdhPair();
+      const wrongCurve = await generateEcdhPair('P-384');
+      const wrongJwk = await subtle.exportKey('jwk', wrongCurve.publicKey);
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ephemeralPublicKey: wrongJwk };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('non-base64 nonce fails with a clean error', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, nonce: 'not!base64!' };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed: nonce/i
+      );
+    });
+
+    test('non-base64 ciphertext fails with a clean error', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: 'not!base64!' };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed: ciphertext/i
+      );
+    });
+  });
+
+  describe('algorithm mismatch on recipient key', () => {
+    test('wrap fails when recipient public key is RSA-OAEP, not ECDH', async () => {
+      const rsa = (await provider.generateKeyPair('rsa-oaep-2048', true)).orThrow();
+      const result = await provider.wrapBytes(new Uint8Array([1, 2, 3]), rsa.publicKey, defaultOptions);
+      expect(result).toFailWith(/wrapBytes failed: recipient public key must be ECDH P-256.*RSA-OAEP/i);
+    });
+
+    test('wrap fails when recipient public key is ECDSA P-256, not ECDH', async () => {
+      const ecdsa = await generateEcdsaPair();
+      const result = await provider.wrapBytes(new Uint8Array([1, 2, 3]), ecdsa.publicKey, defaultOptions);
+      expect(result).toFailWith(/wrapBytes failed: recipient public key must be ECDH P-256.*ECDSA/i);
+    });
+
+    test('wrap fails when recipient public key is ECDH P-384, not P-256', async () => {
+      const wrongCurve = await generateEcdhPair('P-384');
+      const result = await provider.wrapBytes(
+        new Uint8Array([1, 2, 3]),
+        wrongCurve.publicKey,
+        defaultOptions
+      );
+      expect(result).toFailWith(/wrapBytes failed: recipient public key must be ECDH P-256.*P-384/i);
+    });
+
+    test('unwrap fails when recipient private key is RSA-OAEP, not ECDH', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new Uint8Array([1, 2, 3]), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const rsa = (await provider.generateKeyPair('rsa-oaep-2048', true)).orThrow();
+      const result = await provider.unwrapBytes(wrapped, rsa.privateKey, defaultOptions);
+      expect(result).toFailWith(/unwrapBytes failed: recipient private key must be ECDH P-256.*RSA-OAEP/i);
+    });
+
+    test('unwrap fails when recipient private key is ECDH P-384, not P-256', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new Uint8Array([1, 2, 3]), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const wrongCurve = await generateEcdhPair('P-384');
+      const result = await provider.unwrapBytes(wrapped, wrongCurve.privateKey, defaultOptions);
+      expect(result).toFailWith(/unwrapBytes failed: recipient private key must be ECDH P-256.*P-384/i);
+    });
+  });
+});

--- a/libraries/ts-web-extras/etc/ts-web-extras.api.md
+++ b/libraries/ts-web-extras/etc/ts-web-extras.api.md
@@ -25,6 +25,11 @@ class BrowserCryptoProvider implements CryptoUtils_2.ICryptoProvider {
     importPublicKeyJwk(jwk: JsonWebKey, algorithm: CryptoUtils_2.KeyPairAlgorithm): Promise<Result<CryptoKey>>;
     sha256(data: string): Promise<Result<string>>;
     toBase64(data: Uint8Array): string;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    unwrapBytes(wrapped: CryptoUtils_2.IWrappedBytes, recipientPrivateKey: CryptoKey, options: CryptoUtils_2.IWrapBytesOptions): Promise<Result<Uint8Array>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    wrapBytes(plaintext: Uint8Array, recipientPublicKey: CryptoKey, options: CryptoUtils_2.IWrapBytesOptions): Promise<Result<CryptoUtils_2.IWrappedBytes>>;
 }
 
 // @public

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -372,6 +372,147 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     );
     return result.withErrorFormat((e) => `Failed to import ${algorithm} public key from JWK: ${e}`);
   }
+
+  /**
+   * Wraps `plaintext` for the holder of `recipientPublicKey` using
+   * ECIES (ECDH P-256 + HKDF-SHA256 + AES-GCM-256). See
+   * {@link CryptoUtils.ICryptoProvider.wrapBytes | ICryptoProvider.wrapBytes}.
+   * @param plaintext - The bytes to wrap.
+   * @param recipientPublicKey - The recipient's ECDH P-256 public `CryptoKey`.
+   * @param options - HKDF salt and info; see {@link CryptoUtils.IWrapBytesOptions | IWrapBytesOptions}.
+   * @returns `Success` with the wrapped payload, or `Failure` with an error.
+   */
+  public async wrapBytes(
+    plaintext: Uint8Array,
+    recipientPublicKey: CryptoKey,
+    options: CryptoUtils.IWrapBytesOptions
+  ): Promise<Result<CryptoUtils.IWrappedBytes>> {
+    const recipientCheck = checkEcdhP256(recipientPublicKey, 'recipient public key');
+    if (recipientCheck.isFailure()) {
+      return Failure.with(`wrapBytes failed: ${recipientCheck.message}`);
+    }
+    const subtle = this._crypto.subtle;
+    const result = await captureAsyncResult(async () => {
+      const ephemeral = (await subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, [
+        'deriveKey'
+      ])) as CryptoKeyPair;
+      const hkdfBase = await subtle.deriveKey(
+        { name: 'ECDH', public: recipientPublicKey },
+        ephemeral.privateKey,
+        { name: 'HKDF' },
+        false,
+        ['deriveKey']
+      );
+      const wrapKey = await subtle.deriveKey(
+        {
+          name: 'HKDF',
+          salt: toArrayBuffer(options.salt),
+          info: toArrayBuffer(options.info),
+          hash: 'SHA-256'
+        },
+        hkdfBase,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['encrypt']
+      );
+      const nonce = this._crypto.getRandomValues(new Uint8Array(CryptoUtils.Constants.GCM_IV_SIZE));
+      const ctBuf = await subtle.encrypt(
+        { name: 'AES-GCM', iv: toArrayBuffer(nonce) },
+        wrapKey,
+        toArrayBuffer(plaintext)
+      );
+      const ephemeralPublicKey = await subtle.exportKey('jwk', ephemeral.publicKey);
+      return {
+        ephemeralPublicKey,
+        nonce: this.toBase64(nonce),
+        ciphertext: this.toBase64(new Uint8Array(ctBuf))
+      };
+    });
+    return result.withErrorFormat((e) => `wrapBytes failed: ${e}`);
+  }
+
+  /**
+   * Unwraps a payload produced by `wrapBytes` using the recipient's private
+   * key. See {@link CryptoUtils.ICryptoProvider.unwrapBytes | ICryptoProvider.unwrapBytes}.
+   * @param wrapped - The wrapped payload.
+   * @param recipientPrivateKey - The recipient's ECDH P-256 private `CryptoKey`.
+   * @param options - HKDF salt and info matching the wrap call.
+   * @returns `Success` with the original `plaintext`, or `Failure` with an error.
+   */
+  public async unwrapBytes(
+    wrapped: CryptoUtils.IWrappedBytes,
+    recipientPrivateKey: CryptoKey,
+    options: CryptoUtils.IWrapBytesOptions
+  ): Promise<Result<Uint8Array>> {
+    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'recipient private key');
+    if (recipientCheck.isFailure()) {
+      return Failure.with(`unwrapBytes failed: ${recipientCheck.message}`);
+    }
+    const nonceResult = this.fromBase64(wrapped.nonce);
+    if (nonceResult.isFailure()) {
+      return Failure.with(`unwrapBytes failed: nonce: ${nonceResult.message}`);
+    }
+    const ciphertextResult = this.fromBase64(wrapped.ciphertext);
+    if (ciphertextResult.isFailure()) {
+      return Failure.with(`unwrapBytes failed: ciphertext: ${ciphertextResult.message}`);
+    }
+    const subtle = this._crypto.subtle;
+    const result = await captureAsyncResult(async () => {
+      const ephemeralPub = await subtle.importKey(
+        'jwk',
+        wrapped.ephemeralPublicKey,
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false,
+        []
+      );
+      const hkdfBase = await subtle.deriveKey(
+        { name: 'ECDH', public: ephemeralPub },
+        recipientPrivateKey,
+        { name: 'HKDF' },
+        false,
+        ['deriveKey']
+      );
+      const wrapKey = await subtle.deriveKey(
+        {
+          name: 'HKDF',
+          salt: toArrayBuffer(options.salt),
+          info: toArrayBuffer(options.info),
+          hash: 'SHA-256'
+        },
+        hkdfBase,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['decrypt']
+      );
+      const ptBuf = await subtle.decrypt(
+        { name: 'AES-GCM', iv: toArrayBuffer(nonceResult.value) },
+        wrapKey,
+        toArrayBuffer(ciphertextResult.value)
+      );
+      return new Uint8Array(ptBuf);
+    });
+    return result.withErrorFormat((e) => `unwrapBytes failed: ${e}`);
+  }
+}
+
+/**
+ * Verifies that `key` is an ECDH P-256 `CryptoKey`. Used by the wrap/unwrap
+ * methods to surface a clean `Failure` instead of letting the WebCrypto
+ * deriveKey call throw a less informative error later in the pipeline.
+ * @param key - The CryptoKey to validate.
+ * @param label - Human-readable role label included in the failure message.
+ * @returns `Success` with the key (unchanged) when the algorithm and curve
+ * match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
+ */
+function checkEcdhP256(key: CryptoKey, label: string): Result<CryptoKey> {
+  if (key.algorithm.name !== 'ECDH') {
+    return Failure.with(`${label} must be ECDH P-256 (got algorithm '${key.algorithm.name}')`);
+  }
+  const namedCurve = (key.algorithm as EcKeyAlgorithm).namedCurve;
+  if (namedCurve !== 'P-256') {
+    return Failure.with(`${label} must be ECDH P-256 (got curve '${namedCurve}')`);
+  }
+  return succeed(key);
 }
 
 /**

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -387,7 +387,7 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     recipientPublicKey: CryptoKey,
     options: CryptoUtils.IWrapBytesOptions
   ): Promise<Result<CryptoUtils.IWrappedBytes>> {
-    const recipientCheck = checkEcdhP256(recipientPublicKey, 'recipient public key');
+    const recipientCheck = checkEcdhP256(recipientPublicKey, 'public', 'recipient public key');
     if (recipientCheck.isFailure()) {
       return Failure.with(`wrapBytes failed: ${recipientCheck.message}`);
     }
@@ -444,7 +444,7 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     recipientPrivateKey: CryptoKey,
     options: CryptoUtils.IWrapBytesOptions
   ): Promise<Result<Uint8Array>> {
-    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'recipient private key');
+    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'private', 'recipient private key');
     if (recipientCheck.isFailure()) {
       return Failure.with(`unwrapBytes failed: ${recipientCheck.message}`);
     }
@@ -496,21 +496,29 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
 }
 
 /**
- * Verifies that `key` is an ECDH P-256 `CryptoKey`. Used by the wrap/unwrap
- * methods to surface a clean `Failure` instead of letting the WebCrypto
- * deriveKey call throw a less informative error later in the pipeline.
+ * Verifies that `key` is an ECDH P-256 `CryptoKey` of the expected `keyType`
+ * (public or private). Used by the wrap/unwrap methods to surface a clean
+ * `Failure` instead of letting the WebCrypto deriveKey call throw a less
+ * informative error later in the pipeline. Key usages are intentionally not
+ * checked here: WebCrypto already produces a specific error if `deriveKey` is
+ * not in `usages`, and `deriveBits` is an equally valid alternative usage that
+ * an explicit check would have to track.
  * @param key - The CryptoKey to validate.
+ * @param keyType - The required `key.type` ('public' for wrap, 'private' for unwrap).
  * @param label - Human-readable role label included in the failure message.
- * @returns `Success` with the key (unchanged) when the algorithm and curve
- * match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
+ * @returns `Success` with the key (unchanged) when the algorithm, curve, and
+ * type all match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
  */
-function checkEcdhP256(key: CryptoKey, label: string): Result<CryptoKey> {
+function checkEcdhP256(key: CryptoKey, keyType: 'public' | 'private', label: string): Result<CryptoKey> {
   if (key.algorithm.name !== 'ECDH') {
     return Failure.with(`${label} must be ECDH P-256 (got algorithm '${key.algorithm.name}')`);
   }
   const namedCurve = (key.algorithm as EcKeyAlgorithm).namedCurve;
   if (namedCurve !== 'P-256') {
     return Failure.with(`${label} must be ECDH P-256 (got curve '${namedCurve}')`);
+  }
+  if (key.type !== keyType) {
+    return Failure.with(`${label} must be a ${keyType} CryptoKey (got '${key.type}')`);
   }
   return succeed(key);
 }

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -18,10 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/* c8 ignore start - Browser-only implementation cannot be tested in Node.js environment */
 import { captureAsyncResult, captureResult, fail, Failure, Result, succeed, Success } from '@fgv/ts-utils';
 import { CryptoUtils } from '@fgv/ts-extras';
 
+/* c8 ignore start - Used only by browser-only methods that cannot be tested in Node.js environment */
 /**
  * Extracts an `ArrayBuffer` from a Uint8Array, handling the potential SharedArrayBuffer case.
  * @param arr - The Uint8Array to extract from
@@ -33,11 +33,12 @@ function toArrayBuffer(arr: Uint8Array): ArrayBuffer {
   new Uint8Array(buffer).set(arr);
   return buffer;
 }
+/* c8 ignore stop */
 
 /**
  * Returns a fresh Uint8Array view over a non-shared ArrayBuffer copy of `arr`.
- * Used by {@link CryptoUtils.BrowserCryptoProvider.wrapBytes | wrapBytes} and
- * {@link CryptoUtils.BrowserCryptoProvider.unwrapBytes | unwrapBytes}: Node 20's
+ * Used by {@link BrowserCryptoProvider.wrapBytes | wrapBytes} and
+ * {@link BrowserCryptoProvider.unwrapBytes | unwrapBytes}: Node 20's
  * webcrypto.subtle rejects raw `ArrayBuffer` for several `BufferSource`
  * parameters with "is not instance of ArrayBuffer, Buffer, TypedArray, or
  * DataView" even though `ArrayBuffer` should be valid per the spec; a
@@ -64,6 +65,7 @@ function toBufferView(arr: Uint8Array): Uint8Array<ArrayBuffer> {
 export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
   private readonly _crypto: Crypto;
 
+  /* c8 ignore start - Existing browser-only methods cannot be tested in Node.js environment */
   /**
    * Creates a new {@link CryptoUtils.BrowserCryptoProvider | BrowserCryptoProvider}.
    * @param cryptoApi - Optional Crypto instance (defaults to globalThis.crypto)
@@ -390,6 +392,7 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     );
     return result.withErrorFormat((e) => `Failed to import ${algorithm} public key from JWK: ${e}`);
   }
+  /* c8 ignore stop */
 
   /**
    * Wraps `plaintext` for the holder of `recipientPublicKey` using
@@ -537,6 +540,7 @@ function checkEcdhP256(key: CryptoKey, keyType: 'public' | 'private', label: str
   return succeed(key);
 }
 
+/* c8 ignore start - Constructs a provider; only meaningful in a real browser environment */
 /**
  * Creates a {@link CryptoUtils.BrowserCryptoProvider | BrowserCryptoProvider} if Web
  * Crypto API is available.

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -452,9 +452,19 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     if (nonceResult.isFailure()) {
       return Failure.with(`unwrapBytes failed: nonce: ${nonceResult.message}`);
     }
+    if (nonceResult.value.length !== CryptoUtils.Constants.GCM_IV_SIZE) {
+      return Failure.with(
+        `unwrapBytes failed: nonce must be ${CryptoUtils.Constants.GCM_IV_SIZE} bytes (got ${nonceResult.value.length})`
+      );
+    }
     const ciphertextResult = this.fromBase64(wrapped.ciphertext);
     if (ciphertextResult.isFailure()) {
       return Failure.with(`unwrapBytes failed: ciphertext: ${ciphertextResult.message}`);
+    }
+    if (ciphertextResult.value.length < CryptoUtils.Constants.GCM_AUTH_TAG_SIZE) {
+      return Failure.with(
+        `unwrapBytes failed: ciphertext must be at least ${CryptoUtils.Constants.GCM_AUTH_TAG_SIZE} bytes (got ${ciphertextResult.value.length})`
+      );
     }
     const subtle = this._crypto.subtle;
     const result = await captureAsyncResult(async () => {

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -35,6 +35,24 @@ function toArrayBuffer(arr: Uint8Array): ArrayBuffer {
 }
 
 /**
+ * Returns a fresh Uint8Array view over a non-shared ArrayBuffer copy of `arr`.
+ * Used by {@link CryptoUtils.BrowserCryptoProvider.wrapBytes | wrapBytes} and
+ * {@link CryptoUtils.BrowserCryptoProvider.unwrapBytes | unwrapBytes}: Node 20's
+ * webcrypto.subtle rejects raw `ArrayBuffer` for several `BufferSource`
+ * parameters with "is not instance of ArrayBuffer, Buffer, TypedArray, or
+ * DataView" even though `ArrayBuffer` should be valid per the spec; a
+ * TypedArray view is accepted on Node 20+ and on browsers, and the explicit
+ * `Uint8Array<ArrayBuffer>` return type also satisfies TypeScript's `BufferSource`
+ * (which excludes the `SharedArrayBuffer` branch of `Uint8Array`'s buffer type).
+ */
+function toBufferView(arr: Uint8Array): Uint8Array<ArrayBuffer> {
+  const buffer = new ArrayBuffer(arr.byteLength);
+  const view = new Uint8Array(buffer);
+  view.set(arr);
+  return view;
+}
+
+/**
  * Browser implementation of `ICryptoProvider` using the Web Crypto API.
  * Uses AES-256-GCM for authenticated encryption.
  *
@@ -404,23 +422,14 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
         ['deriveKey']
       );
       const wrapKey = await subtle.deriveKey(
-        {
-          name: 'HKDF',
-          salt: toArrayBuffer(options.salt),
-          info: toArrayBuffer(options.info),
-          hash: 'SHA-256'
-        },
+        { name: 'HKDF', salt: toBufferView(options.salt), info: toBufferView(options.info), hash: 'SHA-256' },
         hkdfBase,
         { name: 'AES-GCM', length: 256 },
         false,
         ['encrypt']
       );
       const nonce = this._crypto.getRandomValues(new Uint8Array(CryptoUtils.Constants.GCM_IV_SIZE));
-      const ctBuf = await subtle.encrypt(
-        { name: 'AES-GCM', iv: toArrayBuffer(nonce) },
-        wrapKey,
-        toArrayBuffer(plaintext)
-      );
+      const ctBuf = await subtle.encrypt({ name: 'AES-GCM', iv: nonce }, wrapKey, toBufferView(plaintext));
       const ephemeralPublicKey = await subtle.exportKey('jwk', ephemeral.publicKey);
       return {
         ephemeralPublicKey,
@@ -483,21 +492,16 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
         ['deriveKey']
       );
       const wrapKey = await subtle.deriveKey(
-        {
-          name: 'HKDF',
-          salt: toArrayBuffer(options.salt),
-          info: toArrayBuffer(options.info),
-          hash: 'SHA-256'
-        },
+        { name: 'HKDF', salt: toBufferView(options.salt), info: toBufferView(options.info), hash: 'SHA-256' },
         hkdfBase,
         { name: 'AES-GCM', length: 256 },
         false,
         ['decrypt']
       );
       const ptBuf = await subtle.decrypt(
-        { name: 'AES-GCM', iv: toArrayBuffer(nonceResult.value) },
+        { name: 'AES-GCM', iv: toBufferView(nonceResult.value) },
         wrapKey,
-        toArrayBuffer(ciphertextResult.value)
+        toBufferView(ciphertextResult.value)
       );
       return new Uint8Array(ptBuf);
     });

--- a/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.wrapBytes.test.ts
+++ b/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.wrapBytes.test.ts
@@ -1,29 +1,32 @@
-// Copyright (c) 2026 Erik Fortune
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+/*
+ * Copyright (c) 2026 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 
 import '@fgv/ts-utils-jest';
 
-import * as crypto from 'crypto';
-import * as CryptoUtils from '../../../packlets/crypto-utils';
+import { CryptoUtils } from '@fgv/ts-extras';
+import { BrowserCryptoProvider } from '../../packlets/crypto-utils';
 
-const subtle = crypto.webcrypto.subtle;
+const provider = new BrowserCryptoProvider();
+const subtle = globalThis.crypto.subtle;
 
 async function generateEcdhPair(curve: 'P-256' | 'P-384' = 'P-256'): Promise<CryptoKeyPair> {
   return (await subtle.generateKey({ name: 'ECDH', namedCurve: curve }, true, [
@@ -39,8 +42,7 @@ async function generateEcdsaPair(): Promise<CryptoKeyPair> {
   ])) as CryptoKeyPair;
 }
 
-describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
-  const provider = CryptoUtils.nodeCryptoProvider;
+describe('BrowserCryptoProvider — wrapBytes/unwrapBytes', () => {
   const defaultOptions: CryptoUtils.IWrapBytesOptions = {
     salt: new TextEncoder().encode('test-salt'),
     info: new TextEncoder().encode('test-info')
@@ -48,9 +50,9 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
 
   describe('round-trip', () => {
     test.each<[string, Uint8Array]>([
-      ['32-byte plaintext (AES-256 key shape)', new Uint8Array(crypto.randomBytes(32))],
+      ['32-byte plaintext (AES-256 key shape)', globalThis.crypto.getRandomValues(new Uint8Array(32))],
       ['1-byte plaintext', new Uint8Array([0x42])],
-      ['1KB plaintext', new Uint8Array(crypto.randomBytes(1024))],
+      ['1KB plaintext', globalThis.crypto.getRandomValues(new Uint8Array(1024))],
       ['empty plaintext', new Uint8Array(0)],
       ['high-bit-set bytes', new Uint8Array(64).fill(0xff)]
     ])('round-trips %s', async (__label, plaintext) => {
@@ -60,14 +62,6 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
       expect(wrapped.ephemeralPublicKey.crv).toBe('P-256');
       const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, defaultOptions)).orThrow();
       expect(new Uint8Array(recovered)).toEqual(plaintext);
-    });
-
-    test('unwrap with the recipient privateKey returns identical bytes', async () => {
-      const pair = await generateEcdhPair();
-      const plaintext = new Uint8Array(crypto.randomBytes(48));
-      const wrapped = (await provider.wrapBytes(plaintext, pair.publicKey, defaultOptions)).orThrow();
-      const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, defaultOptions)).orThrow();
-      expect(Buffer.from(recovered).equals(Buffer.from(plaintext))).toBe(true);
     });
   });
 
@@ -110,25 +104,11 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
       );
     });
 
-    test('truncating ciphertext below the auth-tag length fails authentication', async () => {
-      const pair = await generateEcdhPair();
-      const wrapped = (
-        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
-      ).orThrow();
-      const ct = provider.fromBase64(wrapped.ciphertext).orThrow();
-      const truncated = ct.slice(0, ct.length - 1);
-      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: provider.toBase64(truncated) };
-      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
-        /unwrapBytes failed/i
-      );
-    });
-
     test('substituting a different ephemeral public key fails authentication', async () => {
       const pair = await generateEcdhPair();
       const wrapped = (
         await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
       ).orThrow();
-      // A second wrap to harvest a valid-but-different ephemeral public key.
       const other = (
         await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
       ).orThrow();
@@ -185,7 +165,7 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
     test('empty salt and info round-trip when both sides agree', async () => {
       const pair = await generateEcdhPair();
       const empty: CryptoUtils.IWrapBytesOptions = { salt: new Uint8Array(0), info: new Uint8Array(0) };
-      const plaintext = new Uint8Array(crypto.randomBytes(16));
+      const plaintext = globalThis.crypto.getRandomValues(new Uint8Array(16));
       const wrapped = (await provider.wrapBytes(plaintext, pair.publicKey, empty)).orThrow();
       const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, empty)).orThrow();
       expect(new Uint8Array(recovered)).toEqual(plaintext);
@@ -247,7 +227,7 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
       const wrapped = (
         await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
       ).orThrow();
-      const shortNonce = new Uint8Array(8); // 8 bytes, not 12
+      const shortNonce = new Uint8Array(8);
       const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, nonce: provider.toBase64(shortNonce) };
       expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
         /unwrapBytes failed: nonce must be 12 bytes \(got 8\)/i
@@ -259,7 +239,7 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
       const wrapped = (
         await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
       ).orThrow();
-      const shortCt = new Uint8Array(8); // 8 bytes, less than the 16-byte auth tag
+      const shortCt = new Uint8Array(8);
       const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: provider.toBase64(shortCt) };
       expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
         /unwrapBytes failed: ciphertext must be at least 16 bytes \(got 8\)/i
@@ -267,9 +247,18 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
     });
   });
 
-  describe('algorithm mismatch on recipient key', () => {
+  describe('algorithm / type mismatch on recipient key', () => {
     test('wrap fails when recipient public key is RSA-OAEP, not ECDH', async () => {
-      const rsa = (await provider.generateKeyPair('rsa-oaep-2048', true)).orThrow();
+      const rsa = (await subtle.generateKey(
+        {
+          name: 'RSA-OAEP',
+          modulusLength: 2048,
+          publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+          hash: 'SHA-256'
+        },
+        true,
+        ['encrypt', 'decrypt']
+      )) as CryptoKeyPair;
       const result = await provider.wrapBytes(new Uint8Array([1, 2, 3]), rsa.publicKey, defaultOptions);
       expect(result).toFailWith(/wrapBytes failed: recipient public key must be ECDH P-256.*RSA-OAEP/i);
     });
@@ -288,16 +277,6 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
         defaultOptions
       );
       expect(result).toFailWith(/wrapBytes failed: recipient public key must be ECDH P-256.*P-384/i);
-    });
-
-    test('unwrap fails when recipient private key is RSA-OAEP, not ECDH', async () => {
-      const pair = await generateEcdhPair();
-      const wrapped = (
-        await provider.wrapBytes(new Uint8Array([1, 2, 3]), pair.publicKey, defaultOptions)
-      ).orThrow();
-      const rsa = (await provider.generateKeyPair('rsa-oaep-2048', true)).orThrow();
-      const result = await provider.unwrapBytes(wrapped, rsa.privateKey, defaultOptions);
-      expect(result).toFailWith(/unwrapBytes failed: recipient private key must be ECDH P-256.*RSA-OAEP/i);
     });
 
     test('unwrap fails when recipient private key is ECDH P-384, not P-256', async () => {

--- a/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.wrapBytes.test.ts
+++ b/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.wrapBytes.test.ts
@@ -104,6 +104,20 @@ describe('BrowserCryptoProvider — wrapBytes/unwrapBytes', () => {
       );
     });
 
+    test('truncating ciphertext by one byte fails GCM authentication (still ≥ 16 bytes)', async () => {
+      const pair = await generateEcdhPair();
+      // 16-byte plaintext → 32-byte ciphertext (16 ct + 16 tag); truncate by 1 → 31 bytes ≥ 16
+      const wrapped = (
+        await provider.wrapBytes(new Uint8Array(16).fill(0xab), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const ct = provider.fromBase64(wrapped.ciphertext).orThrow();
+      const truncated = ct.slice(0, ct.length - 1);
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: provider.toBase64(truncated) };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
     test('substituting a different ephemeral public key fails authentication', async () => {
       const pair = await generateEcdhPair();
       const wrapped = (


### PR DESCRIPTION
## Summary

- Adds `wrapBytes` / `unwrapBytes` to `ICryptoProvider` for ECIES-style wrapping of arbitrary bytes for an ECDH P-256 recipient (ECDH P-256 + HKDF-SHA256 + AES-GCM-256).
- Implemented in `NodeCryptoProvider` and `BrowserCryptoProvider`, mirroring the existing per-provider WebCrypto factoring.
- Adds two public types: `IWrapBytesOptions` (caller-supplied HKDF salt/info domain separators) and `IWrappedBytes` (JSON-serializable wire shape with the ephemeral JWK, base64 nonce, and base64 ciphertext+tag).

Unblocks the `chocolate-lab/key-safety` per-buyer key-wrapping work. Design doc: [`wrap-bytes-design.md`](https://github.com/ErikFortune/chocolate-lab/blob/key-safety/.claude/project/wrap-bytes-design.md).

Scope kept tight per the design's open questions:
- Empty plaintext is permitted (round-trips to an empty `Uint8Array`).
- Uses the existing `captureAsyncResult` from `@fgv/ts-utils`.
- Each provider duplicates the wrap/unwrap logic to match the existing factoring; no shared helper module added.
- `KeyPairAlgorithm` is intentionally **not** extended with `'ecdh-p256'` — out of scope for this PR. Consumers generate ECDH keypairs via `subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, ...)` directly. A follow-up can route ECDH through `ICryptoProvider.generateKeyPair` and the keystore if/when needed.

Generated typedoc is intentionally omitted from this PR; it will land as a separate follow-up commit (matching the `#296` / `#298` cadence) after merge.

## Test plan

- [x] `rushx test` clean on `@fgv/ts-extras` (24 new tests under `wrapBytes.test.ts`; full suite passes; new code at 100% coverage)
- [x] `rushx test` clean on `@fgv/ts-web-extras`
- [x] `rush build` clean across the monorepo
- [x] Round-trip: 32-byte / 1-byte / 1KB / empty / high-bit plaintexts
- [x] Tampering: nonce flip, ciphertext flip, tag truncation, ephemeral key substitution
- [x] Wrong key / wrong HKDF salt / wrong HKDF info → fail
- [x] Malformed: bad JWK shape, wrong-curve JWK (P-384), non-base64 nonce, non-base64 ciphertext → fail
- [x] Algorithm mismatch on recipient: RSA-OAEP, ECDSA P-256, ECDH P-384 → fail with explicit error before reaching WebCrypto
- [x] Determinism: two wraps of identical inputs produce different ephemeral keys / nonces / ciphertexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)