### PR TITLE
ts-extras(ai-assist): add reference-image support to image generation

### DIFF
--- a/common/changes/@fgv/ts-extras/claude-image-generation-consistency-OUek6_2026-04-27-14-42.json
+++ b/common/changes/@fgv/ts-extras/claude-image-generation-consistency-OUek6_2026-04-27-14-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add the ability to supply reference images when generating an image",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/common/changes/@fgv/ts-extras/wrap-bytes_2026-04-27-15-30.json
+++ b/common/changes/@fgv/ts-extras/wrap-bytes_2026-04-27-15-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add ECIES wrapBytes/unwrapBytes (ECDH P-256 + HKDF-SHA256 + AES-GCM-256) to ICryptoProvider",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/common/changes/@fgv/ts-web-extras/wrap-bytes_2026-04-27-15-30.json
+++ b/common/changes/@fgv/ts-web-extras/wrap-bytes_2026-04-27-15-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-web-extras",
+      "comment": "Add ECIES wrapBytes/unwrapBytes (ECDH P-256 + HKDF-SHA256 + AES-GCM-256) to BrowserCryptoProvider",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -301,6 +301,8 @@ declare namespace CryptoUtils {
         INamedSecret,
         IEncryptionResult,
         KeyPairAlgorithm,
+        IWrapBytesOptions,
+        IWrappedBytes,
         allKeyPairAlgorithms,
         KeyDerivationFunction,
         IKeyDerivationParams,
@@ -767,6 +769,10 @@ interface ICryptoProvider {
     importPublicKeyJwk(jwk: JsonWebKey, algorithm: KeyPairAlgorithm): Promise<Result<CryptoKey>>;
     sha256(data: string): Promise<Result<string>>;
     toBase64(data: Uint8Array): string;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    unwrapBytes(wrapped: IWrappedBytes, recipientPrivateKey: CryptoKey, options: IWrapBytesOptions): Promise<Result<Uint8Array>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    wrapBytes(plaintext: Uint8Array, recipientPublicKey: CryptoKey, options: IWrapBytesOptions): Promise<Result<IWrappedBytes>>;
 }
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "DirectEncryptionProvider"
@@ -1049,6 +1055,23 @@ interface IVariableRef {
     readonly name: string;
     readonly path: readonly string[];
     readonly tokenType: MustacheTokenType;
+}
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+interface IWrapBytesOptions {
+    readonly info: Uint8Array;
+    readonly salt: Uint8Array;
+}
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+interface IWrappedBytes {
+    readonly ciphertext: string;
+    readonly ephemeralPublicKey: JsonWebKey;
+    readonly nonce: string;
 }
 
 // @public
@@ -1357,6 +1380,11 @@ class NodeCryptoProvider implements ICryptoProvider {
     importPublicKeyJwk(jwk: JsonWebKey, algorithm: KeyPairAlgorithm): Promise<Result<CryptoKey>>;
     sha256(data: string): Promise<Result<string>>;
     toBase64(data: Uint8Array): string;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    unwrapBytes(wrapped: IWrappedBytes, recipientPrivateKey: CryptoKey, options: IWrapBytesOptions): Promise<Result<Uint8Array>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    wrapBytes(plaintext: Uint8Array, recipientPublicKey: CryptoKey, options: IWrapBytesOptions): Promise<Result<IWrappedBytes>>;
 }
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -100,7 +100,7 @@ const aiAssistProviderConfig: Converter<IAiAssistProviderConfig>;
 const aiAssistSettings: Converter<IAiAssistSettings>;
 
 // @public
-type AiImageApiFormat = 'openai-images' | 'gemini-imagen' | 'xai-images';
+type AiImageApiFormat = 'openai-images' | 'gemini-imagen' | 'xai-images' | 'gemini-image-out';
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
@@ -610,6 +610,8 @@ interface IAiImageGenerationOptions {
 interface IAiImageGenerationParams {
     readonly options?: IAiImageGenerationOptions;
     readonly prompt: string;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly referenceImages?: ReadonlyArray<IAiImageAttachment>;
 }
 
 // @public
@@ -645,6 +647,8 @@ interface IAiModelInfo {
 // @public
 interface IAiProviderDescriptor {
     readonly acceptsImageInput: boolean;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly acceptsImageReferenceInput?: boolean;
     readonly apiFormat: AiApiFormat;
     readonly baseUrl: string;
     readonly buttonLabel: string;

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -40,6 +40,7 @@ import {
   type AiServerToolConfig,
   type IAiCompletionResponse,
   type IAiGeneratedImage,
+  type IAiImageAttachment,
   type IAiImageGenerationOptions,
   type IAiImageGenerationParams,
   type IAiImageGenerationResponse,
@@ -164,6 +165,98 @@ async function fetchJson(
     return fail('AI API returned non-object JSON response');
   }
   return succeed(json);
+}
+
+/**
+ * Makes a multipart/form-data POST request and returns the parsed JSON, or a
+ * failure. The Content-Type header (with boundary) is set automatically by
+ * `fetch` from the `FormData` body — callers must NOT pass it explicitly.
+ * @internal
+ */
+async function fetchMultipart(
+  url: string,
+  headers: Record<string, string>,
+  body: FormData,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<JsonObject>> {
+  /* c8 ignore next 1 - optional logger */
+  logger?.detail(`AI API request: POST ${url} (multipart)`);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body,
+      signal
+    });
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    /* c8 ignore next 1 - optional logger */
+    logger?.error(`AI API request failed: ${detail}`);
+    return fail(`AI API request failed: ${detail}`);
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'unknown error');
+    /* c8 ignore next 1 - optional logger */
+    logger?.error(`AI API returned ${response.status}: ${errorText}`);
+    return fail(`AI API returned ${response.status}: ${errorText}`);
+  }
+
+  /* c8 ignore next 1 - optional logger */
+  logger?.detail(`AI API response: ${response.status}`);
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    /* c8 ignore next 1 - optional logger */
+    logger?.error('AI API returned invalid JSON response');
+    return fail('AI API returned invalid JSON response');
+  }
+
+  if (!isJsonObject(json)) {
+    /* c8 ignore next 1 - optional logger */
+    logger?.error('AI API returned non-object JSON response');
+    return fail('AI API returned non-object JSON response');
+  }
+  return succeed(json);
+}
+
+/**
+ * Decodes a base64-encoded image attachment into a `Blob` suitable for use as
+ * a multipart file field.
+ * @internal
+ */
+function attachmentToBlob(attachment: IAiImageAttachment): Blob {
+  const binary = atob(attachment.base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: attachment.mimeType });
+}
+
+/**
+ * Maps a MIME type to a sensible file extension for multipart filenames.
+ * @internal
+ */
+function extensionForMimeType(mimeType: string): string {
+  switch (mimeType) {
+    case 'image/png':
+      return 'png';
+    case 'image/jpeg':
+    case 'image/jpg':
+      return 'jpg';
+    case 'image/webp':
+      return 'webp';
+    case 'image/gif':
+      return 'gif';
+    default:
+      return 'bin';
+  }
 }
 
 /**
@@ -768,6 +861,54 @@ const imagenResponse: Validator<IImagenResponse> = Validators.object<IImagenResp
   predictions: Validators.arrayOf(imagenPrediction).withConstraint((arr) => arr.length > 0)
 });
 
+// ---- Gemini image-out (`:generateContent` returning image parts) format ----
+
+/** @internal */
+interface IGeminiImageInlineData {
+  mimeType: string;
+  data: string;
+}
+/** @internal */
+interface IGeminiImageOutPart {
+  text?: string;
+  inlineData?: IGeminiImageInlineData;
+}
+/** @internal */
+interface IGeminiImageOutContent {
+  parts: IGeminiImageOutPart[];
+}
+/** @internal */
+interface IGeminiImageOutCandidate {
+  content: IGeminiImageOutContent;
+  finishReason?: string;
+}
+/** @internal */
+interface IGeminiImageOutResponse {
+  candidates: IGeminiImageOutCandidate[];
+}
+
+const geminiImageInlineData: Validator<IGeminiImageInlineData> = Validators.object<IGeminiImageInlineData>({
+  mimeType: Validators.string,
+  data: Validators.string
+});
+const geminiImageOutPart: Validator<IGeminiImageOutPart> = Validators.object<IGeminiImageOutPart>({
+  text: Validators.string.optional(),
+  inlineData: geminiImageInlineData.optional()
+});
+const geminiImageOutContent: Validator<IGeminiImageOutContent> = Validators.object<IGeminiImageOutContent>({
+  parts: Validators.arrayOf(geminiImageOutPart).withConstraint((arr) => arr.length > 0)
+});
+const geminiImageOutCandidate: Validator<IGeminiImageOutCandidate> =
+  Validators.object<IGeminiImageOutCandidate>({
+    content: geminiImageOutContent,
+    finishReason: Validators.string.optional()
+  });
+const geminiImageOutResponse: Validator<IGeminiImageOutResponse> = Validators.object<IGeminiImageOutResponse>(
+  {
+    candidates: Validators.arrayOf(geminiImageOutCandidate).withConstraint((arr) => arr.length > 0)
+  }
+);
+
 // ---- Proxied image generation response ----
 
 const proxiedGeneratedImage: Validator<IAiGeneratedImage> = Validators.object<IAiGeneratedImage>({
@@ -821,6 +962,11 @@ const proxiedListModelsResponse: Validator<IProxiedListModelsBody> =
  * formats — the request shape is the same; the only difference is whether the
  * `size` field is honored (OpenAI: yes, xAI: ignored at the provider).
  *
+ * When `request.referenceImages` is non-empty, routes to `/images/edits`
+ * (multipart) instead of `/images/generations` (JSON). Per-model edit support
+ * is not validated here (e.g. dall-e-3 does not support edits) — the
+ * provider's 400 surfaces through the failure path.
+ *
  * @internal
  */
 async function callOpenAiImageGeneration(
@@ -830,12 +976,51 @@ async function callOpenAiImageGeneration(
   logger?: Logging.ILogger,
   signal?: AbortSignal
 ): Promise<Result<IAiImageGenerationResponse>> {
-  const url = `${config.baseUrl}/images/generations`;
+  const opts: IAiImageGenerationOptions = request.options ?? {};
+  const refs = request.referenceImages ?? [];
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${config.apiKey}`
+  };
+  const n = opts.count ?? 1;
+
+  const fetched =
+    refs.length > 0
+      ? await callOpenAiImagesEdits(config, request, headers, n, refs, logger, signal)
+      : await callOpenAiImagesGenerations(config, request, headers, n, logger, signal);
+
+  return fetched.onSuccess((json) =>
+    openAiImageResponse
+      .validate(json)
+      .withErrorFormat((msg) => `OpenAI images API response: ${msg}`)
+      .onSuccess((response) =>
+        succeed({
+          images: response.data.map((item) => ({
+            mimeType: defaultMimeType,
+            base64: item.b64_json,
+            ...(item.revised_prompt !== undefined ? { revisedPrompt: item.revised_prompt } : {})
+          }))
+        })
+      )
+  );
+}
+
+/**
+ * Builds and posts the JSON `/images/generations` request (no refs).
+ * @internal
+ */
+function callOpenAiImagesGenerations(
+  config: IAiApiConfig,
+  request: IAiImageGenerationParams,
+  headers: Record<string, string>,
+  n: number,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<JsonObject>> {
   const opts: IAiImageGenerationOptions = request.options ?? {};
   const body: Record<string, unknown> = {
     model: config.model,
     prompt: request.prompt,
-    n: opts.count ?? 1,
+    n,
     response_format: 'b64_json'
   };
   if (opts.size !== undefined) {
@@ -847,28 +1032,93 @@ async function callOpenAiImageGeneration(
   if (opts.seed !== undefined) {
     body.seed = opts.seed;
   }
+  /* c8 ignore next 1 - optional logger */
+  logger?.info(`Image generation: model=${config.model}, n=${n}`);
+  return fetchJson(`${config.baseUrl}/images/generations`, headers, body, logger, signal);
+}
 
+/**
+ * Builds and posts the multipart `/images/edits` request (with refs).
+ * @internal
+ */
+function callOpenAiImagesEdits(
+  config: IAiApiConfig,
+  request: IAiImageGenerationParams,
+  headers: Record<string, string>,
+  n: number,
+  refs: ReadonlyArray<IAiImageAttachment>,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<JsonObject>> {
+  const opts: IAiImageGenerationOptions = request.options ?? {};
+  const form = new FormData();
+  form.append('model', config.model);
+  form.append('prompt', request.prompt);
+  form.append('n', String(n));
+  if (opts.size !== undefined) {
+    form.append('size', opts.size);
+  }
+  if (opts.quality !== undefined) {
+    form.append('quality', opts.quality);
+  }
+  refs.forEach((ref, i) => {
+    form.append('image[]', attachmentToBlob(ref), `ref-${i}.${extensionForMimeType(ref.mimeType)}`);
+  });
+  /* c8 ignore next 1 - optional logger */
+  logger?.info(`Image edit: model=${config.model}, n=${n}, refs=${refs.length}`);
+  return fetchMultipart(`${config.baseUrl}/images/edits`, headers, form, logger, signal);
+}
+
+/**
+ * Calls Gemini's chat-style `:generateContent` endpoint for image output
+ * (Gemini 2.5 Flash Image / "Nano Banana"). Accepts reference images, which
+ * are passed as `inlineData` parts alongside the text prompt.
+ *
+ * @internal
+ */
+async function callGeminiImageOutGeneration(
+  config: IAiApiConfig,
+  request: IAiImageGenerationParams,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<IAiImageGenerationResponse>> {
+  const url = `${config.baseUrl}/models/${config.model}:generateContent`;
+  const refs = request.referenceImages ?? [];
+  const parts: Array<Record<string, unknown>> = [{ text: request.prompt }];
+  for (const ref of refs) {
+    parts.push({ inlineData: { mimeType: ref.mimeType, data: ref.base64 } });
+  }
+  const body: Record<string, unknown> = {
+    contents: [{ role: 'user', parts }]
+  };
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${config.apiKey}`
+    'x-goog-api-key': config.apiKey
   };
 
   /* c8 ignore next 1 - optional logger */
-  logger?.info(`Image generation: model=${config.model}, n=${body.n}`);
-  const jsonResult = await fetchJson(url, headers, body, logger, signal);
-  if (jsonResult.isFailure()) {
-    return fail(jsonResult.message);
-  }
-  return openAiImageResponse
-    .validate(jsonResult.value)
-    .withErrorFormat((msg) => `OpenAI images API response: ${msg}`)
-    .onSuccess((response) => {
-      const images: IAiGeneratedImage[] = response.data.map((item) => ({
-        mimeType: defaultMimeType,
-        base64: item.b64_json,
-        ...(item.revised_prompt !== undefined ? { revisedPrompt: item.revised_prompt } : {})
-      }));
-      return succeed({ images });
-    });
+  logger?.info(`Gemini image-out: model=${config.model}, refs=${refs.length}`);
+  return (await fetchJson(url, headers, body, logger, signal)).onSuccess((json) =>
+    geminiImageOutResponse
+      .validate(json)
+      .withErrorFormat((msg) => `Gemini image API response: ${msg}`)
+      .onSuccess((response) => {
+        const images: IAiGeneratedImage[] = [];
+        for (const candidate of response.candidates) {
+          for (const part of candidate.content.parts) {
+            if (part.inlineData) {
+              images.push({
+                mimeType: part.inlineData.mimeType,
+                base64: part.inlineData.data
+              });
+            }
+          }
+        }
+        if (images.length === 0) {
+          return fail('Gemini image API response: no image parts in response');
+        }
+        return succeed({ images });
+      })
+  );
 }
 
 /**
@@ -933,9 +1183,12 @@ async function callImagenGeneration(
  * Routes based on `descriptor.imageApiFormat`:
  * - `'openai-images'` for OpenAI (DALL-E, gpt-image-1)
  * - `'xai-images'` for xAI Grok image models
- * - `'gemini-imagen'` for Google Imagen
+ * - `'gemini-imagen'` for Google Imagen `:predict`
+ * - `'gemini-image-out'` for Gemini chat-style image output (Nano Banana)
  *
  * Image-model selection reuses the existing `'image'` {@link ModelSpecKey}.
+ * When `request.referenceImages` is non-empty, the call is rejected up front
+ * unless the descriptor declares `acceptsImageReferenceInput`.
  *
  * @param params - Request parameters including descriptor, API key, and prompt
  * @returns The generated images, or a failure
@@ -951,6 +1204,9 @@ export async function callProviderImageGeneration(
   }
   if (!descriptor.baseUrl) {
     return fail(`provider "${descriptor.id}" has no API endpoint configured`);
+  }
+  if ((request.referenceImages?.length ?? 0) > 0 && !descriptor.acceptsImageReferenceInput) {
+    return fail(`provider "${descriptor.id}" does not support reference images for image generation`);
   }
 
   const config: IAiApiConfig = {
@@ -973,6 +1229,8 @@ export async function callProviderImageGeneration(
       return callOpenAiImageGeneration(config, request, 'image/jpeg', logger, signal);
     case 'gemini-imagen':
       return callImagenGeneration(config, request, logger, signal);
+    case 'gemini-image-out':
+      return callGeminiImageOutGeneration(config, request, logger, signal);
     /* c8 ignore next 4 - defensive coding: exhaustive switch guaranteed by TypeScript */
     default: {
       const _exhaustive: never = descriptor.imageApiFormat;
@@ -1481,7 +1739,10 @@ export async function callProxiedCompletion(
  * - Error response body: `{error: string}` (surfaced as `proxy: ${error}`)
  *
  * The proxy server is responsible for descriptor lookup, model resolution,
- * provider dispatch, and response normalization.
+ * provider dispatch, and response normalization. When `params.referenceImages`
+ * is present, the proxy is also responsible for repackaging it into the
+ * upstream wire format (e.g. multipart/form-data for OpenAI `/images/edits`,
+ * `inlineData` parts for Gemini `:generateContent`).
  *
  * @param proxyUrl - Base URL of the proxy server (e.g. `http://localhost:3001`)
  * @param params - Same parameters as {@link callProviderImageGeneration}

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -300,9 +300,20 @@ export type AiApiFormat = 'openai' | 'anthropic' | 'gemini';
 
 /**
  * API format categories for image-generation provider routing.
+ *
+ * @remarks
+ * - `'openai-images'` — OpenAI Images API. Routes to `/images/generations`
+ *   (text-only) or `/images/edits` (when reference images are present).
+ * - `'xai-images'` — xAI Images API. Same wire shape as OpenAI but text-only;
+ *   no reference-image support on grok-2-image.
+ * - `'gemini-imagen'` — Google Imagen `:predict` endpoint. Text-only.
+ * - `'gemini-image-out'` — Google Gemini chat-style `:generateContent`
+ *   endpoint that returns image parts (Gemini 2.5 Flash Image / "Nano
+ *   Banana"). Accepts reference images.
+ *
  * @public
  */
-export type AiImageApiFormat = 'openai-images' | 'gemini-imagen' | 'xai-images';
+export type AiImageApiFormat = 'openai-images' | 'gemini-imagen' | 'xai-images' | 'gemini-image-out';
 
 // ============================================================================
 // Completion Response
@@ -439,6 +450,17 @@ export interface IAiProviderDescriptor {
    * `defaultModel.image`, e.g. `{ base: 'gpt-4o', image: 'dall-e-3' }`.
    */
   readonly imageApiFormat?: AiImageApiFormat;
+  /**
+   * Whether this provider's image-generation API accepts reference images
+   * via {@link AiAssist.IAiImageGenerationParams.referenceImages}. When false
+   * (or undefined), calls that include reference images are rejected up front.
+   *
+   * @remarks
+   * The flag is provider-wide; per-model constraints (e.g. dall-e-3 ignores
+   * edits) are not validated by the library and surface as provider 400s,
+   * consistent with the existing image-generation policy.
+   */
+  readonly acceptsImageReferenceInput?: boolean;
 }
 
 // ============================================================================
@@ -493,6 +515,14 @@ export interface IAiImageGenerationParams {
   readonly prompt: string;
   /** Optional generation options. */
   readonly options?: IAiImageGenerationOptions;
+  /**
+   * Optional reference images. When present, the provider will use them as
+   * visual context (e.g. to preserve a character's appearance across multiple
+   * generations). Providers that do not declare
+   * {@link AiAssist.IAiProviderDescriptor.acceptsImageReferenceInput} reject
+   * the call up front. An empty array is treated identically to `undefined`.
+   */
+  readonly referenceImages?: ReadonlyArray<IAiImageAttachment>;
 }
 
 /**

--- a/libraries/ts-extras/src/packlets/ai-assist/registry.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/registry.ts
@@ -69,12 +69,13 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     needsSecret: true,
     apiFormat: 'gemini',
     baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
-    defaultModel: { base: 'gemini-2.5-flash', image: 'imagen-3.0-generate-002' },
+    defaultModel: { base: 'gemini-2.5-flash', image: 'gemini-2.5-flash-image' },
     supportedTools: ['web_search'],
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: true,
-    imageApiFormat: 'gemini-imagen'
+    imageApiFormat: 'gemini-image-out',
+    acceptsImageReferenceInput: true
   },
   {
     id: 'groq',
@@ -114,7 +115,8 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: true,
-    imageApiFormat: 'openai-images'
+    imageApiFormat: 'openai-images',
+    acceptsImageReferenceInput: true
   },
   {
     id: 'xai-grok',
@@ -206,6 +208,7 @@ export const DEFAULT_MODEL_CAPABILITY_CONFIG: IAiModelCapabilityConfig = {
     ],
     'google-gemini': [
       { idPattern: /^imagen/, capabilities: ['image-generation'] },
+      { idPattern: /^gemini-.*-image/, capabilities: ['image-generation'] },
       { idPattern: /^gemini-/, capabilities: ['chat', 'tools', 'vision'] }
     ],
     anthropic: [{ idPattern: /^claude-/, capabilities: ['chat', 'tools', 'vision'] }],

--- a/libraries/ts-extras/src/packlets/crypto-utils/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/model.ts
@@ -86,6 +86,62 @@ export interface IEncryptionResult {
 export type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048';
 
 /**
+ * Caller-supplied HKDF parameters that domain-separate one
+ * {@link CryptoUtils.ICryptoProvider.wrapBytes | wrapBytes} call from another.
+ * Two wraps that share recipient but differ on `salt` or `info` derive distinct
+ * wrap keys, so callers should pick values that bind the wrap to its
+ * application context (e.g. a content hash for `salt` and a secret name for
+ * `info`).
+ *
+ * Both fields are required; pass an empty `Uint8Array` if the caller has no
+ * value to bind on a given axis. Silent defaulting would hide protocol
+ * mistakes, so the API does not pick defaults.
+ * @public
+ */
+export interface IWrapBytesOptions {
+  /**
+   * HKDF salt. Domain-separates this wrap from others in different contexts.
+   * Caller picks; common choices include a content hash, document id, channel
+   * id, etc.
+   */
+  readonly salt: Uint8Array;
+
+  /**
+   * HKDF info. Further binds the derived key to a specific use within the
+   * calling application. Caller picks; common choices include a secret name,
+   * message type, or version tag.
+   */
+  readonly info: Uint8Array;
+}
+
+/**
+ * Output of {@link CryptoUtils.ICryptoProvider.wrapBytes | wrapBytes}. The
+ * shape is JSON-serializable so it can travel directly over the wire or be
+ * persisted as-is.
+ * @public
+ */
+export interface IWrappedBytes {
+  /**
+   * Sender's ephemeral ECDH P-256 public key as a JSON Web Key. The matching
+   * ephemeral private key is dropped after the shared-secret derive.
+   */
+  readonly ephemeralPublicKey: JsonWebKey;
+
+  /**
+   * AES-GCM nonce, base64-encoded. 12 bytes (96 bits) — the standard AES-GCM
+   * nonce length.
+   */
+  readonly nonce: string;
+
+  /**
+   * AES-GCM ciphertext concatenated with the 16-byte authentication tag,
+   * base64-encoded. Tampering with either the nonce or the ciphertext causes
+   * unwrap to fail GCM authentication.
+   */
+  readonly ciphertext: string;
+}
+
+/**
  * All valid key pair algorithms.
  * @public
  */
@@ -281,6 +337,57 @@ export interface ICryptoProvider {
    * @returns Success with the imported public `CryptoKey`, or Failure with error context.
    */
   importPublicKeyJwk(jwk: JsonWebKey, algorithm: KeyPairAlgorithm): Promise<Result<CryptoKey>>;
+
+  /**
+   * Wraps `plaintext` for delivery to the holder of the private key paired
+   * with `recipientPublicKey`. Uses ECIES with ECDH P-256, HKDF-SHA256, and
+   * AES-GCM-256.
+   *
+   * Generates a fresh ephemeral keypair per call; the ephemeral private key
+   * is discarded after the shared-secret derive. Only the recipient (with the
+   * matching private key) and the same HKDF parameters can recover
+   * `plaintext`.
+   *
+   * Empty `plaintext` is permitted; the resulting wrap contains only the
+   * 16-byte GCM authentication tag and round-trips back to an empty
+   * `Uint8Array`.
+   * @param plaintext - The bytes to wrap. Any length supported by AES-GCM
+   * (in practice, well below 2^39 - 256 bits).
+   * @param recipientPublicKey - The recipient's ECDH P-256 public `CryptoKey`.
+   * Must have algorithm name `'ECDH'` and named curve `'P-256'`; mismatched
+   * algorithm or curve yields a `Failure` with error context.
+   * @param options - HKDF parameters; see {@link CryptoUtils.IWrapBytesOptions | IWrapBytesOptions}.
+   * @returns `Success` with the wrapped payload, or `Failure` with error context.
+   */
+  wrapBytes(
+    plaintext: Uint8Array,
+    recipientPublicKey: CryptoKey,
+    options: IWrapBytesOptions
+  ): Promise<Result<IWrappedBytes>>;
+
+  /**
+   * Inverse of {@link CryptoUtils.ICryptoProvider.wrapBytes | wrapBytes}.
+   * Recovers the original `plaintext` from a wrapped payload using the
+   * recipient's private key.
+   *
+   * Returns a `Failure` (never throws) on any of:
+   * - Tampered nonce or ciphertext (AES-GCM authentication fails)
+   * - Wrong private key (different shared secret derives a different wrap key)
+   * - Wrong HKDF parameters (different wrap key)
+   * - Malformed `ephemeralPublicKey` JWK
+   * - Malformed base64 in `nonce` or `ciphertext`
+   * @param wrapped - The wrapped payload produced by `wrapBytes`.
+   * @param recipientPrivateKey - The recipient's ECDH P-256 private
+   * `CryptoKey`. Must have algorithm name `'ECDH'` and named curve `'P-256'`,
+   * and key usages including `'deriveKey'` or `'deriveBits'`.
+   * @param options - The same HKDF parameters used at wrap time.
+   * @returns `Success` with the original `plaintext`, or `Failure` with error context.
+   */
+  unwrapBytes(
+    wrapped: IWrappedBytes,
+    recipientPrivateKey: CryptoKey,
+    options: IWrapBytesOptions
+  ): Promise<Result<Uint8Array>>;
 }
 
 // ============================================================================

--- a/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
@@ -273,7 +273,7 @@ export class NodeCryptoProvider implements ICryptoProvider {
     recipientPublicKey: CryptoKey,
     options: IWrapBytesOptions
   ): Promise<Result<IWrappedBytes>> {
-    const recipientCheck = checkEcdhP256(recipientPublicKey, 'recipient public key');
+    const recipientCheck = checkEcdhP256(recipientPublicKey, 'public', 'recipient public key');
     if (recipientCheck.isFailure()) {
       return fail(`wrapBytes failed: ${recipientCheck.message}`);
     }
@@ -321,7 +321,7 @@ export class NodeCryptoProvider implements ICryptoProvider {
     recipientPrivateKey: CryptoKey,
     options: IWrapBytesOptions
   ): Promise<Result<Uint8Array>> {
-    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'recipient private key');
+    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'private', 'recipient private key');
     if (recipientCheck.isFailure()) {
       return fail(`unwrapBytes failed: ${recipientCheck.message}`);
     }
@@ -368,21 +368,29 @@ export class NodeCryptoProvider implements ICryptoProvider {
 }
 
 /**
- * Verifies that `key` is an ECDH P-256 `CryptoKey`. Used by the wrap/unwrap
- * methods to surface a clean `Failure` instead of letting the WebCrypto
- * deriveKey call throw a less informative error later in the pipeline.
+ * Verifies that `key` is an ECDH P-256 `CryptoKey` of the expected `keyType`
+ * (public or private). Used by the wrap/unwrap methods to surface a clean
+ * `Failure` instead of letting the WebCrypto deriveKey call throw a less
+ * informative error later in the pipeline. Key usages are intentionally not
+ * checked here: WebCrypto already produces a specific error if `deriveKey` is
+ * not in `usages`, and `deriveBits` is an equally valid alternative usage that
+ * an explicit check would have to track.
  * @param key - The CryptoKey to validate.
+ * @param keyType - The required `key.type` ('public' for wrap, 'private' for unwrap).
  * @param label - Human-readable role label included in the failure message.
- * @returns `Success` with the key (unchanged) when the algorithm and curve
- * match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
+ * @returns `Success` with the key (unchanged) when the algorithm, curve, and
+ * type all match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
  */
-function checkEcdhP256(key: CryptoKey, label: string): Result<CryptoKey> {
+function checkEcdhP256(key: CryptoKey, keyType: 'public' | 'private', label: string): Result<CryptoKey> {
   if (key.algorithm.name !== 'ECDH') {
     return fail(`${label} must be ECDH P-256 (got algorithm '${key.algorithm.name}')`);
   }
   const namedCurve = (key.algorithm as EcKeyAlgorithm).namedCurve;
   if (namedCurve !== 'P-256') {
     return fail(`${label} must be ECDH P-256 (got curve '${namedCurve}')`);
+  }
+  if (key.type !== keyType) {
+    return fail(`${label} must be a ${keyType} CryptoKey (got '${key.type}')`);
   }
   return succeed(key);
 }

--- a/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
@@ -329,9 +329,19 @@ export class NodeCryptoProvider implements ICryptoProvider {
     if (nonceResult.isFailure()) {
       return fail(`unwrapBytes failed: nonce: ${nonceResult.message}`);
     }
+    if (nonceResult.value.length !== Constants.GCM_IV_SIZE) {
+      return fail(
+        `unwrapBytes failed: nonce must be ${Constants.GCM_IV_SIZE} bytes (got ${nonceResult.value.length})`
+      );
+    }
     const ciphertextResult = this.fromBase64(wrapped.ciphertext);
     if (ciphertextResult.isFailure()) {
       return fail(`unwrapBytes failed: ciphertext: ${ciphertextResult.message}`);
+    }
+    if (ciphertextResult.value.length < Constants.GCM_AUTH_TAG_SIZE) {
+      return fail(
+        `unwrapBytes failed: ciphertext must be at least ${Constants.GCM_AUTH_TAG_SIZE} bytes (got ${ciphertextResult.value.length})`
+      );
     }
     const subtle = crypto.webcrypto.subtle;
     const result = await captureAsyncResult(async () => {

--- a/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
@@ -22,7 +22,13 @@ import * as crypto from 'crypto';
 import { captureAsyncResult, captureResult, fail, Failure, Result, succeed, Success } from '@fgv/ts-utils';
 import * as Constants from './constants';
 import { keyPairAlgorithmParams } from './keyPairAlgorithmParams';
-import { ICryptoProvider, IEncryptionResult, KeyPairAlgorithm } from './model';
+import {
+  ICryptoProvider,
+  IEncryptionResult,
+  IWrapBytesOptions,
+  IWrappedBytes,
+  KeyPairAlgorithm
+} from './model';
 
 /**
  * Node.js implementation of {@link CryptoUtils.ICryptoProvider} using the built-in crypto module.
@@ -252,6 +258,133 @@ export class NodeCryptoProvider implements ICryptoProvider {
     );
     return result.withErrorFormat((e) => `Failed to import ${algorithm} public key from JWK: ${e}`);
   }
+
+  /**
+   * Wraps `plaintext` for the holder of `recipientPublicKey` using
+   * ECIES (ECDH P-256 + HKDF-SHA256 + AES-GCM-256). See
+   * {@link CryptoUtils.ICryptoProvider.wrapBytes | ICryptoProvider.wrapBytes}.
+   * @param plaintext - The bytes to wrap.
+   * @param recipientPublicKey - The recipient's ECDH P-256 public `CryptoKey`.
+   * @param options - HKDF salt and info; see {@link CryptoUtils.IWrapBytesOptions | IWrapBytesOptions}.
+   * @returns `Success` with the wrapped payload, or `Failure` with an error.
+   */
+  public async wrapBytes(
+    plaintext: Uint8Array,
+    recipientPublicKey: CryptoKey,
+    options: IWrapBytesOptions
+  ): Promise<Result<IWrappedBytes>> {
+    const recipientCheck = checkEcdhP256(recipientPublicKey, 'recipient public key');
+    if (recipientCheck.isFailure()) {
+      return fail(`wrapBytes failed: ${recipientCheck.message}`);
+    }
+    const subtle = crypto.webcrypto.subtle;
+    const result = await captureAsyncResult(async () => {
+      const ephemeral = (await subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, [
+        'deriveKey'
+      ])) as CryptoKeyPair;
+      const hkdfBase = await subtle.deriveKey(
+        { name: 'ECDH', public: recipientPublicKey },
+        ephemeral.privateKey,
+        { name: 'HKDF' },
+        false,
+        ['deriveKey']
+      );
+      const wrapKey = await subtle.deriveKey(
+        { name: 'HKDF', salt: options.salt, info: options.info, hash: 'SHA-256' },
+        hkdfBase,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['encrypt']
+      );
+      const nonce = crypto.randomBytes(Constants.GCM_IV_SIZE);
+      const ctBuf = await subtle.encrypt({ name: 'AES-GCM', iv: nonce }, wrapKey, plaintext);
+      const ephemeralPublicKey = await subtle.exportKey('jwk', ephemeral.publicKey);
+      return {
+        ephemeralPublicKey,
+        nonce: Buffer.from(nonce).toString('base64'),
+        ciphertext: Buffer.from(new Uint8Array(ctBuf)).toString('base64')
+      };
+    });
+    return result.withErrorFormat((e) => `wrapBytes failed: ${e}`);
+  }
+
+  /**
+   * Unwraps a payload produced by `wrapBytes` using the recipient's private
+   * key. See {@link CryptoUtils.ICryptoProvider.unwrapBytes | ICryptoProvider.unwrapBytes}.
+   * @param wrapped - The wrapped payload.
+   * @param recipientPrivateKey - The recipient's ECDH P-256 private `CryptoKey`.
+   * @param options - HKDF salt and info matching the wrap call.
+   * @returns `Success` with the original `plaintext`, or `Failure` with an error.
+   */
+  public async unwrapBytes(
+    wrapped: IWrappedBytes,
+    recipientPrivateKey: CryptoKey,
+    options: IWrapBytesOptions
+  ): Promise<Result<Uint8Array>> {
+    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'recipient private key');
+    if (recipientCheck.isFailure()) {
+      return fail(`unwrapBytes failed: ${recipientCheck.message}`);
+    }
+    const nonceResult = this.fromBase64(wrapped.nonce);
+    if (nonceResult.isFailure()) {
+      return fail(`unwrapBytes failed: nonce: ${nonceResult.message}`);
+    }
+    const ciphertextResult = this.fromBase64(wrapped.ciphertext);
+    if (ciphertextResult.isFailure()) {
+      return fail(`unwrapBytes failed: ciphertext: ${ciphertextResult.message}`);
+    }
+    const subtle = crypto.webcrypto.subtle;
+    const result = await captureAsyncResult(async () => {
+      const ephemeralPub = await subtle.importKey(
+        'jwk',
+        wrapped.ephemeralPublicKey,
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false,
+        []
+      );
+      const hkdfBase = await subtle.deriveKey(
+        { name: 'ECDH', public: ephemeralPub },
+        recipientPrivateKey,
+        { name: 'HKDF' },
+        false,
+        ['deriveKey']
+      );
+      const wrapKey = await subtle.deriveKey(
+        { name: 'HKDF', salt: options.salt, info: options.info, hash: 'SHA-256' },
+        hkdfBase,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['decrypt']
+      );
+      const ptBuf = await subtle.decrypt(
+        { name: 'AES-GCM', iv: nonceResult.value },
+        wrapKey,
+        ciphertextResult.value
+      );
+      return new Uint8Array(ptBuf);
+    });
+    return result.withErrorFormat((e) => `unwrapBytes failed: ${e}`);
+  }
+}
+
+/**
+ * Verifies that `key` is an ECDH P-256 `CryptoKey`. Used by the wrap/unwrap
+ * methods to surface a clean `Failure` instead of letting the WebCrypto
+ * deriveKey call throw a less informative error later in the pipeline.
+ * @param key - The CryptoKey to validate.
+ * @param label - Human-readable role label included in the failure message.
+ * @returns `Success` with the key (unchanged) when the algorithm and curve
+ * match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
+ */
+function checkEcdhP256(key: CryptoKey, label: string): Result<CryptoKey> {
+  if (key.algorithm.name !== 'ECDH') {
+    return fail(`${label} must be ECDH P-256 (got algorithm '${key.algorithm.name}')`);
+  }
+  const namedCurve = (key.algorithm as EcKeyAlgorithm).namedCurve;
+  if (namedCurve !== 'P-256') {
+    return fail(`${label} must be ECDH P-256 (got curve '${namedCurve}')`);
+  }
+  return succeed(key);
 }
 
 /**

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
@@ -1,0 +1,418 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import { AiAssist } from '../../..';
+// eslint-disable-next-line @rushstack/packlets/mechanics
+import type { IAiProviderDescriptor } from '../../../packlets/ai-assist/model';
+
+// ============================================================================
+// Test helpers (mirrors apiClient.test.ts; kept local to stay under the
+// per-file line cap).
+// ============================================================================
+
+function makeImageDescriptor(overrides: Partial<IAiProviderDescriptor> = {}): IAiProviderDescriptor {
+  return {
+    id: 'openai',
+    label: 'OpenAI',
+    buttonLabel: 'AI Assist | OpenAI',
+    needsSecret: true,
+    apiFormat: 'openai',
+    baseUrl: 'https://api.openai.com/v1',
+    defaultModel: { base: 'gpt-4o', image: 'dall-e-3' },
+    supportedTools: [],
+    corsRestricted: false,
+    acceptsImageInput: true,
+    streamingCorsRestricted: false,
+    imageApiFormat: 'openai-images',
+    ...overrides
+  };
+}
+
+function mockFetchResponse(body: unknown, status: number = 200): void {
+  const response = {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(JSON.stringify(body))
+  };
+  (global.fetch as jest.Mock).mockResolvedValue(response);
+}
+
+function mockFetchError(error: Error): void {
+  (global.fetch as jest.Mock).mockRejectedValue(error);
+}
+
+function mockFetchHttpError(status: number, errorText: string): void {
+  const response = {
+    ok: false,
+    status,
+    text: jest.fn().mockResolvedValue(errorText)
+  };
+  (global.fetch as jest.Mock).mockResolvedValue(response);
+}
+
+function openAiImageBody(b64s: string[]): unknown {
+  return { data: b64s.map((b64) => ({ b64_json: b64 })) };
+}
+
+function geminiImageOutBody(
+  images: ReadonlyArray<{ mimeType: string; base64: string }>,
+  textPart?: string
+): unknown {
+  const parts: Array<Record<string, unknown>> = [];
+  if (textPart !== undefined) {
+    parts.push({ text: textPart });
+  }
+  for (const img of images) {
+    parts.push({ inlineData: { mimeType: img.mimeType, data: img.base64 } });
+  }
+  return {
+    candidates: [{ content: { parts }, finishReason: 'STOP' }]
+  };
+}
+
+const TEST_PNG: AiAssist.IAiImageAttachment = {
+  mimeType: 'image/png',
+  base64: 'AAAA'
+};
+const TEST_JPEG: AiAssist.IAiImageAttachment = {
+  mimeType: 'image/jpeg',
+  base64: 'BBBB',
+  detail: 'high'
+};
+const TEST_WEBP: AiAssist.IAiImageAttachment = {
+  mimeType: 'image/webp',
+  base64: 'CCCC'
+};
+const TEST_GIF: AiAssist.IAiImageAttachment = {
+  mimeType: 'image/gif',
+  base64: 'DDDD'
+};
+const TEST_UNKNOWN_MIME: AiAssist.IAiImageAttachment = {
+  mimeType: 'image/heic',
+  base64: 'EEEE'
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('callProviderImageGeneration — reference images', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('pre-flight', () => {
+    test('rejects refs when descriptor does not declare acceptsImageReferenceInput', async () => {
+      const descriptor = makeImageDescriptor({
+        id: 'xai-grok',
+        baseUrl: 'https://api.x.ai/v1',
+        imageApiFormat: 'xai-images',
+        acceptsImageReferenceInput: undefined
+      });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat', referenceImages: [TEST_PNG] }
+      });
+
+      expect(result).toFailWith(/does not support reference images/i);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('treats empty referenceImages array as no-refs (no pre-flight rejection)', async () => {
+      mockFetchResponse(openAiImageBody(['AAAA']));
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: undefined });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat', referenceImages: [] }
+      });
+
+      expect(result).toSucceed();
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://api.openai.com/v1/images/generations');
+    });
+  });
+
+  describe('openai-images format with reference images', () => {
+    test('routes to /images/edits with multipart body when refs present', async () => {
+      mockFetchResponse(openAiImageBody(['AAAA']));
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        modelOverride: 'gpt-image-1',
+        params: {
+          prompt: 'same character side view',
+          options: { count: 2, size: '1024x1024', quality: 'high' },
+          referenceImages: [TEST_PNG, TEST_JPEG]
+        }
+      });
+
+      expect(result).toSucceedAndSatisfy((response) => {
+        expect(response.images).toHaveLength(1);
+        expect(response.images[0].base64).toBe('AAAA');
+      });
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://api.openai.com/v1/images/edits');
+      // eslint-disable-next-line dot-notation
+      expect(fetchCall[1].headers['Authorization']).toBe('Bearer test-key');
+      expect(fetchCall[1].headers['Content-Type']).toBeUndefined();
+      const body = fetchCall[1].body as FormData;
+      expect(body).toBeInstanceOf(FormData);
+      expect(body.get('model')).toBe('gpt-image-1');
+      expect(body.get('prompt')).toBe('same character side view');
+      expect(body.get('n')).toBe('2');
+      expect(body.get('size')).toBe('1024x1024');
+      expect(body.get('quality')).toBe('high');
+      const refs = body.getAll('image[]');
+      expect(refs).toHaveLength(2);
+      expect((refs[0] as Blob).type).toBe('image/png');
+      expect((refs[1] as Blob).type).toBe('image/jpeg');
+    });
+
+    test('attaches refs of varied mime types with sensible filename extensions', async () => {
+      mockFetchResponse(openAiImageBody(['AAAA']));
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+
+      await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: {
+          prompt: 'mixed refs',
+          referenceImages: [TEST_PNG, TEST_JPEG, TEST_WEBP, TEST_GIF, TEST_UNKNOWN_MIME]
+        }
+      });
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      const body = fetchCall[1].body as FormData;
+      const refs = body.getAll('image[]');
+      expect(refs).toHaveLength(5);
+      expect((refs[0] as Blob).type).toBe('image/png');
+      expect((refs[1] as Blob).type).toBe('image/jpeg');
+      expect((refs[2] as Blob).type).toBe('image/webp');
+      expect((refs[3] as Blob).type).toBe('image/gif');
+      expect((refs[4] as Blob).type).toBe('image/heic');
+    });
+
+    test('forwards abort signal on multipart edits request', async () => {
+      mockFetchResponse(openAiImageBody(['AAAA']));
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+      const controller = new AbortController();
+
+      await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat', referenceImages: [TEST_PNG] },
+        signal: controller.signal
+      });
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[1].signal).toBe(controller.signal);
+    });
+
+    test('surfaces non-2xx errors from /images/edits', async () => {
+      mockFetchHttpError(400, 'unsupported model');
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat', referenceImages: [TEST_PNG] }
+      });
+
+      expect(result).toFailWith(/400/);
+    });
+
+    test('surfaces network errors from /images/edits', async () => {
+      mockFetchError(new Error('ECONNREFUSED'));
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat', referenceImages: [TEST_PNG] }
+      });
+
+      expect(result).toFailWith(/ECONNREFUSED/);
+    });
+  });
+
+  describe('gemini-image-out format', () => {
+    const descriptor = makeImageDescriptor({
+      id: 'google-gemini',
+      label: 'Google Gemini',
+      buttonLabel: 'AI Assist | Gemini',
+      apiFormat: 'gemini',
+      baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+      defaultModel: { base: 'gemini-2.5-flash', image: 'gemini-2.5-flash-image' },
+      imageApiFormat: 'gemini-image-out',
+      acceptsImageReferenceInput: true
+    });
+
+    test('returns image parsed from inlineData parts (text-only request)', async () => {
+      mockFetchResponse(geminiImageOutBody([{ mimeType: 'image/png', base64: 'PPPP' }]));
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a friendly robot' }
+      });
+
+      expect(result).toSucceedAndSatisfy((response) => {
+        expect(response.images).toHaveLength(1);
+        expect(response.images[0].mimeType).toBe('image/png');
+        expect(response.images[0].base64).toBe('PPPP');
+      });
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[0]).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image:generateContent'
+      );
+      expect(fetchCall[1].headers['x-goog-api-key']).toBe('test-key');
+      const body = JSON.parse(fetchCall[1].body);
+      expect(body).toEqual({
+        contents: [{ role: 'user', parts: [{ text: 'a friendly robot' }] }]
+      });
+    });
+
+    test('skips text parts and returns only images when both are present', async () => {
+      mockFetchResponse(
+        geminiImageOutBody([{ mimeType: 'image/png', base64: 'PPPP' }], 'Here is your image:')
+      );
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a robot' }
+      });
+
+      expect(result).toSucceedAndSatisfy((response) => {
+        expect(response.images).toHaveLength(1);
+        expect(response.images[0].base64).toBe('PPPP');
+      });
+    });
+
+    test('sends inlineData parts when reference images are provided', async () => {
+      mockFetchResponse(geminiImageOutBody([{ mimeType: 'image/png', base64: 'PPPP' }]));
+
+      await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: {
+          prompt: 'same character, side view',
+          referenceImages: [TEST_PNG, TEST_JPEG]
+        }
+      });
+
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(body.contents).toHaveLength(1);
+      expect(body.contents[0].role).toBe('user');
+      expect(body.contents[0].parts).toEqual([
+        { text: 'same character, side view' },
+        { inlineData: { mimeType: 'image/png', data: 'AAAA' } },
+        { inlineData: { mimeType: 'image/jpeg', data: 'BBBB' } }
+      ]);
+    });
+
+    test('returns multiple images when response has multiple inlineData parts', async () => {
+      mockFetchResponse(
+        geminiImageOutBody([
+          { mimeType: 'image/png', base64: 'PPPP' },
+          { mimeType: 'image/png', base64: 'QQQQ' }
+        ])
+      );
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'two robots' }
+      });
+
+      expect(result).toSucceedAndSatisfy((response) => {
+        expect(response.images.map((i) => i.base64)).toEqual(['PPPP', 'QQQQ']);
+      });
+    });
+
+    test('fails when response has no inlineData parts', async () => {
+      mockFetchResponse(geminiImageOutBody([], 'sorry, I cannot generate that image'));
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat' }
+      });
+
+      expect(result).toFailWith(/no image parts in response/i);
+    });
+
+    test('fails when response is malformed', async () => {
+      mockFetchResponse({ candidates: [] });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat' }
+      });
+
+      expect(result).toFailWith(/Gemini image API response/i);
+    });
+
+    test('surfaces network errors', async () => {
+      mockFetchError(new Error('ETIMEDOUT'));
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat' }
+      });
+
+      expect(result).toFailWith(/ETIMEDOUT/);
+    });
+
+    test('forwards abort signal', async () => {
+      mockFetchResponse(geminiImageOutBody([{ mimeType: 'image/png', base64: 'PPPP' }]));
+      const controller = new AbortController();
+
+      await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat' },
+        signal: controller.signal
+      });
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[1].signal).toBe(controller.signal);
+    });
+  });
+});

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
@@ -1696,6 +1696,20 @@ describe('callProxiedImageGeneration', () => {
     expect(body.modelOverride).toBe('gpt-image-1');
   });
 
+  test('forwards reference images through to the proxy unchanged', async () => {
+    mockFetchResponse({ images: [{ mimeType: 'image/png', base64: 'AAAA' }] });
+    const descriptor = makeImageDescriptor();
+
+    await AiAssist.callProxiedImageGeneration('http://localhost:3001', {
+      descriptor,
+      apiKey: 'test-key',
+      params: { prompt: 'a cat', referenceImages: [TEST_PNG, TEST_JPEG] }
+    });
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.params.referenceImages).toEqual([TEST_PNG, TEST_JPEG]);
+  });
+
   test('surfaces proxy error response', async () => {
     mockFetchResponse({ error: 'provider rejected request' });
     const descriptor = makeImageDescriptor();

--- a/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
@@ -63,14 +63,16 @@ describe('AiAssist.registry', () => {
     test('returns descriptor with image generation support for openai', () => {
       expect(AiAssist.getProviderDescriptor('openai')).toSucceedAndSatisfy((desc) => {
         expect(desc.imageApiFormat).toBe('openai-images');
+        expect(desc.acceptsImageReferenceInput).toBe(true);
         expect(AiAssist.resolveModel(desc.defaultModel, 'image')).toBe('dall-e-3');
       });
     });
 
     test('returns descriptor with image generation support for google-gemini', () => {
       expect(AiAssist.getProviderDescriptor('google-gemini')).toSucceedAndSatisfy((desc) => {
-        expect(desc.imageApiFormat).toBe('gemini-imagen');
-        expect(AiAssist.resolveModel(desc.defaultModel, 'image')).toBe('imagen-3.0-generate-002');
+        expect(desc.imageApiFormat).toBe('gemini-image-out');
+        expect(desc.acceptsImageReferenceInput).toBe(true);
+        expect(AiAssist.resolveModel(desc.defaultModel, 'image')).toBe('gemini-2.5-flash-image');
       });
     });
 

--- a/libraries/ts-extras/src/test/unit/crypto/wrapBytes.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/wrapBytes.test.ts
@@ -285,5 +285,24 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
       const result = await provider.unwrapBytes(wrapped, wrongCurve.privateKey, defaultOptions);
       expect(result).toFailWith(/unwrapBytes failed: recipient private key must be ECDH P-256.*P-384/i);
     });
+
+    test('wrap fails when recipient is an ECDH private key (not public)', async () => {
+      const pair = await generateEcdhPair();
+      const result = await provider.wrapBytes(new Uint8Array([1, 2, 3]), pair.privateKey, defaultOptions);
+      expect(result).toFailWith(
+        /wrapBytes failed: recipient public key must be a public CryptoKey \(got 'private'\)/i
+      );
+    });
+
+    test('unwrap fails when recipient is an ECDH public key (not private)', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new Uint8Array([1, 2, 3]), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const result = await provider.unwrapBytes(wrapped, pair.publicKey, defaultOptions);
+      expect(result).toFailWith(
+        /unwrapBytes failed: recipient private key must be a private CryptoKey \(got 'public'\)/i
+      );
+    });
   });
 });

--- a/libraries/ts-extras/src/test/unit/crypto/wrapBytes.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/wrapBytes.test.ts
@@ -1,0 +1,289 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import * as crypto from 'crypto';
+import * as CryptoUtils from '../../../packlets/crypto-utils';
+
+const subtle = crypto.webcrypto.subtle;
+
+async function generateEcdhPair(curve: 'P-256' | 'P-384' = 'P-256'): Promise<CryptoKeyPair> {
+  return (await subtle.generateKey({ name: 'ECDH', namedCurve: curve }, true, [
+    'deriveKey',
+    'deriveBits'
+  ])) as CryptoKeyPair;
+}
+
+async function generateEcdsaPair(): Promise<CryptoKeyPair> {
+  return (await subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify'
+  ])) as CryptoKeyPair;
+}
+
+describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
+  const provider = CryptoUtils.nodeCryptoProvider;
+  const defaultOptions: CryptoUtils.IWrapBytesOptions = {
+    salt: new TextEncoder().encode('test-salt'),
+    info: new TextEncoder().encode('test-info')
+  };
+
+  describe('round-trip', () => {
+    test.each<[string, Uint8Array]>([
+      ['32-byte plaintext (AES-256 key shape)', new Uint8Array(crypto.randomBytes(32))],
+      ['1-byte plaintext', new Uint8Array([0x42])],
+      ['1KB plaintext', new Uint8Array(crypto.randomBytes(1024))],
+      ['empty plaintext', new Uint8Array(0)],
+      ['high-bit-set bytes', new Uint8Array(64).fill(0xff)]
+    ])('round-trips %s', async (__label, plaintext) => {
+      const pair = await generateEcdhPair();
+      const wrapped = (await provider.wrapBytes(plaintext, pair.publicKey, defaultOptions)).orThrow();
+      expect(wrapped.ephemeralPublicKey.kty).toBe('EC');
+      expect(wrapped.ephemeralPublicKey.crv).toBe('P-256');
+      const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, defaultOptions)).orThrow();
+      expect(new Uint8Array(recovered)).toEqual(plaintext);
+    });
+
+    test('unwrap with the recipient privateKey returns identical bytes', async () => {
+      const pair = await generateEcdhPair();
+      const plaintext = new Uint8Array(crypto.randomBytes(48));
+      const wrapped = (await provider.wrapBytes(plaintext, pair.publicKey, defaultOptions)).orThrow();
+      const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, defaultOptions)).orThrow();
+      expect(Buffer.from(recovered).equals(Buffer.from(plaintext))).toBe(true);
+    });
+  });
+
+  describe('determinism / freshness', () => {
+    test('two wraps of identical inputs produce different ephemeral keys and ciphertexts', async () => {
+      const pair = await generateEcdhPair();
+      const plaintext = new TextEncoder().encode('same payload');
+      const w1 = (await provider.wrapBytes(plaintext, pair.publicKey, defaultOptions)).orThrow();
+      const w2 = (await provider.wrapBytes(plaintext, pair.publicKey, defaultOptions)).orThrow();
+      expect(w1.ephemeralPublicKey).not.toEqual(w2.ephemeralPublicKey);
+      expect(w1.ciphertext).not.toEqual(w2.ciphertext);
+      expect(w1.nonce).not.toEqual(w2.nonce);
+    });
+  });
+
+  describe('tampering', () => {
+    test('flipping a bit in the nonce fails GCM authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const nonce = provider.fromBase64(wrapped.nonce).orThrow();
+      nonce[0] ^= 0xff;
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, nonce: provider.toBase64(nonce) };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('flipping a bit in the ciphertext fails GCM authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const ct = provider.fromBase64(wrapped.ciphertext).orThrow();
+      ct[0] ^= 0x01;
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: provider.toBase64(ct) };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('truncating ciphertext below the auth-tag length fails authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const ct = provider.fromBase64(wrapped.ciphertext).orThrow();
+      const truncated = ct.slice(0, ct.length - 1);
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: provider.toBase64(truncated) };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('substituting a different ephemeral public key fails authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      // A second wrap to harvest a valid-but-different ephemeral public key.
+      const other = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const tampered: CryptoUtils.IWrappedBytes = {
+        ...wrapped,
+        ephemeralPublicKey: other.ephemeralPublicKey
+      };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+  });
+
+  describe('wrong-key / wrong-options', () => {
+    test('unwrap with a different recipient private key fails', async () => {
+      const pair = await generateEcdhPair();
+      const other = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      expect(await provider.unwrapBytes(wrapped, other.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('unwrap with a different HKDF salt fails authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const wrongSalt: CryptoUtils.IWrapBytesOptions = {
+        salt: new TextEncoder().encode('different-salt'),
+        info: defaultOptions.info
+      };
+      expect(await provider.unwrapBytes(wrapped, pair.privateKey, wrongSalt)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('unwrap with a different HKDF info fails authentication', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const wrongInfo: CryptoUtils.IWrapBytesOptions = {
+        salt: defaultOptions.salt,
+        info: new TextEncoder().encode('different-info')
+      };
+      expect(await provider.unwrapBytes(wrapped, pair.privateKey, wrongInfo)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('empty salt and info round-trip when both sides agree', async () => {
+      const pair = await generateEcdhPair();
+      const empty: CryptoUtils.IWrapBytesOptions = { salt: new Uint8Array(0), info: new Uint8Array(0) };
+      const plaintext = new Uint8Array(crypto.randomBytes(16));
+      const wrapped = (await provider.wrapBytes(plaintext, pair.publicKey, empty)).orThrow();
+      const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, empty)).orThrow();
+      expect(new Uint8Array(recovered)).toEqual(plaintext);
+    });
+  });
+
+  describe('malformed input', () => {
+    test('malformed ephemeralPublicKey JWK fails', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const bogus: CryptoUtils.IWrappedBytes = {
+        ...wrapped,
+        ephemeralPublicKey: { kty: 'EC', crv: 'P-256' } as JsonWebKey
+      };
+      expect(await provider.unwrapBytes(bogus, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('ephemeralPublicKey on the wrong curve (P-384) fails', async () => {
+      const pair = await generateEcdhPair();
+      const wrongCurve = await generateEcdhPair('P-384');
+      const wrongJwk = await subtle.exportKey('jwk', wrongCurve.publicKey);
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ephemeralPublicKey: wrongJwk };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
+    test('non-base64 nonce fails with a clean error', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, nonce: 'not!base64!' };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed: nonce/i
+      );
+    });
+
+    test('non-base64 ciphertext fails with a clean error', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: 'not!base64!' };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed: ciphertext/i
+      );
+    });
+  });
+
+  describe('algorithm mismatch on recipient key', () => {
+    test('wrap fails when recipient public key is RSA-OAEP, not ECDH', async () => {
+      const rsa = (await provider.generateKeyPair('rsa-oaep-2048', true)).orThrow();
+      const result = await provider.wrapBytes(new Uint8Array([1, 2, 3]), rsa.publicKey, defaultOptions);
+      expect(result).toFailWith(/wrapBytes failed: recipient public key must be ECDH P-256.*RSA-OAEP/i);
+    });
+
+    test('wrap fails when recipient public key is ECDSA P-256, not ECDH', async () => {
+      const ecdsa = await generateEcdsaPair();
+      const result = await provider.wrapBytes(new Uint8Array([1, 2, 3]), ecdsa.publicKey, defaultOptions);
+      expect(result).toFailWith(/wrapBytes failed: recipient public key must be ECDH P-256.*ECDSA/i);
+    });
+
+    test('wrap fails when recipient public key is ECDH P-384, not P-256', async () => {
+      const wrongCurve = await generateEcdhPair('P-384');
+      const result = await provider.wrapBytes(
+        new Uint8Array([1, 2, 3]),
+        wrongCurve.publicKey,
+        defaultOptions
+      );
+      expect(result).toFailWith(/wrapBytes failed: recipient public key must be ECDH P-256.*P-384/i);
+    });
+
+    test('unwrap fails when recipient private key is RSA-OAEP, not ECDH', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new Uint8Array([1, 2, 3]), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const rsa = (await provider.generateKeyPair('rsa-oaep-2048', true)).orThrow();
+      const result = await provider.unwrapBytes(wrapped, rsa.privateKey, defaultOptions);
+      expect(result).toFailWith(/unwrapBytes failed: recipient private key must be ECDH P-256.*RSA-OAEP/i);
+    });
+
+    test('unwrap fails when recipient private key is ECDH P-384, not P-256', async () => {
+      const pair = await generateEcdhPair();
+      const wrapped = (
+        await provider.wrapBytes(new Uint8Array([1, 2, 3]), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const wrongCurve = await generateEcdhPair('P-384');
+      const result = await provider.unwrapBytes(wrapped, wrongCurve.privateKey, defaultOptions);
+      expect(result).toFailWith(/unwrapBytes failed: recipient private key must be ECDH P-256.*P-384/i);
+    });
+  });
+});

--- a/libraries/ts-web-extras/etc/ts-web-extras.api.md
+++ b/libraries/ts-web-extras/etc/ts-web-extras.api.md
@@ -25,6 +25,11 @@ class BrowserCryptoProvider implements CryptoUtils_2.ICryptoProvider {
     importPublicKeyJwk(jwk: JsonWebKey, algorithm: CryptoUtils_2.KeyPairAlgorithm): Promise<Result<CryptoKey>>;
     sha256(data: string): Promise<Result<string>>;
     toBase64(data: Uint8Array): string;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    unwrapBytes(wrapped: CryptoUtils_2.IWrappedBytes, recipientPrivateKey: CryptoKey, options: CryptoUtils_2.IWrapBytesOptions): Promise<Result<Uint8Array>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    wrapBytes(plaintext: Uint8Array, recipientPublicKey: CryptoKey, options: CryptoUtils_2.IWrapBytesOptions): Promise<Result<CryptoUtils_2.IWrappedBytes>>;
 }
 
 // @public

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -372,6 +372,147 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     );
     return result.withErrorFormat((e) => `Failed to import ${algorithm} public key from JWK: ${e}`);
   }
+
+  /**
+   * Wraps `plaintext` for the holder of `recipientPublicKey` using
+   * ECIES (ECDH P-256 + HKDF-SHA256 + AES-GCM-256). See
+   * {@link CryptoUtils.ICryptoProvider.wrapBytes | ICryptoProvider.wrapBytes}.
+   * @param plaintext - The bytes to wrap.
+   * @param recipientPublicKey - The recipient's ECDH P-256 public `CryptoKey`.
+   * @param options - HKDF salt and info; see {@link CryptoUtils.IWrapBytesOptions | IWrapBytesOptions}.
+   * @returns `Success` with the wrapped payload, or `Failure` with an error.
+   */
+  public async wrapBytes(
+    plaintext: Uint8Array,
+    recipientPublicKey: CryptoKey,
+    options: CryptoUtils.IWrapBytesOptions
+  ): Promise<Result<CryptoUtils.IWrappedBytes>> {
+    const recipientCheck = checkEcdhP256(recipientPublicKey, 'recipient public key');
+    if (recipientCheck.isFailure()) {
+      return Failure.with(`wrapBytes failed: ${recipientCheck.message}`);
+    }
+    const subtle = this._crypto.subtle;
+    const result = await captureAsyncResult(async () => {
+      const ephemeral = (await subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, [
+        'deriveKey'
+      ])) as CryptoKeyPair;
+      const hkdfBase = await subtle.deriveKey(
+        { name: 'ECDH', public: recipientPublicKey },
+        ephemeral.privateKey,
+        { name: 'HKDF' },
+        false,
+        ['deriveKey']
+      );
+      const wrapKey = await subtle.deriveKey(
+        {
+          name: 'HKDF',
+          salt: toArrayBuffer(options.salt),
+          info: toArrayBuffer(options.info),
+          hash: 'SHA-256'
+        },
+        hkdfBase,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['encrypt']
+      );
+      const nonce = this._crypto.getRandomValues(new Uint8Array(CryptoUtils.Constants.GCM_IV_SIZE));
+      const ctBuf = await subtle.encrypt(
+        { name: 'AES-GCM', iv: toArrayBuffer(nonce) },
+        wrapKey,
+        toArrayBuffer(plaintext)
+      );
+      const ephemeralPublicKey = await subtle.exportKey('jwk', ephemeral.publicKey);
+      return {
+        ephemeralPublicKey,
+        nonce: this.toBase64(nonce),
+        ciphertext: this.toBase64(new Uint8Array(ctBuf))
+      };
+    });
+    return result.withErrorFormat((e) => `wrapBytes failed: ${e}`);
+  }
+
+  /**
+   * Unwraps a payload produced by `wrapBytes` using the recipient's private
+   * key. See {@link CryptoUtils.ICryptoProvider.unwrapBytes | ICryptoProvider.unwrapBytes}.
+   * @param wrapped - The wrapped payload.
+   * @param recipientPrivateKey - The recipient's ECDH P-256 private `CryptoKey`.
+   * @param options - HKDF salt and info matching the wrap call.
+   * @returns `Success` with the original `plaintext`, or `Failure` with an error.
+   */
+  public async unwrapBytes(
+    wrapped: CryptoUtils.IWrappedBytes,
+    recipientPrivateKey: CryptoKey,
+    options: CryptoUtils.IWrapBytesOptions
+  ): Promise<Result<Uint8Array>> {
+    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'recipient private key');
+    if (recipientCheck.isFailure()) {
+      return Failure.with(`unwrapBytes failed: ${recipientCheck.message}`);
+    }
+    const nonceResult = this.fromBase64(wrapped.nonce);
+    if (nonceResult.isFailure()) {
+      return Failure.with(`unwrapBytes failed: nonce: ${nonceResult.message}`);
+    }
+    const ciphertextResult = this.fromBase64(wrapped.ciphertext);
+    if (ciphertextResult.isFailure()) {
+      return Failure.with(`unwrapBytes failed: ciphertext: ${ciphertextResult.message}`);
+    }
+    const subtle = this._crypto.subtle;
+    const result = await captureAsyncResult(async () => {
+      const ephemeralPub = await subtle.importKey(
+        'jwk',
+        wrapped.ephemeralPublicKey,
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false,
+        []
+      );
+      const hkdfBase = await subtle.deriveKey(
+        { name: 'ECDH', public: ephemeralPub },
+        recipientPrivateKey,
+        { name: 'HKDF' },
+        false,
+        ['deriveKey']
+      );
+      const wrapKey = await subtle.deriveKey(
+        {
+          name: 'HKDF',
+          salt: toArrayBuffer(options.salt),
+          info: toArrayBuffer(options.info),
+          hash: 'SHA-256'
+        },
+        hkdfBase,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['decrypt']
+      );
+      const ptBuf = await subtle.decrypt(
+        { name: 'AES-GCM', iv: toArrayBuffer(nonceResult.value) },
+        wrapKey,
+        toArrayBuffer(ciphertextResult.value)
+      );
+      return new Uint8Array(ptBuf);
+    });
+    return result.withErrorFormat((e) => `unwrapBytes failed: ${e}`);
+  }
+}
+
+/**
+ * Verifies that `key` is an ECDH P-256 `CryptoKey`. Used by the wrap/unwrap
+ * methods to surface a clean `Failure` instead of letting the WebCrypto
+ * deriveKey call throw a less informative error later in the pipeline.
+ * @param key - The CryptoKey to validate.
+ * @param label - Human-readable role label included in the failure message.
+ * @returns `Success` with the key (unchanged) when the algorithm and curve
+ * match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
+ */
+function checkEcdhP256(key: CryptoKey, label: string): Result<CryptoKey> {
+  if (key.algorithm.name !== 'ECDH') {
+    return Failure.with(`${label} must be ECDH P-256 (got algorithm '${key.algorithm.name}')`);
+  }
+  const namedCurve = (key.algorithm as EcKeyAlgorithm).namedCurve;
+  if (namedCurve !== 'P-256') {
+    return Failure.with(`${label} must be ECDH P-256 (got curve '${namedCurve}')`);
+  }
+  return succeed(key);
 }
 
 /**

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -387,7 +387,7 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     recipientPublicKey: CryptoKey,
     options: CryptoUtils.IWrapBytesOptions
   ): Promise<Result<CryptoUtils.IWrappedBytes>> {
-    const recipientCheck = checkEcdhP256(recipientPublicKey, 'recipient public key');
+    const recipientCheck = checkEcdhP256(recipientPublicKey, 'public', 'recipient public key');
     if (recipientCheck.isFailure()) {
       return Failure.with(`wrapBytes failed: ${recipientCheck.message}`);
     }
@@ -444,7 +444,7 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     recipientPrivateKey: CryptoKey,
     options: CryptoUtils.IWrapBytesOptions
   ): Promise<Result<Uint8Array>> {
-    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'recipient private key');
+    const recipientCheck = checkEcdhP256(recipientPrivateKey, 'private', 'recipient private key');
     if (recipientCheck.isFailure()) {
       return Failure.with(`unwrapBytes failed: ${recipientCheck.message}`);
     }
@@ -496,21 +496,29 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
 }
 
 /**
- * Verifies that `key` is an ECDH P-256 `CryptoKey`. Used by the wrap/unwrap
- * methods to surface a clean `Failure` instead of letting the WebCrypto
- * deriveKey call throw a less informative error later in the pipeline.
+ * Verifies that `key` is an ECDH P-256 `CryptoKey` of the expected `keyType`
+ * (public or private). Used by the wrap/unwrap methods to surface a clean
+ * `Failure` instead of letting the WebCrypto deriveKey call throw a less
+ * informative error later in the pipeline. Key usages are intentionally not
+ * checked here: WebCrypto already produces a specific error if `deriveKey` is
+ * not in `usages`, and `deriveBits` is an equally valid alternative usage that
+ * an explicit check would have to track.
  * @param key - The CryptoKey to validate.
+ * @param keyType - The required `key.type` ('public' for wrap, 'private' for unwrap).
  * @param label - Human-readable role label included in the failure message.
- * @returns `Success` with the key (unchanged) when the algorithm and curve
- * match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
+ * @returns `Success` with the key (unchanged) when the algorithm, curve, and
+ * type all match; otherwise `Failure` with `<label> must be ECDH P-256 (...)`.
  */
-function checkEcdhP256(key: CryptoKey, label: string): Result<CryptoKey> {
+function checkEcdhP256(key: CryptoKey, keyType: 'public' | 'private', label: string): Result<CryptoKey> {
   if (key.algorithm.name !== 'ECDH') {
     return Failure.with(`${label} must be ECDH P-256 (got algorithm '${key.algorithm.name}')`);
   }
   const namedCurve = (key.algorithm as EcKeyAlgorithm).namedCurve;
   if (namedCurve !== 'P-256') {
     return Failure.with(`${label} must be ECDH P-256 (got curve '${namedCurve}')`);
+  }
+  if (key.type !== keyType) {
+    return Failure.with(`${label} must be a ${keyType} CryptoKey (got '${key.type}')`);
   }
   return succeed(key);
 }

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -18,10 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/* c8 ignore start - Browser-only implementation cannot be tested in Node.js environment */
 import { captureAsyncResult, captureResult, fail, Failure, Result, succeed, Success } from '@fgv/ts-utils';
 import { CryptoUtils } from '@fgv/ts-extras';
 
+/* c8 ignore start - Used only by browser-only methods that cannot be tested in Node.js environment */
 /**
  * Extracts an `ArrayBuffer` from a Uint8Array, handling the potential SharedArrayBuffer case.
  * @param arr - The Uint8Array to extract from
@@ -33,11 +33,12 @@ function toArrayBuffer(arr: Uint8Array): ArrayBuffer {
   new Uint8Array(buffer).set(arr);
   return buffer;
 }
+/* c8 ignore stop */
 
 /**
  * Returns a fresh Uint8Array view over a non-shared ArrayBuffer copy of `arr`.
- * Used by {@link CryptoUtils.BrowserCryptoProvider.wrapBytes | wrapBytes} and
- * {@link CryptoUtils.BrowserCryptoProvider.unwrapBytes | unwrapBytes}: Node 20's
+ * Used by {@link BrowserCryptoProvider.wrapBytes | wrapBytes} and
+ * {@link BrowserCryptoProvider.unwrapBytes | unwrapBytes}: Node 20's
  * webcrypto.subtle rejects raw `ArrayBuffer` for several `BufferSource`
  * parameters with "is not instance of ArrayBuffer, Buffer, TypedArray, or
  * DataView" even though `ArrayBuffer` should be valid per the spec; a
@@ -64,6 +65,7 @@ function toBufferView(arr: Uint8Array): Uint8Array<ArrayBuffer> {
 export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
   private readonly _crypto: Crypto;
 
+  /* c8 ignore start - Existing browser-only methods cannot be tested in Node.js environment */
   /**
    * Creates a new {@link CryptoUtils.BrowserCryptoProvider | BrowserCryptoProvider}.
    * @param cryptoApi - Optional Crypto instance (defaults to globalThis.crypto)
@@ -390,6 +392,7 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     );
     return result.withErrorFormat((e) => `Failed to import ${algorithm} public key from JWK: ${e}`);
   }
+  /* c8 ignore stop */
 
   /**
    * Wraps `plaintext` for the holder of `recipientPublicKey` using
@@ -537,6 +540,7 @@ function checkEcdhP256(key: CryptoKey, keyType: 'public' | 'private', label: str
   return succeed(key);
 }
 
+/* c8 ignore start - Constructs a provider; only meaningful in a real browser environment */
 /**
  * Creates a {@link CryptoUtils.BrowserCryptoProvider | BrowserCryptoProvider} if Web
  * Crypto API is available.

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -452,9 +452,19 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     if (nonceResult.isFailure()) {
       return Failure.with(`unwrapBytes failed: nonce: ${nonceResult.message}`);
     }
+    if (nonceResult.value.length !== CryptoUtils.Constants.GCM_IV_SIZE) {
+      return Failure.with(
+        `unwrapBytes failed: nonce must be ${CryptoUtils.Constants.GCM_IV_SIZE} bytes (got ${nonceResult.value.length})`
+      );
+    }
     const ciphertextResult = this.fromBase64(wrapped.ciphertext);
     if (ciphertextResult.isFailure()) {
       return Failure.with(`unwrapBytes failed: ciphertext: ${ciphertextResult.message}`);
+    }
+    if (ciphertextResult.value.length < CryptoUtils.Constants.GCM_AUTH_TAG_SIZE) {
+      return Failure.with(
+        `unwrapBytes failed: ciphertext must be at least ${CryptoUtils.Constants.GCM_AUTH_TAG_SIZE} bytes (got ${ciphertextResult.value.length})`
+      );
     }
     const subtle = this._crypto.subtle;
     const result = await captureAsyncResult(async () => {

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -35,6 +35,24 @@ function toArrayBuffer(arr: Uint8Array): ArrayBuffer {
 }
 
 /**
+ * Returns a fresh Uint8Array view over a non-shared ArrayBuffer copy of `arr`.
+ * Used by {@link CryptoUtils.BrowserCryptoProvider.wrapBytes | wrapBytes} and
+ * {@link CryptoUtils.BrowserCryptoProvider.unwrapBytes | unwrapBytes}: Node 20's
+ * webcrypto.subtle rejects raw `ArrayBuffer` for several `BufferSource`
+ * parameters with "is not instance of ArrayBuffer, Buffer, TypedArray, or
+ * DataView" even though `ArrayBuffer` should be valid per the spec; a
+ * TypedArray view is accepted on Node 20+ and on browsers, and the explicit
+ * `Uint8Array<ArrayBuffer>` return type also satisfies TypeScript's `BufferSource`
+ * (which excludes the `SharedArrayBuffer` branch of `Uint8Array`'s buffer type).
+ */
+function toBufferView(arr: Uint8Array): Uint8Array<ArrayBuffer> {
+  const buffer = new ArrayBuffer(arr.byteLength);
+  const view = new Uint8Array(buffer);
+  view.set(arr);
+  return view;
+}
+
+/**
  * Browser implementation of `ICryptoProvider` using the Web Crypto API.
  * Uses AES-256-GCM for authenticated encryption.
  *
@@ -404,23 +422,14 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
         ['deriveKey']
       );
       const wrapKey = await subtle.deriveKey(
-        {
-          name: 'HKDF',
-          salt: toArrayBuffer(options.salt),
-          info: toArrayBuffer(options.info),
-          hash: 'SHA-256'
-        },
+        { name: 'HKDF', salt: toBufferView(options.salt), info: toBufferView(options.info), hash: 'SHA-256' },
         hkdfBase,
         { name: 'AES-GCM', length: 256 },
         false,
         ['encrypt']
       );
       const nonce = this._crypto.getRandomValues(new Uint8Array(CryptoUtils.Constants.GCM_IV_SIZE));
-      const ctBuf = await subtle.encrypt(
-        { name: 'AES-GCM', iv: toArrayBuffer(nonce) },
-        wrapKey,
-        toArrayBuffer(plaintext)
-      );
+      const ctBuf = await subtle.encrypt({ name: 'AES-GCM', iv: nonce }, wrapKey, toBufferView(plaintext));
       const ephemeralPublicKey = await subtle.exportKey('jwk', ephemeral.publicKey);
       return {
         ephemeralPublicKey,
@@ -483,21 +492,16 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
         ['deriveKey']
       );
       const wrapKey = await subtle.deriveKey(
-        {
-          name: 'HKDF',
-          salt: toArrayBuffer(options.salt),
-          info: toArrayBuffer(options.info),
-          hash: 'SHA-256'
-        },
+        { name: 'HKDF', salt: toBufferView(options.salt), info: toBufferView(options.info), hash: 'SHA-256' },
         hkdfBase,
         { name: 'AES-GCM', length: 256 },
         false,
         ['decrypt']
       );
       const ptBuf = await subtle.decrypt(
-        { name: 'AES-GCM', iv: toArrayBuffer(nonceResult.value) },
+        { name: 'AES-GCM', iv: toBufferView(nonceResult.value) },
         wrapKey,
-        toArrayBuffer(ciphertextResult.value)
+        toBufferView(ciphertextResult.value)
       );
       return new Uint8Array(ptBuf);
     });

--- a/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.wrapBytes.test.ts
+++ b/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.wrapBytes.test.ts
@@ -1,29 +1,32 @@
-// Copyright (c) 2026 Erik Fortune
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+/*
+ * Copyright (c) 2026 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 
 import '@fgv/ts-utils-jest';
 
-import * as crypto from 'crypto';
-import * as CryptoUtils from '../../../packlets/crypto-utils';
+import { CryptoUtils } from '@fgv/ts-extras';
+import { BrowserCryptoProvider } from '../../packlets/crypto-utils';
 
-const subtle = crypto.webcrypto.subtle;
+const provider = new BrowserCryptoProvider();
+const subtle = globalThis.crypto.subtle;
 
 async function generateEcdhPair(curve: 'P-256' | 'P-384' = 'P-256'): Promise<CryptoKeyPair> {
   return (await subtle.generateKey({ name: 'ECDH', namedCurve: curve }, true, [
@@ -39,8 +42,7 @@ async function generateEcdsaPair(): Promise<CryptoKeyPair> {
   ])) as CryptoKeyPair;
 }
 
-describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
-  const provider = CryptoUtils.nodeCryptoProvider;
+describe('BrowserCryptoProvider — wrapBytes/unwrapBytes', () => {
   const defaultOptions: CryptoUtils.IWrapBytesOptions = {
     salt: new TextEncoder().encode('test-salt'),
     info: new TextEncoder().encode('test-info')
@@ -48,9 +50,9 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
 
   describe('round-trip', () => {
     test.each<[string, Uint8Array]>([
-      ['32-byte plaintext (AES-256 key shape)', new Uint8Array(crypto.randomBytes(32))],
+      ['32-byte plaintext (AES-256 key shape)', globalThis.crypto.getRandomValues(new Uint8Array(32))],
       ['1-byte plaintext', new Uint8Array([0x42])],
-      ['1KB plaintext', new Uint8Array(crypto.randomBytes(1024))],
+      ['1KB plaintext', globalThis.crypto.getRandomValues(new Uint8Array(1024))],
       ['empty plaintext', new Uint8Array(0)],
       ['high-bit-set bytes', new Uint8Array(64).fill(0xff)]
     ])('round-trips %s', async (__label, plaintext) => {
@@ -60,14 +62,6 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
       expect(wrapped.ephemeralPublicKey.crv).toBe('P-256');
       const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, defaultOptions)).orThrow();
       expect(new Uint8Array(recovered)).toEqual(plaintext);
-    });
-
-    test('unwrap with the recipient privateKey returns identical bytes', async () => {
-      const pair = await generateEcdhPair();
-      const plaintext = new Uint8Array(crypto.randomBytes(48));
-      const wrapped = (await provider.wrapBytes(plaintext, pair.publicKey, defaultOptions)).orThrow();
-      const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, defaultOptions)).orThrow();
-      expect(Buffer.from(recovered).equals(Buffer.from(plaintext))).toBe(true);
     });
   });
 
@@ -110,25 +104,11 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
       );
     });
 
-    test('truncating ciphertext below the auth-tag length fails authentication', async () => {
-      const pair = await generateEcdhPair();
-      const wrapped = (
-        await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
-      ).orThrow();
-      const ct = provider.fromBase64(wrapped.ciphertext).orThrow();
-      const truncated = ct.slice(0, ct.length - 1);
-      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: provider.toBase64(truncated) };
-      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
-        /unwrapBytes failed/i
-      );
-    });
-
     test('substituting a different ephemeral public key fails authentication', async () => {
       const pair = await generateEcdhPair();
       const wrapped = (
         await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
       ).orThrow();
-      // A second wrap to harvest a valid-but-different ephemeral public key.
       const other = (
         await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
       ).orThrow();
@@ -185,7 +165,7 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
     test('empty salt and info round-trip when both sides agree', async () => {
       const pair = await generateEcdhPair();
       const empty: CryptoUtils.IWrapBytesOptions = { salt: new Uint8Array(0), info: new Uint8Array(0) };
-      const plaintext = new Uint8Array(crypto.randomBytes(16));
+      const plaintext = globalThis.crypto.getRandomValues(new Uint8Array(16));
       const wrapped = (await provider.wrapBytes(plaintext, pair.publicKey, empty)).orThrow();
       const recovered = (await provider.unwrapBytes(wrapped, pair.privateKey, empty)).orThrow();
       expect(new Uint8Array(recovered)).toEqual(plaintext);
@@ -247,7 +227,7 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
       const wrapped = (
         await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
       ).orThrow();
-      const shortNonce = new Uint8Array(8); // 8 bytes, not 12
+      const shortNonce = new Uint8Array(8);
       const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, nonce: provider.toBase64(shortNonce) };
       expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
         /unwrapBytes failed: nonce must be 12 bytes \(got 8\)/i
@@ -259,7 +239,7 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
       const wrapped = (
         await provider.wrapBytes(new TextEncoder().encode('payload'), pair.publicKey, defaultOptions)
       ).orThrow();
-      const shortCt = new Uint8Array(8); // 8 bytes, less than the 16-byte auth tag
+      const shortCt = new Uint8Array(8);
       const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: provider.toBase64(shortCt) };
       expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
         /unwrapBytes failed: ciphertext must be at least 16 bytes \(got 8\)/i
@@ -267,9 +247,18 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
     });
   });
 
-  describe('algorithm mismatch on recipient key', () => {
+  describe('algorithm / type mismatch on recipient key', () => {
     test('wrap fails when recipient public key is RSA-OAEP, not ECDH', async () => {
-      const rsa = (await provider.generateKeyPair('rsa-oaep-2048', true)).orThrow();
+      const rsa = (await subtle.generateKey(
+        {
+          name: 'RSA-OAEP',
+          modulusLength: 2048,
+          publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+          hash: 'SHA-256'
+        },
+        true,
+        ['encrypt', 'decrypt']
+      )) as CryptoKeyPair;
       const result = await provider.wrapBytes(new Uint8Array([1, 2, 3]), rsa.publicKey, defaultOptions);
       expect(result).toFailWith(/wrapBytes failed: recipient public key must be ECDH P-256.*RSA-OAEP/i);
     });
@@ -288,16 +277,6 @@ describe('Crypto.NodeCryptoProvider — wrapBytes/unwrapBytes', () => {
         defaultOptions
       );
       expect(result).toFailWith(/wrapBytes failed: recipient public key must be ECDH P-256.*P-384/i);
-    });
-
-    test('unwrap fails when recipient private key is RSA-OAEP, not ECDH', async () => {
-      const pair = await generateEcdhPair();
-      const wrapped = (
-        await provider.wrapBytes(new Uint8Array([1, 2, 3]), pair.publicKey, defaultOptions)
-      ).orThrow();
-      const rsa = (await provider.generateKeyPair('rsa-oaep-2048', true)).orThrow();
-      const result = await provider.unwrapBytes(wrapped, rsa.privateKey, defaultOptions);
-      expect(result).toFailWith(/unwrapBytes failed: recipient private key must be ECDH P-256.*RSA-OAEP/i);
     });
 
     test('unwrap fails when recipient private key is ECDH P-384, not P-256', async () => {

--- a/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.wrapBytes.test.ts
+++ b/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.wrapBytes.test.ts
@@ -104,6 +104,20 @@ describe('BrowserCryptoProvider — wrapBytes/unwrapBytes', () => {
       );
     });
 
+    test('truncating ciphertext by one byte fails GCM authentication (still ≥ 16 bytes)', async () => {
+      const pair = await generateEcdhPair();
+      // 16-byte plaintext → 32-byte ciphertext (16 ct + 16 tag); truncate by 1 → 31 bytes ≥ 16
+      const wrapped = (
+        await provider.wrapBytes(new Uint8Array(16).fill(0xab), pair.publicKey, defaultOptions)
+      ).orThrow();
+      const ct = provider.fromBase64(wrapped.ciphertext).orThrow();
+      const truncated = ct.slice(0, ct.length - 1);
+      const tampered: CryptoUtils.IWrappedBytes = { ...wrapped, ciphertext: provider.toBase64(truncated) };
+      expect(await provider.unwrapBytes(tampered, pair.privateKey, defaultOptions)).toFailWith(
+        /unwrapBytes failed/i
+      );
+    });
+
     test('substituting a different ephemeral public key fails authentication', async () => {
       const pair = await generateEcdhPair();
       const wrapped = (

--- a/samples/ai-image-gen-sample/README.md
+++ b/samples/ai-image-gen-sample/README.md
@@ -25,6 +25,14 @@ are exposed via a top-level toggle:
   - OpenAI / xAI: `size`
   - Imagen: `imagen.aspectRatio`
 - Rendering returned images via `AiAssist.toDataUrl`.
+- **Reference images** (where the provider supports them — currently OpenAI
+  `gpt-image-1` and Google `gemini-2.5-flash-image` / "Nano Banana"). Attach
+  one or more PNG/JPEG/WebP files; under the hood OpenAI calls switch to
+  `/v1/images/edits` (multipart) and Gemini calls send `inlineData` parts to
+  `:generateContent`.
+- **Anchor UX for character consistency**: generate once, click **Use as
+  reference** on your favorite result, then iterate. Reference images persist
+  across generations until cleared.
 
 ### Streaming Chat mode
 - Calling `streamDirect` with conversation history (`messagesBefore`),

--- a/samples/ai-image-gen-sample/src/App.tsx
+++ b/samples/ai-image-gen-sample/src/App.tsx
@@ -73,6 +73,7 @@ export function App(): React.JSX.Element {
     undefined
   );
   const [imageError, setImageError] = useState<string | undefined>(undefined);
+  const [referenceImages, setReferenceImages] = useState<ReadonlyArray<AiAssist.IAiImageAttachment>>([]);
 
   // Chat-mode conversation
   const [chatTurns, setChatTurns] = useState<ReadonlyArray<IChatTurn>>([]);
@@ -320,6 +321,8 @@ export function App(): React.JSX.Element {
               provider={provider}
               isWorking={isWorking}
               canSubmit={currentKey.length > 0}
+              referenceImages={referenceImages}
+              onReferenceImagesChange={setReferenceImages}
               onGenerate={handleGenerateImages}
               onAbort={handleAbort}
             />
@@ -328,7 +331,14 @@ export function App(): React.JSX.Element {
                 <strong className="font-semibold">Error:</strong> {imageError}
               </div>
             )}
-            {lastImageResult !== undefined && <ImageResults response={lastImageResult} />}
+            {lastImageResult !== undefined && (
+              <ImageResults
+                response={lastImageResult}
+                onUseAsReference={(image) =>
+                  setReferenceImages((prev) => [...prev, { mimeType: image.mimeType, base64: image.base64 }])
+                }
+              />
+            )}
           </>
         ) : (
           <ChatPanel

--- a/samples/ai-image-gen-sample/src/components/ImageResults.tsx
+++ b/samples/ai-image-gen-sample/src/components/ImageResults.tsx
@@ -2,10 +2,11 @@ import { AiAssist } from '@fgv/ts-extras';
 
 export interface IImageResultsProps {
   readonly response: AiAssist.IAiImageGenerationResponse;
+  readonly onUseAsReference?: (image: AiAssist.IAiGeneratedImage) => void;
 }
 
 export function ImageResults(props: IImageResultsProps): React.JSX.Element {
-  const { response } = props;
+  const { response, onUseAsReference } = props;
   const count = response.images.length;
 
   return (
@@ -30,13 +31,24 @@ export function ImageResults(props: IImageResultsProps): React.JSX.Element {
                   {image.revisedPrompt}
                 </p>
               )}
-              <a
-                href={AiAssist.toDataUrl(image)}
-                download={`generated-${idx + 1}.${image.mimeType.split('/')[1] ?? 'png'}`}
-                className="mt-2 inline-block text-indigo-600 hover:text-indigo-800"
-              >
-                Download
-              </a>
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <a
+                  href={AiAssist.toDataUrl(image)}
+                  download={`generated-${idx + 1}.${image.mimeType.split('/')[1] ?? 'png'}`}
+                  className="text-indigo-600 hover:text-indigo-800"
+                >
+                  Download
+                </a>
+                {onUseAsReference !== undefined && (
+                  <button
+                    type="button"
+                    onClick={() => onUseAsReference(image)}
+                    className="text-indigo-600 hover:text-indigo-800"
+                  >
+                    Use as reference
+                  </button>
+                )}
+              </div>
             </figcaption>
           </figure>
         ))}

--- a/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
+++ b/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
@@ -6,6 +6,8 @@ export interface IPromptPanelProps {
   readonly provider: AiAssist.AiProviderId;
   readonly isWorking: boolean;
   readonly canSubmit: boolean;
+  readonly referenceImages: ReadonlyArray<AiAssist.IAiImageAttachment>;
+  readonly onReferenceImagesChange: (next: ReadonlyArray<AiAssist.IAiImageAttachment>) => void;
   readonly onGenerate: (params: AiAssist.IAiImageGenerationParams) => Promise<void>;
   readonly onAbort: () => void;
 }
@@ -20,8 +22,25 @@ const IMAGEN_ASPECT_RATIOS: ReadonlyArray<
   NonNullable<NonNullable<AiAssist.IAiImageGenerationOptions['imagen']>['aspectRatio']>
 > = ['1:1', '3:4', '4:3', '9:16', '16:9'];
 
+const ACCEPTED_REF_MIME_TYPES = 'image/png,image/jpeg,image/webp';
+
+async function fileToAttachment(file: File): Promise<AiAssist.IAiImageAttachment> {
+  const dataUrl: string = await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error('failed to read file'));
+    reader.readAsDataURL(file);
+  });
+  // dataUrl is like `data:<mime>;base64,<data>`; split into mime + raw base64
+  const commaIdx = dataUrl.indexOf(',');
+  const header = dataUrl.slice(5, dataUrl.indexOf(';'));
+  const base64 = dataUrl.slice(commaIdx + 1);
+  return { mimeType: header || file.type || 'application/octet-stream', base64 };
+}
+
 export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
-  const { provider, isWorking, canSubmit, onGenerate, onAbort } = props;
+  const { provider, isWorking, canSubmit, referenceImages, onReferenceImagesChange, onGenerate, onAbort } =
+    props;
 
   const [prompt, setPrompt] = useState('A friendly robot painting a watercolor landscape');
   const [count, setCount] = useState(1);
@@ -29,10 +48,9 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
   const [aspectRatio, setAspectRatio] =
     useState<NonNullable<NonNullable<AiAssist.IAiImageGenerationOptions['imagen']>['aspectRatio']>>('1:1');
 
-  const imageFormat = useMemo(
-    () => AiAssist.getProviderDescriptor(provider).orDefault()?.imageApiFormat,
-    [provider]
-  );
+  const descriptor = useMemo(() => AiAssist.getProviderDescriptor(provider).orDefault(), [provider]);
+  const imageFormat = descriptor?.imageApiFormat;
+  const acceptsRefs = descriptor?.acceptsImageReferenceInput === true;
 
   const isImagen = imageFormat === 'gemini-imagen';
   const supportsSize = imageFormat === 'openai-images';
@@ -47,7 +65,27 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
       ...(supportsSize ? { size } : {}),
       ...(isImagen ? { imagen: { aspectRatio } } : {})
     };
-    void onGenerate({ prompt, options });
+    void onGenerate({
+      prompt,
+      options,
+      ...(acceptsRefs && referenceImages.length > 0 ? { referenceImages } : {})
+    });
+  };
+
+  const handleAddRefs = async (files: FileList | null): Promise<void> => {
+    if (!files || files.length === 0) {
+      return;
+    }
+    const added = await Promise.all(Array.from(files).map(fileToAttachment));
+    onReferenceImagesChange([...referenceImages, ...added]);
+  };
+
+  const handleRemoveRef = (index: number): void => {
+    onReferenceImagesChange(referenceImages.filter((_, i) => i !== index));
+  };
+
+  const handleClearRefs = (): void => {
+    onReferenceImagesChange([]);
   };
 
   return (
@@ -65,6 +103,62 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
             disabled={isWorking}
           />
         </label>
+
+        {acceptsRefs && (
+          <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-slate-700">
+                Reference images{' '}
+                <span className="font-normal text-slate-500">
+                  ({referenceImages.length} attached) — preserve a character or style across generations
+                </span>
+              </span>
+              {referenceImages.length > 0 && (
+                <button
+                  type="button"
+                  onClick={handleClearRefs}
+                  disabled={isWorking}
+                  className="text-xs font-medium text-slate-600 hover:text-slate-900 disabled:opacity-50"
+                >
+                  Clear all
+                </button>
+              )}
+            </div>
+            <input
+              type="file"
+              accept={ACCEPTED_REF_MIME_TYPES}
+              multiple
+              disabled={isWorking}
+              className="mt-2 block w-full text-sm text-slate-600 file:mr-3 file:rounded-md file:border-0 file:bg-indigo-50 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-indigo-700 hover:file:bg-indigo-100"
+              onChange={(e) => {
+                void handleAddRefs(e.target.files);
+                e.target.value = '';
+              }}
+            />
+            {referenceImages.length > 0 && (
+              <ul className="mt-3 flex flex-wrap gap-2">
+                {referenceImages.map((ref, idx) => (
+                  <li key={idx} className="relative">
+                    <img
+                      src={AiAssist.toDataUrl(ref)}
+                      alt={`Reference ${idx + 1}`}
+                      className="h-16 w-16 rounded-md border border-slate-300 object-cover shadow-sm"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveRef(idx)}
+                      disabled={isWorking}
+                      aria-label={`Remove reference image ${idx + 1}`}
+                      className="absolute -right-1.5 -top-1.5 inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 bg-white text-xs text-slate-700 shadow-sm hover:bg-slate-100 disabled:opacity-50"
+                    >
+                      ×
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
 
         <div className="grid gap-4 md:grid-cols-3">
           <label className="block text-sm">


### PR DESCRIPTION
Adds optional `referenceImages` to image-generation requests so consumers can preserve a character or style across multiple generations.

- New `gemini-image-out` AiImageApiFormat for Gemini 2.5 Flash Image ("Nano Banana") via :generateContent. Built-in google-gemini provider switched from imagen-3.0-generate-002 (text-only :predict) to the new format with default model gemini-2.5-flash-image.
- OpenAI provider routes to /v1/images/edits (multipart) when refs are present, /v1/images/generations (JSON) otherwise.
- Per-provider acceptsImageReferenceInput descriptor flag with up-front rejection for providers that don't declare support (mirrors the chat acceptsImageInput pattern).
- Sample app (ai-image-gen-sample) demonstrates the feature: file picker for refs, thumbnail strip with remove buttons, and a "Use as reference" button on results to anchor character consistency across iterations.

https://claude.ai/code/session_01FgrPVyiHQ9DzpTPJjQ2imx