### PR TITLE
ts-extras(ai-assist): add reference-image support to image generation 

### DIFF
--- a/common/changes/@fgv/ts-app-shell/reference-images_2026-04-27-16-57.json
+++ b/common/changes/@fgv/ts-app-shell/reference-images_2026-04-27-16-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-app-shell",
+      "comment": "understand model limitations wrt reference images",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-app-shell"
+}

--- a/common/changes/@fgv/ts-extras/reference-images_2026-04-27-14-54.json
+++ b/common/changes/@fgv/ts-extras/reference-images_2026-04-27-14-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add reference image support to ai-assist",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/libraries/ts-app-shell/src/packlets/ai-assist/useAiAssist.ts
+++ b/libraries/ts-app-shell/src/packlets/ai-assist/useAiAssist.ts
@@ -378,7 +378,7 @@ export function useAiAssist(params: IUseAiAssistParams): IUseAiAssistResult {
       }
       const descriptor = descriptorResult.value;
 
-      if (descriptor.imageApiFormat === undefined) {
+      if (!AiAssist.supportsImageGeneration(descriptor)) {
         return fail(`Provider "${provider}" does not support image generation`);
       }
 

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -33,6 +33,7 @@ declare namespace AiAssist {
         IChatMessage,
         AiApiFormat,
         AiImageApiFormat,
+        IAiImageModelCapability,
         IAiProviderDescriptor,
         IAiAssistProviderConfig,
         IAiAssistSettings,
@@ -62,6 +63,8 @@ declare namespace AiAssist {
         allProviderIds,
         getProviderDescriptors,
         getProviderDescriptor,
+        resolveImageCapability,
+        supportsImageGeneration,
         DEFAULT_MODEL_CAPABILITY_CONFIG,
         callProviderCompletion,
         callProxiedCompletion,
@@ -184,6 +187,8 @@ function callProviderCompletion(params: IProviderCompletionParams): Promise<Resu
 // @public
 function callProviderCompletionStream(params: IProviderCompletionStreamParams): Promise<Result<AsyncIterable<IAiStreamEvent>>>;
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiImageModelCapability"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiProviderDescriptor"
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "ModelSpecKey"
 //
 // @public
@@ -621,6 +626,16 @@ interface IAiImageGenerationResponse {
     readonly images: ReadonlyArray<IAiGeneratedImage>;
 }
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiProviderDescriptor"
+//
+// @public
+interface IAiImageModelCapability {
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly acceptsImageReferenceInput?: boolean;
+    readonly format: AiImageApiFormat;
+    readonly modelPrefix: string;
+}
+
 // @public
 interface IAiModelCapabilityConfig {
     readonly global?: ReadonlyArray<IAiModelCapabilityRule>;
@@ -649,8 +664,6 @@ interface IAiModelInfo {
 // @public
 interface IAiProviderDescriptor {
     readonly acceptsImageInput: boolean;
-    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-    readonly acceptsImageReferenceInput?: boolean;
     readonly apiFormat: AiApiFormat;
     readonly baseUrl: string;
     readonly buttonLabel: string;
@@ -658,7 +671,7 @@ interface IAiProviderDescriptor {
     readonly defaultModel: ModelSpec;
     readonly id: AiProviderId;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "ModelSpecKey"
-    readonly imageApiFormat?: AiImageApiFormat;
+    readonly imageGeneration?: ReadonlyArray<IAiImageModelCapability>;
     readonly label: string;
     readonly needsSecret: boolean;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiProviderDescriptor"
@@ -1484,6 +1497,11 @@ export { RecordJar }
 // @public
 function resolveEffectiveTools(descriptor: IAiProviderDescriptor, settingsTools?: ReadonlyArray<IAiToolEnablement>, perCallTools?: ReadonlyArray<AiServerToolConfig>): ReadonlyArray<AiServerToolConfig>;
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiProviderDescriptor"
+//
+// @public
+function resolveImageCapability(descriptor: IAiProviderDescriptor, modelId: string): IAiImageModelCapability | undefined;
+
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "ModelSpec"
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "MODEL_SPEC_BASE_KEY"
 //
@@ -1492,6 +1510,11 @@ function resolveModel(spec: ModelSpec, context?: string): string;
 
 // @public
 type SecretProvider = (secretName: string) => Promise<Result<Uint8Array>>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiProviderDescriptor"
+//
+// @public
+function supportsImageGeneration(descriptor: IAiProviderDescriptor): boolean;
 
 // @public
 function templateString(defaultContext?: unknown): Conversion.StringConverter<string, unknown>;

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -670,6 +670,7 @@ interface IAiProviderDescriptor {
     readonly corsRestricted: boolean;
     readonly defaultModel: ModelSpec;
     readonly id: AiProviderId;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "ModelSpecKey"
     readonly imageGeneration?: ReadonlyArray<IAiImageModelCapability>;
     readonly label: string;

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -100,7 +100,7 @@ const aiAssistProviderConfig: Converter<IAiAssistProviderConfig>;
 const aiAssistSettings: Converter<IAiAssistSettings>;
 
 // @public
-type AiImageApiFormat = 'openai-images' | 'gemini-imagen' | 'xai-images';
+type AiImageApiFormat = 'openai-images' | 'gemini-imagen' | 'xai-images' | 'gemini-image-out';
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
@@ -610,6 +610,8 @@ interface IAiImageGenerationOptions {
 interface IAiImageGenerationParams {
     readonly options?: IAiImageGenerationOptions;
     readonly prompt: string;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly referenceImages?: ReadonlyArray<IAiImageAttachment>;
 }
 
 // @public
@@ -645,6 +647,8 @@ interface IAiModelInfo {
 // @public
 interface IAiProviderDescriptor {
     readonly acceptsImageInput: boolean;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly acceptsImageReferenceInput?: boolean;
     readonly apiFormat: AiApiFormat;
     readonly baseUrl: string;
     readonly buttonLabel: string;

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -32,7 +32,7 @@
  */
 
 import { isJsonObject, type JsonObject } from '@fgv/ts-json-base';
-import { fail, type Logging, Result, succeed, type Validator, Validators } from '@fgv/ts-utils';
+import { fail, type Logging, mapResults, Result, succeed, type Validator, Validators } from '@fgv/ts-utils';
 
 import {
   AiPrompt,
@@ -226,17 +226,43 @@ async function fetchMultipart(
 }
 
 /**
+ * Decodes a base64 string into bytes in a runtime-agnostic way: `Buffer` in
+ * Node, `atob` in browsers. Returns a failure (rather than throwing) on
+ * invalid input so callers can surface the error through the `Result`
+ * contract.
+ * @internal
+ */
+function decodeBase64ToBytes(base64: string): Result<Uint8Array<ArrayBuffer>> {
+  try {
+    if (typeof Buffer !== 'undefined') {
+      const buf = Buffer.from(base64, 'base64');
+      const bytes = new Uint8Array(buf.length);
+      bytes.set(buf);
+      return succeed(bytes);
+    }
+    /* c8 ignore start - Browser-only fallback cannot be tested in Node.js environment */
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return succeed(bytes);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return fail(`Invalid base64: ${message}`);
+  }
+  /* c8 ignore stop */
+}
+
+/**
  * Decodes a base64-encoded image attachment into a `Blob` suitable for use as
  * a multipart file field.
  * @internal
  */
-function attachmentToBlob(attachment: IAiImageAttachment): Blob {
-  const binary = atob(attachment.base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return new Blob([bytes], { type: attachment.mimeType });
+function attachmentToBlob(attachment: IAiImageAttachment): Result<Blob> {
+  return decodeBase64ToBytes(attachment.base64).onSuccess((bytes) =>
+    succeed(new Blob([bytes], { type: attachment.mimeType }))
+  );
 }
 
 /**
@@ -1041,7 +1067,7 @@ function callOpenAiImagesGenerations(
  * Builds and posts the multipart `/images/edits` request (with refs).
  * @internal
  */
-function callOpenAiImagesEdits(
+async function callOpenAiImagesEdits(
   config: IAiApiConfig,
   request: IAiImageGenerationParams,
   headers: Record<string, string>,
@@ -1050,19 +1076,28 @@ function callOpenAiImagesEdits(
   logger?: Logging.ILogger,
   signal?: AbortSignal
 ): Promise<Result<JsonObject>> {
+  const blobsResult = mapResults(
+    refs.map((ref, i) => attachmentToBlob(ref).withErrorFormat((msg) => `reference image ${i}: ${msg}`))
+  );
+  /* c8 ignore next 3 - decode failure unreachable via Node's Buffer.from (silently strips invalid input) */
+  if (blobsResult.isFailure()) {
+    return fail(blobsResult.message);
+  }
+
   const opts: IAiImageGenerationOptions = request.options ?? {};
   const form = new FormData();
   form.append('model', config.model);
   form.append('prompt', request.prompt);
   form.append('n', String(n));
+  form.append('response_format', 'b64_json');
   if (opts.size !== undefined) {
     form.append('size', opts.size);
   }
   if (opts.quality !== undefined) {
     form.append('quality', opts.quality);
   }
-  refs.forEach((ref, i) => {
-    form.append('image[]', attachmentToBlob(ref), `ref-${i}.${extensionForMimeType(ref.mimeType)}`);
+  blobsResult.value.forEach((blob, i) => {
+    form.append('image[]', blob, `ref-${i}.${extensionForMimeType(refs[i].mimeType)}`);
   });
   /* c8 ignore next 1 - optional logger */
   logger?.info(`Image edit: model=${config.model}, n=${n}, refs=${refs.length}`);

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -40,6 +40,7 @@ import {
   type AiServerToolConfig,
   type IAiCompletionResponse,
   type IAiGeneratedImage,
+  type IAiImageAttachment,
   type IAiImageGenerationOptions,
   type IAiImageGenerationParams,
   type IAiImageGenerationResponse,
@@ -164,6 +165,98 @@ async function fetchJson(
     return fail('AI API returned non-object JSON response');
   }
   return succeed(json);
+}
+
+/**
+ * Makes a multipart/form-data POST request and returns the parsed JSON, or a
+ * failure. The Content-Type header (with boundary) is set automatically by
+ * `fetch` from the `FormData` body — callers must NOT pass it explicitly.
+ * @internal
+ */
+async function fetchMultipart(
+  url: string,
+  headers: Record<string, string>,
+  body: FormData,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<JsonObject>> {
+  /* c8 ignore next 1 - optional logger */
+  logger?.detail(`AI API request: POST ${url} (multipart)`);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body,
+      signal
+    });
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    /* c8 ignore next 1 - optional logger */
+    logger?.error(`AI API request failed: ${detail}`);
+    return fail(`AI API request failed: ${detail}`);
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'unknown error');
+    /* c8 ignore next 1 - optional logger */
+    logger?.error(`AI API returned ${response.status}: ${errorText}`);
+    return fail(`AI API returned ${response.status}: ${errorText}`);
+  }
+
+  /* c8 ignore next 1 - optional logger */
+  logger?.detail(`AI API response: ${response.status}`);
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    /* c8 ignore next 1 - optional logger */
+    logger?.error('AI API returned invalid JSON response');
+    return fail('AI API returned invalid JSON response');
+  }
+
+  if (!isJsonObject(json)) {
+    /* c8 ignore next 1 - optional logger */
+    logger?.error('AI API returned non-object JSON response');
+    return fail('AI API returned non-object JSON response');
+  }
+  return succeed(json);
+}
+
+/**
+ * Decodes a base64-encoded image attachment into a `Blob` suitable for use as
+ * a multipart file field.
+ * @internal
+ */
+function attachmentToBlob(attachment: IAiImageAttachment): Blob {
+  const binary = atob(attachment.base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: attachment.mimeType });
+}
+
+/**
+ * Maps a MIME type to a sensible file extension for multipart filenames.
+ * @internal
+ */
+function extensionForMimeType(mimeType: string): string {
+  switch (mimeType) {
+    case 'image/png':
+      return 'png';
+    case 'image/jpeg':
+    case 'image/jpg':
+      return 'jpg';
+    case 'image/webp':
+      return 'webp';
+    case 'image/gif':
+      return 'gif';
+    default:
+      return 'bin';
+  }
 }
 
 /**
@@ -768,6 +861,54 @@ const imagenResponse: Validator<IImagenResponse> = Validators.object<IImagenResp
   predictions: Validators.arrayOf(imagenPrediction).withConstraint((arr) => arr.length > 0)
 });
 
+// ---- Gemini image-out (`:generateContent` returning image parts) format ----
+
+/** @internal */
+interface IGeminiImageInlineData {
+  mimeType: string;
+  data: string;
+}
+/** @internal */
+interface IGeminiImageOutPart {
+  text?: string;
+  inlineData?: IGeminiImageInlineData;
+}
+/** @internal */
+interface IGeminiImageOutContent {
+  parts: IGeminiImageOutPart[];
+}
+/** @internal */
+interface IGeminiImageOutCandidate {
+  content: IGeminiImageOutContent;
+  finishReason?: string;
+}
+/** @internal */
+interface IGeminiImageOutResponse {
+  candidates: IGeminiImageOutCandidate[];
+}
+
+const geminiImageInlineData: Validator<IGeminiImageInlineData> = Validators.object<IGeminiImageInlineData>({
+  mimeType: Validators.string,
+  data: Validators.string
+});
+const geminiImageOutPart: Validator<IGeminiImageOutPart> = Validators.object<IGeminiImageOutPart>({
+  text: Validators.string.optional(),
+  inlineData: geminiImageInlineData.optional()
+});
+const geminiImageOutContent: Validator<IGeminiImageOutContent> = Validators.object<IGeminiImageOutContent>({
+  parts: Validators.arrayOf(geminiImageOutPart).withConstraint((arr) => arr.length > 0)
+});
+const geminiImageOutCandidate: Validator<IGeminiImageOutCandidate> =
+  Validators.object<IGeminiImageOutCandidate>({
+    content: geminiImageOutContent,
+    finishReason: Validators.string.optional()
+  });
+const geminiImageOutResponse: Validator<IGeminiImageOutResponse> = Validators.object<IGeminiImageOutResponse>(
+  {
+    candidates: Validators.arrayOf(geminiImageOutCandidate).withConstraint((arr) => arr.length > 0)
+  }
+);
+
 // ---- Proxied image generation response ----
 
 const proxiedGeneratedImage: Validator<IAiGeneratedImage> = Validators.object<IAiGeneratedImage>({
@@ -821,6 +962,11 @@ const proxiedListModelsResponse: Validator<IProxiedListModelsBody> =
  * formats — the request shape is the same; the only difference is whether the
  * `size` field is honored (OpenAI: yes, xAI: ignored at the provider).
  *
+ * When `request.referenceImages` is non-empty, routes to `/images/edits`
+ * (multipart) instead of `/images/generations` (JSON). Per-model edit support
+ * is not validated here (e.g. dall-e-3 does not support edits) — the
+ * provider's 400 surfaces through the failure path.
+ *
  * @internal
  */
 async function callOpenAiImageGeneration(
@@ -830,12 +976,51 @@ async function callOpenAiImageGeneration(
   logger?: Logging.ILogger,
   signal?: AbortSignal
 ): Promise<Result<IAiImageGenerationResponse>> {
-  const url = `${config.baseUrl}/images/generations`;
+  const opts: IAiImageGenerationOptions = request.options ?? {};
+  const refs = request.referenceImages ?? [];
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${config.apiKey}`
+  };
+  const n = opts.count ?? 1;
+
+  const fetched =
+    refs.length > 0
+      ? await callOpenAiImagesEdits(config, request, headers, n, refs, logger, signal)
+      : await callOpenAiImagesGenerations(config, request, headers, n, logger, signal);
+
+  return fetched.onSuccess((json) =>
+    openAiImageResponse
+      .validate(json)
+      .withErrorFormat((msg) => `OpenAI images API response: ${msg}`)
+      .onSuccess((response) =>
+        succeed({
+          images: response.data.map((item) => ({
+            mimeType: defaultMimeType,
+            base64: item.b64_json,
+            ...(item.revised_prompt !== undefined ? { revisedPrompt: item.revised_prompt } : {})
+          }))
+        })
+      )
+  );
+}
+
+/**
+ * Builds and posts the JSON `/images/generations` request (no refs).
+ * @internal
+ */
+function callOpenAiImagesGenerations(
+  config: IAiApiConfig,
+  request: IAiImageGenerationParams,
+  headers: Record<string, string>,
+  n: number,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<JsonObject>> {
   const opts: IAiImageGenerationOptions = request.options ?? {};
   const body: Record<string, unknown> = {
     model: config.model,
     prompt: request.prompt,
-    n: opts.count ?? 1,
+    n,
     response_format: 'b64_json'
   };
   if (opts.size !== undefined) {
@@ -847,28 +1032,93 @@ async function callOpenAiImageGeneration(
   if (opts.seed !== undefined) {
     body.seed = opts.seed;
   }
+  /* c8 ignore next 1 - optional logger */
+  logger?.info(`Image generation: model=${config.model}, n=${n}`);
+  return fetchJson(`${config.baseUrl}/images/generations`, headers, body, logger, signal);
+}
 
+/**
+ * Builds and posts the multipart `/images/edits` request (with refs).
+ * @internal
+ */
+function callOpenAiImagesEdits(
+  config: IAiApiConfig,
+  request: IAiImageGenerationParams,
+  headers: Record<string, string>,
+  n: number,
+  refs: ReadonlyArray<IAiImageAttachment>,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<JsonObject>> {
+  const opts: IAiImageGenerationOptions = request.options ?? {};
+  const form = new FormData();
+  form.append('model', config.model);
+  form.append('prompt', request.prompt);
+  form.append('n', String(n));
+  if (opts.size !== undefined) {
+    form.append('size', opts.size);
+  }
+  if (opts.quality !== undefined) {
+    form.append('quality', opts.quality);
+  }
+  refs.forEach((ref, i) => {
+    form.append('image[]', attachmentToBlob(ref), `ref-${i}.${extensionForMimeType(ref.mimeType)}`);
+  });
+  /* c8 ignore next 1 - optional logger */
+  logger?.info(`Image edit: model=${config.model}, n=${n}, refs=${refs.length}`);
+  return fetchMultipart(`${config.baseUrl}/images/edits`, headers, form, logger, signal);
+}
+
+/**
+ * Calls Gemini's chat-style `:generateContent` endpoint for image output
+ * (Gemini 2.5 Flash Image / "Nano Banana"). Accepts reference images, which
+ * are passed as `inlineData` parts alongside the text prompt.
+ *
+ * @internal
+ */
+async function callGeminiImageOutGeneration(
+  config: IAiApiConfig,
+  request: IAiImageGenerationParams,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<IAiImageGenerationResponse>> {
+  const url = `${config.baseUrl}/models/${config.model}:generateContent`;
+  const refs = request.referenceImages ?? [];
+  const parts: Array<Record<string, unknown>> = [{ text: request.prompt }];
+  for (const ref of refs) {
+    parts.push({ inlineData: { mimeType: ref.mimeType, data: ref.base64 } });
+  }
+  const body: Record<string, unknown> = {
+    contents: [{ role: 'user', parts }]
+  };
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${config.apiKey}`
+    'x-goog-api-key': config.apiKey
   };
 
   /* c8 ignore next 1 - optional logger */
-  logger?.info(`Image generation: model=${config.model}, n=${body.n}`);
-  const jsonResult = await fetchJson(url, headers, body, logger, signal);
-  if (jsonResult.isFailure()) {
-    return fail(jsonResult.message);
-  }
-  return openAiImageResponse
-    .validate(jsonResult.value)
-    .withErrorFormat((msg) => `OpenAI images API response: ${msg}`)
-    .onSuccess((response) => {
-      const images: IAiGeneratedImage[] = response.data.map((item) => ({
-        mimeType: defaultMimeType,
-        base64: item.b64_json,
-        ...(item.revised_prompt !== undefined ? { revisedPrompt: item.revised_prompt } : {})
-      }));
-      return succeed({ images });
-    });
+  logger?.info(`Gemini image-out: model=${config.model}, refs=${refs.length}`);
+  return (await fetchJson(url, headers, body, logger, signal)).onSuccess((json) =>
+    geminiImageOutResponse
+      .validate(json)
+      .withErrorFormat((msg) => `Gemini image API response: ${msg}`)
+      .onSuccess((response) => {
+        const images: IAiGeneratedImage[] = [];
+        for (const candidate of response.candidates) {
+          for (const part of candidate.content.parts) {
+            if (part.inlineData) {
+              images.push({
+                mimeType: part.inlineData.mimeType,
+                base64: part.inlineData.data
+              });
+            }
+          }
+        }
+        if (images.length === 0) {
+          return fail('Gemini image API response: no image parts in response');
+        }
+        return succeed({ images });
+      })
+  );
 }
 
 /**
@@ -933,9 +1183,12 @@ async function callImagenGeneration(
  * Routes based on `descriptor.imageApiFormat`:
  * - `'openai-images'` for OpenAI (DALL-E, gpt-image-1)
  * - `'xai-images'` for xAI Grok image models
- * - `'gemini-imagen'` for Google Imagen
+ * - `'gemini-imagen'` for Google Imagen `:predict`
+ * - `'gemini-image-out'` for Gemini chat-style image output (Nano Banana)
  *
  * Image-model selection reuses the existing `'image'` {@link ModelSpecKey}.
+ * When `request.referenceImages` is non-empty, the call is rejected up front
+ * unless the descriptor declares `acceptsImageReferenceInput`.
  *
  * @param params - Request parameters including descriptor, API key, and prompt
  * @returns The generated images, or a failure
@@ -951,6 +1204,9 @@ export async function callProviderImageGeneration(
   }
   if (!descriptor.baseUrl) {
     return fail(`provider "${descriptor.id}" has no API endpoint configured`);
+  }
+  if ((request.referenceImages?.length ?? 0) > 0 && !descriptor.acceptsImageReferenceInput) {
+    return fail(`provider "${descriptor.id}" does not support reference images for image generation`);
   }
 
   const config: IAiApiConfig = {
@@ -973,6 +1229,8 @@ export async function callProviderImageGeneration(
       return callOpenAiImageGeneration(config, request, 'image/jpeg', logger, signal);
     case 'gemini-imagen':
       return callImagenGeneration(config, request, logger, signal);
+    case 'gemini-image-out':
+      return callGeminiImageOutGeneration(config, request, logger, signal);
     /* c8 ignore next 4 - defensive coding: exhaustive switch guaranteed by TypeScript */
     default: {
       const _exhaustive: never = descriptor.imageApiFormat;
@@ -1481,7 +1739,10 @@ export async function callProxiedCompletion(
  * - Error response body: `{error: string}` (surfaced as `proxy: ${error}`)
  *
  * The proxy server is responsible for descriptor lookup, model resolution,
- * provider dispatch, and response normalization.
+ * provider dispatch, and response normalization. When `params.referenceImages`
+ * is present, the proxy is also responsible for repackaging it into the
+ * upstream wire format (e.g. multipart/form-data for OpenAI `/images/edits`,
+ * `inlineData` parts for Gemini `:generateContent`).
  *
  * @param proxyUrl - Base URL of the proxy server (e.g. `http://localhost:3001`)
  * @param params - Same parameters as {@link callProviderImageGeneration}

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -226,46 +226,32 @@ async function fetchMultipart(
 }
 
 /**
- * Decodes a base64 string into bytes in a runtime-agnostic way: `Buffer` in
- * Node, `atob` in browsers. Wraps decoding in a `Result` so any thrown error
- * (e.g. from `atob` on invalid input) is surfaced as a failure. Note that
- * Node's `Buffer.from(..., 'base64')` does not throw on invalid input — it
- * silently strips unrecognized characters — so failures are only observable
- * in the browser path. Inputs to this function come from `FileReader` or
- * prior provider responses, which are trusted to be valid.
+ * Decodes a base64-encoded image attachment into a `Blob` suitable for use as
+ * a multipart file field. On Node hands the `Buffer` straight to `Blob`
+ * (Buffer extends Uint8Array) to skip an intermediate copy; falls back to
+ * `atob` in browsers. Inputs come from `FileReader` or prior provider
+ * responses, which are trusted to be valid. Note that Node's
+ * `Buffer.from(..., 'base64')` silently strips invalid characters rather
+ * than throwing, so failures are only observable in the browser path.
  * @internal
  */
-function decodeBase64ToBytes(base64: string): Result<Uint8Array<ArrayBuffer>> {
+function attachmentToBlob(attachment: IAiImageAttachment): Result<Blob> {
+  if (typeof Buffer !== 'undefined') {
+    return succeed(new Blob([Buffer.from(attachment.base64, 'base64')], { type: attachment.mimeType }));
+  }
+  /* c8 ignore start - Browser-only fallback cannot be tested in Node.js environment */
   try {
-    if (typeof Buffer !== 'undefined') {
-      const buf = Buffer.from(base64, 'base64');
-      const bytes = new Uint8Array(buf.length);
-      bytes.set(buf);
-      return succeed(bytes);
-    }
-    /* c8 ignore start - Browser-only fallback cannot be tested in Node.js environment */
-    const binary = atob(base64);
+    const binary = atob(attachment.base64);
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) {
       bytes[i] = binary.charCodeAt(i);
     }
-    return succeed(bytes);
+    return succeed(new Blob([bytes], { type: attachment.mimeType }));
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     return fail(`Invalid base64: ${message}`);
   }
   /* c8 ignore stop */
-}
-
-/**
- * Decodes a base64-encoded image attachment into a `Blob` suitable for use as
- * a multipart file field.
- * @internal
- */
-function attachmentToBlob(attachment: IAiImageAttachment): Result<Blob> {
-  return decodeBase64ToBytes(attachment.base64).onSuccess((bytes) =>
-    succeed(new Blob([bytes], { type: attachment.mimeType }))
-  );
 }
 
 /**

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -1270,8 +1270,21 @@ export async function callProviderImageGeneration(
       return callOpenAiImageGeneration(config, request, 'image/jpeg', logger, signal);
     case 'gemini-imagen':
       return callImagenGeneration(config, request, logger, signal);
-    case 'gemini-image-out':
+    case 'gemini-image-out': {
+      // Google's Gemini provider hosts two distinct image surfaces under a
+      // single baseUrl: `gemini-2.5-flash-image` via chat-style
+      // `:generateContent` (accepts reference images) and the `imagen-*`
+      // family via predict-only `:predict` (no reference images). The
+      // descriptor's `imageApiFormat` is per-provider, so dispatch by the
+      // resolved model name to pick the right endpoint.
+      if (config.model.startsWith('imagen-')) {
+        if ((request.referenceImages?.length ?? 0) > 0) {
+          return fail(`model "${config.model}" does not support reference images`);
+        }
+        return callImagenGeneration(config, request, logger, signal);
+      }
       return callGeminiImageOutGeneration(config, request, logger, signal);
+    }
     /* c8 ignore next 4 - defensive coding: exhaustive switch guaranteed by TypeScript */
     default: {
       const _exhaustive: never = descriptor.imageApiFormat;

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -59,7 +59,7 @@ import {
   buildOpenAiChatUserContent,
   buildOpenAiResponsesUserContent
 } from './chatRequestBuilders';
-import { DEFAULT_MODEL_CAPABILITY_CONFIG } from './registry';
+import { DEFAULT_MODEL_CAPABILITY_CONFIG, resolveImageCapability, supportsImageGeneration } from './registry';
 import { toAnthropicTools, toGeminiTools, toResponsesApiTools } from './toolFormats';
 
 // ============================================================================
@@ -1221,7 +1221,9 @@ async function callImagenGeneration(
 /**
  * Calls the appropriate image-generation API for a given provider.
  *
- * Routes based on `descriptor.imageApiFormat`:
+ * Resolves a {@link IAiImageModelCapability} from
+ * {@link IAiProviderDescriptor.imageGeneration} for the requested model and
+ * routes by its `format`:
  * - `'openai-images'` for OpenAI (DALL-E, gpt-image-1)
  * - `'xai-images'` for xAI Grok image models
  * - `'gemini-imagen'` for Google Imagen `:predict`
@@ -1229,7 +1231,7 @@ async function callImagenGeneration(
  *
  * Image-model selection reuses the existing `'image'` {@link ModelSpecKey}.
  * When `request.referenceImages` is non-empty, the call is rejected up front
- * unless the descriptor declares `acceptsImageReferenceInput`.
+ * unless the resolved capability declares `acceptsImageReferenceInput`.
  *
  * @param params - Request parameters including descriptor, API key, and prompt
  * @returns The generated images, or a failure
@@ -1240,54 +1242,47 @@ export async function callProviderImageGeneration(
 ): Promise<Result<IAiImageGenerationResponse>> {
   const { descriptor, apiKey, params: request, modelOverride, logger, signal } = params;
 
-  if (descriptor.imageApiFormat === undefined) {
+  if (!supportsImageGeneration(descriptor)) {
     return fail(`provider "${descriptor.id}" does not support image generation`);
   }
   if (!descriptor.baseUrl) {
     return fail(`provider "${descriptor.id}" has no API endpoint configured`);
   }
-  if ((request.referenceImages?.length ?? 0) > 0 && !descriptor.acceptsImageReferenceInput) {
-    return fail(`provider "${descriptor.id}" does not support reference images for image generation`);
+
+  const model = resolveModel(modelOverride ?? descriptor.defaultModel, 'image');
+  const capability = resolveImageCapability(descriptor, model);
+  if (capability === undefined) {
+    return fail(`provider "${descriptor.id}" does not support image generation for model "${model}"`);
+  }
+  if ((request.referenceImages?.length ?? 0) > 0 && !capability.acceptsImageReferenceInput) {
+    return fail(`model "${model}" does not support reference images`);
   }
 
   const config: IAiApiConfig = {
     baseUrl: descriptor.baseUrl,
     apiKey,
-    model: resolveModel(modelOverride ?? descriptor.defaultModel, 'image')
+    model
   };
   /* c8 ignore next 6 - optional logger diagnostic output */
   if (logger) {
     logger.info(
-      `AI image generation: provider=${descriptor.id}, format=${descriptor.imageApiFormat}, ` +
+      `AI image generation: provider=${descriptor.id}, format=${capability.format}, ` +
         `model=${config.model}`
     );
   }
 
-  switch (descriptor.imageApiFormat) {
+  switch (capability.format) {
     case 'openai-images':
       return callOpenAiImageGeneration(config, request, 'image/png', logger, signal);
     case 'xai-images':
       return callOpenAiImageGeneration(config, request, 'image/jpeg', logger, signal);
     case 'gemini-imagen':
       return callImagenGeneration(config, request, logger, signal);
-    case 'gemini-image-out': {
-      // Google's Gemini provider hosts two distinct image surfaces under a
-      // single baseUrl: `gemini-2.5-flash-image` via chat-style
-      // `:generateContent` (accepts reference images) and the `imagen-*`
-      // family via predict-only `:predict` (no reference images). The
-      // descriptor's `imageApiFormat` is per-provider, so dispatch by the
-      // resolved model name to pick the right endpoint.
-      if (config.model.startsWith('imagen-')) {
-        if ((request.referenceImages?.length ?? 0) > 0) {
-          return fail(`model "${config.model}" does not support reference images`);
-        }
-        return callImagenGeneration(config, request, logger, signal);
-      }
+    case 'gemini-image-out':
       return callGeminiImageOutGeneration(config, request, logger, signal);
-    }
     /* c8 ignore next 4 - defensive coding: exhaustive switch guaranteed by TypeScript */
     default: {
-      const _exhaustive: never = descriptor.imageApiFormat;
+      const _exhaustive: never = capability.format;
       return fail(`unsupported image API format: ${String(_exhaustive)}`);
     }
   }

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -227,9 +227,12 @@ async function fetchMultipart(
 
 /**
  * Decodes a base64 string into bytes in a runtime-agnostic way: `Buffer` in
- * Node, `atob` in browsers. Returns a failure (rather than throwing) on
- * invalid input so callers can surface the error through the `Result`
- * contract.
+ * Node, `atob` in browsers. Wraps decoding in a `Result` so any thrown error
+ * (e.g. from `atob` on invalid input) is surfaced as a failure. Note that
+ * Node's `Buffer.from(..., 'base64')` does not throw on invalid input — it
+ * silently strips unrecognized characters — so failures are only observable
+ * in the browser path. Inputs to this function come from `FileReader` or
+ * prior provider responses, which are trusted to be valid.
  * @internal
  */
 function decodeBase64ToBytes(base64: string): Result<Uint8Array<ArrayBuffer>> {
@@ -1095,6 +1098,9 @@ async function callOpenAiImagesEdits(
   }
   if (opts.quality !== undefined) {
     form.append('quality', opts.quality);
+  }
+  if (opts.seed !== undefined) {
+    form.append('seed', String(opts.seed));
   }
   blobsResult.value.forEach((blob, i) => {
     form.append('image[]', blob, `ref-${i}.${extensionForMimeType(refs[i].mimeType)}`);

--- a/libraries/ts-extras/src/packlets/ai-assist/index.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/index.ts
@@ -15,6 +15,7 @@ export {
   type IChatMessage,
   type AiApiFormat,
   type AiImageApiFormat,
+  type IAiImageModelCapability,
   type IAiProviderDescriptor,
   type IAiAssistProviderConfig,
   type IAiAssistSettings,
@@ -47,6 +48,8 @@ export {
   allProviderIds,
   getProviderDescriptors,
   getProviderDescriptor,
+  resolveImageCapability,
+  supportsImageGeneration,
   DEFAULT_MODEL_CAPABILITY_CONFIG
 } from './registry';
 

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -300,9 +300,20 @@ export type AiApiFormat = 'openai' | 'anthropic' | 'gemini';
 
 /**
  * API format categories for image-generation provider routing.
+ *
+ * @remarks
+ * - `'openai-images'` — OpenAI Images API. Routes to `/images/generations`
+ *   (text-only) or `/images/edits` (when reference images are present).
+ * - `'xai-images'` — xAI Images API. Same wire shape as OpenAI but text-only;
+ *   no reference-image support on grok-2-image.
+ * - `'gemini-imagen'` — Google Imagen `:predict` endpoint. Text-only.
+ * - `'gemini-image-out'` — Google Gemini chat-style `:generateContent`
+ *   endpoint that returns image parts (Gemini 2.5 Flash Image / "Nano
+ *   Banana"). Accepts reference images.
+ *
  * @public
  */
-export type AiImageApiFormat = 'openai-images' | 'gemini-imagen' | 'xai-images';
+export type AiImageApiFormat = 'openai-images' | 'gemini-imagen' | 'xai-images' | 'gemini-image-out';
 
 // ============================================================================
 // Completion Response
@@ -439,6 +450,17 @@ export interface IAiProviderDescriptor {
    * `defaultModel.image`, e.g. `{ base: 'gpt-4o', image: 'dall-e-3' }`.
    */
   readonly imageApiFormat?: AiImageApiFormat;
+  /**
+   * Whether this provider's image-generation API accepts reference images
+   * via {@link AiAssist.IAiImageGenerationParams.referenceImages}. When false
+   * (or undefined), calls that include reference images are rejected up front.
+   *
+   * @remarks
+   * The flag is provider-wide; per-model constraints (e.g. dall-e-3 ignores
+   * edits) are not validated by the library and surface as provider 400s,
+   * consistent with the existing image-generation policy.
+   */
+  readonly acceptsImageReferenceInput?: boolean;
 }
 
 // ============================================================================
@@ -493,6 +515,14 @@ export interface IAiImageGenerationParams {
   readonly prompt: string;
   /** Optional generation options. */
   readonly options?: IAiImageGenerationOptions;
+  /**
+   * Optional reference images. When present, the provider will use them as
+   * visual context (e.g. to preserve a character's appearance across multiple
+   * generations). Providers that do not declare
+   * {@link AiAssist.IAiProviderDescriptor.acceptsImageReferenceInput} reject
+   * the call up front. An empty array is treated identically to `undefined`.
+   */
+  readonly referenceImages?: ReadonlyArray<IAiImageAttachment>;
 }
 
 /**

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -445,10 +445,10 @@ export interface IAiProviderDescriptor {
    * undefined means the provider does not support image generation.
    *
    * @remarks
-   * Rules are evaluated in order against the resolved image model id; the
-   * first whose `modelPrefix` matches wins. An empty `modelPrefix` is the
-   * catch-all (matches every model id) and must come last among entries that
-   * could otherwise overlap.
+   * The dispatcher matches the resolved model id against each rule's
+   * `modelPrefix` and selects the longest match (see
+   * {@link AiAssist.resolveImageCapability}). An empty `modelPrefix` is the
+   * catch-all and matches every model id.
    *
    * Multiple entries support providers that host more than one image-API
    * surface under one baseUrl. Google Gemini is the canonical case: the
@@ -473,7 +473,9 @@ export interface IAiProviderDescriptor {
 export interface IAiImageModelCapability {
   /**
    * Prefix matched against the resolved image model id. The empty string is
-   * the catch-all and matches every model.
+   * the catch-all and matches every model. When multiple rules' prefixes
+   * match a model id, the longest prefix wins; ties are broken by
+   * first-encountered.
    */
   readonly modelPrefix: string;
   /** API format used to dispatch requests for matching models. */

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -441,24 +441,52 @@ export interface IAiProviderDescriptor {
    */
   readonly acceptsImageInput: boolean;
   /**
-   * Which image-generation API format this provider uses, or undefined if it
-   * does not support image generation.
+   * Image-generation capabilities, scoped to model id prefixes. Empty or
+   * undefined means the provider does not support image generation.
    *
    * @remarks
+   * Rules are evaluated in order against the resolved image model id; the
+   * first whose `modelPrefix` matches wins. An empty `modelPrefix` is the
+   * catch-all (matches every model id) and must come last among entries that
+   * could otherwise overlap.
+   *
+   * Multiple entries support providers that host more than one image-API
+   * surface under one baseUrl. Google Gemini is the canonical case: the
+   * `imagen-*` family is predict-only via `:predict`, while
+   * `gemini-2.5-flash-image` uses chat-style `:generateContent` and accepts
+   * reference images. Listing both lets callers pick the right model and the
+   * dispatcher routes accordingly.
+   *
    * Image-model selection reuses the existing `image` {@link ModelSpecKey}.
-   * Providers with `imageApiFormat` set should declare a model in
+   * Providers that declare `imageGeneration` should declare a model in
    * `defaultModel.image`, e.g. `{ base: 'gpt-4o', image: 'dall-e-3' }`.
    */
-  readonly imageApiFormat?: AiImageApiFormat;
+  readonly imageGeneration?: ReadonlyArray<IAiImageModelCapability>;
+}
+
+/**
+ * Image-generation capability for a model family within a provider. Used as
+ * an entry in {@link IAiProviderDescriptor.imageGeneration}.
+ *
+ * @public
+ */
+export interface IAiImageModelCapability {
   /**
-   * Whether this provider's image-generation API accepts reference images
-   * via {@link AiAssist.IAiImageGenerationParams.referenceImages}. When false
-   * (or undefined), calls that include reference images are rejected up front.
+   * Prefix matched against the resolved image model id. The empty string is
+   * the catch-all and matches every model.
+   */
+  readonly modelPrefix: string;
+  /** API format used to dispatch requests for matching models. */
+  readonly format: AiImageApiFormat;
+  /**
+   * Whether matching models accept reference images via
+   * {@link AiAssist.IAiImageGenerationParams.referenceImages}. When false or
+   * undefined, calls that include reference images are rejected up front.
    *
    * @remarks
-   * The flag is provider-wide; per-model constraints (e.g. dall-e-3 ignores
-   * edits) are not validated by the library and surface as provider 400s,
-   * consistent with the existing image-generation policy.
+   * Per-model constraints beyond ref support (e.g. dall-e-3 ignores edits)
+   * are not validated here and surface as provider 400s, consistent with the
+   * existing image-generation policy.
    */
   readonly acceptsImageReferenceInput?: boolean;
 }
@@ -518,9 +546,11 @@ export interface IAiImageGenerationParams {
   /**
    * Optional reference images. When present, the provider will use them as
    * visual context (e.g. to preserve a character's appearance across multiple
-   * generations). Providers that do not declare
-   * {@link AiAssist.IAiProviderDescriptor.acceptsImageReferenceInput} reject
-   * the call up front. An empty array is treated identically to `undefined`.
+   * generations). The dispatcher resolves the
+   * {@link AiAssist.IAiImageModelCapability} for the requested model and
+   * rejects the call up front if `acceptsImageReferenceInput` is not set on
+   * the matching capability. An empty array is treated identically to
+   * `undefined`.
    */
   readonly referenceImages?: ReadonlyArray<IAiImageAttachment>;
 }

--- a/libraries/ts-extras/src/packlets/ai-assist/registry.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/registry.ts
@@ -80,8 +80,8 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     streamingCorsRestricted: false,
     acceptsImageInput: true,
     imageGeneration: [
-      // Imagen models are predict-only and do not accept reference images.
-      // Order matters: the more specific prefix must come before the catch-all.
+      // imagen-* models are predict-only and do not accept reference images;
+      // everything else uses chat-style :generateContent with refs.
       { modelPrefix: 'imagen-', format: 'gemini-imagen' },
       { modelPrefix: '', format: 'gemini-image-out', acceptsImageReferenceInput: true }
     ]
@@ -124,7 +124,14 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: true,
-    imageGeneration: [{ modelPrefix: '', format: 'openai-images', acceptsImageReferenceInput: true }]
+    imageGeneration: [
+      // gpt-image-1 supports /images/edits with reference images. dall-e-3
+      // (the default image model) does not, so the catch-all rule omits
+      // acceptsImageReferenceInput; callers selecting dall-e-3 with refs hit
+      // the up-front rejection rather than a provider 400.
+      { modelPrefix: 'gpt-image-', format: 'openai-images', acceptsImageReferenceInput: true },
+      { modelPrefix: '', format: 'openai-images' }
+    ]
   },
   {
     id: 'xai-grok',
@@ -201,9 +208,11 @@ export function supportsImageGeneration(descriptor: IAiProviderDescriptor): bool
 
 /**
  * Resolve the image-generation capability that applies to a given model id
- * for a provider. Walks {@link IAiProviderDescriptor.imageGeneration} in
- * order and returns the first entry whose `modelPrefix` is a prefix of
- * `modelId` (the empty prefix matches everything).
+ * for a provider. Returns the entry from
+ * {@link IAiProviderDescriptor.imageGeneration} whose `modelPrefix` is the
+ * longest prefix of `modelId`. Ties are broken by first-encountered, so rule
+ * order does not matter for correctness — only for tie-breaking among rules
+ * with identical-length prefixes (an unusual case).
  *
  * @param descriptor - The provider descriptor
  * @param modelId - The resolved image model id
@@ -215,7 +224,12 @@ export function resolveImageCapability(
   descriptor: IAiProviderDescriptor,
   modelId: string
 ): IAiImageModelCapability | undefined {
-  return descriptor.imageGeneration?.find((cap) => modelId.startsWith(cap.modelPrefix));
+  return (descriptor.imageGeneration ?? [])
+    .filter((cap) => modelId.startsWith(cap.modelPrefix))
+    .reduce<IAiImageModelCapability | undefined>(
+      (best, cap) => (best && best.modelPrefix.length >= cap.modelPrefix.length ? best : cap),
+      undefined
+    );
 }
 
 // ============================================================================

--- a/libraries/ts-extras/src/packlets/ai-assist/registry.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/registry.ts
@@ -69,12 +69,13 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     needsSecret: true,
     apiFormat: 'gemini',
     baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
-    defaultModel: { base: 'gemini-2.5-flash', image: 'imagen-3.0-generate-002' },
+    defaultModel: { base: 'gemini-2.5-flash', image: 'gemini-2.5-flash-image' },
     supportedTools: ['web_search'],
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: true,
-    imageApiFormat: 'gemini-imagen'
+    imageApiFormat: 'gemini-image-out',
+    acceptsImageReferenceInput: true
   },
   {
     id: 'groq',
@@ -114,7 +115,8 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: true,
-    imageApiFormat: 'openai-images'
+    imageApiFormat: 'openai-images',
+    acceptsImageReferenceInput: true
   },
   {
     id: 'xai-grok',
@@ -206,6 +208,7 @@ export const DEFAULT_MODEL_CAPABILITY_CONFIG: IAiModelCapabilityConfig = {
     ],
     'google-gemini': [
       { idPattern: /^imagen/, capabilities: ['image-generation'] },
+      { idPattern: /^gemini-.*-image/, capabilities: ['image-generation'] },
       { idPattern: /^gemini-/, capabilities: ['chat', 'tools', 'vision'] }
     ],
     anthropic: [{ idPattern: /^claude-/, capabilities: ['chat', 'tools', 'vision'] }],

--- a/libraries/ts-extras/src/packlets/ai-assist/registry.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/registry.ts
@@ -25,7 +25,12 @@
 
 import { fail, Result, succeed } from '@fgv/ts-utils';
 
-import { type AiProviderId, type IAiModelCapabilityConfig, type IAiProviderDescriptor } from './model';
+import {
+  type AiProviderId,
+  type IAiImageModelCapability,
+  type IAiModelCapabilityConfig,
+  type IAiProviderDescriptor
+} from './model';
 
 // ============================================================================
 // Built-in providers
@@ -74,8 +79,12 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: true,
-    imageApiFormat: 'gemini-image-out',
-    acceptsImageReferenceInput: true
+    imageGeneration: [
+      // Imagen models are predict-only and do not accept reference images.
+      // Order matters: the more specific prefix must come before the catch-all.
+      { modelPrefix: 'imagen-', format: 'gemini-imagen' },
+      { modelPrefix: '', format: 'gemini-image-out', acceptsImageReferenceInput: true }
+    ]
   },
   {
     id: 'groq',
@@ -115,8 +124,7 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: true,
-    imageApiFormat: 'openai-images',
-    acceptsImageReferenceInput: true
+    imageGeneration: [{ modelPrefix: '', format: 'openai-images', acceptsImageReferenceInput: true }]
   },
   {
     id: 'xai-grok',
@@ -134,7 +142,7 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     corsRestricted: true,
     streamingCorsRestricted: true,
     acceptsImageInput: true,
-    imageApiFormat: 'xai-images'
+    imageGeneration: [{ modelPrefix: '', format: 'xai-images' }]
   }
 ];
 
@@ -177,6 +185,37 @@ export function getProviderDescriptor(id: string): Result<IAiProviderDescriptor>
     return fail(`unknown AI provider: ${id}`);
   }
   return succeed(descriptor);
+}
+
+/**
+ * Whether a provider declares any image-generation capability at all.
+ *
+ * @param descriptor - The provider descriptor
+ * @returns `true` when {@link IAiProviderDescriptor.imageGeneration} has at
+ *   least one entry; `false` otherwise.
+ * @public
+ */
+export function supportsImageGeneration(descriptor: IAiProviderDescriptor): boolean {
+  return (descriptor.imageGeneration?.length ?? 0) > 0;
+}
+
+/**
+ * Resolve the image-generation capability that applies to a given model id
+ * for a provider. Walks {@link IAiProviderDescriptor.imageGeneration} in
+ * order and returns the first entry whose `modelPrefix` is a prefix of
+ * `modelId` (the empty prefix matches everything).
+ *
+ * @param descriptor - The provider descriptor
+ * @param modelId - The resolved image model id
+ * @returns The matching capability, or `undefined` when no rule matches or
+ *   the provider declares no image-generation capabilities.
+ * @public
+ */
+export function resolveImageCapability(
+  descriptor: IAiProviderDescriptor,
+  modelId: string
+): IAiImageModelCapability | undefined {
+  return descriptor.imageGeneration?.find((cap) => modelId.startsWith(cap.modelPrefix));
 }
 
 // ============================================================================

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
@@ -173,7 +173,7 @@ describe('callProviderImageGeneration — reference images', () => {
         modelOverride: 'gpt-image-1',
         params: {
           prompt: 'same character side view',
-          options: { count: 2, size: '1024x1024', quality: 'high' },
+          options: { count: 2, size: '1024x1024', quality: 'high', seed: 42 },
           referenceImages: [TEST_PNG, TEST_JPEG]
         }
       });
@@ -196,6 +196,7 @@ describe('callProviderImageGeneration — reference images', () => {
       expect(body.get('response_format')).toBe('b64_json');
       expect(body.get('size')).toBe('1024x1024');
       expect(body.get('quality')).toBe('high');
+      expect(body.get('seed')).toBe('42');
       const refs = body.getAll('image[]');
       expect(refs).toHaveLength(2);
       expect((refs[0] as Blob).type).toBe('image/png');

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
@@ -416,5 +416,39 @@ describe('callProviderImageGeneration — reference images', () => {
       const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
       expect(fetchCall[1].signal).toBe(controller.signal);
     });
+
+    // Google's Gemini provider hosts both `:generateContent` (gemini-2.5-flash-image)
+    // and `:predict` (imagen-*) image surfaces. The descriptor flag is per-provider,
+    // so the dispatcher routes by resolved model name.
+    test('routes imagen-* models to :predict when descriptor format is gemini-image-out', async () => {
+      mockFetchResponse({ predictions: [{ bytesBase64Encoded: 'III', mimeType: 'image/png' }] });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        modelOverride: 'imagen-3.0-generate-002',
+        params: { prompt: 'a cat' }
+      });
+
+      expect(result).toSucceedAndSatisfy((response) => {
+        expect(response.images[0].base64).toBe('III');
+      });
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[0]).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/models/imagen-3.0-generate-002:predict'
+      );
+    });
+
+    test('rejects reference images for imagen-* models (predict-only, no refs)', async () => {
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        modelOverride: 'imagen-3.0-generate-002',
+        params: { prompt: 'a cat', referenceImages: [TEST_PNG] }
+      });
+
+      expect(result).toFailWith(/imagen-3\.0-generate-002.*reference images/i);
+      expect((global.fetch as jest.Mock).mock.calls).toHaveLength(0);
+    });
   });
 });

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
@@ -22,12 +22,29 @@ import '@fgv/ts-utils-jest';
 
 import { AiAssist } from '../../..';
 // eslint-disable-next-line @rushstack/packlets/mechanics
-import type { IAiProviderDescriptor } from '../../../packlets/ai-assist/model';
+import type {
+  AiImageApiFormat,
+  IAiImageModelCapability,
+  IAiProviderDescriptor
+} from '../../../packlets/ai-assist/model';
 
 // ============================================================================
 // Test helpers (mirrors apiClient.test.ts; kept local to stay under the
 // per-file line cap).
 // ============================================================================
+
+function imgGen(
+  format: AiImageApiFormat,
+  acceptsRefs: boolean = false
+): ReadonlyArray<IAiImageModelCapability> {
+  return [
+    {
+      modelPrefix: '',
+      format,
+      ...(acceptsRefs ? { acceptsImageReferenceInput: true } : {})
+    }
+  ];
+}
 
 function makeImageDescriptor(overrides: Partial<IAiProviderDescriptor> = {}): IAiProviderDescriptor {
   return {
@@ -42,7 +59,7 @@ function makeImageDescriptor(overrides: Partial<IAiProviderDescriptor> = {}): IA
     corsRestricted: false,
     acceptsImageInput: true,
     streamingCorsRestricted: false,
-    imageApiFormat: 'openai-images',
+    imageGeneration: imgGen('openai-images'),
     ...overrides
   };
 }
@@ -128,12 +145,11 @@ describe('callProviderImageGeneration — reference images', () => {
   });
 
   describe('pre-flight', () => {
-    test('rejects refs when descriptor does not declare acceptsImageReferenceInput', async () => {
+    test('rejects refs when capability does not declare acceptsImageReferenceInput', async () => {
       const descriptor = makeImageDescriptor({
         id: 'xai-grok',
         baseUrl: 'https://api.x.ai/v1',
-        imageApiFormat: 'xai-images',
-        acceptsImageReferenceInput: undefined
+        imageGeneration: imgGen('xai-images')
       });
 
       const result = await AiAssist.callProviderImageGeneration({
@@ -146,9 +162,28 @@ describe('callProviderImageGeneration — reference images', () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
+    test('rejects when no capability rule matches the resolved model', async () => {
+      // Descriptor declares image generation, but only for `imagen-*` models —
+      // there's no catch-all, and the requested model `gpt-image-1` doesn't
+      // match the prefix.
+      const descriptor = makeImageDescriptor({
+        defaultModel: { base: 'gpt-4o', image: 'gpt-image-1' },
+        imageGeneration: [{ modelPrefix: 'imagen-', format: 'gemini-imagen' }]
+      });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat' }
+      });
+
+      expect(result).toFailWith(/does not support image generation for model "gpt-image-1"/i);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
     test('treats empty referenceImages array as no-refs (no pre-flight rejection)', async () => {
       mockFetchResponse(openAiImageBody(['AAAA']));
-      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: undefined });
+      const descriptor = makeImageDescriptor();
 
       const result = await AiAssist.callProviderImageGeneration({
         descriptor,
@@ -165,7 +200,7 @@ describe('callProviderImageGeneration — reference images', () => {
   describe('openai-images format with reference images', () => {
     test('routes to /images/edits with multipart body when refs present', async () => {
       mockFetchResponse(openAiImageBody(['AAAA']));
-      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+      const descriptor = makeImageDescriptor({ imageGeneration: imgGen('openai-images', true) });
 
       const result = await AiAssist.callProviderImageGeneration({
         descriptor,
@@ -205,7 +240,7 @@ describe('callProviderImageGeneration — reference images', () => {
 
     test('attaches refs of varied mime types with sensible filename extensions', async () => {
       mockFetchResponse(openAiImageBody(['AAAA']));
-      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+      const descriptor = makeImageDescriptor({ imageGeneration: imgGen('openai-images', true) });
 
       await AiAssist.callProviderImageGeneration({
         descriptor,
@@ -229,7 +264,7 @@ describe('callProviderImageGeneration — reference images', () => {
 
     test('forwards abort signal on multipart edits request', async () => {
       mockFetchResponse(openAiImageBody(['AAAA']));
-      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+      const descriptor = makeImageDescriptor({ imageGeneration: imgGen('openai-images', true) });
       const controller = new AbortController();
 
       await AiAssist.callProviderImageGeneration({
@@ -245,7 +280,7 @@ describe('callProviderImageGeneration — reference images', () => {
 
     test('surfaces non-2xx errors from /images/edits', async () => {
       mockFetchHttpError(400, 'unsupported model');
-      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+      const descriptor = makeImageDescriptor({ imageGeneration: imgGen('openai-images', true) });
 
       const result = await AiAssist.callProviderImageGeneration({
         descriptor,
@@ -258,7 +293,7 @@ describe('callProviderImageGeneration — reference images', () => {
 
     test('surfaces network errors from /images/edits', async () => {
       mockFetchError(new Error('ECONNREFUSED'));
-      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+      const descriptor = makeImageDescriptor({ imageGeneration: imgGen('openai-images', true) });
 
       const result = await AiAssist.callProviderImageGeneration({
         descriptor,
@@ -278,8 +313,12 @@ describe('callProviderImageGeneration — reference images', () => {
       apiFormat: 'gemini',
       baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
       defaultModel: { base: 'gemini-2.5-flash', image: 'gemini-2.5-flash-image' },
-      imageApiFormat: 'gemini-image-out',
-      acceptsImageReferenceInput: true
+      // Mirrors the built-in google-gemini descriptor: imagen-* models route to
+      // :predict, everything else to :generateContent. Order matters.
+      imageGeneration: [
+        { modelPrefix: 'imagen-', format: 'gemini-imagen' },
+        { modelPrefix: '', format: 'gemini-image-out', acceptsImageReferenceInput: true }
+      ]
     });
 
     test('returns image parsed from inlineData parts (text-only request)', async () => {
@@ -418,9 +457,9 @@ describe('callProviderImageGeneration — reference images', () => {
     });
 
     // Google's Gemini provider hosts both `:generateContent` (gemini-2.5-flash-image)
-    // and `:predict` (imagen-*) image surfaces. The descriptor flag is per-provider,
-    // so the dispatcher routes by resolved model name.
-    test('routes imagen-* models to :predict when descriptor format is gemini-image-out', async () => {
+    // and `:predict` (imagen-*) image surfaces. The dispatcher resolves the
+    // capability by model id and routes accordingly.
+    test('routes imagen-* models to :predict when descriptor exposes both rules', async () => {
       mockFetchResponse({ predictions: [{ bytesBase64Encoded: 'III', mimeType: 'image/png' }] });
 
       const result = await AiAssist.callProviderImageGeneration({

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
@@ -193,6 +193,7 @@ describe('callProviderImageGeneration — reference images', () => {
       expect(body.get('model')).toBe('gpt-image-1');
       expect(body.get('prompt')).toBe('same character side view');
       expect(body.get('n')).toBe('2');
+      expect(body.get('response_format')).toBe('b64_json');
       expect(body.get('size')).toBe('1024x1024');
       expect(body.get('quality')).toBe('high');
       const refs = body.getAll('image[]');

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.refImages.test.ts
@@ -1,0 +1,418 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import { AiAssist } from '../../..';
+// eslint-disable-next-line @rushstack/packlets/mechanics
+import type { IAiProviderDescriptor } from '../../../packlets/ai-assist/model';
+
+// ============================================================================
+// Test helpers (mirrors apiClient.test.ts; kept local to stay under the
+// per-file line cap).
+// ============================================================================
+
+function makeImageDescriptor(overrides: Partial<IAiProviderDescriptor> = {}): IAiProviderDescriptor {
+  return {
+    id: 'openai',
+    label: 'OpenAI',
+    buttonLabel: 'AI Assist | OpenAI',
+    needsSecret: true,
+    apiFormat: 'openai',
+    baseUrl: 'https://api.openai.com/v1',
+    defaultModel: { base: 'gpt-4o', image: 'dall-e-3' },
+    supportedTools: [],
+    corsRestricted: false,
+    acceptsImageInput: true,
+    streamingCorsRestricted: false,
+    imageApiFormat: 'openai-images',
+    ...overrides
+  };
+}
+
+function mockFetchResponse(body: unknown, status: number = 200): void {
+  const response = {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(JSON.stringify(body))
+  };
+  (global.fetch as jest.Mock).mockResolvedValue(response);
+}
+
+function mockFetchError(error: Error): void {
+  (global.fetch as jest.Mock).mockRejectedValue(error);
+}
+
+function mockFetchHttpError(status: number, errorText: string): void {
+  const response = {
+    ok: false,
+    status,
+    text: jest.fn().mockResolvedValue(errorText)
+  };
+  (global.fetch as jest.Mock).mockResolvedValue(response);
+}
+
+function openAiImageBody(b64s: string[]): unknown {
+  return { data: b64s.map((b64) => ({ b64_json: b64 })) };
+}
+
+function geminiImageOutBody(
+  images: ReadonlyArray<{ mimeType: string; base64: string }>,
+  textPart?: string
+): unknown {
+  const parts: Array<Record<string, unknown>> = [];
+  if (textPart !== undefined) {
+    parts.push({ text: textPart });
+  }
+  for (const img of images) {
+    parts.push({ inlineData: { mimeType: img.mimeType, data: img.base64 } });
+  }
+  return {
+    candidates: [{ content: { parts }, finishReason: 'STOP' }]
+  };
+}
+
+const TEST_PNG: AiAssist.IAiImageAttachment = {
+  mimeType: 'image/png',
+  base64: 'AAAA'
+};
+const TEST_JPEG: AiAssist.IAiImageAttachment = {
+  mimeType: 'image/jpeg',
+  base64: 'BBBB',
+  detail: 'high'
+};
+const TEST_WEBP: AiAssist.IAiImageAttachment = {
+  mimeType: 'image/webp',
+  base64: 'CCCC'
+};
+const TEST_GIF: AiAssist.IAiImageAttachment = {
+  mimeType: 'image/gif',
+  base64: 'DDDD'
+};
+const TEST_UNKNOWN_MIME: AiAssist.IAiImageAttachment = {
+  mimeType: 'image/heic',
+  base64: 'EEEE'
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('callProviderImageGeneration — reference images', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('pre-flight', () => {
+    test('rejects refs when descriptor does not declare acceptsImageReferenceInput', async () => {
+      const descriptor = makeImageDescriptor({
+        id: 'xai-grok',
+        baseUrl: 'https://api.x.ai/v1',
+        imageApiFormat: 'xai-images',
+        acceptsImageReferenceInput: undefined
+      });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat', referenceImages: [TEST_PNG] }
+      });
+
+      expect(result).toFailWith(/does not support reference images/i);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('treats empty referenceImages array as no-refs (no pre-flight rejection)', async () => {
+      mockFetchResponse(openAiImageBody(['AAAA']));
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: undefined });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat', referenceImages: [] }
+      });
+
+      expect(result).toSucceed();
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://api.openai.com/v1/images/generations');
+    });
+  });
+
+  describe('openai-images format with reference images', () => {
+    test('routes to /images/edits with multipart body when refs present', async () => {
+      mockFetchResponse(openAiImageBody(['AAAA']));
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        modelOverride: 'gpt-image-1',
+        params: {
+          prompt: 'same character side view',
+          options: { count: 2, size: '1024x1024', quality: 'high' },
+          referenceImages: [TEST_PNG, TEST_JPEG]
+        }
+      });
+
+      expect(result).toSucceedAndSatisfy((response) => {
+        expect(response.images).toHaveLength(1);
+        expect(response.images[0].base64).toBe('AAAA');
+      });
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://api.openai.com/v1/images/edits');
+      // eslint-disable-next-line dot-notation
+      expect(fetchCall[1].headers['Authorization']).toBe('Bearer test-key');
+      expect(fetchCall[1].headers['Content-Type']).toBeUndefined();
+      const body = fetchCall[1].body as FormData;
+      expect(body).toBeInstanceOf(FormData);
+      expect(body.get('model')).toBe('gpt-image-1');
+      expect(body.get('prompt')).toBe('same character side view');
+      expect(body.get('n')).toBe('2');
+      expect(body.get('size')).toBe('1024x1024');
+      expect(body.get('quality')).toBe('high');
+      const refs = body.getAll('image[]');
+      expect(refs).toHaveLength(2);
+      expect((refs[0] as Blob).type).toBe('image/png');
+      expect((refs[1] as Blob).type).toBe('image/jpeg');
+    });
+
+    test('attaches refs of varied mime types with sensible filename extensions', async () => {
+      mockFetchResponse(openAiImageBody(['AAAA']));
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+
+      await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: {
+          prompt: 'mixed refs',
+          referenceImages: [TEST_PNG, TEST_JPEG, TEST_WEBP, TEST_GIF, TEST_UNKNOWN_MIME]
+        }
+      });
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      const body = fetchCall[1].body as FormData;
+      const refs = body.getAll('image[]');
+      expect(refs).toHaveLength(5);
+      expect((refs[0] as Blob).type).toBe('image/png');
+      expect((refs[1] as Blob).type).toBe('image/jpeg');
+      expect((refs[2] as Blob).type).toBe('image/webp');
+      expect((refs[3] as Blob).type).toBe('image/gif');
+      expect((refs[4] as Blob).type).toBe('image/heic');
+    });
+
+    test('forwards abort signal on multipart edits request', async () => {
+      mockFetchResponse(openAiImageBody(['AAAA']));
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+      const controller = new AbortController();
+
+      await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat', referenceImages: [TEST_PNG] },
+        signal: controller.signal
+      });
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[1].signal).toBe(controller.signal);
+    });
+
+    test('surfaces non-2xx errors from /images/edits', async () => {
+      mockFetchHttpError(400, 'unsupported model');
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat', referenceImages: [TEST_PNG] }
+      });
+
+      expect(result).toFailWith(/400/);
+    });
+
+    test('surfaces network errors from /images/edits', async () => {
+      mockFetchError(new Error('ECONNREFUSED'));
+      const descriptor = makeImageDescriptor({ acceptsImageReferenceInput: true });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat', referenceImages: [TEST_PNG] }
+      });
+
+      expect(result).toFailWith(/ECONNREFUSED/);
+    });
+  });
+
+  describe('gemini-image-out format', () => {
+    const descriptor = makeImageDescriptor({
+      id: 'google-gemini',
+      label: 'Google Gemini',
+      buttonLabel: 'AI Assist | Gemini',
+      apiFormat: 'gemini',
+      baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+      defaultModel: { base: 'gemini-2.5-flash', image: 'gemini-2.5-flash-image' },
+      imageApiFormat: 'gemini-image-out',
+      acceptsImageReferenceInput: true
+    });
+
+    test('returns image parsed from inlineData parts (text-only request)', async () => {
+      mockFetchResponse(geminiImageOutBody([{ mimeType: 'image/png', base64: 'PPPP' }]));
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a friendly robot' }
+      });
+
+      expect(result).toSucceedAndSatisfy((response) => {
+        expect(response.images).toHaveLength(1);
+        expect(response.images[0].mimeType).toBe('image/png');
+        expect(response.images[0].base64).toBe('PPPP');
+      });
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[0]).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image:generateContent'
+      );
+      expect(fetchCall[1].headers['x-goog-api-key']).toBe('test-key');
+      const body = JSON.parse(fetchCall[1].body);
+      expect(body).toEqual({
+        contents: [{ role: 'user', parts: [{ text: 'a friendly robot' }] }]
+      });
+    });
+
+    test('skips text parts and returns only images when both are present', async () => {
+      mockFetchResponse(
+        geminiImageOutBody([{ mimeType: 'image/png', base64: 'PPPP' }], 'Here is your image:')
+      );
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a robot' }
+      });
+
+      expect(result).toSucceedAndSatisfy((response) => {
+        expect(response.images).toHaveLength(1);
+        expect(response.images[0].base64).toBe('PPPP');
+      });
+    });
+
+    test('sends inlineData parts when reference images are provided', async () => {
+      mockFetchResponse(geminiImageOutBody([{ mimeType: 'image/png', base64: 'PPPP' }]));
+
+      await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: {
+          prompt: 'same character, side view',
+          referenceImages: [TEST_PNG, TEST_JPEG]
+        }
+      });
+
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(body.contents).toHaveLength(1);
+      expect(body.contents[0].role).toBe('user');
+      expect(body.contents[0].parts).toEqual([
+        { text: 'same character, side view' },
+        { inlineData: { mimeType: 'image/png', data: 'AAAA' } },
+        { inlineData: { mimeType: 'image/jpeg', data: 'BBBB' } }
+      ]);
+    });
+
+    test('returns multiple images when response has multiple inlineData parts', async () => {
+      mockFetchResponse(
+        geminiImageOutBody([
+          { mimeType: 'image/png', base64: 'PPPP' },
+          { mimeType: 'image/png', base64: 'QQQQ' }
+        ])
+      );
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'two robots' }
+      });
+
+      expect(result).toSucceedAndSatisfy((response) => {
+        expect(response.images.map((i) => i.base64)).toEqual(['PPPP', 'QQQQ']);
+      });
+    });
+
+    test('fails when response has no inlineData parts', async () => {
+      mockFetchResponse(geminiImageOutBody([], 'sorry, I cannot generate that image'));
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat' }
+      });
+
+      expect(result).toFailWith(/no image parts in response/i);
+    });
+
+    test('fails when response is malformed', async () => {
+      mockFetchResponse({ candidates: [] });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat' }
+      });
+
+      expect(result).toFailWith(/Gemini image API response/i);
+    });
+
+    test('surfaces network errors', async () => {
+      mockFetchError(new Error('ETIMEDOUT'));
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat' }
+      });
+
+      expect(result).toFailWith(/ETIMEDOUT/);
+    });
+
+    test('forwards abort signal', async () => {
+      mockFetchResponse(geminiImageOutBody([{ mimeType: 'image/png', base64: 'PPPP' }]));
+      const controller = new AbortController();
+
+      await AiAssist.callProviderImageGeneration({
+        descriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a cat' },
+        signal: controller.signal
+      });
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[1].signal).toBe(controller.signal);
+    });
+  });
+});

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
@@ -1696,6 +1696,20 @@ describe('callProxiedImageGeneration', () => {
     expect(body.modelOverride).toBe('gpt-image-1');
   });
 
+  test('forwards reference images through to the proxy unchanged', async () => {
+    mockFetchResponse({ images: [{ mimeType: 'image/png', base64: 'AAAA' }] });
+    const descriptor = makeImageDescriptor();
+
+    await AiAssist.callProxiedImageGeneration('http://localhost:3001', {
+      descriptor,
+      apiKey: 'test-key',
+      params: { prompt: 'a cat', referenceImages: [TEST_PNG, TEST_JPEG] }
+    });
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.params.referenceImages).toEqual([TEST_PNG, TEST_JPEG]);
+  });
+
   test('surfaces proxy error response', async () => {
     mockFetchResponse({ error: 'provider rejected request' });
     const descriptor = makeImageDescriptor();

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
@@ -1303,8 +1303,8 @@ describe('callProviderImageGeneration', () => {
   });
 
   describe('common validation', () => {
-    test('fails when descriptor has no imageApiFormat', async () => {
-      const descriptor = makeDescriptor(); // chat-only xai-grok descriptor with no imageApiFormat
+    test('fails when descriptor declares no image-generation capabilities', async () => {
+      const descriptor = makeDescriptor(); // chat-only xai-grok descriptor; imageGeneration is unset
 
       const result = await AiAssist.callProviderImageGeneration({
         descriptor,

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
@@ -22,7 +22,11 @@ import '@fgv/ts-utils-jest';
 
 import { AiAssist } from '../../..';
 // eslint-disable-next-line @rushstack/packlets/mechanics
-import type { IAiProviderDescriptor } from '../../../packlets/ai-assist/model';
+import type {
+  AiImageApiFormat,
+  IAiImageModelCapability,
+  IAiProviderDescriptor
+} from '../../../packlets/ai-assist/model';
 
 // ============================================================================
 // Test helpers
@@ -920,6 +924,19 @@ describe('callProviderCompletion', () => {
 // Image generation
 // ============================================================================
 
+function imgGen(
+  format: AiImageApiFormat,
+  acceptsRefs: boolean = false
+): ReadonlyArray<IAiImageModelCapability> {
+  return [
+    {
+      modelPrefix: '',
+      format,
+      ...(acceptsRefs ? { acceptsImageReferenceInput: true } : {})
+    }
+  ];
+}
+
 function makeImageDescriptor(overrides: Partial<IAiProviderDescriptor> = {}): IAiProviderDescriptor {
   return {
     id: 'openai',
@@ -933,7 +950,7 @@ function makeImageDescriptor(overrides: Partial<IAiProviderDescriptor> = {}): IA
     corsRestricted: false,
     acceptsImageInput: true,
     streamingCorsRestricted: false,
-    imageApiFormat: 'openai-images',
+    imageGeneration: imgGen('openai-images'),
     ...overrides
   };
 }
@@ -1500,7 +1517,7 @@ describe('callProviderImageGeneration', () => {
       baseUrl: 'https://api.x.ai/v1',
       defaultModel: { base: 'grok-4-1-fast', image: 'grok-2-image-1212' },
       corsRestricted: true,
-      imageApiFormat: 'xai-images'
+      imageGeneration: imgGen('xai-images')
     });
 
     test('returns image with default jpeg mime type', async () => {
@@ -1540,7 +1557,7 @@ describe('callProviderImageGeneration', () => {
       apiFormat: 'gemini',
       baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
       defaultModel: { base: 'gemini-2.5-flash', image: 'imagen-3.0-generate-002' },
-      imageApiFormat: 'gemini-imagen'
+      imageGeneration: [{ modelPrefix: 'imagen-', format: 'gemini-imagen' }]
     });
 
     test('returns image using mimeType from prediction', async () => {

--- a/libraries/ts-extras/src/test/unit/ai-assist/listModels.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/listModels.test.ts
@@ -58,7 +58,7 @@ function makeImageDescriptor(overrides: Partial<IAiProviderDescriptor> = {}): IA
     corsRestricted: false,
     acceptsImageInput: true,
     streamingCorsRestricted: false,
-    imageApiFormat: 'openai-images',
+    imageGeneration: [{ modelPrefix: '', format: 'openai-images' }],
     ...overrides
   };
 }

--- a/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
@@ -56,22 +56,25 @@ describe('AiAssist.registry', () => {
           image: 'grok-2-image-1212'
         });
         expect(desc.supportedTools).toContain('web_search');
-        expect(desc.imageApiFormat).toBe('xai-images');
+        expect(desc.imageGeneration).toEqual([{ modelPrefix: '', format: 'xai-images' }]);
       });
     });
 
     test('returns descriptor with image generation support for openai', () => {
       expect(AiAssist.getProviderDescriptor('openai')).toSucceedAndSatisfy((desc) => {
-        expect(desc.imageApiFormat).toBe('openai-images');
-        expect(desc.acceptsImageReferenceInput).toBe(true);
+        expect(desc.imageGeneration).toEqual([
+          { modelPrefix: '', format: 'openai-images', acceptsImageReferenceInput: true }
+        ]);
         expect(AiAssist.resolveModel(desc.defaultModel, 'image')).toBe('dall-e-3');
       });
     });
 
     test('returns descriptor with image generation support for google-gemini', () => {
       expect(AiAssist.getProviderDescriptor('google-gemini')).toSucceedAndSatisfy((desc) => {
-        expect(desc.imageApiFormat).toBe('gemini-image-out');
-        expect(desc.acceptsImageReferenceInput).toBe(true);
+        expect(desc.imageGeneration).toEqual([
+          { modelPrefix: 'imagen-', format: 'gemini-imagen' },
+          { modelPrefix: '', format: 'gemini-image-out', acceptsImageReferenceInput: true }
+        ]);
         expect(AiAssist.resolveModel(desc.defaultModel, 'image')).toBe('gemini-2.5-flash-image');
       });
     });
@@ -92,19 +95,13 @@ describe('AiAssist.registry', () => {
       }
     });
 
-    test('chat-only providers leave imageApiFormat undefined', () => {
-      expect(AiAssist.getProviderDescriptor('anthropic')).toSucceedAndSatisfy((desc) => {
-        expect(desc.imageApiFormat).toBeUndefined();
-      });
-      expect(AiAssist.getProviderDescriptor('groq')).toSucceedAndSatisfy((desc) => {
-        expect(desc.imageApiFormat).toBeUndefined();
-      });
-      expect(AiAssist.getProviderDescriptor('mistral')).toSucceedAndSatisfy((desc) => {
-        expect(desc.imageApiFormat).toBeUndefined();
-      });
-      expect(AiAssist.getProviderDescriptor('copy-paste')).toSucceedAndSatisfy((desc) => {
-        expect(desc.imageApiFormat).toBeUndefined();
-      });
+    test('chat-only providers do not declare image-generation capabilities', () => {
+      for (const id of ['anthropic', 'groq', 'mistral', 'copy-paste'] as const) {
+        expect(AiAssist.getProviderDescriptor(id)).toSucceedAndSatisfy((desc) => {
+          expect(desc.imageGeneration).toBeUndefined();
+          expect(AiAssist.supportsImageGeneration(desc)).toBe(false);
+        });
+      }
     });
 
     test('copy-paste provider has no supported tools', () => {
@@ -115,6 +112,29 @@ describe('AiAssist.registry', () => {
 
     test('fails for unknown provider', () => {
       expect(AiAssist.getProviderDescriptor('unknown-provider')).toFailWith(/unknown AI provider/i);
+    });
+  });
+
+  describe('resolveImageCapability', () => {
+    test('returns the matching capability for a model that hits a specific prefix', () => {
+      const descriptor = AiAssist.getProviderDescriptor('google-gemini').orThrow();
+      const capability = AiAssist.resolveImageCapability(descriptor, 'imagen-3.0-generate-002');
+      expect(capability).toEqual({ modelPrefix: 'imagen-', format: 'gemini-imagen' });
+    });
+
+    test('falls back to the catch-all entry when no specific prefix matches', () => {
+      const descriptor = AiAssist.getProviderDescriptor('google-gemini').orThrow();
+      const capability = AiAssist.resolveImageCapability(descriptor, 'gemini-2.5-flash-image');
+      expect(capability).toEqual({
+        modelPrefix: '',
+        format: 'gemini-image-out',
+        acceptsImageReferenceInput: true
+      });
+    });
+
+    test('returns undefined when the provider declares no image-generation capabilities', () => {
+      const descriptor = AiAssist.getProviderDescriptor('anthropic').orThrow();
+      expect(AiAssist.resolveImageCapability(descriptor, 'claude-3-opus')).toBeUndefined();
     });
   });
 

--- a/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
@@ -63,7 +63,8 @@ describe('AiAssist.registry', () => {
     test('returns descriptor with image generation support for openai', () => {
       expect(AiAssist.getProviderDescriptor('openai')).toSucceedAndSatisfy((desc) => {
         expect(desc.imageGeneration).toEqual([
-          { modelPrefix: '', format: 'openai-images', acceptsImageReferenceInput: true }
+          { modelPrefix: 'gpt-image-', format: 'openai-images', acceptsImageReferenceInput: true },
+          { modelPrefix: '', format: 'openai-images' }
         ]);
         expect(AiAssist.resolveModel(desc.defaultModel, 'image')).toBe('dall-e-3');
       });
@@ -129,6 +130,48 @@ describe('AiAssist.registry', () => {
         modelPrefix: '',
         format: 'gemini-image-out',
         acceptsImageReferenceInput: true
+      });
+    });
+
+    test('selects the most specific (longest) prefix even when the catch-all is listed first', () => {
+      // Order is intentionally "wrong": catch-all first, specific prefix
+      // second. The longest matching prefix should still win.
+      const descriptor: AiAssist.IAiProviderDescriptor = {
+        id: 'openai',
+        label: 'X',
+        buttonLabel: 'X',
+        needsSecret: true,
+        apiFormat: 'openai',
+        baseUrl: 'https://example.com',
+        defaultModel: 'gpt-image-1',
+        supportedTools: [],
+        corsRestricted: false,
+        streamingCorsRestricted: false,
+        acceptsImageInput: true,
+        imageGeneration: [
+          { modelPrefix: '', format: 'openai-images' },
+          { modelPrefix: 'gpt-image-', format: 'openai-images', acceptsImageReferenceInput: true }
+        ]
+      };
+      expect(AiAssist.resolveImageCapability(descriptor, 'gpt-image-1')).toEqual({
+        modelPrefix: 'gpt-image-',
+        format: 'openai-images',
+        acceptsImageReferenceInput: true
+      });
+    });
+
+    test('routes openai built-in models to the right capability by prefix', () => {
+      const descriptor = AiAssist.getProviderDescriptor('openai').orThrow();
+      // gpt-image-1 hits the specific prefix → refs supported.
+      expect(AiAssist.resolveImageCapability(descriptor, 'gpt-image-1')).toEqual({
+        modelPrefix: 'gpt-image-',
+        format: 'openai-images',
+        acceptsImageReferenceInput: true
+      });
+      // dall-e-3 falls back to the catch-all → no refs (per OpenAI's API).
+      expect(AiAssist.resolveImageCapability(descriptor, 'dall-e-3')).toEqual({
+        modelPrefix: '',
+        format: 'openai-images'
       });
     });
 

--- a/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
@@ -63,14 +63,16 @@ describe('AiAssist.registry', () => {
     test('returns descriptor with image generation support for openai', () => {
       expect(AiAssist.getProviderDescriptor('openai')).toSucceedAndSatisfy((desc) => {
         expect(desc.imageApiFormat).toBe('openai-images');
+        expect(desc.acceptsImageReferenceInput).toBe(true);
         expect(AiAssist.resolveModel(desc.defaultModel, 'image')).toBe('dall-e-3');
       });
     });
 
     test('returns descriptor with image generation support for google-gemini', () => {
       expect(AiAssist.getProviderDescriptor('google-gemini')).toSucceedAndSatisfy((desc) => {
-        expect(desc.imageApiFormat).toBe('gemini-imagen');
-        expect(AiAssist.resolveModel(desc.defaultModel, 'image')).toBe('imagen-3.0-generate-002');
+        expect(desc.imageApiFormat).toBe('gemini-image-out');
+        expect(desc.acceptsImageReferenceInput).toBe(true);
+        expect(AiAssist.resolveModel(desc.defaultModel, 'image')).toBe('gemini-2.5-flash-image');
       });
     });
 

--- a/samples/ai-image-gen-sample/README.md
+++ b/samples/ai-image-gen-sample/README.md
@@ -25,6 +25,14 @@ are exposed via a top-level toggle:
   - OpenAI / xAI: `size`
   - Imagen: `imagen.aspectRatio`
 - Rendering returned images via `AiAssist.toDataUrl`.
+- **Reference images** (where the provider supports them — currently OpenAI
+  `gpt-image-1` and Google `gemini-2.5-flash-image` / "Nano Banana"). Attach
+  one or more PNG/JPEG/WebP files; under the hood OpenAI calls switch to
+  `/v1/images/edits` (multipart) and Gemini calls send `inlineData` parts to
+  `:generateContent`.
+- **Anchor UX for character consistency**: generate once, click **Use as
+  reference** on your favorite result, then iterate. Reference images persist
+  across generations until cleared.
 
 ### Streaming Chat mode
 - Calling `streamDirect` with conversation history (`messagesBefore`),

--- a/samples/ai-image-gen-sample/src/App.tsx
+++ b/samples/ai-image-gen-sample/src/App.tsx
@@ -14,7 +14,7 @@ type Mode = 'image' | 'chat';
 const ALL_DESCRIPTORS = AiAssist.getProviderDescriptors();
 
 const PROVIDERS_BY_MODE: Record<Mode, ReadonlyArray<AiAssist.AiProviderId>> = {
-  image: ALL_DESCRIPTORS.filter((d) => d.imageApiFormat !== undefined).map((d) => d.id),
+  image: ALL_DESCRIPTORS.filter((d) => AiAssist.supportsImageGeneration(d)).map((d) => d.id),
   // Anything with a baseUrl can do chat — the registry's only no-baseUrl entry
   // is copy-paste, which we don't exercise from the streaming chat panel.
   chat: ALL_DESCRIPTORS.filter((d) => d.baseUrl.length > 0).map((d) => d.id)
@@ -85,8 +85,12 @@ export function App(): React.JSX.Element {
   const provider = providersByMode[mode];
   const capability = CAPABILITY_BY_MODE[mode];
   const providers = PROVIDERS_BY_MODE[mode];
-  const providerAcceptsRefs =
-    AiAssist.getProviderDescriptor(provider).orDefault()?.acceptsImageReferenceInput === true;
+  const currentImageModel = perMode.image.models.get(provider) ?? defaultModelFor(provider, 'image');
+  const imageCapability = useMemo(() => {
+    const descriptor = AiAssist.getProviderDescriptor(provider).orDefault();
+    return descriptor ? AiAssist.resolveImageCapability(descriptor, currentImageModel) : undefined;
+  }, [provider, currentImageModel]);
+  const modelAcceptsRefs = imageCapability?.acceptsImageReferenceInput === true;
 
   const keyStore = useMemo(() => {
     const secrets = new Map<string, string>();
@@ -321,6 +325,7 @@ export function App(): React.JSX.Element {
           <>
             <PromptPanel
               provider={provider}
+              imageCapability={imageCapability}
               isWorking={isWorking}
               canSubmit={currentKey.length > 0}
               referenceImages={referenceImages}
@@ -337,7 +342,7 @@ export function App(): React.JSX.Element {
               <ImageResults
                 response={lastImageResult}
                 onUseAsReference={
-                  providerAcceptsRefs
+                  modelAcceptsRefs
                     ? (image) =>
                         setReferenceImages((prev) => [
                           ...prev,

--- a/samples/ai-image-gen-sample/src/App.tsx
+++ b/samples/ai-image-gen-sample/src/App.tsx
@@ -85,6 +85,8 @@ export function App(): React.JSX.Element {
   const provider = providersByMode[mode];
   const capability = CAPABILITY_BY_MODE[mode];
   const providers = PROVIDERS_BY_MODE[mode];
+  const providerAcceptsRefs =
+    AiAssist.getProviderDescriptor(provider).orDefault()?.acceptsImageReferenceInput === true;
 
   const keyStore = useMemo(() => {
     const secrets = new Map<string, string>();
@@ -334,8 +336,14 @@ export function App(): React.JSX.Element {
             {lastImageResult !== undefined && (
               <ImageResults
                 response={lastImageResult}
-                onUseAsReference={(image) =>
-                  setReferenceImages((prev) => [...prev, { mimeType: image.mimeType, base64: image.base64 }])
+                onUseAsReference={
+                  providerAcceptsRefs
+                    ? (image) =>
+                        setReferenceImages((prev) => [
+                          ...prev,
+                          { mimeType: image.mimeType, base64: image.base64 }
+                        ])
+                    : undefined
                 }
               />
             )}

--- a/samples/ai-image-gen-sample/src/App.tsx
+++ b/samples/ai-image-gen-sample/src/App.tsx
@@ -73,6 +73,7 @@ export function App(): React.JSX.Element {
     undefined
   );
   const [imageError, setImageError] = useState<string | undefined>(undefined);
+  const [referenceImages, setReferenceImages] = useState<ReadonlyArray<AiAssist.IAiImageAttachment>>([]);
 
   // Chat-mode conversation
   const [chatTurns, setChatTurns] = useState<ReadonlyArray<IChatTurn>>([]);
@@ -320,6 +321,8 @@ export function App(): React.JSX.Element {
               provider={provider}
               isWorking={isWorking}
               canSubmit={currentKey.length > 0}
+              referenceImages={referenceImages}
+              onReferenceImagesChange={setReferenceImages}
               onGenerate={handleGenerateImages}
               onAbort={handleAbort}
             />
@@ -328,7 +331,14 @@ export function App(): React.JSX.Element {
                 <strong className="font-semibold">Error:</strong> {imageError}
               </div>
             )}
-            {lastImageResult !== undefined && <ImageResults response={lastImageResult} />}
+            {lastImageResult !== undefined && (
+              <ImageResults
+                response={lastImageResult}
+                onUseAsReference={(image) =>
+                  setReferenceImages((prev) => [...prev, { mimeType: image.mimeType, base64: image.base64 }])
+                }
+              />
+            )}
           </>
         ) : (
           <ChatPanel

--- a/samples/ai-image-gen-sample/src/components/ImageResults.tsx
+++ b/samples/ai-image-gen-sample/src/components/ImageResults.tsx
@@ -2,10 +2,11 @@ import { AiAssist } from '@fgv/ts-extras';
 
 export interface IImageResultsProps {
   readonly response: AiAssist.IAiImageGenerationResponse;
+  readonly onUseAsReference?: (image: AiAssist.IAiGeneratedImage) => void;
 }
 
 export function ImageResults(props: IImageResultsProps): React.JSX.Element {
-  const { response } = props;
+  const { response, onUseAsReference } = props;
   const count = response.images.length;
 
   return (
@@ -30,13 +31,24 @@ export function ImageResults(props: IImageResultsProps): React.JSX.Element {
                   {image.revisedPrompt}
                 </p>
               )}
-              <a
-                href={AiAssist.toDataUrl(image)}
-                download={`generated-${idx + 1}.${image.mimeType.split('/')[1] ?? 'png'}`}
-                className="mt-2 inline-block text-indigo-600 hover:text-indigo-800"
-              >
-                Download
-              </a>
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <a
+                  href={AiAssist.toDataUrl(image)}
+                  download={`generated-${idx + 1}.${image.mimeType.split('/')[1] ?? 'png'}`}
+                  className="text-indigo-600 hover:text-indigo-800"
+                >
+                  Download
+                </a>
+                {onUseAsReference !== undefined && (
+                  <button
+                    type="button"
+                    onClick={() => onUseAsReference(image)}
+                    className="text-indigo-600 hover:text-indigo-800"
+                  >
+                    Use as reference
+                  </button>
+                )}
+              </div>
             </figcaption>
           </figure>
         ))}

--- a/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
+++ b/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
@@ -6,6 +6,8 @@ export interface IPromptPanelProps {
   readonly provider: AiAssist.AiProviderId;
   readonly isWorking: boolean;
   readonly canSubmit: boolean;
+  readonly referenceImages: ReadonlyArray<AiAssist.IAiImageAttachment>;
+  readonly onReferenceImagesChange: (next: ReadonlyArray<AiAssist.IAiImageAttachment>) => void;
   readonly onGenerate: (params: AiAssist.IAiImageGenerationParams) => Promise<void>;
   readonly onAbort: () => void;
 }
@@ -20,8 +22,25 @@ const IMAGEN_ASPECT_RATIOS: ReadonlyArray<
   NonNullable<NonNullable<AiAssist.IAiImageGenerationOptions['imagen']>['aspectRatio']>
 > = ['1:1', '3:4', '4:3', '9:16', '16:9'];
 
+const ACCEPTED_REF_MIME_TYPES = 'image/png,image/jpeg,image/webp';
+
+async function fileToAttachment(file: File): Promise<AiAssist.IAiImageAttachment> {
+  const dataUrl: string = await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error('failed to read file'));
+    reader.readAsDataURL(file);
+  });
+  // dataUrl is like `data:<mime>;base64,<data>`; split into mime + raw base64
+  const commaIdx = dataUrl.indexOf(',');
+  const header = dataUrl.slice(5, dataUrl.indexOf(';'));
+  const base64 = dataUrl.slice(commaIdx + 1);
+  return { mimeType: header || file.type || 'application/octet-stream', base64 };
+}
+
 export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
-  const { provider, isWorking, canSubmit, onGenerate, onAbort } = props;
+  const { provider, isWorking, canSubmit, referenceImages, onReferenceImagesChange, onGenerate, onAbort } =
+    props;
 
   const [prompt, setPrompt] = useState('A friendly robot painting a watercolor landscape');
   const [count, setCount] = useState(1);
@@ -29,10 +48,9 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
   const [aspectRatio, setAspectRatio] =
     useState<NonNullable<NonNullable<AiAssist.IAiImageGenerationOptions['imagen']>['aspectRatio']>>('1:1');
 
-  const imageFormat = useMemo(
-    () => AiAssist.getProviderDescriptor(provider).orDefault()?.imageApiFormat,
-    [provider]
-  );
+  const descriptor = useMemo(() => AiAssist.getProviderDescriptor(provider).orDefault(), [provider]);
+  const imageFormat = descriptor?.imageApiFormat;
+  const acceptsRefs = descriptor?.acceptsImageReferenceInput === true;
 
   const isImagen = imageFormat === 'gemini-imagen';
   const supportsSize = imageFormat === 'openai-images';
@@ -47,7 +65,27 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
       ...(supportsSize ? { size } : {}),
       ...(isImagen ? { imagen: { aspectRatio } } : {})
     };
-    void onGenerate({ prompt, options });
+    void onGenerate({
+      prompt,
+      options,
+      ...(acceptsRefs && referenceImages.length > 0 ? { referenceImages } : {})
+    });
+  };
+
+  const handleAddRefs = async (files: FileList | null): Promise<void> => {
+    if (!files || files.length === 0) {
+      return;
+    }
+    const added = await Promise.all(Array.from(files).map(fileToAttachment));
+    onReferenceImagesChange([...referenceImages, ...added]);
+  };
+
+  const handleRemoveRef = (index: number): void => {
+    onReferenceImagesChange(referenceImages.filter((_, i) => i !== index));
+  };
+
+  const handleClearRefs = (): void => {
+    onReferenceImagesChange([]);
   };
 
   return (
@@ -65,6 +103,62 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
             disabled={isWorking}
           />
         </label>
+
+        {acceptsRefs && (
+          <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-slate-700">
+                Reference images{' '}
+                <span className="font-normal text-slate-500">
+                  ({referenceImages.length} attached) — preserve a character or style across generations
+                </span>
+              </span>
+              {referenceImages.length > 0 && (
+                <button
+                  type="button"
+                  onClick={handleClearRefs}
+                  disabled={isWorking}
+                  className="text-xs font-medium text-slate-600 hover:text-slate-900 disabled:opacity-50"
+                >
+                  Clear all
+                </button>
+              )}
+            </div>
+            <input
+              type="file"
+              accept={ACCEPTED_REF_MIME_TYPES}
+              multiple
+              disabled={isWorking}
+              className="mt-2 block w-full text-sm text-slate-600 file:mr-3 file:rounded-md file:border-0 file:bg-indigo-50 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-indigo-700 hover:file:bg-indigo-100"
+              onChange={(e) => {
+                void handleAddRefs(e.target.files);
+                e.target.value = '';
+              }}
+            />
+            {referenceImages.length > 0 && (
+              <ul className="mt-3 flex flex-wrap gap-2">
+                {referenceImages.map((ref, idx) => (
+                  <li key={idx} className="relative">
+                    <img
+                      src={AiAssist.toDataUrl(ref)}
+                      alt={`Reference ${idx + 1}`}
+                      className="h-16 w-16 rounded-md border border-slate-300 object-cover shadow-sm"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveRef(idx)}
+                      disabled={isWorking}
+                      aria-label={`Remove reference image ${idx + 1}`}
+                      className="absolute -right-1.5 -top-1.5 inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 bg-white text-xs text-slate-700 shadow-sm hover:bg-slate-100 disabled:opacity-50"
+                    >
+                      ×
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
 
         <div className="grid gap-4 md:grid-cols-3">
           <label className="block text-sm">

--- a/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
+++ b/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
@@ -92,7 +92,7 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
   };
 
   const handleRemoveRef = (index: number): void => {
-    onReferenceImagesChange(referenceImages.filter((_, i) => i !== index));
+    onReferenceImagesChange((prev) => prev.filter((_, i) => i !== index));
   };
 
   const handleClearRefs = (): void => {

--- a/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
+++ b/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
@@ -22,9 +22,15 @@ const IMAGEN_ASPECT_RATIOS: ReadonlyArray<
   NonNullable<NonNullable<AiAssist.IAiImageGenerationOptions['imagen']>['aspectRatio']>
 > = ['1:1', '3:4', '4:3', '9:16', '16:9'];
 
-const ACCEPTED_REF_MIME_TYPES = 'image/png,image/jpeg,image/webp';
+const ACCEPTED_REF_MIME_TYPE_LIST = ['image/png', 'image/jpeg', 'image/webp'] as const;
+const ACCEPTED_REF_MIME_TYPES = ACCEPTED_REF_MIME_TYPE_LIST.join(',');
+const ACCEPTED_REF_MIME_TYPE_SET: ReadonlySet<string> = new Set(ACCEPTED_REF_MIME_TYPE_LIST);
 
 async function fileToAttachment(file: File): Promise<AiAssist.IAiImageAttachment> {
+  // `<input accept>` is only a hint, so validate explicitly (drag-drop / "All files" can bypass it).
+  if (!ACCEPTED_REF_MIME_TYPE_SET.has(file.type)) {
+    throw new Error(`unsupported file type: ${file.type || 'unknown'}`);
+  }
   const dataUrl: string = await new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => resolve(reader.result as string);
@@ -35,7 +41,7 @@ async function fileToAttachment(file: File): Promise<AiAssist.IAiImageAttachment
   const commaIdx = dataUrl.indexOf(',');
   const header = dataUrl.slice(5, dataUrl.indexOf(';'));
   const base64 = dataUrl.slice(commaIdx + 1);
-  return { mimeType: header || file.type || 'application/octet-stream', base64 };
+  return { mimeType: header || file.type, base64 };
 }
 
 export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
@@ -129,6 +135,7 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
               accept={ACCEPTED_REF_MIME_TYPES}
               multiple
               disabled={isWorking}
+              aria-label="Add reference images"
               className="mt-2 block w-full text-sm text-slate-600 file:mr-3 file:rounded-md file:border-0 file:bg-indigo-50 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-indigo-700 hover:file:bg-indigo-100"
               onChange={(e) => {
                 void handleAddRefs(e.target.files);

--- a/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
+++ b/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
@@ -7,7 +7,11 @@ export interface IPromptPanelProps {
   readonly isWorking: boolean;
   readonly canSubmit: boolean;
   readonly referenceImages: ReadonlyArray<AiAssist.IAiImageAttachment>;
-  readonly onReferenceImagesChange: (next: ReadonlyArray<AiAssist.IAiImageAttachment>) => void;
+  // Mirrors a `useState` setter so callers can pass `setX` directly and we can
+  // use the functional form to avoid stale-closure overwrites during async file reads.
+  readonly onReferenceImagesChange: React.Dispatch<
+    React.SetStateAction<ReadonlyArray<AiAssist.IAiImageAttachment>>
+  >;
   readonly onGenerate: (params: AiAssist.IAiImageGenerationParams) => Promise<void>;
   readonly onAbort: () => void;
 }
@@ -83,7 +87,8 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
       return;
     }
     const added = await Promise.all(Array.from(files).map(fileToAttachment));
-    onReferenceImagesChange([...referenceImages, ...added]);
+    // Functional update guards against state changing while file reads are in flight.
+    onReferenceImagesChange((prev) => [...prev, ...added]);
   };
 
   const handleRemoveRef = (index: number): void => {
@@ -138,7 +143,12 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
               aria-label="Add reference images"
               className="mt-2 block w-full text-sm text-slate-600 file:mr-3 file:rounded-md file:border-0 file:bg-indigo-50 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-indigo-700 hover:file:bg-indigo-100"
               onChange={(e) => {
-                void handleAddRefs(e.target.files);
+                handleAddRefs(e.target.files).catch((error: unknown) => {
+                  console.error('Failed to add reference images.', error);
+                  window.alert(
+                    error instanceof Error ? error.message : 'Failed to add one or more reference images.'
+                  );
+                });
                 e.target.value = '';
               }}
             />

--- a/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
+++ b/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
@@ -48,11 +48,23 @@ async function fileToAttachment(file: File): Promise<AiAssist.IAiImageAttachment
     reader.onerror = () => reject(reader.error ?? new Error('failed to read file'));
     reader.readAsDataURL(file);
   });
-  // dataUrl is like `data:<mime>;base64,<data>`; split into mime + raw base64
-  const commaIdx = dataUrl.indexOf(',');
-  const header = dataUrl.slice(5, dataUrl.indexOf(';'));
-  const base64 = dataUrl.slice(commaIdx + 1);
-  return { mimeType: header || file.type, base64 };
+  // FileReader.readAsDataURL is spec-defined to produce `data:<mime>;base64,<data>`,
+  // but validate the structure explicitly so a malformed prefix fails loudly
+  // instead of producing a silently miscomputed mime/base64.
+  const PREFIX = 'data:';
+  const MARKER = ';base64,';
+  if (!dataUrl.startsWith(PREFIX)) {
+    throw new Error('failed to read file: invalid data URL format');
+  }
+  const markerIdx = dataUrl.indexOf(MARKER);
+  if (markerIdx === -1) {
+    throw new Error('failed to read file: expected base64 data URL');
+  }
+  const base64 = dataUrl.slice(markerIdx + MARKER.length);
+  if (!base64) {
+    throw new Error('failed to read file: empty base64 payload');
+  }
+  return { mimeType: dataUrl.slice(PREFIX.length, markerIdx) || file.type, base64 };
 }
 
 export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
@@ -169,7 +181,9 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
             {referenceImages.length > 0 && (
               <ul className="mt-3 flex flex-wrap gap-2">
                 {referenceImages.map((ref, idx) => (
-                  <li key={idx} className="relative">
+                  // base64 payload is unique per attachment and stable across
+                  // removes, so React won't reuse DOM nodes when indices shift.
+                  <li key={ref.base64} className="relative">
                     <img
                       src={AiAssist.toDataUrl(ref)}
                       alt={`Reference ${idx + 1}`}

--- a/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
+++ b/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
@@ -1,9 +1,16 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { AiAssist } from '@fgv/ts-extras';
 
 export interface IPromptPanelProps {
   readonly provider: AiAssist.AiProviderId;
+  /**
+   * Image-generation capability resolved for the currently selected provider
+   * + model. `undefined` means the current model has no matching capability
+   * (e.g. an unknown model id) and the panel will surface no image-specific
+   * affordances.
+   */
+  readonly imageCapability: AiAssist.IAiImageModelCapability | undefined;
   readonly isWorking: boolean;
   readonly canSubmit: boolean;
   readonly referenceImages: ReadonlyArray<AiAssist.IAiImageAttachment>;
@@ -49,8 +56,16 @@ async function fileToAttachment(file: File): Promise<AiAssist.IAiImageAttachment
 }
 
 export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
-  const { provider, isWorking, canSubmit, referenceImages, onReferenceImagesChange, onGenerate, onAbort } =
-    props;
+  const {
+    provider,
+    imageCapability,
+    isWorking,
+    canSubmit,
+    referenceImages,
+    onReferenceImagesChange,
+    onGenerate,
+    onAbort
+  } = props;
 
   const [prompt, setPrompt] = useState('A friendly robot painting a watercolor landscape');
   const [count, setCount] = useState(1);
@@ -58,9 +73,8 @@ export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {
   const [aspectRatio, setAspectRatio] =
     useState<NonNullable<NonNullable<AiAssist.IAiImageGenerationOptions['imagen']>['aspectRatio']>>('1:1');
 
-  const descriptor = useMemo(() => AiAssist.getProviderDescriptor(provider).orDefault(), [provider]);
-  const imageFormat = descriptor?.imageApiFormat;
-  const acceptsRefs = descriptor?.acceptsImageReferenceInput === true;
+  const imageFormat = imageCapability?.format;
+  const acceptsRefs = imageCapability?.acceptsImageReferenceInput === true;
 
   const isImagen = imageFormat === 'gemini-imagen';
   const supportsSize = imageFormat === 'openai-images';

--- a/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
+++ b/samples/ai-image-gen-sample/src/components/PromptPanel.tsx
@@ -38,8 +38,11 @@ const ACCEPTED_REF_MIME_TYPES = ACCEPTED_REF_MIME_TYPE_LIST.join(',');
 const ACCEPTED_REF_MIME_TYPE_SET: ReadonlySet<string> = new Set(ACCEPTED_REF_MIME_TYPE_LIST);
 
 async function fileToAttachment(file: File): Promise<AiAssist.IAiImageAttachment> {
+  // Some browsers/OSes report JPEGs as `image/jpg`; normalize to the canonical
+  // `image/jpeg` before validation so they aren't rejected.
+  const fileType = file.type === 'image/jpg' ? 'image/jpeg' : file.type;
   // `<input accept>` is only a hint, so validate explicitly (drag-drop / "All files" can bypass it).
-  if (!ACCEPTED_REF_MIME_TYPE_SET.has(file.type)) {
+  if (!ACCEPTED_REF_MIME_TYPE_SET.has(fileType)) {
     throw new Error(`unsupported file type: ${file.type || 'unknown'}`);
   }
   const dataUrl: string = await new Promise((resolve, reject) => {
@@ -64,7 +67,9 @@ async function fileToAttachment(file: File): Promise<AiAssist.IAiImageAttachment
   if (!base64) {
     throw new Error('failed to read file: empty base64 payload');
   }
-  return { mimeType: dataUrl.slice(PREFIX.length, markerIdx) || file.type, base64 };
+  const headerMime = dataUrl.slice(PREFIX.length, markerIdx);
+  const mimeType = (headerMime === 'image/jpg' ? 'image/jpeg' : headerMime) || fileType;
+  return { mimeType, base64 };
 }
 
 export function PromptPanel(props: IPromptPanelProps): React.JSX.Element {


### PR DESCRIPTION
Adds optional referenceImages to image-generation requests so consumers can preserve a character or style across multiple generations.

New gemini-image-out AiImageApiFormat for Gemini 2.5 Flash Image ("Nano Banana") via :generateContent. Built-in google-gemini provider switched from imagen-3.0-generate-002 (text-only :predict) to the new format with default model gemini-2.5-flash-image.
OpenAI provider routes to /v1/images/edits (multipart) when refs are present, /v1/images/generations (JSON) otherwise.
Per-provider acceptsImageReferenceInput descriptor flag with up-front rejection for providers that don't declare support (mirrors the chat acceptsImageInput pattern).
Sample app (ai-image-gen-sample) demonstrates the feature: file picker for refs, thumbnail strip with remove buttons, and a "Use as reference" button on results to anchor character consistency across iterations.