### PR TITLE
Add ecdh-p256 to KeyPairAlgorithm

### DIFF
--- a/common/changes/@fgv/ts-extras/wrap-bug_2026-04-27-17-27.json
+++ b/common/changes/@fgv/ts-extras/wrap-bug_2026-04-27-17-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add 'ecdh-p256' to KeyPairAlgorithm so wrapBytes/unwrapBytes recipient keypairs can be minted via the public surface",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -1137,8 +1137,11 @@ const keyDerivationFunction: Converter<KeyDerivationFunction>;
 // @public
 const keyDerivationParams: Converter<IKeyDerivationParams>;
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
 // @public
-type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048';
+type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048' | 'ecdh-p256';
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //

--- a/libraries/ts-extras/src/packlets/crypto-utils/keyPairAlgorithmParams.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/keyPairAlgorithmParams.ts
@@ -77,5 +77,15 @@ export const keyPairAlgorithmParams: Readonly<Record<KeyPairAlgorithm, IKeyPairA
     importPublicKey: { name: 'RSA-OAEP', hash: 'SHA-256' },
     keyPairUsages: ['encrypt', 'decrypt'],
     publicKeyUsages: ['encrypt']
+  },
+  'ecdh-p256': {
+    generateKey: { name: 'ECDH', namedCurve: 'P-256' },
+    importPublicKey: { name: 'ECDH', namedCurve: 'P-256' },
+    // WebCrypto filters per-role: the private key takes both derive usages,
+    // and the public key gets [] since an ECDH public key alone cannot derive.
+    keyPairUsages: ['deriveKey', 'deriveBits'],
+    // Importing only the recipient's public key — empty usages because a
+    // standalone ECDH public key has no derivation capability.
+    publicKeyUsages: []
   }
 };

--- a/libraries/ts-extras/src/packlets/crypto-utils/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/model.ts
@@ -81,9 +81,13 @@ export interface IEncryptionResult {
  * Asymmetric keypair algorithms supported by the crypto provider.
  * - `'ecdsa-p256'`: ECDSA over the P-256 curve, for signing.
  * - `'rsa-oaep-2048'`: RSA-OAEP, 2048-bit modulus with SHA-256, for encryption.
+ * - `'ecdh-p256'`: ECDH over the P-256 curve, for key agreement
+ *   (e.g. as the recipient keypair in
+ *   {@link CryptoUtils.ICryptoProvider.wrapBytes | wrapBytes} /
+ *   {@link CryptoUtils.ICryptoProvider.unwrapBytes | unwrapBytes}).
  * @public
  */
-export type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048';
+export type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048' | 'ecdh-p256';
 
 /**
  * Caller-supplied HKDF parameters that domain-separate one
@@ -145,7 +149,11 @@ export interface IWrappedBytes {
  * All valid key pair algorithms.
  * @public
  */
-export const allKeyPairAlgorithms: ReadonlyArray<KeyPairAlgorithm> = ['ecdsa-p256', 'rsa-oaep-2048'];
+export const allKeyPairAlgorithms: ReadonlyArray<KeyPairAlgorithm> = [
+  'ecdsa-p256',
+  'rsa-oaep-2048',
+  'ecdh-p256'
+];
 
 /**
  * Supported key derivation functions.

--- a/libraries/ts-extras/src/test/unit/crypto/keystore/keyStore.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/keystore/keyStore.test.ts
@@ -1730,6 +1730,77 @@ describe('KeyStore', () => {
         expect(result).toFailWith(/asymmetric keypair, not symmetric/i);
       });
     });
+
+    describe('ECDH P-256 keypairs', () => {
+      test('addKeyPair persists an ECDH P-256 entry with an EC public-key JWK', async () => {
+        const result = await keystore.addKeyPair('buyer-key', { algorithm: 'ecdh-p256' });
+
+        expect(result).toSucceedAndSatisfy(({ entry, replaced, warning }) => {
+          expect(entry.algorithm).toBe('ecdh-p256');
+          expect(entry.publicKeyJwk.kty).toBe('EC');
+          expect(entry.publicKeyJwk.crv).toBe('P-256');
+          expect(replaced).toBe(false);
+          expect(warning).toBeUndefined();
+        });
+
+        const entry = keystore.getSecret('buyer-key').orThrow();
+        if (entry.type !== 'asymmetric-keypair') {
+          throw new Error('expected asymmetric entry');
+        }
+        expect(storage.entries.has(entry.id)).toBe(true);
+      });
+
+      test('getPublicKeyJwk returns the stored ECDH P-256 JWK', async () => {
+        const added = (await keystore.addKeyPair('buyer-key', { algorithm: 'ecdh-p256' })).orThrow();
+        expect(keystore.getPublicKeyJwk('buyer-key')).toSucceedWith(added.entry.publicKeyJwk);
+      });
+
+      test('getKeyPair returns an importable ECDH public key and storage-loaded private key', async () => {
+        await keystore.addKeyPair('buyer-key', { algorithm: 'ecdh-p256' });
+
+        const result = await keystore.getKeyPair('buyer-key');
+        expect(result).toSucceedAndSatisfy(({ publicKey, privateKey }) => {
+          expect(publicKey.algorithm.name).toBe('ECDH');
+          expect(privateKey.algorithm.name).toBe('ECDH');
+          expect((publicKey.algorithm as EcKeyAlgorithm).namedCurve).toBe('P-256');
+          expect((privateKey.algorithm as EcKeyAlgorithm).namedCurve).toBe('P-256');
+        });
+      });
+
+      test('end-to-end: keystore-generated ECDH P-256 keypair round-trips through wrapBytes/unwrapBytes', async () => {
+        await keystore.addKeyPair('buyer-key', { algorithm: 'ecdh-p256' });
+        const { publicKey, privateKey } = (await keystore.getKeyPair('buyer-key')).orThrow();
+
+        const plaintext = new TextEncoder().encode('per-buyer wrapped secret');
+        const options = {
+          salt: new TextEncoder().encode('content-hash'),
+          info: new TextEncoder().encode('secret-name')
+        };
+
+        const wrapped = (await provider.wrapBytes(plaintext, publicKey, options)).orThrow();
+        const unwrapped = (await provider.unwrapBytes(wrapped, privateKey, options)).orThrow();
+        expect(unwrapped).toEqual(plaintext);
+      });
+
+      test('save and reopen preserves the ECDH P-256 entry; getKeyPair still works', async () => {
+        const added = (await keystore.addKeyPair('buyer-key', { algorithm: 'ecdh-p256' })).orThrow();
+        const file = (await keystore.save(testPassword)).orThrow();
+
+        const ks2 = CryptoUtils.KeyStore.KeyStore.open({
+          cryptoProvider: provider,
+          keystoreFile: file,
+          privateKeyStorage: storage
+        }).orThrow();
+        await ks2.unlock(testPassword);
+
+        const result = await ks2.getKeyPair('buyer-key');
+        expect(result).toSucceedAndSatisfy(({ publicKey, privateKey }) => {
+          expect(publicKey.algorithm.name).toBe('ECDH');
+          expect(privateKey).toBe(storage.entries.get(added.entry.id));
+        });
+        expect(ks2.getPublicKeyJwk('buyer-key')).toSucceedWith(added.entry.publicKeyJwk);
+      });
+    });
   });
 
   // ==========================================================================

--- a/libraries/ts-extras/src/test/unit/crypto/nodeCryptoProvider.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/nodeCryptoProvider.test.ts
@@ -349,6 +349,28 @@ describe('Crypto.NodeCryptoProvider', () => {
       const jwk2 = (await provider.exportPublicKeyJwk(pair2.publicKey)).orThrow();
       expect(jwk1).not.toEqual(jwk2);
     });
+
+    test('generates an ECDH P-256 keypair with derive usages on the private key', async () => {
+      const result = await provider.generateKeyPair('ecdh-p256', true);
+      expect(result).toSucceedAndSatisfy((pair) => {
+        expect(pair.privateKey.algorithm.name).toBe('ECDH');
+        expect(pair.publicKey.algorithm.name).toBe('ECDH');
+        expect((pair.privateKey.algorithm as EcKeyAlgorithm).namedCurve).toBe('P-256');
+        expect((pair.publicKey.algorithm as EcKeyAlgorithm).namedCurve).toBe('P-256');
+        expect(pair.privateKey.usages).toContain('deriveKey');
+        // WebCrypto strips usages a public ECDH key cannot exercise.
+        expect(pair.publicKey.usages).toEqual([]);
+        expect(pair.privateKey.extractable).toBe(true);
+        expect(pair.publicKey.extractable).toBe(true);
+      });
+    });
+
+    test('generates a non-extractable ECDH P-256 private key when extractable=false', async () => {
+      const result = await provider.generateKeyPair('ecdh-p256', false);
+      expect(result).toSucceedAndSatisfy((pair) => {
+        expect(pair.privateKey.extractable).toBe(false);
+      });
+    });
   });
 
   describe('exportPublicKeyJwk', () => {
@@ -370,6 +392,17 @@ describe('Crypto.NodeCryptoProvider', () => {
         expect(jwk.kty).toBe('RSA');
         expect(typeof jwk.n).toBe('string');
         expect(jwk.e).toBe('AQAB');
+      });
+    });
+
+    test('exports an ECDH public key as a P-256 EC JWK', async () => {
+      const pair = (await provider.generateKeyPair('ecdh-p256', true)).orThrow();
+      const result = await provider.exportPublicKeyJwk(pair.publicKey);
+      expect(result).toSucceedAndSatisfy((jwk) => {
+        expect(jwk.kty).toBe('EC');
+        expect(jwk.crv).toBe('P-256');
+        expect(typeof jwk.x).toBe('string');
+        expect(typeof jwk.y).toBe('string');
       });
     });
 
@@ -401,6 +434,18 @@ describe('Crypto.NodeCryptoProvider', () => {
       expect(result).toSucceedAndSatisfy((reimported) => {
         expect(reimported.algorithm.name).toBe('RSA-OAEP');
         expect(reimported.usages).toEqual(['encrypt']);
+      });
+    });
+
+    test('round-trips an ECDH P-256 public key through JWK', async () => {
+      const pair = (await provider.generateKeyPair('ecdh-p256', true)).orThrow();
+      const jwk = (await provider.exportPublicKeyJwk(pair.publicKey)).orThrow();
+      const result = await provider.importPublicKeyJwk(jwk, 'ecdh-p256');
+      expect(result).toSucceedAndSatisfy((reimported) => {
+        expect(reimported.algorithm.name).toBe('ECDH');
+        expect((reimported.algorithm as EcKeyAlgorithm).namedCurve).toBe('P-256');
+        // Public ECDH keys cannot derive on their own — empty usages.
+        expect(reimported.usages).toEqual([]);
       });
     });
 
@@ -453,6 +498,22 @@ describe('Crypto.NodeCryptoProvider', () => {
         ciphertext
       );
       expect(new TextDecoder().decode(decrypted)).toBe('confidential payload');
+    });
+
+    test('ECDH P-256: wrapBytes with re-imported public key, unwrapBytes with private key', async () => {
+      const recipient = (await provider.generateKeyPair('ecdh-p256', true)).orThrow();
+      const jwk = (await provider.exportPublicKeyJwk(recipient.publicKey)).orThrow();
+      const recipientPublic = (await provider.importPublicKeyJwk(jwk, 'ecdh-p256')).orThrow();
+
+      const plaintext = new TextEncoder().encode('per-buyer wrapped secret');
+      const options = {
+        salt: new TextEncoder().encode('content-hash'),
+        info: new TextEncoder().encode('secret-name')
+      };
+
+      const wrapped = (await provider.wrapBytes(plaintext, recipientPublic, options)).orThrow();
+      const unwrapped = (await provider.unwrapBytes(wrapped, recipient.privateKey, options)).orThrow();
+      expect(unwrapped).toEqual(plaintext);
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `'ecdh-p256'` as the third `KeyPairAlgorithm` so callers can mint the recipient keypair that `wrapBytes` / `unwrapBytes` (added in 5.1.0-19) require. Previously the union only allowed `'ecdsa-p256' | 'rsa-oaep-2048'`, which left no type-safe path through `generateKeyPair`, `importPublicKeyJwk`, or `KeyStore.addKeyPair` to obtain an ECDH P-256 keypair — the wrap primitive worked but its key-generation surface didn't.
- Wires up the new entry in `keyPairAlgorithmParams` (`{ name: 'ECDH', namedCurve: 'P-256' }`, `keyPairUsages: ['deriveKey', 'deriveBits']`, `publicKeyUsages: []` — WebCrypto filters per-role and a standalone ECDH public key cannot derive). All other call sites read this table and pick up the new algorithm with no further code changes; the keystore vault converter accepts it via `allKeyPairAlgorithms`.
- Tests cover `generateKeyPair` / `exportPublicKeyJwk` / `importPublicKeyJwk` for `'ecdh-p256'`, an end-to-end `wrapBytes`/`unwrapBytes` round-trip with a manually-generated keypair, and a parallel KeyStore set (`addKeyPair`, `getPublicKeyJwk`, `getKeyPair`, save+reopen, plus a keystore-minted-keypair → `wrapBytes` round-trip). `crypto-utils` stays at 100% coverage.

Unblocks the chocolate-lab per-buyer key-wrapping work that 5.1.0-19 was supposed to enable.

## Test plan

- [x] `rushx test` in `libraries/ts-extras` — 928 passed, 0 failed; `crypto-utils` files at 100%
- [x] `rushx test` in `libraries/ts-web-extras` — passes (BrowserCryptoProvider's keypair surface is c8-ignored, but it shares the params table with no code changes required)
- [x] `rush change --verify` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)