### PR TITLE
ts-extras(crypto-utils): add Ed25519 keypair algorithm for signing

### DIFF
--- a/common/changes/@fgv/ts-extras/add-ed25519-signing_2026-05-01-00-00.json
+++ b/common/changes/@fgv/ts-extras/add-ed25519-signing_2026-05-01-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add Ed25519 to KeyPairAlgorithm for signing",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/common/changes/@fgv/ts-web-extras/add-ed25519-signing_2026-05-01-00-00.json
+++ b/common/changes/@fgv/ts-web-extras/add-ed25519-signing_2026-05-01-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-web-extras",
+      "comment": "Update BrowserCryptoProvider.generateKeyPair for the widened IKeyPairAlgorithmParams (Ed25519 support)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -857,8 +857,12 @@ interface IKeyDerivationParams {
 //
 // @public
 interface IKeyPairAlgorithmParams {
-    readonly generateKey: RsaHashedKeyGenParams | EcKeyGenParams | Algorithm;
-    readonly importPublicKey: RsaHashedImportParams | EcKeyImportParams | Algorithm;
+    readonly generateKey: RsaHashedKeyGenParams | EcKeyGenParams | {
+        readonly name: 'Ed25519';
+    };
+    readonly importPublicKey: RsaHashedImportParams | EcKeyImportParams | {
+        readonly name: 'Ed25519';
+    };
     readonly keyPairUsages: ReadonlyArray<KeyUsage>;
     readonly publicKeyUsages: ReadonlyArray<KeyUsage>;
 }

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -857,8 +857,8 @@ interface IKeyDerivationParams {
 //
 // @public
 interface IKeyPairAlgorithmParams {
-    readonly generateKey: RsaHashedKeyGenParams | EcKeyGenParams;
-    readonly importPublicKey: RsaHashedImportParams | EcKeyImportParams;
+    readonly generateKey: RsaHashedKeyGenParams | EcKeyGenParams | Algorithm;
+    readonly importPublicKey: RsaHashedImportParams | EcKeyImportParams | Algorithm;
     readonly keyPairUsages: ReadonlyArray<KeyUsage>;
     readonly publicKeyUsages: ReadonlyArray<KeyUsage>;
 }
@@ -1146,7 +1146,7 @@ const keyDerivationParams: Converter<IKeyDerivationParams>;
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048' | 'ecdh-p256';
+type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048' | 'ecdh-p256' | 'ed25519';
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //

--- a/libraries/ts-extras/src/packlets/crypto-utils/keyPairAlgorithmParams.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/keyPairAlgorithmParams.ts
@@ -31,17 +31,21 @@ export interface IKeyPairAlgorithmParams {
   /**
    * Algorithm parameters for `crypto.subtle.generateKey`. Always an asymmetric
    * variant — these algorithms produce a `CryptoKeyPair`, not a single key.
-   * The plain `Algorithm` shape covers WebCrypto Secure-Curves entries such as
-   * Ed25519, which take only `{ name }`.
+   * The literal `{ name: 'Ed25519' }` member covers WebCrypto's Secure-Curves
+   * Ed25519 algorithm, which takes only a `name`; using a literal rather than
+   * the base `Algorithm` keeps the union closed to the algorithms this table
+   * supports.
    */
-  readonly generateKey: RsaHashedKeyGenParams | EcKeyGenParams | Algorithm;
+  readonly generateKey: RsaHashedKeyGenParams | EcKeyGenParams | { readonly name: 'Ed25519' };
 
   /**
    * Algorithm parameters for `crypto.subtle.importKey('jwk', ...)` when
-   * importing the public half of a keypair. The plain `Algorithm` shape covers
-   * WebCrypto Secure-Curves entries such as Ed25519, which take only `{ name }`.
+   * importing the public half of a keypair. The literal `{ name: 'Ed25519' }`
+   * member covers Ed25519 imports, which take only a `name`; using a literal
+   * rather than the base `Algorithm` keeps the union closed to the algorithms
+   * this table supports.
    */
-  readonly importPublicKey: RsaHashedImportParams | EcKeyImportParams | Algorithm;
+  readonly importPublicKey: RsaHashedImportParams | EcKeyImportParams | { readonly name: 'Ed25519' };
 
   /**
    * Default key usages for the generated `CryptoKeyPair`. Both halves receive

--- a/libraries/ts-extras/src/packlets/crypto-utils/keyPairAlgorithmParams.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/keyPairAlgorithmParams.ts
@@ -31,14 +31,17 @@ export interface IKeyPairAlgorithmParams {
   /**
    * Algorithm parameters for `crypto.subtle.generateKey`. Always an asymmetric
    * variant — these algorithms produce a `CryptoKeyPair`, not a single key.
+   * The plain `Algorithm` shape covers WebCrypto Secure-Curves entries such as
+   * Ed25519, which take only `{ name }`.
    */
-  readonly generateKey: RsaHashedKeyGenParams | EcKeyGenParams;
+  readonly generateKey: RsaHashedKeyGenParams | EcKeyGenParams | Algorithm;
 
   /**
    * Algorithm parameters for `crypto.subtle.importKey('jwk', ...)` when
-   * importing the public half of a keypair.
+   * importing the public half of a keypair. The plain `Algorithm` shape covers
+   * WebCrypto Secure-Curves entries such as Ed25519, which take only `{ name }`.
    */
-  readonly importPublicKey: RsaHashedImportParams | EcKeyImportParams;
+  readonly importPublicKey: RsaHashedImportParams | EcKeyImportParams | Algorithm;
 
   /**
    * Default key usages for the generated `CryptoKeyPair`. Both halves receive
@@ -87,5 +90,11 @@ export const keyPairAlgorithmParams: Readonly<Record<KeyPairAlgorithm, IKeyPairA
     // Importing only the recipient's public key — empty usages because a
     // standalone ECDH public key has no derivation capability.
     publicKeyUsages: []
+  },
+  ed25519: {
+    generateKey: { name: 'Ed25519' },
+    importPublicKey: { name: 'Ed25519' },
+    keyPairUsages: ['sign', 'verify'],
+    publicKeyUsages: ['verify']
   }
 };

--- a/libraries/ts-extras/src/packlets/crypto-utils/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/model.ts
@@ -86,8 +86,10 @@ export interface IEncryptionResult {
  *   {@link CryptoUtils.ICryptoProvider.wrapBytes | wrapBytes} /
  *   {@link CryptoUtils.ICryptoProvider.unwrapBytes | unwrapBytes}).
  * - `'ed25519'`: EdDSA over the Edwards25519 curve, for signing.
- *   Deterministic, no per-signature nonce, simpler to use safely than ECDSA.
- *   Distinct from X25519 (key agreement over the Montgomery form, Curve25519).
+ *   Deterministic — the per-signature nonce is derived from the private key
+ *   and message rather than sampled randomly, eliminating the random-nonce
+ *   reuse risk that ECDSA carries. Distinct from X25519 (key agreement over
+ *   the Montgomery form, Curve25519).
  * @public
  */
 export type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048' | 'ecdh-p256' | 'ed25519';

--- a/libraries/ts-extras/src/packlets/crypto-utils/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/model.ts
@@ -85,9 +85,9 @@ export interface IEncryptionResult {
  *   (e.g. as the recipient keypair in
  *   {@link CryptoUtils.ICryptoProvider.wrapBytes | wrapBytes} /
  *   {@link CryptoUtils.ICryptoProvider.unwrapBytes | unwrapBytes}).
- * - `'ed25519'`: Edwards-curve Digital Signature Algorithm over Curve25519,
- *   for signing. Deterministic, no per-signature nonce, simpler to use
- *   safely than ECDSA.
+ * - `'ed25519'`: EdDSA over the Edwards25519 curve, for signing.
+ *   Deterministic, no per-signature nonce, simpler to use safely than ECDSA.
+ *   Distinct from X25519 (key agreement over the Montgomery form, Curve25519).
  * @public
  */
 export type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048' | 'ecdh-p256' | 'ed25519';

--- a/libraries/ts-extras/src/packlets/crypto-utils/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/model.ts
@@ -85,9 +85,12 @@ export interface IEncryptionResult {
  *   (e.g. as the recipient keypair in
  *   {@link CryptoUtils.ICryptoProvider.wrapBytes | wrapBytes} /
  *   {@link CryptoUtils.ICryptoProvider.unwrapBytes | unwrapBytes}).
+ * - `'ed25519'`: Edwards-curve Digital Signature Algorithm over Curve25519,
+ *   for signing. Deterministic, no per-signature nonce, simpler to use
+ *   safely than ECDSA.
  * @public
  */
-export type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048' | 'ecdh-p256';
+export type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048' | 'ecdh-p256' | 'ed25519';
 
 /**
  * Caller-supplied HKDF parameters that domain-separate one
@@ -152,7 +155,8 @@ export interface IWrappedBytes {
 export const allKeyPairAlgorithms: ReadonlyArray<KeyPairAlgorithm> = [
   'ecdsa-p256',
   'rsa-oaep-2048',
-  'ecdh-p256'
+  'ecdh-p256',
+  'ed25519'
 ];
 
 /**

--- a/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
@@ -221,8 +221,14 @@ export class NodeCryptoProvider implements ICryptoProvider {
     extractable: boolean
   ): Promise<Result<CryptoKeyPair>> {
     const params = keyPairAlgorithmParams[algorithm];
-    const result = await captureAsyncResult(() =>
-      crypto.webcrypto.subtle.generateKey(params.generateKey, extractable, params.keyPairUsages)
+    // Falls through `subtle.generateKey`'s broad `AlgorithmIdentifier` overload
+    // because the table mixes asymmetric variants (RSA / EC / Ed25519). Every
+    // entry is asymmetric by construction, so the result is a `CryptoKeyPair`.
+    const result = await captureAsyncResult(
+      async () =>
+        (await crypto.webcrypto.subtle.generateKey(params.generateKey as AlgorithmIdentifier, extractable, [
+          ...params.keyPairUsages
+        ])) as CryptoKeyPair
     );
     return result.withErrorFormat((e) => `Failed to generate ${algorithm} keypair: ${e}`);
   }

--- a/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
@@ -221,15 +221,22 @@ export class NodeCryptoProvider implements ICryptoProvider {
     extractable: boolean
   ): Promise<Result<CryptoKeyPair>> {
     const params = keyPairAlgorithmParams[algorithm];
-    // Falls through `subtle.generateKey`'s broad `AlgorithmIdentifier` overload
-    // because the table mixes asymmetric variants (RSA / EC / Ed25519). Every
-    // entry is asymmetric by construction, so the result is a `CryptoKeyPair`.
-    const result = await captureAsyncResult(
-      async () =>
-        (await crypto.webcrypto.subtle.generateKey(params.generateKey as AlgorithmIdentifier, extractable, [
-          ...params.keyPairUsages
-        ])) as CryptoKeyPair
-    );
+    // Widening upcast to `AlgorithmIdentifier` steers TS to subtle.generateKey's
+    // broad overload, which accepts the Ed25519 `{ name: 'Ed25519' }` shape and
+    // returns `CryptoKey | CryptoKeyPair`. The narrowing back to `CryptoKeyPair`
+    // is a runtime check via the `in` operator, not a type assertion.
+    const result = await captureAsyncResult(async () => {
+      const generated = await crypto.webcrypto.subtle.generateKey(
+        params.generateKey as AlgorithmIdentifier,
+        extractable,
+        [...params.keyPairUsages]
+      );
+      if ('privateKey' in generated && 'publicKey' in generated) {
+        return generated;
+      }
+      /* c8 ignore next - unreachable: every entry in keyPairAlgorithmParams produces a keypair */
+      throw new Error(`${algorithm} unexpectedly produced a single CryptoKey`);
+    });
     return result.withErrorFormat((e) => `Failed to generate ${algorithm} keypair: ${e}`);
   }
 

--- a/libraries/ts-extras/src/test/unit/crypto/keystore/converters.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/keystore/converters.test.ts
@@ -84,8 +84,12 @@ describe('Key Store Converters', () => {
       );
     });
 
+    test('accepts ed25519', () => {
+      expect(CryptoUtils.KeyStore.Converters.keyPairAlgorithm.convert('ed25519')).toSucceedWith('ed25519');
+    });
+
     test('rejects unknown algorithm', () => {
-      expect(CryptoUtils.KeyStore.Converters.keyPairAlgorithm.convert('ed25519')).toFail();
+      expect(CryptoUtils.KeyStore.Converters.keyPairAlgorithm.convert('rsa-pss-2048')).toFail();
     });
 
     test('rejects non-string', () => {
@@ -256,7 +260,7 @@ describe('Key Store Converters', () => {
       expect(
         CryptoUtils.KeyStore.Converters.keystoreAsymmetricEntryJson.convert({
           ...validInput,
-          algorithm: 'ed25519'
+          algorithm: 'rsa-pss-2048'
         })
       ).toFail();
     });

--- a/libraries/ts-extras/src/test/unit/crypto/nodeCryptoProvider.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/nodeCryptoProvider.test.ts
@@ -371,6 +371,25 @@ describe('Crypto.NodeCryptoProvider', () => {
         expect(pair.privateKey.extractable).toBe(false);
       });
     });
+
+    test('generates an Ed25519 keypair with sign/verify usages', async () => {
+      const result = await provider.generateKeyPair('ed25519', true);
+      expect(result).toSucceedAndSatisfy((pair) => {
+        expect(pair.privateKey.algorithm.name).toBe('Ed25519');
+        expect(pair.publicKey.algorithm.name).toBe('Ed25519');
+        expect(pair.privateKey.usages).toContain('sign');
+        expect(pair.publicKey.usages).toContain('verify');
+        expect(pair.privateKey.extractable).toBe(true);
+        expect(pair.publicKey.extractable).toBe(true);
+      });
+    });
+
+    test('generates a non-extractable Ed25519 private key when extractable=false', async () => {
+      const result = await provider.generateKeyPair('ed25519', false);
+      expect(result).toSucceedAndSatisfy((pair) => {
+        expect(pair.privateKey.extractable).toBe(false);
+      });
+    });
   });
 
   describe('exportPublicKeyJwk', () => {
@@ -403,6 +422,16 @@ describe('Crypto.NodeCryptoProvider', () => {
         expect(jwk.crv).toBe('P-256');
         expect(typeof jwk.x).toBe('string');
         expect(typeof jwk.y).toBe('string');
+      });
+    });
+
+    test('exports an Ed25519 public key as an OKP JWK', async () => {
+      const pair = (await provider.generateKeyPair('ed25519', true)).orThrow();
+      const result = await provider.exportPublicKeyJwk(pair.publicKey);
+      expect(result).toSucceedAndSatisfy((jwk) => {
+        expect(jwk.kty).toBe('OKP');
+        expect(jwk.crv).toBe('Ed25519');
+        expect(typeof jwk.x).toBe('string');
       });
     });
 
@@ -446,6 +475,16 @@ describe('Crypto.NodeCryptoProvider', () => {
         expect((reimported.algorithm as EcKeyAlgorithm).namedCurve).toBe('P-256');
         // Public ECDH keys cannot derive on their own — empty usages.
         expect(reimported.usages).toEqual([]);
+      });
+    });
+
+    test('round-trips an Ed25519 public key through JWK', async () => {
+      const pair = (await provider.generateKeyPair('ed25519', true)).orThrow();
+      const jwk = (await provider.exportPublicKeyJwk(pair.publicKey)).orThrow();
+      const result = await provider.importPublicKeyJwk(jwk, 'ed25519');
+      expect(result).toSucceedAndSatisfy((reimported) => {
+        expect(reimported.algorithm.name).toBe('Ed25519');
+        expect(reimported.usages).toEqual(['verify']);
       });
     });
 
@@ -498,6 +537,32 @@ describe('Crypto.NodeCryptoProvider', () => {
         ciphertext
       );
       expect(new TextDecoder().decode(decrypted)).toBe('confidential payload');
+    });
+
+    test('Ed25519: signs with private key, verifies with re-imported public key', async () => {
+      const pair = (await provider.generateKeyPair('ed25519', true)).orThrow();
+      const jwk = (await provider.exportPublicKeyJwk(pair.publicKey)).orThrow();
+      const verifyKey = (await provider.importPublicKeyJwk(jwk, 'ed25519')).orThrow();
+
+      const message = new TextEncoder().encode('hello, edwards');
+      const signature = await crypto.webcrypto.subtle.sign({ name: 'Ed25519' }, pair.privateKey, message);
+
+      const verified = await crypto.webcrypto.subtle.verify(
+        { name: 'Ed25519' },
+        verifyKey,
+        signature,
+        message
+      );
+      expect(verified).toBe(true);
+
+      const tampered = new TextEncoder().encode('hello, edwards!');
+      const verifiedTampered = await crypto.webcrypto.subtle.verify(
+        { name: 'Ed25519' },
+        verifyKey,
+        signature,
+        tampered
+      );
+      expect(verifiedTampered).toBe(false);
     });
 
     test('ECDH P-256: wrapBytes with re-imported public key, unwrapBytes with private key', async () => {

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -352,8 +352,14 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     extractable: boolean
   ): Promise<Result<CryptoKeyPair>> {
     const params = CryptoUtils.keyPairAlgorithmParams[algorithm];
-    const result = await captureAsyncResult(() =>
-      this._crypto.subtle.generateKey(params.generateKey, extractable, params.keyPairUsages)
+    // Falls through `subtle.generateKey`'s broad `AlgorithmIdentifier` overload
+    // because the table mixes asymmetric variants (RSA / EC / Ed25519). Every
+    // entry is asymmetric by construction, so the result is a `CryptoKeyPair`.
+    const result = await captureAsyncResult(
+      async () =>
+        (await this._crypto.subtle.generateKey(params.generateKey as AlgorithmIdentifier, extractable, [
+          ...params.keyPairUsages
+        ])) as CryptoKeyPair
     );
     return result.withErrorFormat((e) => `Failed to generate ${algorithm} keypair: ${e}`);
   }

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -352,15 +352,22 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
     extractable: boolean
   ): Promise<Result<CryptoKeyPair>> {
     const params = CryptoUtils.keyPairAlgorithmParams[algorithm];
-    // Falls through `subtle.generateKey`'s broad `AlgorithmIdentifier` overload
-    // because the table mixes asymmetric variants (RSA / EC / Ed25519). Every
-    // entry is asymmetric by construction, so the result is a `CryptoKeyPair`.
-    const result = await captureAsyncResult(
-      async () =>
-        (await this._crypto.subtle.generateKey(params.generateKey as AlgorithmIdentifier, extractable, [
-          ...params.keyPairUsages
-        ])) as CryptoKeyPair
-    );
+    // Widening upcast to `AlgorithmIdentifier` steers TS to subtle.generateKey's
+    // broad overload, which accepts the Ed25519 `{ name: 'Ed25519' }` shape and
+    // returns `CryptoKey | CryptoKeyPair`. The narrowing back to `CryptoKeyPair`
+    // is a runtime check via the `in` operator, not a type assertion.
+    const result = await captureAsyncResult(async () => {
+      const generated = await this._crypto.subtle.generateKey(
+        params.generateKey as AlgorithmIdentifier,
+        extractable,
+        [...params.keyPairUsages]
+      );
+      if ('privateKey' in generated && 'publicKey' in generated) {
+        return generated;
+      }
+      /* c8 ignore next - unreachable: every entry in keyPairAlgorithmParams produces a keypair */
+      throw new Error(`${algorithm} unexpectedly produced a single CryptoKey`);
+    });
     return result.withErrorFormat((e) => `Failed to generate ${algorithm} keypair: ${e}`);
   }
 

--- a/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.keyPair.test.ts
+++ b/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.keyPair.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import '@fgv/ts-utils-jest';
+
+import { BrowserCryptoProvider } from '../../packlets/crypto-utils';
+
+const provider = new BrowserCryptoProvider();
+const subtle = globalThis.crypto.subtle;
+
+describe('BrowserCryptoProvider — Ed25519 keypair', () => {
+  describe('generateKeyPair', () => {
+    test('generates an Ed25519 keypair with sign/verify usages', async () => {
+      const result = await provider.generateKeyPair('ed25519', true);
+      expect(result).toSucceedAndSatisfy((pair) => {
+        expect(pair.privateKey.algorithm.name).toBe('Ed25519');
+        expect(pair.publicKey.algorithm.name).toBe('Ed25519');
+        expect(pair.privateKey.usages).toContain('sign');
+        expect(pair.publicKey.usages).toContain('verify');
+        expect(pair.privateKey.extractable).toBe(true);
+        expect(pair.publicKey.extractable).toBe(true);
+      });
+    });
+
+    test('generates a non-extractable Ed25519 private key when extractable=false', async () => {
+      const result = await provider.generateKeyPair('ed25519', false);
+      expect(result).toSucceedAndSatisfy((pair) => {
+        expect(pair.privateKey.extractable).toBe(false);
+      });
+    });
+  });
+
+  describe('end-to-end sign/verify', () => {
+    test('signs with private key and verifies with re-imported public key', async () => {
+      const pair = (await provider.generateKeyPair('ed25519', true)).orThrow();
+      const jwk = (await provider.exportPublicKeyJwk(pair.publicKey)).orThrow();
+      expect(jwk.kty).toBe('OKP');
+      expect(jwk.crv).toBe('Ed25519');
+      const verifyKey = (await provider.importPublicKeyJwk(jwk, 'ed25519')).orThrow();
+
+      const message = new TextEncoder().encode('hello, edwards');
+      const signature = await subtle.sign({ name: 'Ed25519' }, pair.privateKey, message);
+
+      const verified = await subtle.verify({ name: 'Ed25519' }, verifyKey, signature, message);
+      expect(verified).toBe(true);
+
+      const tampered = new TextEncoder().encode('hello, edwards!');
+      const verifiedTampered = await subtle.verify({ name: 'Ed25519' }, verifyKey, signature, tampered);
+      expect(verifiedTampered).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `'ed25519'` as a fourth `KeyPairAlgorithm` alongside `ecdsa-p256`, `rsa-oaep-2048`, and `ecdh-p256`, in response to a security review request to support Edwards-curve signing (deterministic, no per-signature nonce risk, simpler to use safely than ECDSA).

- Plumbs ed25519 through `model.ts` (`KeyPairAlgorithm` union + `allKeyPairAlgorithms`), `keyPairAlgorithmParams.ts` (new entry; `IKeyPairAlgorithmParams.generateKey`/`importPublicKey` widened to accept the bare `Algorithm` shape used by WebCrypto Secure-Curves), and `nodeCryptoProvider.ts` (`generateKeyPair` narrows back to `CryptoKeyPair` at the call site, mirroring the existing pattern in `wrapBytes`).
- Keystore is algorithm-agnostic, so the new value flows through `keyPairAlgorithm` converter and asymmetric vault entries with no further changes.
- API report regenerated; `crypto-utils` and `crypto-utils/keystore` remain at 100% coverage.

## Test plan

- [x] New `nodeCryptoProvider.test.ts` cases: ed25519 generate (extractable + non-extractable), JWK export (OKP / Ed25519 / x), JWK round-trip, end-to-end sign/verify with a tampered-message negative case.
- [x] Keystore `converters.test.ts` flipped from "ed25519 is unknown" to "ed25519 is accepted"; the unknown-algorithm case now uses `rsa-pss-2048`.
- [x] `rush build --to @fgv/ts-extras` clean (api-extractor regenerated `etc/ts-extras.api.md`).
- [x] Full ts-extras test suite passes; `crypto-utils` reports 100/100/100/100.

https://claude.ai/code/session_016rUUZzyzeb5s41jbGTLMiS

---
_Generated by [Claude Code](https://claude.ai/code/session_016rUUZzyzeb5s41jbGTLMiS)_