### PR TITLE
Reorganize FileTree-based helpers into core helper modules

### DIFF
--- a/common/changes/@fgv/ts-extras/claude-fix-browser-entry-points-GikX2_2026-05-04-07-27.json
+++ b/common/changes/@fgv/ts-extras/claude-fix-browser-entry-points-GikX2_2026-05-04-07-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "fix node leakage into browser exports",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/common/changes/@fgv/ts-json-base/claude-fix-browser-entry-points-GikX2_2026-05-04-07-34.json
+++ b/common/changes/@fgv/ts-json-base/claude-fix-browser-entry-points-GikX2_2026-05-04-07-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-json-base",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-json-base"
+}

--- a/common/changes/@fgv/ts-utils/claude-fix-browser-entry-points-GikX2_2026-05-04-07-34.json
+++ b/common/changes/@fgv/ts-utils/claude-fix-browser-entry-points-GikX2_2026-05-04-07-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-utils",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-utils"
+}

--- a/common/changes/@fgv/ts-web-extras/claude-fix-browser-entry-points-GikX2_2026-05-04-07-34.json
+++ b/common/changes/@fgv/ts-web-extras/claude-fix-browser-entry-points-GikX2_2026-05-04-07-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-web-extras",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras"
+}

--- a/libraries/ts-extras/docs/AiAssist/README.md
+++ b/libraries/ts-extras/docs/AiAssist/README.md
@@ -282,6 +282,42 @@ Parameters for a list-models request.
 Parameters for a streaming completion request.
 
 </td></tr>
+<tr><td>
+
+[IFencedStringifiedJsonExtractorOptions](./interfaces/IFencedStringifiedJsonExtractorOptions.md)
+
+</td><td>
+
+Options shared by every AiAssist.fencedStringifiedJson call.
+
+</td></tr>
+<tr><td>
+
+[IFencedStringifiedJsonOptions](./interfaces/IFencedStringifiedJsonOptions.md)
+
+</td><td>
+
+Options for the validating overload of AiAssist.fencedStringifiedJson.
+
+</td></tr>
+<tr><td>
+
+[IGenerateJsonCompletionParams](./interfaces/IGenerateJsonCompletionParams.md)
+
+</td><td>
+
+Parameters for AiAssist.generateJsonCompletion.
+
+</td></tr>
+<tr><td>
+
+[IGenerateJsonCompletionResult](./interfaces/IGenerateJsonCompletionResult.md)
+
+</td><td>
+
+Successful result of AiAssist.generateJsonCompletion.
+
+</td></tr>
 </tbody></table>
 
 ## Type Aliases
@@ -375,6 +411,25 @@ Discriminated union of events emitted by a streaming completion.
 </td><td>
 
 Known context keys for model specification maps.
+
+</td></tr>
+<tr><td>
+
+[JsonTextExtractor](./type-aliases/JsonTextExtractor.md)
+
+</td><td>
+
+A function that pulls a JSON-shaped substring out of arbitrary model text.
+
+</td></tr>
+<tr><td>
+
+[JsonPromptHint](./type-aliases/JsonPromptHint.md)
+
+</td><td>
+
+Controls the optional system-prompt augmentation applied by
+AiAssist.generateJsonCompletion.
 
 </td></tr>
 </tbody></table>
@@ -529,6 +584,27 @@ Calls the streaming chat endpoint on a proxy server instead of calling
 Resolves the effective tools for a completion call.
 
 </td></tr>
+<tr><td>
+
+[fencedStringifiedJson](./functions/fencedStringifiedJson.md)
+
+</td><td>
+
+Creates a `Converter` that accepts raw LLM response text, runs it through a
+
+</td></tr>
+<tr><td>
+
+[generateJsonCompletion](./functions/generateJsonCompletion.md)
+
+</td><td>
+
+Calls AiAssist.callProviderCompletion, then runs the response text
+through a tolerant JSON converter (default:
+AiAssist.fencedStringifiedJson) and the caller's
+`converter`/`validator`.
+
+</td></tr>
 </tbody></table>
 
 ## Variables
@@ -668,6 +744,25 @@ Converter for ModelSpecKey.
 </td><td>
 
 Recursive converter for ModelSpec.
+
+</td></tr>
+<tr><td>
+
+[extractJsonText](./variables/extractJsonText.md)
+
+</td><td>
+
+Default AiAssist.JsonTextExtractor | extractor for LLM responses.
+
+</td></tr>
+<tr><td>
+
+[SMART_JSON_PROMPT_HINT](./variables/SMART_JSON_PROMPT_HINT.md)
+
+</td><td>
+
+Default system-prompt suffix appended when AiAssist.IGenerateJsonCompletionParams.promptHint
+is `'smart'` (the default).
 
 </td></tr>
 </tbody></table>

--- a/libraries/ts-extras/docs/AiAssist/functions/fencedStringifiedJson.md
+++ b/libraries/ts-extras/docs/AiAssist/functions/fencedStringifiedJson.md
@@ -1,0 +1,14 @@
+[Home](../../README.md) > [AiAssist](../README.md) > fencedStringifiedJson
+
+# Function: fencedStringifiedJson
+
+Creates a `Converter` that accepts raw LLM response text, runs it through a
+tolerant extractor (default: AiAssist.extractJsonText), parses the
+extracted substring as JSON, and applies an optional inner converter or
+validator.
+
+## Signature
+
+```typescript
+function fencedStringifiedJson(options: IFencedStringifiedJsonExtractorOptions): Converter<JsonValue>
+```

--- a/libraries/ts-extras/docs/AiAssist/functions/generateJsonCompletion.md
+++ b/libraries/ts-extras/docs/AiAssist/functions/generateJsonCompletion.md
@@ -1,0 +1,15 @@
+[Home](../../README.md) > [AiAssist](../README.md) > generateJsonCompletion
+
+# Function: generateJsonCompletion
+
+Calls AiAssist.callProviderCompletion, then runs the response text
+through a tolerant JSON converter (default:
+AiAssist.fencedStringifiedJson) and the caller's
+`converter`/`validator`. Returns the validated value plus the raw text and
+underlying completion response for diagnostics.
+
+## Signature
+
+```typescript
+function generateJsonCompletion(params: IGenerateJsonCompletionParams<T>): Promise<Result<IGenerateJsonCompletionResult<T>>>
+```

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IFencedStringifiedJsonExtractorOptions.extractor.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IFencedStringifiedJsonExtractorOptions.extractor.md
@@ -1,0 +1,13 @@
+[Home](../../README.md) > [AiAssist](../README.md) > [IFencedStringifiedJsonExtractorOptions](./IFencedStringifiedJsonExtractorOptions.md) > extractor
+
+## IFencedStringifiedJsonExtractorOptions.extractor property
+
+Optional pre-parse extractor. Defaults to AiAssist.extractJsonText.
+Provide a custom extractor to handle response shapes the default does not
+understand.
+
+**Signature:**
+
+```typescript
+readonly extractor: JsonTextExtractor;
+```

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IFencedStringifiedJsonExtractorOptions.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IFencedStringifiedJsonExtractorOptions.md
@@ -1,0 +1,44 @@
+[Home](../../README.md) > [AiAssist](../README.md) > IFencedStringifiedJsonExtractorOptions
+
+# Interface: IFencedStringifiedJsonExtractorOptions
+
+Options shared by every AiAssist.fencedStringifiedJson call.
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody>
+<tr><td>
+
+[extractor](./IFencedStringifiedJsonExtractorOptions.extractor.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[JsonTextExtractor](../../type-aliases/JsonTextExtractor.md)
+
+</td><td>
+
+Optional pre-parse extractor.
+
+</td></tr>
+</tbody></table>

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IFencedStringifiedJsonOptions.inner.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IFencedStringifiedJsonOptions.inner.md
@@ -1,0 +1,11 @@
+[Home](../../README.md) > [AiAssist](../README.md) > [IFencedStringifiedJsonOptions](./IFencedStringifiedJsonOptions.md) > inner
+
+## IFencedStringifiedJsonOptions.inner property
+
+Inner converter or validator applied to the parsed JSON value.
+
+**Signature:**
+
+```typescript
+readonly inner: Converter<T, unknown> | Validator<T, unknown>;
+```

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IFencedStringifiedJsonOptions.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IFencedStringifiedJsonOptions.md
@@ -1,0 +1,65 @@
+[Home](../../README.md) > [AiAssist](../README.md) > IFencedStringifiedJsonOptions
+
+# Interface: IFencedStringifiedJsonOptions
+
+Options for the validating overload of AiAssist.fencedStringifiedJson.
+`inner` is required so the typed `Converter<T>` return value can never lie
+about the runtime shape.
+
+**Extends:** [`IFencedStringifiedJsonExtractorOptions`](../../interfaces/IFencedStringifiedJsonExtractorOptions.md)
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody>
+<tr><td>
+
+[inner](./IFencedStringifiedJsonOptions.inner.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+Converter&lt;T, unknown&gt; | Validator&lt;T, unknown&gt;
+
+</td><td>
+
+Inner converter or validator applied to the parsed JSON value.
+
+</td></tr>
+<tr><td>
+
+[extractor](./IFencedStringifiedJsonExtractorOptions.extractor.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[JsonTextExtractor](../../type-aliases/JsonTextExtractor.md)
+
+</td><td>
+
+Optional pre-parse extractor.
+
+</td></tr>
+</tbody></table>

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionParams.converter.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionParams.converter.md
@@ -1,0 +1,14 @@
+[Home](../../README.md) > [AiAssist](../README.md) > [IGenerateJsonCompletionParams](./IGenerateJsonCompletionParams.md) > converter
+
+## IGenerateJsonCompletionParams.converter property
+
+Caller-supplied `Converter<T>` or `Validator<T>` applied to the parsed
+JSON value. Wrapped internally in AiAssist.fencedStringifiedJson
+unless AiAssist.IGenerateJsonCompletionParams.jsonConverter is
+provided.
+
+**Signature:**
+
+```typescript
+readonly converter: Converter<T, unknown> | Validator<T, unknown>;
+```

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionParams.jsonConverter.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionParams.jsonConverter.md
@@ -1,0 +1,14 @@
+[Home](../../README.md) > [AiAssist](../README.md) > [IGenerateJsonCompletionParams](./IGenerateJsonCompletionParams.md) > jsonConverter
+
+## IGenerateJsonCompletionParams.jsonConverter property
+
+Full string-to-`T` pipeline override. When supplied, takes precedence over
+AiAssist.IGenerateJsonCompletionParams.converter and lets the
+caller plug in a custom extractor or skip the default fence tolerance
+entirely.
+
+**Signature:**
+
+```typescript
+readonly jsonConverter: Converter<T, unknown>;
+```

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionParams.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionParams.md
@@ -1,0 +1,252 @@
+[Home](../../README.md) > [AiAssist](../README.md) > IGenerateJsonCompletionParams
+
+# Interface: IGenerateJsonCompletionParams
+
+Parameters for AiAssist.generateJsonCompletion. Extends
+AiAssist.IProviderCompletionParams with JSON-validation knobs.
+
+**Extends:** [`IProviderCompletionParams`](../../interfaces/IProviderCompletionParams.md)
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody>
+<tr><td>
+
+[converter](./IGenerateJsonCompletionParams.converter.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+Converter&lt;T, unknown&gt; | Validator&lt;T, unknown&gt;
+
+</td><td>
+
+Caller-supplied `Converter<T>` or `Validator<T>` applied to the parsed
+JSON value.
+
+</td></tr>
+<tr><td>
+
+[jsonConverter](./IGenerateJsonCompletionParams.jsonConverter.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+Converter&lt;T, unknown&gt;
+
+</td><td>
+
+Full string-to-`T` pipeline override.
+
+</td></tr>
+<tr><td>
+
+[promptHint](./IGenerateJsonCompletionParams.promptHint.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[JsonPromptHint](../../type-aliases/JsonPromptHint.md)
+
+</td><td>
+
+Controls the optional system-prompt augmentation.
+
+</td></tr>
+<tr><td>
+
+[descriptor](./IProviderCompletionParams.descriptor.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[IAiProviderDescriptor](../../interfaces/IAiProviderDescriptor.md)
+
+</td><td>
+
+The provider descriptor
+
+</td></tr>
+<tr><td>
+
+[apiKey](./IProviderCompletionParams.apiKey.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+string
+
+</td><td>
+
+API key for authentication
+
+</td></tr>
+<tr><td>
+
+[prompt](./IProviderCompletionParams.prompt.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[AiPrompt](../../classes/AiPrompt.md)
+
+</td><td>
+
+The structured prompt to send
+
+</td></tr>
+<tr><td>
+
+[additionalMessages](./IProviderCompletionParams.additionalMessages.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+readonly [IChatMessage](../../interfaces/IChatMessage.md)[]
+
+</td><td>
+
+Additional messages to append after system+user (e.g.
+
+</td></tr>
+<tr><td>
+
+[temperature](./IProviderCompletionParams.temperature.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+number
+
+</td><td>
+
+Sampling temperature (default: 0.7)
+
+</td></tr>
+<tr><td>
+
+[modelOverride](./IProviderCompletionParams.modelOverride.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[ModelSpec](../../type-aliases/ModelSpec.md)
+
+</td><td>
+
+Optional model override — string or context-aware map (uses descriptor.defaultModel otherwise)
+
+</td></tr>
+<tr><td>
+
+[logger](./IProviderCompletionParams.logger.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+ILogger
+
+</td><td>
+
+Optional logger for request/response observability.
+
+</td></tr>
+<tr><td>
+
+[tools](./IProviderCompletionParams.tools.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+readonly [IAiWebSearchToolConfig](../../interfaces/IAiWebSearchToolConfig.md)[]
+
+</td><td>
+
+Server-side tools to include in the request.
+
+</td></tr>
+<tr><td>
+
+[signal](./IProviderCompletionParams.signal.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+AbortSignal
+
+</td><td>
+
+Optional abort signal for cancelling the in-flight request.
+
+</td></tr>
+<tr><td>
+
+[endpoint](./IProviderCompletionParams.endpoint.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+string
+
+</td><td>
+
+Optional override of the descriptor's default base URL.
+
+</td></tr>
+</tbody></table>

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionParams.promptHint.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionParams.promptHint.md
@@ -1,0 +1,12 @@
+[Home](../../README.md) > [AiAssist](../README.md) > [IGenerateJsonCompletionParams](./IGenerateJsonCompletionParams.md) > promptHint
+
+## IGenerateJsonCompletionParams.promptHint property
+
+Controls the optional system-prompt augmentation. Defaults to `'smart'`.
+Pass `'none'` to disable, or a string to append custom guidance.
+
+**Signature:**
+
+```typescript
+readonly promptHint: JsonPromptHint;
+```

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionResult.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionResult.md
@@ -1,0 +1,78 @@
+[Home](../../README.md) > [AiAssist](../README.md) > IGenerateJsonCompletionResult
+
+# Interface: IGenerateJsonCompletionResult
+
+Successful result of AiAssist.generateJsonCompletion.
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody>
+<tr><td>
+
+[value](./IGenerateJsonCompletionResult.value.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+T
+
+</td><td>
+
+The validated JSON value.
+
+</td></tr>
+<tr><td>
+
+[raw](./IGenerateJsonCompletionResult.raw.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+string
+
+</td><td>
+
+The raw response text returned by the provider.
+
+</td></tr>
+<tr><td>
+
+[response](./IGenerateJsonCompletionResult.response.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[IAiCompletionResponse](../../interfaces/IAiCompletionResponse.md)
+
+</td><td>
+
+The full underlying completion response.
+
+</td></tr>
+</tbody></table>

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionResult.raw.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionResult.raw.md
@@ -1,0 +1,11 @@
+[Home](../../README.md) > [AiAssist](../README.md) > [IGenerateJsonCompletionResult](./IGenerateJsonCompletionResult.md) > raw
+
+## IGenerateJsonCompletionResult.raw property
+
+The raw response text returned by the provider.
+
+**Signature:**
+
+```typescript
+readonly raw: string;
+```

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionResult.response.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionResult.response.md
@@ -1,0 +1,11 @@
+[Home](../../README.md) > [AiAssist](../README.md) > [IGenerateJsonCompletionResult](./IGenerateJsonCompletionResult.md) > response
+
+## IGenerateJsonCompletionResult.response property
+
+The full underlying completion response.
+
+**Signature:**
+
+```typescript
+readonly response: IAiCompletionResponse;
+```

--- a/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionResult.value.md
+++ b/libraries/ts-extras/docs/AiAssist/interfaces/IGenerateJsonCompletionResult.value.md
@@ -1,0 +1,11 @@
+[Home](../../README.md) > [AiAssist](../README.md) > [IGenerateJsonCompletionResult](./IGenerateJsonCompletionResult.md) > value
+
+## IGenerateJsonCompletionResult.value property
+
+The validated JSON value.
+
+**Signature:**
+
+```typescript
+readonly value: T;
+```

--- a/libraries/ts-extras/docs/AiAssist/type-aliases/JsonPromptHint.md
+++ b/libraries/ts-extras/docs/AiAssist/type-aliases/JsonPromptHint.md
@@ -1,0 +1,16 @@
+[Home](../../README.md) > [AiAssist](../README.md) > JsonPromptHint
+
+# Type Alias: JsonPromptHint
+
+Controls the optional system-prompt augmentation applied by
+AiAssist.generateJsonCompletion.
+
+- `'smart'` (default): append AiAssist.SMART_JSON_PROMPT_HINT.
+- `'none'`: do not modify the prompt.
+- A string: append the supplied text verbatim.
+
+## Type
+
+```typescript
+type JsonPromptHint = "smart" | "none" | string & {}
+```

--- a/libraries/ts-extras/docs/AiAssist/type-aliases/JsonTextExtractor.md
+++ b/libraries/ts-extras/docs/AiAssist/type-aliases/JsonTextExtractor.md
@@ -1,0 +1,13 @@
+[Home](../../README.md) > [AiAssist](../README.md) > JsonTextExtractor
+
+# Type Alias: JsonTextExtractor
+
+A function that pulls a JSON-shaped substring out of arbitrary model text.
+Implementations strip whatever wrappers the model added (fences, preamble,
+trailing prose) and return the JSON-shaped substring ready for `JSON.parse`.
+
+## Type
+
+```typescript
+type JsonTextExtractor = (text: string) => Result<string>
+```

--- a/libraries/ts-extras/docs/AiAssist/variables/SMART_JSON_PROMPT_HINT.md
+++ b/libraries/ts-extras/docs/AiAssist/variables/SMART_JSON_PROMPT_HINT.md
@@ -1,0 +1,11 @@
+[Home](../../README.md) > [AiAssist](../README.md) > SMART_JSON_PROMPT_HINT
+
+# Variable: SMART_JSON_PROMPT_HINT
+
+Default system-prompt suffix appended when AiAssist.IGenerateJsonCompletionParams.promptHint
+is `'smart'` (the default). Designed to discourage code fences and prose in
+the model's response while still tolerating them via the read-side extractor.
+
+## Type
+
+`string`

--- a/libraries/ts-extras/docs/AiAssist/variables/extractJsonText.md
+++ b/libraries/ts-extras/docs/AiAssist/variables/extractJsonText.md
@@ -1,0 +1,16 @@
+[Home](../../README.md) > [AiAssist](../README.md) > extractJsonText
+
+# Variable: extractJsonText
+
+Default AiAssist.JsonTextExtractor | extractor for LLM responses. Tolerates:
+
+- Leading/trailing whitespace and a leading byte-order mark.
+- Markdown code fences (with or without a language tag).
+- Conversational preamble before the first `{` or `[`.
+- Trailing prose after the matched closing `}` or `]`.
+
+Out of scope: repairing malformed JSON, handling smart quotes, etc.
+
+## Type
+
+`JsonTextExtractor`

--- a/libraries/ts-extras/docs/CryptoUtils/KeyStore/classes/KeyStore.md
+++ b/libraries/ts-extras/docs/CryptoUtils/KeyStore/classes/KeyStore.md
@@ -304,6 +304,21 @@ Adds a secret derived from a password using PBKDF2.
 </td></tr>
 <tr><td>
 
+[verifySecretFromPassword(name, password, keyDerivation)](./KeyStore.verifySecretFromPassword.md)
+
+</td><td>
+
+
+
+</td><td>
+
+Verifies that a candidate password derives the same key material currently
+stored under `name`, using the supplied
+CryptoUtils.IKeyDerivationParams | key derivation parameters.
+
+</td></tr>
+<tr><td>
+
 [removeSecret(name)](./KeyStore.removeSecret.md)
 
 </td><td>

--- a/libraries/ts-extras/docs/CryptoUtils/KeyStore/classes/KeyStore.verifySecretFromPassword.md
+++ b/libraries/ts-extras/docs/CryptoUtils/KeyStore/classes/KeyStore.verifySecretFromPassword.md
@@ -1,0 +1,51 @@
+[Home](../../../README.md) > [CryptoUtils](../../README.md) > [KeyStore](../README.md) > [KeyStore](./KeyStore.md) > verifySecretFromPassword
+
+## KeyStore.verifySecretFromPassword() method
+
+Verifies that a candidate password derives the same key material currently
+stored under `name`, using the supplied
+CryptoUtils.IKeyDerivationParams | key derivation parameters.
+
+The keystore does not persist per-slot key derivation parameters with the
+entry — callers receive them from `addSecretFromPassword` and store them
+alongside the encrypted artifact (or wherever else makes sense). Pass
+those same parameters here for verification.
+
+Re-derives a key from `password` + `keyDerivation`, then compares it to
+the stored key material in constant time. Restricted to entries of type
+`'encryption-key'` — the type produced by `addSecretFromPassword`. Other
+symmetric types (`'api-key'`) and asymmetric entries are rejected so
+the boolean result reflects "this slot accepts this password" rather
+than an incidental byte-equality match against unrelated material.
+
+Note: the keystore does not currently flag whether an `'encryption-key'`
+entry was actually password-derived (vs. random via `addSecret` or raw
+via `importSecret`). A `true` result therefore means "the candidate
+password produces the same 32 bytes currently stored", which is what
+the equivalent consumer-side helper (`verifyGatePassword`) already
+implies for entries it manages.
+
+**Signature:**
+
+```typescript
+verifySecretFromPassword(name: string, password: string, keyDerivation: IKeyDerivationParams): Promise<Result<boolean>>;
+```
+
+**Parameters:**
+
+<table><thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td>name</td><td>string</td><td>Name of the secret to verify against</td></tr>
+<tr><td>password</td><td>string</td><td>Candidate password to test</td></tr>
+<tr><td>keyDerivation</td><td>IKeyDerivationParams</td><td>The key derivation parameters returned by
+`addSecretFromPassword` when the secret was created. Only
+`kdf: 'pbkdf2'` is supported.</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;Result&lt;boolean&gt;&gt;
+
+Success(true) when the candidate matches the stored key,
+Success(false) when it does not, Failure if locked, secret missing,
+wrong type, unsupported `kdf`, or key derivation fails

--- a/libraries/ts-extras/docs/CryptoUtils/classes/KeyStore.md
+++ b/libraries/ts-extras/docs/CryptoUtils/classes/KeyStore.md
@@ -304,6 +304,21 @@ Adds a secret derived from a password using PBKDF2.
 </td></tr>
 <tr><td>
 
+[verifySecretFromPassword(name, password, keyDerivation)](./KeyStore.verifySecretFromPassword.md)
+
+</td><td>
+
+
+
+</td><td>
+
+Verifies that a candidate password derives the same key material currently
+stored under `name`, using the supplied
+CryptoUtils.IKeyDerivationParams | key derivation parameters.
+
+</td></tr>
+<tr><td>
+
 [removeSecret(name)](./KeyStore.removeSecret.md)
 
 </td><td>

--- a/libraries/ts-extras/docs/CryptoUtils/classes/KeyStore.verifySecretFromPassword.md
+++ b/libraries/ts-extras/docs/CryptoUtils/classes/KeyStore.verifySecretFromPassword.md
@@ -1,0 +1,51 @@
+[Home](../../README.md) > [CryptoUtils](../README.md) > [KeyStore](./KeyStore.md) > verifySecretFromPassword
+
+## KeyStore.verifySecretFromPassword() method
+
+Verifies that a candidate password derives the same key material currently
+stored under `name`, using the supplied
+CryptoUtils.IKeyDerivationParams | key derivation parameters.
+
+The keystore does not persist per-slot key derivation parameters with the
+entry — callers receive them from `addSecretFromPassword` and store them
+alongside the encrypted artifact (or wherever else makes sense). Pass
+those same parameters here for verification.
+
+Re-derives a key from `password` + `keyDerivation`, then compares it to
+the stored key material in constant time. Restricted to entries of type
+`'encryption-key'` — the type produced by `addSecretFromPassword`. Other
+symmetric types (`'api-key'`) and asymmetric entries are rejected so
+the boolean result reflects "this slot accepts this password" rather
+than an incidental byte-equality match against unrelated material.
+
+Note: the keystore does not currently flag whether an `'encryption-key'`
+entry was actually password-derived (vs. random via `addSecret` or raw
+via `importSecret`). A `true` result therefore means "the candidate
+password produces the same 32 bytes currently stored", which is what
+the equivalent consumer-side helper (`verifyGatePassword`) already
+implies for entries it manages.
+
+**Signature:**
+
+```typescript
+verifySecretFromPassword(name: string, password: string, keyDerivation: IKeyDerivationParams): Promise<Result<boolean>>;
+```
+
+**Parameters:**
+
+<table><thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td>name</td><td>string</td><td>Name of the secret to verify against</td></tr>
+<tr><td>password</td><td>string</td><td>Candidate password to test</td></tr>
+<tr><td>keyDerivation</td><td>IKeyDerivationParams</td><td>The key derivation parameters returned by
+`addSecretFromPassword` when the secret was created. Only
+`kdf: 'pbkdf2'` is supported.</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;Result&lt;boolean&gt;&gt;
+
+Success(true) when the candidate matches the stored key,
+Success(false) when it does not, Failure if locked, secret missing,
+wrong type, unsupported `kdf`, or key derivation fails

--- a/libraries/ts-extras/docs/CryptoUtils/classes/NodeCryptoProvider.generateUuid.md
+++ b/libraries/ts-extras/docs/CryptoUtils/classes/NodeCryptoProvider.generateUuid.md
@@ -1,0 +1,18 @@
+[Home](../../README.md) > [CryptoUtils](../README.md) > [NodeCryptoProvider](./NodeCryptoProvider.md) > generateUuid
+
+## NodeCryptoProvider.generateUuid() method
+
+Generates a cryptographically random UUIDv4 via the platform Web Crypto API.
+
+**Signature:**
+
+```typescript
+generateUuid(): Result<Uuid>;
+```
+
+**Returns:**
+
+Result&lt;Uuid&gt;
+
+`Success` with the generated UUID, or `Failure` if the runtime
+does not expose `globalThis.crypto.randomUUID`.

--- a/libraries/ts-extras/docs/CryptoUtils/classes/NodeCryptoProvider.md
+++ b/libraries/ts-extras/docs/CryptoUtils/classes/NodeCryptoProvider.md
@@ -134,6 +134,19 @@ Generates cryptographically secure random bytes.
 </td></tr>
 <tr><td>
 
+[generateUuid()](./NodeCryptoProvider.generateUuid.md)
+
+</td><td>
+
+
+
+</td><td>
+
+Generates a cryptographically random UUIDv4 via the platform Web Crypto API.
+
+</td></tr>
+<tr><td>
+
 [toBase64(data)](./NodeCryptoProvider.toBase64.md)
 
 </td><td>

--- a/libraries/ts-extras/docs/CryptoUtils/interfaces/ICryptoProvider.generateUuid.md
+++ b/libraries/ts-extras/docs/CryptoUtils/interfaces/ICryptoProvider.generateUuid.md
@@ -1,0 +1,21 @@
+[Home](../../README.md) > [CryptoUtils](../README.md) > [ICryptoProvider](./ICryptoProvider.md) > generateUuid
+
+## ICryptoProvider.generateUuid() method
+
+Generates a cryptographically random UUIDv4 using the provider's
+underlying source of randomness. The default Node and browser
+implementations delegate to `globalThis.crypto.randomUUID`;
+deterministic providers (e.g. test stubs) may override to produce
+reproducible values.
+
+**Signature:**
+
+```typescript
+generateUuid(): Result<Uuid>;
+```
+
+**Returns:**
+
+Result&lt;Uuid&gt;
+
+Success with a canonical UUID, or Failure with error.

--- a/libraries/ts-extras/docs/CryptoUtils/interfaces/ICryptoProvider.md
+++ b/libraries/ts-extras/docs/CryptoUtils/interfaces/ICryptoProvider.md
@@ -101,6 +101,20 @@ Generates cryptographically secure random bytes.
 </td></tr>
 <tr><td>
 
+[generateUuid()](./ICryptoProvider.generateUuid.md)
+
+</td><td>
+
+
+
+</td><td>
+
+Generates a cryptographically random UUIDv4 using the provider's
+underlying source of randomness.
+
+</td></tr>
+<tr><td>
+
 [toBase64(data)](./ICryptoProvider.toBase64.md)
 
 </td><td>

--- a/libraries/ts-extras/docs/Csv/README.md
+++ b/libraries/ts-extras/docs/Csv/README.md
@@ -48,20 +48,20 @@ Parses CSV data from a string.
 </td></tr>
 <tr><td>
 
-[readCsvFileSync](./functions/readCsvFileSync.md)
-
-</td><td>
-
-Reads a CSV file from a supplied path.
-
-</td></tr>
-<tr><td>
-
 [readCsvFromTree](./functions/readCsvFromTree.md)
 
 </td><td>
 
 Reads a CSV file from a FileTree.
+
+</td></tr>
+<tr><td>
+
+[readCsvFileSync](./functions/readCsvFileSync.md)
+
+</td><td>
+
+Reads a CSV file from a supplied path.
 
 </td></tr>
 </tbody></table>

--- a/libraries/ts-extras/docs/KeyStore/classes/KeyStore.md
+++ b/libraries/ts-extras/docs/KeyStore/classes/KeyStore.md
@@ -304,6 +304,21 @@ Adds a secret derived from a password using PBKDF2.
 </td></tr>
 <tr><td>
 
+[verifySecretFromPassword(name, password, keyDerivation)](./KeyStore.verifySecretFromPassword.md)
+
+</td><td>
+
+
+
+</td><td>
+
+Verifies that a candidate password derives the same key material currently
+stored under `name`, using the supplied
+CryptoUtils.IKeyDerivationParams | key derivation parameters.
+
+</td></tr>
+<tr><td>
+
 [removeSecret(name)](./KeyStore.removeSecret.md)
 
 </td><td>

--- a/libraries/ts-extras/docs/KeyStore/classes/KeyStore.verifySecretFromPassword.md
+++ b/libraries/ts-extras/docs/KeyStore/classes/KeyStore.verifySecretFromPassword.md
@@ -1,0 +1,51 @@
+[Home](../../README.md) > [KeyStore](../README.md) > [KeyStore](./KeyStore.md) > verifySecretFromPassword
+
+## KeyStore.verifySecretFromPassword() method
+
+Verifies that a candidate password derives the same key material currently
+stored under `name`, using the supplied
+CryptoUtils.IKeyDerivationParams | key derivation parameters.
+
+The keystore does not persist per-slot key derivation parameters with the
+entry — callers receive them from `addSecretFromPassword` and store them
+alongside the encrypted artifact (or wherever else makes sense). Pass
+those same parameters here for verification.
+
+Re-derives a key from `password` + `keyDerivation`, then compares it to
+the stored key material in constant time. Restricted to entries of type
+`'encryption-key'` — the type produced by `addSecretFromPassword`. Other
+symmetric types (`'api-key'`) and asymmetric entries are rejected so
+the boolean result reflects "this slot accepts this password" rather
+than an incidental byte-equality match against unrelated material.
+
+Note: the keystore does not currently flag whether an `'encryption-key'`
+entry was actually password-derived (vs. random via `addSecret` or raw
+via `importSecret`). A `true` result therefore means "the candidate
+password produces the same 32 bytes currently stored", which is what
+the equivalent consumer-side helper (`verifyGatePassword`) already
+implies for entries it manages.
+
+**Signature:**
+
+```typescript
+verifySecretFromPassword(name: string, password: string, keyDerivation: IKeyDerivationParams): Promise<Result<boolean>>;
+```
+
+**Parameters:**
+
+<table><thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td>name</td><td>string</td><td>Name of the secret to verify against</td></tr>
+<tr><td>password</td><td>string</td><td>Candidate password to test</td></tr>
+<tr><td>keyDerivation</td><td>IKeyDerivationParams</td><td>The key derivation parameters returned by
+`addSecretFromPassword` when the secret was created. Only
+`kdf: 'pbkdf2'` is supported.</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;Result&lt;boolean&gt;&gt;
+
+Success(true) when the candidate matches the stored key,
+Success(false) when it does not, Failure if locked, secret missing,
+wrong type, unsupported `kdf`, or key derivation fails

--- a/libraries/ts-extras/docs/RecordJar/README.md
+++ b/libraries/ts-extras/docs/RecordJar/README.md
@@ -80,20 +80,20 @@ Reads a record-jar from an array of strings, each of which represents one
 </td></tr>
 <tr><td>
 
-[readRecordJarFileSync](./functions/readRecordJarFileSync.md)
-
-</td><td>
-
-Reads a record-jar file from a supplied path.
-
-</td></tr>
-<tr><td>
-
 [readRecordJarFromTree](./functions/readRecordJarFromTree.md)
 
 </td><td>
 
 Reads a record-jar file from a FileTree.
+
+</td></tr>
+<tr><td>
+
+[readRecordJarFileSync](./functions/readRecordJarFileSync.md)
+
+</td><td>
+
+Reads a record-jar file from a supplied path.
 
 </td></tr>
 </tbody></table>

--- a/libraries/ts-extras/docs/classes/KeyStore.md
+++ b/libraries/ts-extras/docs/classes/KeyStore.md
@@ -304,6 +304,21 @@ Adds a secret derived from a password using PBKDF2.
 </td></tr>
 <tr><td>
 
+[verifySecretFromPassword(name, password, keyDerivation)](./KeyStore.verifySecretFromPassword.md)
+
+</td><td>
+
+
+
+</td><td>
+
+Verifies that a candidate password derives the same key material currently
+stored under `name`, using the supplied
+CryptoUtils.IKeyDerivationParams | key derivation parameters.
+
+</td></tr>
+<tr><td>
+
 [removeSecret(name)](./KeyStore.removeSecret.md)
 
 </td><td>

--- a/libraries/ts-extras/docs/classes/KeyStore.verifySecretFromPassword.md
+++ b/libraries/ts-extras/docs/classes/KeyStore.verifySecretFromPassword.md
@@ -1,0 +1,51 @@
+[Home](../README.md) > [KeyStore](./KeyStore.md) > verifySecretFromPassword
+
+## KeyStore.verifySecretFromPassword() method
+
+Verifies that a candidate password derives the same key material currently
+stored under `name`, using the supplied
+CryptoUtils.IKeyDerivationParams | key derivation parameters.
+
+The keystore does not persist per-slot key derivation parameters with the
+entry — callers receive them from `addSecretFromPassword` and store them
+alongside the encrypted artifact (or wherever else makes sense). Pass
+those same parameters here for verification.
+
+Re-derives a key from `password` + `keyDerivation`, then compares it to
+the stored key material in constant time. Restricted to entries of type
+`'encryption-key'` — the type produced by `addSecretFromPassword`. Other
+symmetric types (`'api-key'`) and asymmetric entries are rejected so
+the boolean result reflects "this slot accepts this password" rather
+than an incidental byte-equality match against unrelated material.
+
+Note: the keystore does not currently flag whether an `'encryption-key'`
+entry was actually password-derived (vs. random via `addSecret` or raw
+via `importSecret`). A `true` result therefore means "the candidate
+password produces the same 32 bytes currently stored", which is what
+the equivalent consumer-side helper (`verifyGatePassword`) already
+implies for entries it manages.
+
+**Signature:**
+
+```typescript
+verifySecretFromPassword(name: string, password: string, keyDerivation: IKeyDerivationParams): Promise<Result<boolean>>;
+```
+
+**Parameters:**
+
+<table><thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td>name</td><td>string</td><td>Name of the secret to verify against</td></tr>
+<tr><td>password</td><td>string</td><td>Candidate password to test</td></tr>
+<tr><td>keyDerivation</td><td>IKeyDerivationParams</td><td>The key derivation parameters returned by
+`addSecretFromPassword` when the secret was created. Only
+`kdf: 'pbkdf2'` is supported.</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;Result&lt;boolean&gt;&gt;
+
+Success(true) when the candidate matches the stored key,
+Success(false) when it does not, Failure if locked, secret missing,
+wrong type, unsupported `kdf`, or key derivation fails

--- a/libraries/ts-extras/docs/classes/NodeCryptoProvider.generateUuid.md
+++ b/libraries/ts-extras/docs/classes/NodeCryptoProvider.generateUuid.md
@@ -1,0 +1,18 @@
+[Home](../README.md) > [NodeCryptoProvider](./NodeCryptoProvider.md) > generateUuid
+
+## NodeCryptoProvider.generateUuid() method
+
+Generates a cryptographically random UUIDv4 via the platform Web Crypto API.
+
+**Signature:**
+
+```typescript
+generateUuid(): Result<Uuid>;
+```
+
+**Returns:**
+
+Result&lt;Uuid&gt;
+
+`Success` with the generated UUID, or `Failure` if the runtime
+does not expose `globalThis.crypto.randomUUID`.

--- a/libraries/ts-extras/docs/classes/NodeCryptoProvider.md
+++ b/libraries/ts-extras/docs/classes/NodeCryptoProvider.md
@@ -134,6 +134,19 @@ Generates cryptographically secure random bytes.
 </td></tr>
 <tr><td>
 
+[generateUuid()](./NodeCryptoProvider.generateUuid.md)
+
+</td><td>
+
+
+
+</td><td>
+
+Generates a cryptographically random UUIDv4 via the platform Web Crypto API.
+
+</td></tr>
+<tr><td>
+
 [toBase64(data)](./NodeCryptoProvider.toBase64.md)
 
 </td><td>

--- a/libraries/ts-extras/docs/functions/fencedStringifiedJson.md
+++ b/libraries/ts-extras/docs/functions/fencedStringifiedJson.md
@@ -1,0 +1,14 @@
+[Home](../README.md) > fencedStringifiedJson
+
+# Function: fencedStringifiedJson
+
+Creates a `Converter` that accepts raw LLM response text, runs it through a
+tolerant extractor (default: AiAssist.extractJsonText), parses the
+extracted substring as JSON, and applies an optional inner converter or
+validator.
+
+## Signature
+
+```typescript
+function fencedStringifiedJson(options: IFencedStringifiedJsonExtractorOptions): Converter<JsonValue>
+```

--- a/libraries/ts-extras/docs/functions/generateJsonCompletion.md
+++ b/libraries/ts-extras/docs/functions/generateJsonCompletion.md
@@ -1,0 +1,15 @@
+[Home](../README.md) > generateJsonCompletion
+
+# Function: generateJsonCompletion
+
+Calls AiAssist.callProviderCompletion, then runs the response text
+through a tolerant JSON converter (default:
+AiAssist.fencedStringifiedJson) and the caller's
+`converter`/`validator`. Returns the validated value plus the raw text and
+underlying completion response for diagnostics.
+
+## Signature
+
+```typescript
+function generateJsonCompletion(params: IGenerateJsonCompletionParams<T>): Promise<Result<IGenerateJsonCompletionResult<T>>>
+```

--- a/libraries/ts-extras/docs/interfaces/ICryptoProvider.generateUuid.md
+++ b/libraries/ts-extras/docs/interfaces/ICryptoProvider.generateUuid.md
@@ -1,0 +1,21 @@
+[Home](../README.md) > [ICryptoProvider](./ICryptoProvider.md) > generateUuid
+
+## ICryptoProvider.generateUuid() method
+
+Generates a cryptographically random UUIDv4 using the provider's
+underlying source of randomness. The default Node and browser
+implementations delegate to `globalThis.crypto.randomUUID`;
+deterministic providers (e.g. test stubs) may override to produce
+reproducible values.
+
+**Signature:**
+
+```typescript
+generateUuid(): Result<Uuid>;
+```
+
+**Returns:**
+
+Result&lt;Uuid&gt;
+
+Success with a canonical UUID, or Failure with error.

--- a/libraries/ts-extras/docs/interfaces/ICryptoProvider.md
+++ b/libraries/ts-extras/docs/interfaces/ICryptoProvider.md
@@ -101,6 +101,20 @@ Generates cryptographically secure random bytes.
 </td></tr>
 <tr><td>
 
+[generateUuid()](./ICryptoProvider.generateUuid.md)
+
+</td><td>
+
+
+
+</td><td>
+
+Generates a cryptographically random UUIDv4 using the provider's
+underlying source of randomness.
+
+</td></tr>
+<tr><td>
+
 [toBase64(data)](./ICryptoProvider.toBase64.md)
 
 </td><td>

--- a/libraries/ts-extras/docs/interfaces/IFencedStringifiedJsonExtractorOptions.extractor.md
+++ b/libraries/ts-extras/docs/interfaces/IFencedStringifiedJsonExtractorOptions.extractor.md
@@ -1,0 +1,13 @@
+[Home](../README.md) > [IFencedStringifiedJsonExtractorOptions](./IFencedStringifiedJsonExtractorOptions.md) > extractor
+
+## IFencedStringifiedJsonExtractorOptions.extractor property
+
+Optional pre-parse extractor. Defaults to AiAssist.extractJsonText.
+Provide a custom extractor to handle response shapes the default does not
+understand.
+
+**Signature:**
+
+```typescript
+readonly extractor: JsonTextExtractor;
+```

--- a/libraries/ts-extras/docs/interfaces/IFencedStringifiedJsonExtractorOptions.md
+++ b/libraries/ts-extras/docs/interfaces/IFencedStringifiedJsonExtractorOptions.md
@@ -1,0 +1,44 @@
+[Home](../README.md) > IFencedStringifiedJsonExtractorOptions
+
+# Interface: IFencedStringifiedJsonExtractorOptions
+
+Options shared by every AiAssist.fencedStringifiedJson call.
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody>
+<tr><td>
+
+[extractor](./IFencedStringifiedJsonExtractorOptions.extractor.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[JsonTextExtractor](../type-aliases/JsonTextExtractor.md)
+
+</td><td>
+
+Optional pre-parse extractor.
+
+</td></tr>
+</tbody></table>

--- a/libraries/ts-extras/docs/interfaces/IFencedStringifiedJsonOptions.inner.md
+++ b/libraries/ts-extras/docs/interfaces/IFencedStringifiedJsonOptions.inner.md
@@ -1,0 +1,11 @@
+[Home](../README.md) > [IFencedStringifiedJsonOptions](./IFencedStringifiedJsonOptions.md) > inner
+
+## IFencedStringifiedJsonOptions.inner property
+
+Inner converter or validator applied to the parsed JSON value.
+
+**Signature:**
+
+```typescript
+readonly inner: Converter<T, unknown> | Validator<T, unknown>;
+```

--- a/libraries/ts-extras/docs/interfaces/IFencedStringifiedJsonOptions.md
+++ b/libraries/ts-extras/docs/interfaces/IFencedStringifiedJsonOptions.md
@@ -1,0 +1,65 @@
+[Home](../README.md) > IFencedStringifiedJsonOptions
+
+# Interface: IFencedStringifiedJsonOptions
+
+Options for the validating overload of AiAssist.fencedStringifiedJson.
+`inner` is required so the typed `Converter<T>` return value can never lie
+about the runtime shape.
+
+**Extends:** [`IFencedStringifiedJsonExtractorOptions`](IFencedStringifiedJsonExtractorOptions.md)
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody>
+<tr><td>
+
+[inner](./IFencedStringifiedJsonOptions.inner.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+Converter&lt;T, unknown&gt; | Validator&lt;T, unknown&gt;
+
+</td><td>
+
+Inner converter or validator applied to the parsed JSON value.
+
+</td></tr>
+<tr><td>
+
+[extractor](./IFencedStringifiedJsonExtractorOptions.extractor.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[JsonTextExtractor](../type-aliases/JsonTextExtractor.md)
+
+</td><td>
+
+Optional pre-parse extractor.
+
+</td></tr>
+</tbody></table>

--- a/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionParams.converter.md
+++ b/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionParams.converter.md
@@ -1,0 +1,14 @@
+[Home](../README.md) > [IGenerateJsonCompletionParams](./IGenerateJsonCompletionParams.md) > converter
+
+## IGenerateJsonCompletionParams.converter property
+
+Caller-supplied `Converter<T>` or `Validator<T>` applied to the parsed
+JSON value. Wrapped internally in AiAssist.fencedStringifiedJson
+unless AiAssist.IGenerateJsonCompletionParams.jsonConverter is
+provided.
+
+**Signature:**
+
+```typescript
+readonly converter: Converter<T, unknown> | Validator<T, unknown>;
+```

--- a/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionParams.jsonConverter.md
+++ b/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionParams.jsonConverter.md
@@ -1,0 +1,14 @@
+[Home](../README.md) > [IGenerateJsonCompletionParams](./IGenerateJsonCompletionParams.md) > jsonConverter
+
+## IGenerateJsonCompletionParams.jsonConverter property
+
+Full string-to-`T` pipeline override. When supplied, takes precedence over
+AiAssist.IGenerateJsonCompletionParams.converter and lets the
+caller plug in a custom extractor or skip the default fence tolerance
+entirely.
+
+**Signature:**
+
+```typescript
+readonly jsonConverter: Converter<T, unknown>;
+```

--- a/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionParams.md
+++ b/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionParams.md
@@ -1,0 +1,252 @@
+[Home](../README.md) > IGenerateJsonCompletionParams
+
+# Interface: IGenerateJsonCompletionParams
+
+Parameters for AiAssist.generateJsonCompletion. Extends
+AiAssist.IProviderCompletionParams with JSON-validation knobs.
+
+**Extends:** [`IProviderCompletionParams`](IProviderCompletionParams.md)
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody>
+<tr><td>
+
+[converter](./IGenerateJsonCompletionParams.converter.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+Converter&lt;T, unknown&gt; | Validator&lt;T, unknown&gt;
+
+</td><td>
+
+Caller-supplied `Converter<T>` or `Validator<T>` applied to the parsed
+JSON value.
+
+</td></tr>
+<tr><td>
+
+[jsonConverter](./IGenerateJsonCompletionParams.jsonConverter.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+Converter&lt;T, unknown&gt;
+
+</td><td>
+
+Full string-to-`T` pipeline override.
+
+</td></tr>
+<tr><td>
+
+[promptHint](./IGenerateJsonCompletionParams.promptHint.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[JsonPromptHint](../type-aliases/JsonPromptHint.md)
+
+</td><td>
+
+Controls the optional system-prompt augmentation.
+
+</td></tr>
+<tr><td>
+
+[descriptor](./IProviderCompletionParams.descriptor.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[IAiProviderDescriptor](IAiProviderDescriptor.md)
+
+</td><td>
+
+The provider descriptor
+
+</td></tr>
+<tr><td>
+
+[apiKey](./IProviderCompletionParams.apiKey.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+string
+
+</td><td>
+
+API key for authentication
+
+</td></tr>
+<tr><td>
+
+[prompt](./IProviderCompletionParams.prompt.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[AiPrompt](../classes/AiPrompt.md)
+
+</td><td>
+
+The structured prompt to send
+
+</td></tr>
+<tr><td>
+
+[additionalMessages](./IProviderCompletionParams.additionalMessages.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+readonly [IChatMessage](IChatMessage.md)[]
+
+</td><td>
+
+Additional messages to append after system+user (e.g.
+
+</td></tr>
+<tr><td>
+
+[temperature](./IProviderCompletionParams.temperature.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+number
+
+</td><td>
+
+Sampling temperature (default: 0.7)
+
+</td></tr>
+<tr><td>
+
+[modelOverride](./IProviderCompletionParams.modelOverride.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[ModelSpec](../type-aliases/ModelSpec.md)
+
+</td><td>
+
+Optional model override — string or context-aware map (uses descriptor.defaultModel otherwise)
+
+</td></tr>
+<tr><td>
+
+[logger](./IProviderCompletionParams.logger.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+ILogger
+
+</td><td>
+
+Optional logger for request/response observability.
+
+</td></tr>
+<tr><td>
+
+[tools](./IProviderCompletionParams.tools.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+readonly [IAiWebSearchToolConfig](IAiWebSearchToolConfig.md)[]
+
+</td><td>
+
+Server-side tools to include in the request.
+
+</td></tr>
+<tr><td>
+
+[signal](./IProviderCompletionParams.signal.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+AbortSignal
+
+</td><td>
+
+Optional abort signal for cancelling the in-flight request.
+
+</td></tr>
+<tr><td>
+
+[endpoint](./IProviderCompletionParams.endpoint.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+string
+
+</td><td>
+
+Optional override of the descriptor's default base URL.
+
+</td></tr>
+</tbody></table>

--- a/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionParams.promptHint.md
+++ b/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionParams.promptHint.md
@@ -1,0 +1,12 @@
+[Home](../README.md) > [IGenerateJsonCompletionParams](./IGenerateJsonCompletionParams.md) > promptHint
+
+## IGenerateJsonCompletionParams.promptHint property
+
+Controls the optional system-prompt augmentation. Defaults to `'smart'`.
+Pass `'none'` to disable, or a string to append custom guidance.
+
+**Signature:**
+
+```typescript
+readonly promptHint: JsonPromptHint;
+```

--- a/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionResult.md
+++ b/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionResult.md
@@ -1,0 +1,78 @@
+[Home](../README.md) > IGenerateJsonCompletionResult
+
+# Interface: IGenerateJsonCompletionResult
+
+Successful result of AiAssist.generateJsonCompletion.
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody>
+<tr><td>
+
+[value](./IGenerateJsonCompletionResult.value.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+T
+
+</td><td>
+
+The validated JSON value.
+
+</td></tr>
+<tr><td>
+
+[raw](./IGenerateJsonCompletionResult.raw.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+string
+
+</td><td>
+
+The raw response text returned by the provider.
+
+</td></tr>
+<tr><td>
+
+[response](./IGenerateJsonCompletionResult.response.md)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+[IAiCompletionResponse](IAiCompletionResponse.md)
+
+</td><td>
+
+The full underlying completion response.
+
+</td></tr>
+</tbody></table>

--- a/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionResult.raw.md
+++ b/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionResult.raw.md
@@ -1,0 +1,11 @@
+[Home](../README.md) > [IGenerateJsonCompletionResult](./IGenerateJsonCompletionResult.md) > raw
+
+## IGenerateJsonCompletionResult.raw property
+
+The raw response text returned by the provider.
+
+**Signature:**
+
+```typescript
+readonly raw: string;
+```

--- a/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionResult.response.md
+++ b/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionResult.response.md
@@ -1,0 +1,11 @@
+[Home](../README.md) > [IGenerateJsonCompletionResult](./IGenerateJsonCompletionResult.md) > response
+
+## IGenerateJsonCompletionResult.response property
+
+The full underlying completion response.
+
+**Signature:**
+
+```typescript
+readonly response: IAiCompletionResponse;
+```

--- a/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionResult.value.md
+++ b/libraries/ts-extras/docs/interfaces/IGenerateJsonCompletionResult.value.md
@@ -1,0 +1,11 @@
+[Home](../README.md) > [IGenerateJsonCompletionResult](./IGenerateJsonCompletionResult.md) > value
+
+## IGenerateJsonCompletionResult.value property
+
+The validated JSON value.
+
+**Signature:**
+
+```typescript
+readonly value: T;
+```

--- a/libraries/ts-extras/docs/type-aliases/JsonPromptHint.md
+++ b/libraries/ts-extras/docs/type-aliases/JsonPromptHint.md
@@ -1,0 +1,16 @@
+[Home](../README.md) > JsonPromptHint
+
+# Type Alias: JsonPromptHint
+
+Controls the optional system-prompt augmentation applied by
+AiAssist.generateJsonCompletion.
+
+- `'smart'` (default): append AiAssist.SMART_JSON_PROMPT_HINT.
+- `'none'`: do not modify the prompt.
+- A string: append the supplied text verbatim.
+
+## Type
+
+```typescript
+type JsonPromptHint = "smart" | "none" | string & {}
+```

--- a/libraries/ts-extras/docs/type-aliases/JsonTextExtractor.md
+++ b/libraries/ts-extras/docs/type-aliases/JsonTextExtractor.md
@@ -1,0 +1,13 @@
+[Home](../README.md) > JsonTextExtractor
+
+# Type Alias: JsonTextExtractor
+
+A function that pulls a JSON-shaped substring out of arbitrary model text.
+Implementations strip whatever wrappers the model added (fences, preamble,
+trailing prose) and return the JSON-shaped substring ready for `JSON.parse`.
+
+## Type
+
+```typescript
+type JsonTextExtractor = (text: string) => Result<string>
+```

--- a/libraries/ts-extras/docs/variables/SMART_JSON_PROMPT_HINT.md
+++ b/libraries/ts-extras/docs/variables/SMART_JSON_PROMPT_HINT.md
@@ -1,0 +1,11 @@
+[Home](../README.md) > SMART_JSON_PROMPT_HINT
+
+# Variable: SMART_JSON_PROMPT_HINT
+
+Default system-prompt suffix appended when AiAssist.IGenerateJsonCompletionParams.promptHint
+is `'smart'` (the default). Designed to discourage code fences and prose in
+the model's response while still tolerating them via the read-side extractor.
+
+## Type
+
+`string`

--- a/libraries/ts-extras/docs/variables/extractJsonText.md
+++ b/libraries/ts-extras/docs/variables/extractJsonText.md
@@ -1,0 +1,16 @@
+[Home](../README.md) > extractJsonText
+
+# Variable: extractJsonText
+
+Default AiAssist.JsonTextExtractor | extractor for LLM responses. Tolerates:
+
+- Leading/trailing whitespace and a leading byte-order mark.
+- Markdown code fences (with or without a language tag).
+- Conversational preamble before the first `{` or `[`.
+- Trailing prose after the matched closing `}` or `]`.
+
+Out of scope: repairing malformed JSON, handling smart quotes, etc.
+
+## Type
+
+`JsonTextExtractor`

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -335,9 +335,9 @@ export { CryptoUtils }
 declare namespace Csv {
     export {
         parseCsvString,
+        readCsvFromTree,
         CsvOptions,
-        readCsvFileSync,
-        readCsvFromTree
+        readCsvFileSync
     }
 }
 export { Csv }
@@ -1580,11 +1580,11 @@ function readRecordJarFromTree(fileTree: FileTree.FileTree, filePath: string, op
 declare namespace RecordJar {
     export {
         parseRecordJarLines,
+        readRecordJarFromTree,
         JarRecord,
         JarFieldPicker,
         JarRecordParserOptions,
-        readRecordJarFileSync,
-        readRecordJarFromTree
+        readRecordJarFileSync
     }
 }
 export { RecordJar }

--- a/libraries/ts-extras/src/packlets/csv/csvFileHelpers.ts
+++ b/libraries/ts-extras/src/packlets/csv/csvFileHelpers.ts
@@ -21,7 +21,6 @@
  */
 
 import { Result, captureResult } from '@fgv/ts-utils';
-import { FileTree } from '@fgv/ts-json-base';
 import * as fs from 'fs';
 import * as path from 'path';
 import { parseCsvString, CsvOptions } from './csvHelpers';
@@ -42,21 +41,3 @@ export function readCsvFileSync(srcPath: string, options?: CsvOptions): Result<u
   });
 }
 
-/**
- * Reads a CSV file from a FileTree.
- * @param fileTree - The FileTree to read from.
- * @param filePath - Path of the file within the tree.
- * @param options - optional parameters to control the processing
- * @returns The parsed CSV data.
- * @beta
- */
-export function readCsvFromTree(
-  fileTree: FileTree.FileTree,
-  filePath: string,
-  options?: CsvOptions
-): Result<unknown> {
-  return fileTree
-    .getFile(filePath)
-    .onSuccess((file) => file.getRawContents())
-    .onSuccess((contents) => parseCsvString(contents, options));
-}

--- a/libraries/ts-extras/src/packlets/csv/csvHelpers.ts
+++ b/libraries/ts-extras/src/packlets/csv/csvHelpers.ts
@@ -21,6 +21,7 @@
  */
 
 import { Result, captureResult } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
 import { parse } from 'papaparse';
 
 /**
@@ -51,4 +52,23 @@ export function parseCsvString(body: string, options?: CsvOptions): Result<unkno
       ...options
     }).data.slice(1);
   });
+}
+
+/**
+ * Reads a CSV file from a FileTree.
+ * @param fileTree - The FileTree to read from.
+ * @param filePath - Path of the file within the tree.
+ * @param options - optional parameters to control the processing
+ * @returns The parsed CSV data.
+ * @beta
+ */
+export function readCsvFromTree(
+  fileTree: FileTree.FileTree,
+  filePath: string,
+  options?: CsvOptions
+): Result<unknown> {
+  return fileTree
+    .getFile(filePath)
+    .onSuccess((file) => file.getRawContents())
+    .onSuccess((contents) => parseCsvString(contents, options));
 }

--- a/libraries/ts-extras/src/packlets/csv/index.browser.ts
+++ b/libraries/ts-extras/src/packlets/csv/index.browser.ts
@@ -22,11 +22,8 @@
 
 // Browser-safe CSV exports - excludes Node.js filesystem dependencies
 
-// Export all browser-safe parsing functionality
+// Export all browser-safe parsing functionality (includes readCsvFromTree)
 export * from './csvHelpers';
-
-// Export FileTree-based reading (web-compatible)
-export { readCsvFromTree } from './csvFileHelpers';
 
 // Exclude:
 // - readCsvFileSync (requires Node.js fs/path)

--- a/libraries/ts-extras/src/packlets/record-jar/index.browser.ts
+++ b/libraries/ts-extras/src/packlets/record-jar/index.browser.ts
@@ -22,11 +22,8 @@
 
 // Browser-safe RecordJar exports - excludes Node.js filesystem dependencies
 
-// Export all browser-safe parsing functionality
+// Export all browser-safe parsing functionality (includes readRecordJarFromTree)
 export * from './recordJarHelpers';
-
-// Export FileTree-based reading (web-compatible)
-export { readRecordJarFromTree } from './recordJarFileHelpers';
 
 // Exclude:
 // - readRecordJarFileSync (requires Node.js fs/path)

--- a/libraries/ts-extras/src/packlets/record-jar/recordJarFileHelpers.ts
+++ b/libraries/ts-extras/src/packlets/record-jar/recordJarFileHelpers.ts
@@ -24,7 +24,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { Result, captureResult } from '@fgv/ts-utils';
-import { FileTree } from '@fgv/ts-json-base';
 import { JarRecord, JarRecordParserOptions, parseRecordJarLines } from './recordJarHelpers';
 
 /**
@@ -47,25 +46,3 @@ export function readRecordJarFileSync(
   });
 }
 
-/**
- * Reads a record-jar file from a FileTree.
- * @param fileTree - The FileTree to read from.
- * @param filePath - Path of the file within the tree.
- * @param options - Optional parser configuration
- * @returns The contents of the file as an array of `Record<string, string>`
- * @see https://datatracker.ietf.org/doc/html/draft-phillips-record-jar-01
- * @public
- */
-export function readRecordJarFromTree(
-  fileTree: FileTree.FileTree,
-  filePath: string,
-  options?: JarRecordParserOptions
-): Result<JarRecord[]> {
-  return fileTree
-    .getFile(filePath)
-    .onSuccess((file) => file.getRawContents())
-    .onSuccess((contents) => {
-      const lines = contents.split(/\r?\n/);
-      return parseRecordJarLines(lines, options);
-    });
-}

--- a/libraries/ts-extras/src/packlets/record-jar/recordJarHelpers.ts
+++ b/libraries/ts-extras/src/packlets/record-jar/recordJarHelpers.ts
@@ -21,6 +21,7 @@
  */
 
 import { Result, fail, isKeyOf, succeed } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
 
 interface IRecordBody {
   body: string;
@@ -251,4 +252,27 @@ class RecordParser {
  */
 export function parseRecordJarLines(lines: string[], options?: JarRecordParserOptions): Result<JarRecord[]> {
   return RecordParser.parse(lines, options);
+}
+
+/**
+ * Reads a record-jar file from a FileTree.
+ * @param fileTree - The FileTree to read from.
+ * @param filePath - Path of the file within the tree.
+ * @param options - Optional parser configuration
+ * @returns The contents of the file as an array of `Record<string, string>`
+ * @see https://datatracker.ietf.org/doc/html/draft-phillips-record-jar-01
+ * @public
+ */
+export function readRecordJarFromTree(
+  fileTree: FileTree.FileTree,
+  filePath: string,
+  options?: JarRecordParserOptions
+): Result<JarRecord[]> {
+  return fileTree
+    .getFile(filePath)
+    .onSuccess((file) => file.getRawContents())
+    .onSuccess((contents) => {
+      const lines = contents.split(/\r?\n/);
+      return parseRecordJarLines(lines, options);
+    });
 }

--- a/libraries/ts-json-base/docs/Converters/functions/stringifiedJson.md
+++ b/libraries/ts-json-base/docs/Converters/functions/stringifiedJson.md
@@ -1,0 +1,12 @@
+[Home](../../README.md) > [Converters](../README.md) > stringifiedJson
+
+# Function: stringifiedJson
+
+Creates a converter that accepts a string, parses it as JSON, and optionally
+applies the supplied inner converter or validator to the parsed value.
+
+## Signature
+
+```typescript
+function stringifiedJson(): Converter<JsonValue>
+```

--- a/libraries/ts-json-base/docs/functions/stringifiedJson.md
+++ b/libraries/ts-json-base/docs/functions/stringifiedJson.md
@@ -1,0 +1,12 @@
+[Home](../README.md) > stringifiedJson
+
+# Function: stringifiedJson
+
+Creates a converter that accepts a string, parses it as JSON, and optionally
+applies the supplied inner converter or validator to the parsed value.
+
+## Signature
+
+```typescript
+function stringifiedJson(): Converter<JsonValue>
+```

--- a/libraries/ts-utils/docs/README.md
+++ b/libraries/ts-utils/docs/README.md
@@ -424,6 +424,16 @@ Async continuation callback to be called in the event that a
 Helper type to extract the element type and preserve readonly status.
 
 </td></tr>
+<tr><td>
+
+[Uuid](./type-aliases/Uuid.md)
+
+</td><td>
+
+A canonical UUIDv4 string: 8-4-4-4-12 lowercase hex digits with version
+nibble `4` and variant nibble in `[89ab]`.
+
+</td></tr>
 </tbody></table>
 
 ## Functions
@@ -761,6 +771,25 @@ Applies a factory method to convert an optional `ReadonlyMap<string, TS>` into a
 </td><td>
 
 Applies a factory method to convert an optional `ReadonlyMap<string, TS>` into a `Record<string, TD>`
+
+</td></tr>
+<tr><td>
+
+[isValidUuid](./functions/isValidUuid.md)
+
+</td><td>
+
+Type guard that returns `true` when the input is a canonical UUIDv4 string.
+
+</td></tr>
+<tr><td>
+
+[generateUuid](./functions/generateUuid.md)
+
+</td><td>
+
+Generates a cryptographically random UUIDv4 using the platform's Web Crypto
+API (`globalThis.crypto.randomUUID`).
 
 </td></tr>
 </tbody></table>

--- a/libraries/ts-utils/docs/functions/generateUuid.md
+++ b/libraries/ts-utils/docs/functions/generateUuid.md
@@ -1,0 +1,13 @@
+[Home](../README.md) > generateUuid
+
+# Function: generateUuid
+
+Generates a cryptographically random UUIDv4 using the platform's Web Crypto
+API (`globalThis.crypto.randomUUID`). Works in Node.js \>= 18 and modern
+browsers without per-call runtime checks.
+
+## Signature
+
+```typescript
+function generateUuid(): Uuid
+```

--- a/libraries/ts-utils/docs/functions/isValidUuid.md
+++ b/libraries/ts-utils/docs/functions/isValidUuid.md
@@ -1,0 +1,11 @@
+[Home](../README.md) > isValidUuid
+
+# Function: isValidUuid
+
+Type guard that returns `true` when the input is a canonical UUIDv4 string.
+
+## Signature
+
+```typescript
+function isValidUuid(value: string): value is Uuid
+```

--- a/libraries/ts-utils/docs/type-aliases/Uuid.md
+++ b/libraries/ts-utils/docs/type-aliases/Uuid.md
@@ -1,0 +1,13 @@
+[Home](../README.md) > Uuid
+
+# Type Alias: Uuid
+
+A canonical UUIDv4 string: 8-4-4-4-12 lowercase hex digits with version
+nibble `4` and variant nibble in `[89ab]`. Produced by generateUuid
+and validated by isValidUuid.
+
+## Type
+
+```typescript
+type Uuid = Brand<string, "Uuid">
+```

--- a/libraries/ts-web-extras/docs/CryptoUtils/classes/BrowserCryptoProvider.generateUuid.md
+++ b/libraries/ts-web-extras/docs/CryptoUtils/classes/BrowserCryptoProvider.generateUuid.md
@@ -1,0 +1,19 @@
+[Home](../../README.md) > [CryptoUtils](../README.md) > [BrowserCryptoProvider](./BrowserCryptoProvider.md) > generateUuid
+
+## BrowserCryptoProvider.generateUuid() method
+
+Generates a cryptographically random UUIDv4 using the injected
+`Crypto` instance.
+
+**Signature:**
+
+```typescript
+generateUuid(): Result<Uuid>;
+```
+
+**Returns:**
+
+Result&lt;Uuid&gt;
+
+`Success` with the generated UUID, or `Failure` if the underlying
+`Crypto` instance does not expose `randomUUID`.

--- a/libraries/ts-web-extras/docs/CryptoUtils/classes/BrowserCryptoProvider.md
+++ b/libraries/ts-web-extras/docs/CryptoUtils/classes/BrowserCryptoProvider.md
@@ -137,6 +137,19 @@ Generates cryptographically secure random bytes.
 </td></tr>
 <tr><td>
 
+[generateUuid()](./BrowserCryptoProvider.generateUuid.md)
+
+</td><td>
+
+
+
+</td><td>
+
+Generates a cryptographically random UUIDv4 using the injected
+
+</td></tr>
+<tr><td>
+
 [toBase64(data)](./BrowserCryptoProvider.toBase64.md)
 
 </td><td>

--- a/libraries/ts-web-extras/docs/classes/BrowserCryptoProvider.generateUuid.md
+++ b/libraries/ts-web-extras/docs/classes/BrowserCryptoProvider.generateUuid.md
@@ -1,0 +1,19 @@
+[Home](../README.md) > [BrowserCryptoProvider](./BrowserCryptoProvider.md) > generateUuid
+
+## BrowserCryptoProvider.generateUuid() method
+
+Generates a cryptographically random UUIDv4 using the injected
+`Crypto` instance.
+
+**Signature:**
+
+```typescript
+generateUuid(): Result<Uuid>;
+```
+
+**Returns:**
+
+Result&lt;Uuid&gt;
+
+`Success` with the generated UUID, or `Failure` if the underlying
+`Crypto` instance does not expose `randomUUID`.

--- a/libraries/ts-web-extras/docs/classes/BrowserCryptoProvider.md
+++ b/libraries/ts-web-extras/docs/classes/BrowserCryptoProvider.md
@@ -137,6 +137,19 @@ Generates cryptographically secure random bytes.
 </td></tr>
 <tr><td>
 
+[generateUuid()](./BrowserCryptoProvider.generateUuid.md)
+
+</td><td>
+
+
+
+</td><td>
+
+Generates a cryptographically random UUIDv4 using the injected
+
+</td></tr>
+<tr><td>
+
 [toBase64(data)](./BrowserCryptoProvider.toBase64.md)
 
 </td><td>


### PR DESCRIPTION
## Summary
Reorganized the codebase to move FileTree-based file reading functions from file-specific helper modules into their corresponding core helper modules. This improves code organization by co-locating related functionality and simplifies browser exports.

## Key Changes
- **Record Jar**: Moved `readRecordJarFromTree()` from `recordJarFileHelpers.ts` to `recordJarHelpers.ts`
- **CSV**: Moved `readCsvFromTree()` from `csvFileHelpers.ts` to `csvHelpers.ts`
- **Browser Exports**: Updated `index.browser.ts` files for both packlets to export FileTree functions directly from the core helper modules, eliminating the need for separate imports from file-specific modules
- **Imports**: Added `FileTree` import to the core helper modules where the functions now reside

## Implementation Details
- The FileTree-based functions are now grouped with their parsing counterparts in the core helper modules, making the API more discoverable
- Browser-safe exports remain unchanged in functionality—they now simply re-export from the consolidated helper modules
- File-specific helpers (`recordJarFileHelpers.ts` and `csvFileHelpers.ts`) now focus exclusively on Node.js filesystem operations
- This change maintains backward compatibility while improving the logical organization of the codebase

https://claude.ai/code/session_01TWM6g8R7mdmwoNyqFFUZsj