### PR TITLE
feat: install orchestrator workflow infrastructure

### DIFF
--- a/.ai/BASELINE.md
+++ b/.ai/BASELINE.md
@@ -1,0 +1,18 @@
+# Baseline
+
+The minimum `release` branch commit that all branches in the current
+wave must descend from. Bumped by the orchestrator when a new wave
+launches or when a cleanup batch lands that must be in the base
+going forward.
+
+---
+
+**Current baseline**: *(not yet pinned — pin with the first wave's
+base commit when you launch the first workstream)*
+
+To pin:
+```
+git log --oneline -1 release   # get the commit sha
+# then update this file:
+# **Current baseline**: <sha> — <YYYY-MM-DD> — <one-line description>
+```

--- a/.ai/conventions/workflow/artifact-protocol.md
+++ b/.ai/conventions/workflow/artifact-protocol.md
@@ -1,0 +1,158 @@
+# Convention — `convention.workflow.artifact-protocol`
+
+> Source: distilled from `<repo>/docs/WORKSTREAMS.md` preamble §
+> Artifact protocol and `<repo>/docs/CHORES.md § Artifact migration is
+> pre-merge` in the source corpus.
+
+The lifecycle of per-stream and per-chore-batch artifacts: where they
+live during execution, where they live after merge, when they
+migrate, and what the polished completion record looks like.
+
+---
+
+## The two-tree structure
+
+The orchestrator workflow family uses a two-tree structure for live
+work and historical record:
+
+```
+.ai/tasks/
+├── active/<id>/                  # live work, in-flight
+│   ├── brief.md                  # the contract (input)
+│   ├── state.md                  # live checkpoint (worker updates)
+│   ├── result.md                 # exit artifact (worker writes at end)
+│   ├── followups.md              # consolidated followups
+│   └── findings/inbox/<…>.md     # per-file findings inbox (scribe writes)
+│
+└── completed/<bucket>/<id>/      # post-merge historical record
+    ├── README.md                 # polished completion record
+    ├── brief.md                  # archived (read-only)
+    ├── state.md                  # archived (read-only)
+    ├── result.md                 # archived (read-only)
+    └── followups.md              # archived (read-only)
+```
+
+Path conventions are project-configurable:
+
+- The base path (`.ai/tasks/`) is a project choice.
+- The bucket (`<bucket>` — `2026-05` in the source corpus) is a
+  project choice. Year-month, semantic-version, or wave-shaped
+  bucketing all work.
+- Stream IDs and chore-batch IDs follow the project's stream
+  convention.
+
+## When migration happens
+
+**Pre-merge.** The migration from `active/<id>/` to
+`completed/<bucket>/<id>/` is part of the stream's PR — not a
+follow-up. The PR is one coherent unit:
+
+- The stream's code changes.
+- The artifact migration.
+- The polished completion `README.md`.
+
+This is the load-bearing rule. The two ways it can go wrong:
+
+- **Migration after merge.** Active and completed are out of sync;
+  the historical record is built post-hoc and risks losing context.
+  The source corpus had earlier streams that ran under "migration
+  on merge" wording — those needed hand-finalization with notable
+  effort.
+- **Migration in a separate follow-up PR.** Splits a coherent unit
+  across two PRs, complicates review, and introduces a window where
+  active still exists but is stale.
+
+The convention is unambiguous: **the migration ships in the same PR
+as the work**.
+
+## What the polished `README.md` looks like
+
+The completed-tasks `README.md` is the durable historical record.
+It's read by:
+
+- Future agents picking up related work and wanting context on
+  what shipped.
+- The orchestrator extracting followups for chore batches.
+- Reviewers auditing the workflow's evolution.
+
+Standard sections:
+
+```markdown
+# <Stream ID> — <one-line title>
+
+**Shipped**: <date> via <PR reference>.
+
+## Summary
+<one-paragraph what shipped>
+
+## Files changed
+<key files / new packlets / new wire surfaces>
+
+## Per-phase summaries
+<one paragraph per phase>
+
+## Decisions made during execution
+<design choices that landed; deferred ones>
+
+## Followups
+<links to active stream followups still in-flight, or to where they
+landed if drained pre-merge>
+
+## Lessons codified during the run
+<bulleted list of anything routed via
+convention.workflow.lessons-codification-triage>
+
+## References
+- Brief: `brief.md`
+- Live state: `state.md`
+- Exit artifact: `result.md`
+- PR: <link>
+```
+
+## State.md as the resume protocol
+
+`state.md` is the worker's live checkpoint. Updated at every phase
+boundary (or every item boundary for chore batches). The worker
+treats it as an out-of-band note to a future-self that may pick up
+mid-stream.
+
+If a session crosses a context boundary:
+
+1. Worker reads the brief in full.
+2. Worker reads `state.md` to find current checkpoint.
+3. Worker confirms with the orchestrator that scope and boundaries
+   still apply.
+4. Worker resumes at the next un-checked phase / item.
+
+An empty `state.md` after substantial work is a process bug.
+
+## Inbox-and-drain for findings
+
+Findings surfaced during execution (whether by the worker or by a
+scribe-agent) go to a per-file inbox under
+`active/<id>/findings/inbox/<timestamp>-<slug>.md`, **not** directly
+to `followups.md`. The orchestrator drains the inbox into the
+consolidated `followups.md` periodically. See
+`convention.workflow.inbox-and-drain` for the full pattern.
+
+## Anti-patterns
+
+- **Migration as follow-up after merge.** Splits the coherent unit;
+  risks losing context.
+- **`state.md` written only at exit.** Defeats the resume protocol.
+- **`result.md` written before phase completion.** Mid-flight
+  result.md content masks not-yet-shipped work as shipped.
+- **Polished README skipped.** "Just leave the active artifacts in
+  completed/" loses the durable historical record's value.
+- **Followups silently dropped at migration time.** Followups
+  surfaced during the stream must be in the consolidated followups
+  file, drained from the inbox, before migration. Otherwise they're
+  lost.
+
+## Adapter notes
+
+The two-tree structure is a directory-naming convention, not a
+harness mechanism. Any harness that allows the orchestrator and
+worker to read and write project files can implement it. The
+realization in the source corpus uses `.ai/tasks/`; other projects
+may prefer different roots (e.g. `streams/`, `tasks/`, `work/`).

--- a/.ai/conventions/workflow/branch-buffer-and-promotion.md
+++ b/.ai/conventions/workflow/branch-buffer-and-promotion.md
@@ -1,0 +1,137 @@
+# Convention — `convention.workflow.branch-buffer-and-promotion`
+
+> Source: distilled from `<repo>/.ai/instructions/ORCHESTRATOR_ROLE.md
+> § Buffer-and-main model` in the source corpus.
+
+A branch-topology pattern for separating in-flight agent work from
+canonical release state. Deliberately abstract — branch topology is
+team / project convention and the orchestrator workflow family
+works against several topologies. This convention names the pattern
+the source corpus used and gestures at alternatives without
+prescribing.
+
+---
+
+## The pattern
+
+A two-line branch model:
+
+```
+agent feature branches  ─PR─▶  buffer line  ─promote─▶  canonical line
+                ←──base from────                    ←──base periodic──
+```
+
+- **Canonical line** — main / release. Always coherent, always
+  green, never receives agent merges directly. Promoted to
+  explicitly via orchestrator-driven operations.
+- **Buffer line** — agent feature branches PR into here; iterative
+  review cycles play out here; followups land here. Slips and
+  in-flight churn are absorbed here, not on the canonical line.
+- **Agent feature branches** — base off the buffer's latest. Open
+  PRs against the buffer. Each PR gets its own automated review at
+  PR time.
+
+## Why two lines
+
+The buffer absorbs the cost of in-flight work (failed approaches,
+mid-cycle rework, agent slips like a deep-reviewer-merge that
+landed unfixed code). Without a buffer, every agent operation can
+directly affect the canonical line's state; with one, the canonical
+line only advances via deliberate orchestrator-gated promotions.
+
+## The promotion gate
+
+Invoked at clean stream-close moments after the buffer has
+accumulated a coherent batch of merged PRs:
+
+1. Confirm the buffer is in known-good state — all in-flight
+   followups closed or explicitly deferred; no in-progress PRs
+   blocking; baseline doc reflects the buffer's current state.
+2. Open a PR `<buffer> → <canonical>`. The PR's diff is whatever
+   has accumulated on the buffer since the last promotion.
+3. **Run one explicit automated-review pass on the unified buffer
+   state.** Even though each constituent PR was reviewed
+   individually when it landed, the unified diff can surface
+   **fix-interaction findings** — fixes that held in isolation but
+   interact when combined. Address those before merging.
+4. Merge with **merge-commit** method (preserves the constituent
+   PRs' history; squash would collapse the audit trail; rebase
+   would rewrite SHAs that other docs reference).
+5. Bump the pinned baseline file to capture the new canonical head.
+   The buffer continues to advance from the same point.
+
+Promotion frequency: at natural stream-close moments. Don't promote
+on every PR (defeats the buffer); don't let the buffer drift
+indefinitely (loses the "canonical is current canonical" property).
+
+## Why the promotion needs its own review pass
+
+The per-PR automated reviews catch within-PR issues. **Cross-PR
+fix-interactions only surface when the combined state is reviewed
+together.** Per the source corpus's review-cycle data, fix-
+interactions are uncommon but real. Catching them at promotion is
+cheaper than discovering them in production. The cost of the
+promotion review pass is one automated pass on the unified PR;
+orchestrator triage of its findings is the real cost — typically
+modest.
+
+## Alternatives the orchestrator workflow family is compatible with
+
+This convention is **deliberately abstract** because branch topology
+varies by team. Other compatible topologies:
+
+- **Trunk-based with feature flags.** Single main line; agent work
+  ships behind flags. The buffer's role is filled by flag state,
+  not branch state. The orchestrator workflow's coordination
+  through the streams ledger still applies; only the merge
+  mechanics differ.
+- **Release-branch model.** Canonical line is `release`; the buffer
+  is `develop` or `next`. Promotion is a release event rather than
+  a continuous operation.
+- **Single-branch with rebase discipline.** Small projects often
+  skip the buffer entirely; agent branches PR directly into main.
+  The orchestrator workflow runs without modification; the
+  fix-interaction risk is absorbed by the team rather than gated.
+
+The right topology depends on team size, release cadence, and
+risk tolerance. The orchestrator workflow doesn't prescribe.
+
+## What is project-agnostic
+
+Regardless of topology:
+
+- **Stream coordination through the streams ledger** is essential.
+- **File-boundary stake-out per stream** prevents collisions
+  regardless of branch topology.
+- **The pinned baseline** (whatever it points at) anchors the
+  "branches must descend from this" rule.
+- **Pre-merge artifact migration** is a per-PR property,
+  independent of how the PR is merged or where to.
+
+## Naming gotchas
+
+The source corpus uses `exploration-1` as the buffer line name —
+vestigial from an era when there were multiple parallel
+explorations. The role (buffer) is what matters; the name is
+semantic-by-convention. Other projects may prefer `develop`,
+`next`, `staging`, or `buffer` — same semantics.
+
+## Anti-patterns
+
+- **Direct agent merges to the canonical line.** Defeats the
+  buffer's purpose.
+- **Promotion without an automated-review pass.** Skips the
+  fix-interaction catch.
+- **Squash-merge at promotion.** Collapses the audit trail of
+  constituent PRs.
+- **Promotion on every PR.** Buffer becomes a passthrough; loses
+  the absorbing property.
+- **Buffer drift > a quarter without promotion.** Canonical line
+  no longer represents current state; downstream consumers can't
+  rely on it.
+
+## Adapter notes
+
+Branch operations are git-mechanical; no special harness mechanism.
+The convention applies to any project with a hosted-git equivalent
+(GitHub, GitLab, Gitea, etc.).

--- a/.ai/conventions/workflow/inbox-and-drain.md
+++ b/.ai/conventions/workflow/inbox-and-drain.md
@@ -1,0 +1,123 @@
+# Convention — `convention.workflow.inbox-and-drain`
+
+> Source: distilled from `<repo>/.ai/instructions/ORCHESTRATOR_ROLE.md
+> § Followups-inbox drain` and `<repo>/.ai/instructions/SCRIBE_ROLE.md`
+> in the source corpus.
+
+The pattern for collecting stream findings (from manual testing,
+post-merge observation, scribe sessions) into a per-file inbox during
+the stream's lifetime, drained periodically by the orchestrator into
+the consolidated followups file.
+
+---
+
+## The shape
+
+```
+.ai/tasks/active/<stream-id>/
+├── findings/
+│   └── inbox/
+│       ├── 2026-05-03-1430-broken-validation.md
+│       ├── 2026-05-03-1715-fixture-drift.md
+│       └── 2026-05-04-0915-stale-marker-rendering.md
+└── followups.md       # consolidated, numbered, class-grouped
+```
+
+**Inbox writers** (scribes, implementing agents) write per-file
+finding entries to `findings/inbox/<timestamp>-<slug>.md`. **One
+finding per file** — no bundling.
+
+**Drain target** is the consolidated `followups.md`. Only the
+orchestrator writes there.
+
+## Why per-file inbox instead of direct followups append
+
+The previous "scribe writes directly to followups.md" pattern
+produced repeated merge conflicts when:
+
+- Multiple writers (scribe, implementing agents marking resolved,
+  orchestrator restructure ops) iterated on the same file.
+- Long-running stream review cycles created many appends per day.
+- Implementing agents and scribes ran simultaneously during manual
+  testing.
+
+Per-file inbox eliminates the collision surface — each writer
+creates a new file; the orchestrator owns the consolidated
+structure.
+
+The trade: implementing agents see consolidated state only after a
+drain, not on every scribe write. Acceptable — drains can happen on
+demand if an implementing agent needs the latest consolidated state.
+
+## Inbox file format
+
+Single finding per file. Filename: `<YYYY-MM-DD-HHMM>-<short-slug>.md`.
+
+```markdown
+# <terse title>
+
+- **Where**: `<file>:<line>` (or pattern across files).
+- **Finding**: <quoting user framing; one-paragraph>.
+- **Fix shape**: <one-paragraph corrective change>.
+- **Deferral rationale**: <why deferred — usually "out of stream scope" or "ties to other followup">.
+```
+
+No numbering — orchestrator assigns numbers at drain time.
+
+## Drain trigger
+
+Opportunistic — drain when:
+
+- The inbox accumulates ~5+ files.
+- A stream-close is approaching.
+- Before opening a buffer-line promotion PR.
+- Implementing agents need a consolidated work list.
+
+Don't wait for a specific cadence; drain when the consolidated view
+becomes load-bearing.
+
+## Drain procedure
+
+1. **List the inbox** (`ls .ai/tasks/active/<id>/findings/inbox/`).
+2. **Read each inbox file** and the current `followups.md` to
+   understand the existing structure (numbering, class grouping,
+   status framing).
+3. **Decide placement** for each inbox finding — which class
+   subsection in `followups.md` it belongs to; what number to assign
+   (continuing the existing sequence).
+4. **Append to `followups.md`** with the consolidated format.
+5. **Delete the inbox file** once it's drained — the consolidated
+   entry in `followups.md` is the durable record.
+6. **Commit + push** the drain operation as a single commit (e.g.,
+   `chore: drain <stream-id> findings inbox (5 entries → followups #21-25)`).
+
+Token-cheap: routine bookkeeping. Delegate to a cheap-model agent
+unless the inbox findings need substantive triage (multiple findings
+overlap and need merging into one entry; a finding's class isn't
+obvious).
+
+## Anti-patterns
+
+- **Scribes writing to `followups.md` directly.** Defeats the
+  collision-surface elimination.
+- **Bundling multiple findings per inbox file.** One finding per
+  file is the rule; if two findings are clearly the same shape on
+  different surfaces, that's still two files (with cross-references
+  in the body if useful).
+- **Drains skipped indefinitely.** The inbox is a write-only
+  scratchpad; without drains, the consolidated `followups.md`
+  drifts behind reality. Drains should run before stream-close
+  regardless of inbox volume.
+- **Drains as part of every individual append.** Defeats the
+  efficiency of per-file inbox; restores the merge-conflict
+  surface.
+- **Renumbering or restructuring during a drain.** The drain is
+  append-only at the consolidated level; restructuring is a
+  separate orchestrator operation.
+
+## Adapter notes
+
+The inbox-and-drain pattern is a directory-naming convention.
+Realization in source corpus uses `findings/inbox/` under the active
+task directory; project paths can vary as long as the per-file
+write-only inbox property holds.

--- a/.ai/conventions/workflow/kickoff-prompt-shape.md
+++ b/.ai/conventions/workflow/kickoff-prompt-shape.md
@@ -1,0 +1,122 @@
+# Convention — `convention.workflow.kickoff-prompt-shape`
+
+> Source: distilled from `<repo>/docs/CHORES.md § Kickoff-prompt
+> shape for chore agents` and the `workstream-brief` skill in the
+> source corpus.
+
+The shape of a kickoff prompt the orchestrator hands to a worker
+agent. Different from the operational brief itself — the kickoff is
+the message that wraps and points at the brief.
+
+---
+
+## Two shapes by workflow
+
+### Stream kickoff — full upfront context
+
+For a stream worker (`role.orchestrator.stream-agent`), the kickoff
+delivers the full operational brief in one message. The brief is the
+contract; the worker reads it in full, loads required reading, and
+proceeds.
+
+Shape:
+
+- **Mission** — what success looks like, briefly.
+- **Status entering** — what's already shipped that this stream
+  depends on.
+- **In-scope paths / out-of-scope paths** — file-boundary stake-out.
+- **Required reading** — explicit list, in order of priority.
+- **Skills to load when relevant** — explicitly named, with their
+  trigger conditions.
+- **Missing-input rule** — STOP if a required input is missing
+  rather than fabricating context.
+- **Dependencies** — hard and soft.
+- **Phases** — numbered phases inside this stream, each with
+  sub-steps.
+- **Acceptance criteria** — exit gates as a checklist.
+- **Required exit artifact** — the result.md shape.
+- **Resume protocol** — how to resume mid-stream from state.md.
+- **Coordination boundaries** — repo conventions to honor.
+- **Branch + PR posture** — branch naming, PR opening rhythm,
+  model recommendation.
+
+### Chore-batch kickoff — interleaved per item
+
+For a chore-batch worker (`role.orchestrator.chore-batch-agent`),
+the kickoff delivers an interleaved-per-item shape, **not** the
+upfront full-context shape. This is the load-bearing innovation of
+the chore-batch workflow.
+
+Don't give the agent a single upfront "Read everything before
+coding" list spanning all items. That signals "deeply understand all
+N items before starting any" and produces:
+
+- **Context bloat** (N × M file reads before any code lands; real
+  compaction risk on longer sessions).
+- **Long time-to-first-commit** (no signal to the user that the
+  batch is progressing).
+- **Wasted exploration on independent items** (the agent re-orients
+  when it gets there anyway).
+- **Premature planning of items that depend on shape produced by
+  *other* items** (e.g. coverage closure planned before the file it
+  covers stabilizes).
+
+The interleaved shape:
+
+- **One short upfront read for batch-level context only** — the
+  batch register entry, immediately-prior stream READMEs, the
+  canonical docs that explain the *why*, **not** per-item file
+  surfaces.
+- **For each item**: read item N's specific code surface → write the
+  brief.md section for item N → ship item N → checkpoint in
+  state.md → move to item N+1.
+- **For items that explicitly depend on prior items' output**: say
+  "do not scope item N until items M-X have shipped." Don't rely on
+  the agent to infer the dependency from "run last" framing.
+
+## What both shapes share
+
+- **A contract, not a draft.** Either you have enough to ship a
+  complete prompt, or you don't. If you don't, ask the targeted
+  clarifying question — don't deliver a half-prompt.
+- **The missing-input rule.** Both stream and chore-batch kickoffs
+  must include the explicit STOP-and-surface-the-gap rule for any
+  required-reading file or declared input that doesn't exist.
+- **File boundaries staked out.** In-scope and out-of-scope paths
+  named explicitly. Out-of-scope is load-bearing because it prevents
+  collisions with parallel streams.
+- **Skill triggers named.** Skills the worker should load are named
+  with their trigger conditions, not just listed.
+- **Resume protocol.** How to resume from `state.md` if the session
+  crosses a context boundary.
+
+## Anti-patterns
+
+- **Half-prompt asking the user to fill blanks.** Either ship a
+  complete prompt or ask a clarifying question.
+- **Upfront read-all-items list for chore batches.** Defeats the
+  interleaved shape; produces the failure modes named above.
+- **Implicit dependencies between items.** "Run last" without "do
+  not scope item N until items M-X have shipped" produces shallow
+  scoping.
+- **Out-of-scope paths missing.** Worker has no way to know what
+  parallel streams own; collisions follow.
+- **Skill list without trigger conditions.** "Load these skills"
+  without naming when produces under-loading; the worker doesn't
+  know if a given file surface should trigger the load.
+
+## Pattern observed (provenance)
+
+The pre-S2.3 cleanup chore batch in the source corpus mixed signals
+— the upfront read-list spanned all 5 items, but First Moves said
+"spike item 1 first." The agent reasonably read it as "thorough
+upfront exploration"; the result was fine but slower than necessary.
+Future chore-batch prompts in the corpus use the interleaved shape;
+this convention captures the lesson.
+
+## Adapter notes
+
+The kickoff prompt is realized as the message text the orchestrator
+hands the worker. Harness mechanics vary (parallel cloud agent
+invocation, sub-agent Task call, fresh chat session) but the prompt
+shape is harness-agnostic.

--- a/.ai/conventions/workflow/lessons-codification-triage.md
+++ b/.ai/conventions/workflow/lessons-codification-triage.md
@@ -1,0 +1,153 @@
+# Convention — `convention.workflow.lessons-codification-triage`
+
+> Source: distilled from `<repo>/.ai/instructions/ORCHESTRATOR_ROLE.md
+> § Working style / lesson-extraction has four buckets` in the source
+> corpus.
+
+The meta-convention that governs where every other convention, skill,
+or rule lands. When the orchestrator notices a recurring pattern —
+an avoidable bug, a rolled-own utility that already had a published
+primitive, a missing convention — this convention says where the
+fix goes.
+
+---
+
+## The destinations
+
+Five destinations in increasing weight. Each has a different load
+pattern and a different cost.
+
+| Destination | Shape | Load pattern | Cost |
+|-------------|-------|--------------|------|
+| **Stream-local note** (`result.md`) | One-off observation | Read by future agents working on this stream's followups | Negligible — a paragraph |
+| **Doc convention** (one of the cross-cutting docs) | Design-shape lesson that applies to a surface | Read when working on the surface | Low — an entry in an existing doc |
+| **Code-review checklist item** | Exit-gate check | Read at code review time | Low — a line in the priority-ranked list |
+| **Skill** (project's harness skill directory) | Procedural knowledge | Loaded just-in-time when relevant work surface is touched | Medium — a SKILL.md with examples + anti-patterns |
+| **Always-on rule** (project-instructions file) | Non-negotiable | Loaded every session | High — competes with every other always-on rule for attention |
+
+Workflow shapes (a process change) are a sixth destination — the
+heaviest. Loading a new workflow into the family is a substantial
+operation.
+
+## The triage
+
+For each surfaced pattern, ask:
+
+1. **Is it a one-off?** → Stream-local note. No further routing.
+2. **Does it apply to a specific design surface?** → Doc convention
+   in the surface's cross-cutting doc.
+3. **Is it a check that runs at code-review time?** → Code-review
+   checklist item.
+4. **Is it procedural knowledge that needs to fire just-in-time when
+   a specific work surface is touched?** → Skill.
+5. **Is it non-negotiable, always-applies, every-session?** →
+   Always-on rule.
+6. **Is it a process change, not a code change?** → Workflow shape.
+
+The triage is the load-bearing thing. Without it, the same lesson
+re-learns itself every cycle, or competes for attention in the
+always-on slot when it should be just-in-time.
+
+## Indicators for each destination
+
+### Stream-local note
+
+- The pattern is specific to this stream's surface.
+- The fix lands in this stream or a follow-up that doesn't recur
+  elsewhere.
+- A future agent working on a related stream wouldn't benefit from
+  the framing.
+
+### Doc convention
+
+- The pattern is design-shape — it informs how to think about a
+  surface (a wire model, an auth flow, a data shape).
+- The right home is an existing cross-cutting doc.
+- The agent reading the doc *is* the audience; they'll see the
+  lesson when working on the relevant surface.
+
+### Code-review checklist item
+
+- The pattern is mechanical at review time — grep, eyeball-pass,
+  structural check.
+- The fix is "verify X is or isn't in the diff."
+- The pattern doesn't need procedural framing during authoring;
+  catching it at review is sufficient.
+
+### Skill
+
+- The pattern is procedural — it tells the worker *how to do
+  something*, not *what to verify*.
+- The trigger is concrete (specific work surfaces, specific
+  imports, specific shapes).
+- The cost of loading is justified by the load-just-in-time
+  property — the worker only needs it when the trigger fires.
+- Pattern indicator: when a doc-convention or always-on rule isn't
+  firing reliably because the surface is too broad, promote to
+  skill (the just-in-time load gives the reflex a concrete
+  trigger).
+
+### Always-on rule
+
+- The pattern is non-negotiable at the project level.
+- It applies broadly enough that just-in-time loading is too late.
+- The cost (every-session attention) is justified by the breadth
+  of applicability.
+- Use sparingly — every always-on rule competes with every other
+  for the agent's reading attention.
+
+### Workflow shape
+
+- The pattern requires a structural process change, not a code
+  change.
+- Existing workflows can't accommodate it without bending.
+- The new shape will recur often enough to justify a workflow
+  family member of its own.
+
+## Promotion across destinations
+
+Lessons can move between destinations as their pattern matures:
+
+- **Doc convention → skill**: when the convention isn't firing
+  reliably because its load-pattern is too implicit. Source corpus
+  pattern: an always-on rule about checking the toolset's published
+  primitives wasn't firing for the fourth instance; promoted to
+  the `published-primitives-reflex` skill.
+- **Skill → always-on rule**: rare. When a skill's trigger pattern
+  generalizes broadly enough that every-session loading is cheaper
+  than every-session deciding-whether-to-load.
+- **Doc convention → code-review checklist item**: when a
+  convention recurs in PR review enough that catching at exit is
+  more efficient than catching at authoring.
+- **Stream-local note → any of the above**: when a one-off pattern
+  recurs across multiple streams.
+
+## Anti-patterns
+
+- **Default to always-on rule.** Every-session attention is
+  expensive; over-using the always-on slot diminishes returns on
+  every rule there.
+- **Default to doc convention without considering skill.** If the
+  surface is too broad for the agent to "remember to read the
+  doc," promote to skill.
+- **Skip the triage entirely.** "Just add a TODO" is the worst
+  outcome — the lesson lands nowhere durable.
+- **Multiple destinations for the same lesson.** Pick one; link
+  from the others. Duplication leads to drift; the linked source
+  stays canonical.
+- **Workflow shape as the default for process pain.** Most
+  process pain is convention-shaped, not workflow-shaped. Adding
+  a workflow has high cost; reach for it only when convention
+  changes can't accommodate.
+
+## The convention is itself codified here
+
+This convention is the meta-convention — it's the rule that governs
+where new rules land. As such, it lives in the workflow conventions
+section so it's discoverable when the orchestrator is composing a
+new lesson's destination.
+
+## Adapter notes
+
+The triage is procedural — applied through the orchestrator's
+judgment when surfacing lessons. No special harness mechanism.

--- a/.ai/conventions/workflow/long-pr-review.md
+++ b/.ai/conventions/workflow/long-pr-review.md
@@ -1,0 +1,139 @@
+# Convention — `convention.workflow.long-pr-review`
+
+> Source: distilled from `<repo>/.ai/instructions/ORCHESTRATOR_ROLE.md
+> § Babysitting a long PR review cycle` in the source corpus.
+
+The rhythm and intervention points for substantial PRs that go
+through repeated rounds of automated review (Copilot, Cursor, etc.).
+Watch the trajectory of substantive findings, not just thread volume,
+and switch to followup-capture mode at a threshold rather than
+iterating findings indefinitely.
+
+---
+
+## Reading the trajectory
+
+Three signals beyond raw volume help read whether a review cycle is
+converging or "still discovering":
+
+### Fix-interaction shape
+
+Consecutive rounds find findings whose fixes interact (round 7's X
+plus round 8's Y produces a hole in round 9). Stronger
+"architecture still discovering" signal than volume alone.
+
+### Asymmetric-by-design awareness in the agent's resolutions
+
+The agent declining to apply a pattern when field semantics demand
+otherwise (e.g., NOT trimming a value where the field's contract
+permits whitespace). Positive signal: the agent's scaffolding is
+intact; "keep going" is the right call.
+
+### Convention-drift recurrence under iteration load
+
+Earlier-swept conventions reappearing in late rounds (e.g., a
+test-naming convention that was clean at round 1 reappearing at
+round 9). The convention isn't reflexive yet; the right response is
+reinforcing the brief's exit-checklist, not piling more sweeps on
+the agent.
+
+## The threshold (≈10 rounds)
+
+When a review cycle exceeds ~10 rounds with consistent substantive
+volume across rounds, switch the implementing agent from inline-fix
+mode to **document-for-followup mode**. The motivating insight: each
+fix opens new surface area whose siblings need their own sweep.
+Iterating findings round-by-round doesn't converge; capturing them
+as followups + doing a single sibling-sweep pass post-merge is more
+efficient.
+
+## What still gets inline fixes after the threshold
+
+Only **truly critical** findings:
+
+- **Production-blocking** — the feature doesn't work against the
+  real server (e.g., wrong actor-id format the production validator
+  rejects but the test fixture accepts).
+- **Data-corruption** — a bad write or a wrong precondition that
+  would produce inconsistent state.
+- **Security** — credential leak, missing auth check, exposed
+  secret.
+- **Recovery-path-broken** — the user can be permanently stranded
+  with no way back to a workable state.
+
+Everything else gets recorded in the stream's followups inbox with
+`file:line`, finding shape, fix shape, deferral rationale.
+
+## The implementing agent's role after the threshold
+
+The implementing agent posts thread replies acknowledging each
+deferred finding and pointing at the consolidated followups so the
+review threads don't look ignored. Wording is up to the agent;
+goal is closing thread context without inline iteration.
+
+## The fresh-agent post-merge sibling-sweep
+
+After merge, the structured sibling-sweep self-review is done by a
+**fresh agent**, not the implementing agent. Two reasons:
+
+1. The implementing agent had every opportunity across the review
+   cycle and didn't catch the misses. Running self-review
+   reproduces the same author-blind-spot.
+2. A fresh agent reads the diff with no commitment bias and the
+   lens explicit. They catch the asymmetric-by-accident divergences
+   the implementing agent normalized to during implementation.
+
+Findings → followups → subsequent focused PRs.
+
+The fresh-agent prompt should:
+
+- Define the sibling-sweep lens with concrete examples from the
+  recent review cycle (loads the shape).
+- Point at the merged diff scope.
+- Point at existing followups so the agent doesn't re-discover
+  already-captured findings.
+- Set scope guardrails: don't fix, don't review code outside the
+  diff, findings must fit a focused subsequent PR.
+- Apply lenses for: existing-followup siblings, asymmetric-by-design
+  vs by-accident, convention drift across touched files,
+  surface-introducing changes, test fixture pattern.
+
+## Why the rule exists
+
+Pattern observed in the source corpus: a 19-round PR review cycle
+where substantive-finding volume held at ~3-5 per round across
+rounds 13-18 because each new fix opened new sibling surfaces. The
+implementing agent landed every fix structurally well but didn't
+proactively sweep siblings. Capturing followups + fresh-agent
+sibling-sweep pass is the structural fix to that pattern.
+
+## The rule is on the orchestrator, not the implementing agent
+
+The implementing agent shouldn't decide to abandon inline iteration;
+that's an orchestrator-level decision based on cycle trajectory. The
+implementing agent's role is to consume the orchestrator's guidance
+and execute it — including documenting followups and posting thread
+replies cleanly.
+
+## Anti-patterns
+
+- **Inline-fix every finding through 20 review rounds.** Diminishing
+  returns; switch to followup-capture mode after the threshold.
+- **Posting thread replies without addressing the finding.** Either
+  fix it or capture it in followups with a clear deferral
+  rationale; don't acknowledge-and-ignore.
+- **Implementing agent self-decides to stop inline-fixing.** The
+  threshold decision is orchestrator-level.
+- **Fresh-agent sibling-sweep skipped post-merge.** Author-blind-
+  spot-recovery is the value; skipping it forfeits it.
+- **Treating the threshold as exact (10.0 rounds).** It's
+  approximate — the trajectory signals (fix-interaction,
+  convention-drift recurrence) matter as much as the count.
+
+## Adapter notes
+
+Realization in source corpus uses GitHub PR review threads with
+Copilot as the automated reviewer. Other harnesses with iterative
+automated review (Cursor, code-review GPT actions) compose the
+same way. The convention is review-rhythm-specific, not
+harness-specific.

--- a/.ai/conventions/workflow/sibling-sweep-lens.md
+++ b/.ai/conventions/workflow/sibling-sweep-lens.md
@@ -1,0 +1,123 @@
+# Convention — `convention.workflow.sibling-sweep-lens`
+
+> Source: distilled from the `workstream-brief` skill's exit-checklist
+> section + `<repo>/.ai/instructions/ORCHESTRATOR_ROLE.md § Babysitting
+> a long PR review cycle` in the source corpus.
+
+The structural review pass run at exit-time on every stream and at
+post-merge time on substantial PRs. Different shape from a grep-based
+convention check — a structural review with the explicit lens "what
+siblings of each new surface did I asymmetrically diverge from?"
+
+---
+
+## When the lens applies
+
+- **Worker exit-time** — the implementing agent runs it as part of
+  the stream's exit checklist before writing `result.md`.
+- **Pre-PR-open deep-reviewer pass** — for substantial PRs, a fresh
+  agent runs it before the PR opens, to reduce review-round count.
+- **Post-merge fresh-agent sweep** — after a long-PR-review cycle
+  hits the threshold (~10 rounds), a fresh agent runs the lens
+  against the merged diff. The implementing agent is *not* the right
+  fit for this — author-blind-spot reproduces.
+
+## The lens — what to look for
+
+For each new surface in the diff, ask: what siblings of this surface
+exist elsewhere in the codebase, and did this stream asymmetrically
+diverge from them?
+
+Concrete categories the lens covers:
+
+### New validation site
+
+Does the same field have a validator elsewhere (entry form, retry
+form, server-side handler)? Are they consistent on trim / case /
+required-vs-optional?
+
+The recurring miss: validation rules added on one path don't get
+mirrored on sibling paths. The fixture-vs-production drift pattern
+(fixtures that accept inputs production validators reject) is a
+specific instance of this lens missing.
+
+### New control-flow branch
+
+Does the new branch's precondition match siblings? E.g., a
+fall-through-to-public rule that's `(!a && !b)` when sibling rules
+elsewhere use just `(!a)` — the conjunction is probably overfit.
+
+### New error-rendering path
+
+Does it classify failures the same way as sibling paths? Raw error
+text vs friendly copy vs disclosure pattern. The recurring miss is
+that error-classification helpers added on one path don't get
+applied on the other.
+
+### New helper function / state-clearing patch / discriminator
+
+Does the carve-out logic match the actual asymmetry? E.g., a "clear
+secrets" helper that uniformly preserves a field when only one
+branch needs it. Asymmetric-by-design vs asymmetric-by-accident
+matters; the lens forces explicitness.
+
+### New prop on a component
+
+Is it forwarded consistently along every parent chain that mounts
+the component? Drop-on-the-floor in one path is a common miss.
+
+### New fixture subclass
+
+Would this carve-out be needed across multiple tests? If yes, that's
+a base-fixture-hardening smell — when a fixture pattern recurs
+across many tests, the base fixture wants extending, not the
+subclass cluster growing.
+
+## What the lens is not
+
+- **Not a grep.** A grep catches `it()` vs `test()`, `as never`,
+  temporal comments. Those are convention checks. The sibling-sweep
+  is structural — it looks at the *shape* of what landed and
+  whether the shape matches sibling code's shape.
+- **Not "review every file."** It's targeted at the diff's *new
+  surfaces* — new functions, new branches, new components, new
+  fixture patterns. Sibling code is touched only when the lens
+  flags an asymmetry.
+- **Not a self-review for catching architectural issues.** The
+  fresh-agent variant catches what the implementing agent's
+  author-blind-spot can't. The author-self variant catches what's
+  visible from the lens but missed in implementation.
+
+## Why the convention exists
+
+Pattern that motivated it: a fix walks the path it was scoped to;
+the new surface's asymmetric divergences with siblings get missed
+and surface in the next review round. The source corpus tracked
+this across multiple stream review cycles — substantive-finding
+volume held high across rounds 13-18 of one cycle because each new
+fix opened new sibling surfaces.
+
+Doing the sibling-sweep at exit-time costs ~10 minutes; absorbing
+it across multiple review rounds costs hours.
+
+## Doing it well
+
+The lens is reflexive when the implementing agent has the discipline,
+load-bearing for fresh-agent variants. The fresh-agent prompt
+should:
+
+- **Define the lens with concrete examples** from the recent review
+  cycle (so the agent has the shape).
+- **Point at the merged diff scope** (PR number / branch).
+- **Point at existing followups** so the agent doesn't re-discover
+  already-captured findings.
+- **Set scope guardrails**: don't fix, don't review code outside
+  the diff, findings must fit a focused subsequent PR.
+- **Apply lenses for**: existing-followup siblings, asymmetric-by-
+  design vs by-accident, convention drift across touched files,
+  surface-introducing changes, test fixture pattern.
+
+## Adapter notes
+
+The lens is applied through code reading, not tooling. No special
+harness mechanism required.

--- a/.ai/conventions/workflow/stale-marker-scan.md
+++ b/.ai/conventions/workflow/stale-marker-scan.md
@@ -1,0 +1,68 @@
+# Convention — `convention.workflow.stale-marker-scan`
+
+> Source: distilled from `<repo>/.ai/instructions/ORCHESTRATOR_ROLE.md
+> § Post-merge bookkeeping` in the source corpus.
+
+A post-merge orchestrator pass that scans the streams ledger for
+stale status markers on dependency-referenced streams that have
+shipped since the last sweep. Runs as part of post-merge bookkeeping.
+
+---
+
+## What the scan catches
+
+When a stream merges, the orchestrator flips its status marker from
+"in flight" (e.g. 🔵) to "shipped" (e.g. ✅) in the streams ledger.
+The scan extends this: **also walk the ledger for related streams
+whose status markers may have rotted silently.**
+
+Specific failure mode: a stream that "trails by a beat" in the
+sequencing summary stays marked 🟡 (planned) even after its hard
+dependency shipped. A fresh agent picking up a mid-stream task can
+misread the stale 🟡 as "open work to grab," derailing their pickup.
+
+The source corpus had a concrete instance — a stream that should
+have been 🔵 stayed 🟡 from one date to another and tripped a
+mid-stream pickup; caught only by manual orchestrator review.
+
+## The scan
+
+The orchestrator runs the scan as part of post-merge bookkeeping:
+
+1. **Identify just-merged streams.** What status flipped in this
+   bookkeeping pass.
+2. **For each merged stream's dependency references**, walk the
+   streams ledger and find the entries that mention them as
+   dependencies.
+3. **For each dependency-referenced entry**: does its status marker
+   reflect current reality?
+   - Was it 🟡 (planned) but actually now eligible to start (or
+     in-flight)?
+   - Was it 🔴 (blocked) but the blocker just shipped?
+   - Is its sequencing-summary position still accurate?
+4. **Flip stale markers** to current state.
+
+## Anti-patterns
+
+- **Skipping the scan after a non-wave-close merge.** Markers can
+  rot at any merge, not just at wave boundaries. Run the scan as
+  part of every post-merge bookkeeping pass.
+- **Flipping markers but not updating the sequencing summary.**
+  The summary is its own surface and rots independently.
+- **Trusting "I just looked at the ledger yesterday" as proof of
+  freshness.** Yesterday's state plus today's merges produce
+  today's stale markers; the scan is what catches the drift.
+
+## Why this is its own convention
+
+Earlier orchestrator workflow versions treated the stale-marker scan
+as folklore — "you'll notice if a marker is wrong." Empirically,
+the orchestrator missed a stale marker for two days; a parallel
+agent picked up work against the stale signal. Naming the scan as
+an explicit step in post-merge bookkeeping turned it into a reliable
+gate.
+
+## Adapter notes
+
+The scan is applied through reading the streams-ledger doc — no
+special harness mechanism required.

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -1,0 +1,180 @@
+---
+name: orchestrator
+description: Use to start a coordinated workstream session. The orchestrator maintains the artifact substrate (docs/WORKSTREAMS.md, docs/CHORES.md, docs/TECH_DEBT.md, docs/FUTURE.md, .ai/tasks/), selects workflow shapes (stream / chore-batch / design-triage-implement), composes kickoff briefs for worker agents, and closes the lessons loop. Designed for frontier-model sessions where you are the orchestrator, not an implementer. Use /workstream-brief to extract a stream brief; use /triage-cycle to draft a triage-agent kickoff.
+tools: Task, Bash, Glob, Grep, LS, Read, Edit, MultiEdit, Write, WebFetch, TodoWrite, WebSearch
+model: opus
+color: purple
+---
+
+# Orchestrator
+
+Your job is **not** primarily to write code — it's to:
+
+- Coordinate parallel workstreams.
+- Maintain the substrate of canonical docs that make work legible across sessions:
+  - Streams ledger: `docs/WORKSTREAMS.md`
+  - Batch register: `docs/CHORES.md`
+  - Deferred-work split: `docs/TECH_DEBT.md` + `docs/FUTURE.md`
+  - Design-cycle process: `docs/DESIGN_PROCESS.md`
+  - Pinned baseline: `.ai/BASELINE.md`
+  - Project instructions: `CLAUDE.md`
+  - Skill corpus: `.claude/skills/`
+- Draft kickoff prompts for parallel agents (cloud + local).
+- Review their results, extract lessons learned, and codify them as conventions, skills, or always-on rules through `.ai/conventions/workflow/lessons-codification-triage.md`.
+
+## Working style
+
+- **Push back when the user's framing has a gap.** Don't just execute. Surface tradeoffs, name the ambiguity, propose options.
+- **Tight, conversational responses.** Long bulleted plans are noise unless the user asks for one.
+- **Kickoff prompts ship paste-ready.** When the user asks for a kickoff prompt, deliver it in one message — full context, not a draft to iterate on. If you don't have enough context to write a complete prompt, ask the targeted clarifying question — don't deliver a half-prompt and ask the user to fill in the blanks.
+- **Lesson-extraction has destinations of differing weight.** When extracting lessons, route to: stream-local note / doc convention / code-review checklist item / skill / always-on rule / workflow shape. Each has a different load pattern and cost. See `.ai/conventions/workflow/lessons-codification-triage.md`.
+- **You write docs and prompts; agents (and occasionally you) write code.** Default to delegation for implementation work.
+- **Match model to task.** Cheap models handle routine bookkeeping well — artifact migrations, status flips, doc-rot fixes, baseline bumps, convention sweeps. Reserve frontier models for architectural reasoning, kickoff-prompt drafting, and triage of substantive review findings.
+- **Honor the published-primitives reflex yourself** before suggesting any utility-shaped code: check the `@fgv/*` toolset libraries first via `/published-primitives-reflex`.
+
+## Read on session start
+
+Before doing anything, read these — they carry the conventions your predecessor codified:
+
+- `CLAUDE.md` and `.ai/instructions/ACTIVE_DEVELOPMENT.md`
+- `docs/WORKSTREAMS.md` preamble (status conventions, stream versions, shared types, baseline check, artifact protocol)
+- `docs/CHORES.md` (current active batch shape + completed precedents)
+- `.ai/BASELINE.md` (pinned baseline commit — verify before any new branch)
+- Cross-cutting design docs in `docs/` relevant to the work in flight
+
+Then check `.ai/tasks/active/` for in-flight task artifacts before starting any new orchestration work.
+
+## Workflow shapes
+
+Three shapes. Pick by request shape:
+
+| Request | Shape |
+|---------|-------|
+| Sequential walk through 3–6 small unrelated cleanup items | `chore-batch` |
+| Substantial feature needing design exploration before the brief can be written | `design-triage-implement` |
+| Substantial feature with a known shape | `stream` |
+| Quick fix (≤30 min, no surface-area exploration) | No workflow — handle directly or one-shot code-monkey invocation |
+| Investigation / question | No workflow — delegate to Explore agent or handle directly |
+
+The boundary between "stream" and "design-triage-implement": if you can write a complete stream brief in one pass (file boundaries, acceptance criteria, exit checklist) it's a stream. If brief composition exposes unresolved design questions, it's design-triage-implement.
+
+Full workflow procedures: `.ai/conventions/workflow/` and `docs/DESIGN_PROCESS.md`.
+
+## Common operations
+
+### Stream kickoff
+
+1. Load `/workstream-brief` for the stream ID.
+2. Verify file-boundary collision avoidance against any other in-flight parallel streams.
+3. Verify the branch base against `.ai/BASELINE.md`.
+4. Commit `brief.md` + empty `state.md` to `.ai/tasks/active/<stream-id>/`.
+5. Deliver kickoff prompt paste-ready: mission, in/out-of-scope paths, required reading, skills to load (with trigger conditions), missing-input rule, phases, acceptance criteria, exit artifact shape, resume protocol.
+
+### Chore-batch kickoff
+
+Compose following the interleaved-per-item shape from `.ai/conventions/workflow/kickoff-prompt-shape.md`. Do NOT give the agent a single upfront "Read everything" list spanning all items. For each item: read surface → implement → checkpoint → move to next item.
+
+### Design triage cycle
+
+1. Load `/triage-cycle` for the feature id + implementing stream id.
+2. Verify phase B (bundle drop) is clean before drafting the kickoff.
+3. Hold the phase-C completion gate: present all four triage outputs to the user for sign-off before launching phase D. Gate is real — the user may surface a change.
+
+### Post-merge bookkeeping
+
+1. Flip the stream's status marker in `docs/WORKSTREAMS.md` to ✅.
+2. Run a stale-marker scan (`.ai/conventions/workflow/stale-marker-scan.md`): anything in the ledger now stale?
+3. Drain stream followups (`.ai/conventions/workflow/inbox-and-drain.md`) — route each to FUTURE / TECH_DEBT / next chore batch / next stream.
+4. Bump `.ai/BASELINE.md` if this stream is the last in its wave.
+5. Triage any surfaced lessons (`.ai/conventions/workflow/lessons-codification-triage.md`).
+
+### Pre-wave chore batch assembly
+
+1. Read each completed stream's polished `README.md` in `.ai/tasks/completed/`.
+2. Extract every chore-shaped item, follow-up, or deferred note.
+3. Categorize each: **chore batch** / **stream** / **TECH_DEBT** / **FUTURE**.
+4. Compile proposed batch (3–6 items, tied to a concrete transition trigger).
+5. Present to user for sign-off before landing in `docs/CHORES.md`.
+
+### Babysitting a long PR review cycle
+
+Watch trajectory, not just thread volume. Three signals:
+- **Fix-interaction shape** — consecutive rounds find findings whose fixes interact.
+- **Asymmetric-by-design awareness** — agent declining a pattern for good field-semantic reasons (positive signal).
+- **Convention-drift recurrence** — earlier-swept conventions reappearing under iteration load.
+
+**Threshold (~10 rounds)**: switch from inline-fix mode to document-for-followup mode. Only truly critical findings get inline fixes after the threshold: production-blocking, data-corruption, security, recovery-path-broken. Everything else: record in findings inbox with `file:line`, finding shape, fix shape, deferral rationale.
+
+Post-merge: run sibling-sweep as a **fresh agent**, not the implementing agent. See `.ai/conventions/workflow/long-pr-review.md` and `.ai/conventions/workflow/sibling-sweep-lens.md`.
+
+### Delegating capture to a scribe session
+
+When the user is doing manual testing or posting batches of findings: suggest spinning up a fresh sub-agent session in scribe mode — mirrors the four-bucket sort, writes per-file inbox entries, proposes routings. Token-cheap. Delegate rather than handling each finding inline.
+
+### Buffer-and-main promotion
+
+When the buffer line has accumulated a coherent batch of merged PRs: confirm known-good state → open PR buffer→main → run unified automated-review pass (catches fix-interaction findings) → merge with merge-commit → bump `.ai/BASELINE.md`. See `.ai/conventions/workflow/branch-buffer-and-promotion.md`.
+
+## Kickoff prompt checklist
+
+Every kickoff prompt (stream or chore-batch) must include:
+
+- [ ] Mission (1–2 sentences)
+- [ ] In-scope paths — explicit list
+- [ ] Out-of-scope paths — explicit list (load-bearing for parallel-stream collision avoidance)
+- [ ] Required reading in priority order
+- [ ] Skills to load with trigger conditions (name the skill, name the condition)
+- [ ] Missing-input rule: STOP if a required input is missing; do NOT recreate it from codebase exploration
+- [ ] Dependencies (hard and soft)
+- [ ] Phases with sub-steps
+- [ ] Acceptance criteria (exit gates)
+- [ ] Required exit artifact (`result.md` shape)
+- [ ] Resume protocol (read brief + state.md)
+- [ ] Branch + PR posture
+
+## Artifact substrate
+
+All task artifacts live in `.ai/tasks/`:
+
+```
+.ai/tasks/
+├── active/<id>/
+│   ├── brief.md          # the contract (input, written by orchestrator)
+│   ├── state.md          # live checkpoint (worker updates per phase)
+│   ├── result.md         # exit artifact (worker writes at end)
+│   ├── followups.md      # consolidated followups (orchestrator drains inbox here)
+│   └── findings/inbox/   # per-file findings (scribe writes; orchestrator drains)
+└── completed/<bucket>/<id>/
+    ├── README.md          # polished completion record
+    ├── brief.md           # archived
+    ├── state.md           # archived
+    ├── result.md          # archived
+    └── followups.md       # archived
+```
+
+Migration is **pre-merge** — part of the stream's PR, not a follow-up. See `.ai/conventions/workflow/artifact-protocol.md`.
+
+Bucket convention: `YYYY-MM` (e.g. `2026-05`).
+
+## Skills reference
+
+| Work surface | Load |
+|---|---|
+| Any file I/O, directory walk, importer/exporter | `/filetree-io` |
+| Any diagnostic output, logger construction, boot path | `/ts-utils-logging` |
+| Any structural equality, dedup, object-as-map-key | `/value-hashing` |
+| Any utility-shaped code (feels like "someone must have this") | `/published-primitives-reflex` |
+| Writing or reviewing Result<T>-returning code | `/result-pattern` |
+| Writing or reviewing tests | `/result-tests` |
+| Writing or reviewing converters, validators, type guards | `/type-safe-validation` |
+| Extracting a stream brief | `/workstream-brief` |
+| Drafting a triage-agent kickoff | `/triage-cycle` |
+
+## Anti-patterns
+
+- **Don't execute without reading the brief.** The user's framing usually has a gap; surface it before acting.
+- **Don't bundle unrelated work into a chore batch.** Each batch ties to a specific transition. Items without a concrete trigger belong in TECH_DEBT or FUTURE.
+- **Don't draft kickoff prompts as iterative drafts.** Either you have enough to ship a complete prompt, or you don't. If you don't, ask the targeted clarifying question.
+- **Don't write code by default.** Delegate to a code-shaped agent unless the work is small, self-contained, and orchestration-adjacent (e.g. updating a doc, fixing a typo, landing a chore-batch artifact).
+- **Don't skip the out-of-scope list in kickoff prompts.** That's the whole point of doing this for parallel runs.
+- **Don't default to always-on rules.** Every-session attention is expensive. Prefer skill (just-in-time) or doc convention over adding to CLAUDE.md unless the rule is genuinely non-negotiable and session-wide.

--- a/.claude/skills/filetree-io/SKILL.md
+++ b/.claude/skills/filetree-io/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: filetree-io
+description: Use when writing or reviewing any code that does file I/O — importers, exporters, directory walks, file reads/writes — in projects using the FGV toolset. The convention is to use the FileTree abstraction from @fgv/ts-json-base instead of node fs APIs directly, so the same code works against node fs, in-memory, zip files, browser localStorage, and the browser File System Access API. Load this skill BEFORE writing fs.readFile, fs.writeFile, fs.readdir, fs.mkdir, path.join, glob/fast-glob, or any importer/exporter signature; load it BEFORE writing browser File-System-Access code; load it during code review when code has reached for node fs in business logic. Covers the read/write/walk operations, the adapter-selection idiom, the canonical createFileTreeRoot helper, and the anti-patterns that distinguish business logic from boot-edge code.
+---
+
+# FileTree I/O
+
+> Source: `<repo>/.claude/skills/filetree-io/SKILL.md` in the source
+> corpus. Toolset binding: `@fgv/ts-json-base` (with adapter homes
+> in `@fgv/ts-extras` and `@fgv/ts-web-extras`).
+
+Projects using the FGV toolset use the `FileTree` abstraction from
+`@fgv/ts-json-base` for file I/O — never node `fs` directly in
+business logic. The benefit is portability: the same
+importer/exporter works against node fs, in-memory trees, zip files,
+browser localStorage, and the browser File System Access API. Pick
+the adapter at the boot edge; everything downstream takes a
+`FileTreeItem` and is platform-agnostic.
+
+## Mental model
+
+`FileTree` is a uniform read/write/walk tree of `IFileTreeFileItem`
+and `IFileTreeDirectoryItem` nodes (union: `FileTreeItem`) wrapped
+around a pluggable `IFileTreeAccessors` adapter. **All operations
+return `Result<T>` — there is no throwing API.**
+
+| Operation | Method |
+|-----------|--------|
+| Read children | `dir.getChildren()` |
+| Read raw text | `file.getRawContents()` (returns `string`) |
+| Read parsed JSON | `file.getContents()` |
+| Write raw text | `file.setRawContents(text)` (mutable only) |
+| Write JSON | `file.setContents(value)` (mutable only) |
+| Create file | `dir.createChildFile(name, content)` (mutable only) |
+| Create dir | `dir.createChildDirectory(name)` (mutable only) |
+| Delete | `item.delete()` (mutable only) |
+| Walk | recurse on `getChildren()`, dispatch on `child.type === 'directory' \| 'file'` |
+
+**Mutability gate**: before any write, call the type guards.
+
+```typescript
+if (!FileTree.isMutableFileItem(file)) return fail(`${file.absolutePath}: not mutable`);
+if (!FileTree.isMutableDirectoryItem(dir)) return fail(`${dir.absolutePath}: not mutable`);
+```
+
+## Adapters
+
+| Adapter | Source | When |
+|---------|--------|------|
+| `FileTree.FsFileTreeAccessors` | `@fgv/ts-json-base` | Node filesystem |
+| In-memory accessors | `@fgv/ts-json-base` | Tests, RAM-only |
+| `ZipFileTree.ZipFileTreeAccessors` | `@fgv/ts-extras` | Read/write zip blobs |
+| `FileApiTreeAccessors` | `@fgv/ts-web-extras` | Browser localStorage, File System Access (`DirectoryHandle`), HTTP-backed cloud |
+
+**Loaders never branch on adapter type.** They take a `FileTreeItem`
+and call the same API regardless of who's behind it.
+
+## The "single importer, any source" pattern
+
+Importer signatures take `FileTree.IFileTreeDirectoryItem` or
+`FileTree.FileTreeItem` — never paths, file handles, or buffers. The
+adapter is selected once at boot and injected downward.
+
+```typescript
+public loadFromFileTree(
+  fileTree: FileTree.FileTreeItem,                  // accepts ANY adapter
+  params: ILoadCollectionParams = {}
+): Result<ICollectionLoadResult> {
+  return filter.filterDirectory(fileTree, dirParams).onSuccess((items) => {
+    const results = items.map((item) =>
+      item.item
+        .getRawContents()                           // adapter-agnostic read
+        .onSuccess((raw) => parseContents(raw))     // JSON or YAML
+        .onSuccess((json) => sourceFileConverter.convert(json))
+        .onSuccess((sourceFile) =>
+          collectionConverter.convert({
+            id: item.name,
+            items: sourceFile.items,
+            metadata: sourceFile.metadata
+          }).onSuccess((collection) =>
+            succeed({ ...collection, sourceItem: item.item })   // back-pointer (see below)
+          )
+        )
+    );
+    return mapResults(results).onSuccess((collections) => succeed({ collections }));
+  });
+}
+```
+
+**Source-item back-pointer pattern**: stamp each loaded record with
+the `FileTreeItem` it came from. A later writer can call
+`record.sourceItem.setRawContents(...)` or `.delete()` without
+knowing which adapter produced it. This is how persistence layers
+round-trip edits without re-resolving paths.
+
+## A representative exporter
+
+Same shape — takes a directory item, doesn't care which adapter
+backs it. The two helpers below (`_ensureDirectory`, `_writeFile`)
+are reusable verbatim across consumers.
+
+```typescript
+async function publishCollection(params: IPublishParams): Promise<Result<IPublishOutcome>> {
+  const { publisherDir, subLibraryId, collectionId, content, filename } = params;
+
+  const subLibPath = getSubLibraryPath(subLibraryId);
+  const targetDirResult = await _ensureDirectory(publisherDir, subLibPath);
+  if (targetDirResult.isFailure()) return fail(`${subLibraryId}/${collectionId}: ${targetDirResult.message}`);
+  const targetDir = targetDirResult.value;
+
+  const writeResult = _writeFile(targetDir, filename, content);
+  if (writeResult.isFailure()) return fail(`${subLibraryId}/${collectionId}: write: ${writeResult.message}`);
+
+  return succeed({ filePath: `${targetDir.absolutePath}/${filename}` });
+}
+
+async function _ensureDirectory(
+  root: FileTree.IFileTreeDirectoryItem,
+  relativePath: string
+): Promise<Result<FileTree.IFileTreeDirectoryItem>> {
+  let current = root;
+  for (const segment of relativePath.split('/').filter((s) => s.length > 0)) {
+    const childrenResult = current.getChildren();
+    if (childrenResult.isFailure()) return fail(childrenResult.message);
+    const existing = childrenResult.value.find((c) => c.name === segment && c.type === 'directory');
+    if (existing) {
+      current = existing as FileTree.IFileTreeDirectoryItem;
+      continue;
+    }
+    if (!FileTree.isMutableDirectoryItem(current)) return fail(`${current.absolutePath}: not mutable`);
+    const createResult = current.createChildDirectory(segment);
+    if (createResult.isFailure()) return fail(createResult.message);
+    current = createResult.value;
+  }
+  return succeed(current);
+}
+
+function _writeFile(
+  dir: FileTree.IFileTreeDirectoryItem,
+  filename: string,
+  content: string
+): Result<string> {
+  return dir.getChildren().onSuccess((children) => {
+    const existing = children.find((c) => c.name === filename && c.type === 'file');
+    if (existing) {
+      if (!FileTree.isMutableFileItem(existing)) return fail(`${dir.absolutePath}/${filename}: not mutable`);
+      return existing.setRawContents(content).onSuccess(() => succeed(content));
+    }
+    if (!FileTree.isMutableDirectoryItem(dir)) return fail(`${dir.absolutePath}: not mutable`);
+    return dir.createChildFile(filename, content).onSuccess(() => succeed(content));
+  });
+}
+```
+
+## Anti-patterns (self-check before merging)
+
+If your code does any of the below in business logic, you have not
+yet drawn the adapter seam. Push the `fs` / `path` / `Buffer` work
+outward until the loader takes a `FileTreeItem`.
+
+- **No `fs.readFile` / `fs.writeFile`** (sync or async). Reads →
+  `item.getRawContents()` / `item.getContents()`. Writes →
+  `item.setRawContents()` / `item.createChildFile()`.
+- **No `path.join` / `path.resolve`** in importers/exporters. Path
+  composition is `'/'`-joins on FileTree-relative paths. Absolute
+  filesystem paths exist only inside adapter construction.
+- **No `glob` / `fast-glob` / `readdir` recursion.** Directory
+  traversal is `getChildren()` + recursion + `child.type ===
+  'directory'` dispatch.
+- **No `Buffer` / `ArrayBuffer` shuffling around the read path.**
+  `getRawContents()` returns `string`. Buffers live only at zip and
+  HTTP boundaries.
+- **No `mkdirSync` / `mkdir({ recursive: true })`** in business
+  logic. Directory creation is `_ensureDirectory(root, relativePath)`
+  walking the tree.
+- **No write through a non-mutable item.** Every write is gated on
+  the type guards.
+- **No string paths flowing into loaders.** Loader signatures take
+  `FileTree.IFileTreeDirectoryItem` or `FileTree.FileTreeItem`,
+  never `string`. If a loader needs to be told which subdirectory
+  to start from, it takes a `directoryNavigator: (root) =>
+  Result<dir>` callback — not a path string.
+
+## When to drop down to node fs anyway
+
+Two legitimate cases, both at the **boot edge**, never in feature
+code:
+
+1. **Constructing the `FsFileTreeAccessors` itself.** You need
+   `path.resolve`, `fs.existsSync`, `fs.statSync`, possibly
+   `fs.mkdirSync` to validate or create the root before wrapping it.
+2. **Reading a file outside any FileTree.** E.g. a keystore at a
+   user-provided absolute path that isn't inside an opened tree. If
+   the file *is* inside an opened tree, use `getChildren()` /
+   `getItem()` — don't bypass.
+
+Everything else — loading, saving, walking, transforming,
+publishing — stays inside FileTree.
+
+## Adapter selection idiom
+
+Selection is **not** a runtime detection helper. The boot script
+picks one based on environment and injects the resulting
+`FileTreeItem` downward. Loaders never branch on adapter type.
+
+### Node fs — canonical helper
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+import { FileTree } from '@fgv/ts-json-base';
+import { fail, Result } from '@fgv/ts-utils';
+
+export function createFileTreeRoot(
+  dirPath: string,
+  options?: { mutable?: boolean }
+): Result<FileTree.IFileTreeDirectoryItem> {
+  const resolved = path.resolve(dirPath);
+  if (!fs.existsSync(resolved)) return fail(`${dirPath}: not found`);
+  if (!fs.statSync(resolved).isDirectory()) return fail(`${dirPath}: not a directory`);
+  const accessors = new FileTree.FsFileTreeAccessors({
+    prefix: resolved,
+    mutable: options?.mutable === true
+  });
+  return FileTree.DirectoryItem.create('.', accessors);
+}
+```
+
+### Zip — read / write
+
+```typescript
+import { ZipFileTree } from '@fgv/ts-extras';
+
+// read
+const accessorsResult = await ZipFileTree.ZipFileTreeAccessors.fromBufferAsync(zipData);
+
+// write
+const files: Array<{ path: string; contents: string }> = [...];
+return ZipFileTree.createZipFromTextFiles(files);                  // → Result<Uint8Array>
+```
+
+### Browser localStorage / File System Access
+
+```typescript
+import { FileApiTreeAccessors } from '@fgv/ts-web-extras';
+
+// localStorage
+const treeResult = FileApiTreeAccessors.createFromLocalStorage({
+  pathToKeyMap, storage: window.localStorage, mutable: true, autoSync: true
+});
+
+// File System Access
+const treeResult = await FileApiTreeAccessors.createPersistent(dirHandle, { autoSync: true });
+```
+
+## Boot-script injection pattern
+
+Platform initializers own adapter selection. They produce a result
+where every tree-typed field is
+`FileTree.IFileTreeDirectoryItem`. From that point downward, no
+module knows or cares which adapter is in play.
+
+When building a new consumer of FileTree:
+
+1. **One entry function per environment** (`createNodeRoot`,
+   `createBrowserRoot`, `createInMemoryRoot`) that hands back
+   `FileTreeItem`s.
+2. **Feature code takes those items as parameters.** No fs imports,
+   no environment branching.
+3. **Tests inject in-memory trees.** Same feature code; different
+   adapter.
+
+If you can't write a single feature function that works against all
+four adapter types, the seam isn't drawn far enough out — keep
+refactoring.

--- a/.claude/skills/published-primitives-reflex/SKILL.md
+++ b/.claude/skills/published-primitives-reflex/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: published-primitives-reflex
+description: Use BEFORE writing utility-shaped code that touches file I/O, diagnostics, logging, structural equality / deep-equal / hashing, normalization, collection helpers, YAML loading, template substitution / `{{name}}` placeholders, password hashing / key derivation / PBKDF2, symmetric encryption, random bytes, UUIDs, CSV / record-jar parsing, BCP-47 language tags, URL parsing, browser File API, zip files, or anything else that feels "obviously general" — the @fgv/* libraries almost certainly already publish a primitive, and rolling your own is a recurring miss-pattern. Load this skill BEFORE writing `fs.readFile`, `path.join`, `glob`, `console.log`, `console.error`, `JSON.stringify(...) === JSON.stringify(...)`, a hand-rolled `deepEqual`, a regex-based `{{...}}` replacer, `bcrypt` / `argon2` / `crypto.pbkdf2` import, `crypto.randomBytes` / `crypto.randomUUID` import, `js-yaml.load`, or any custom CSV / record-jar / BCP-47 parser.
+---
+
+# Published Primitives Reflex
+
+A project's toolset libraries publish the answer to most "obviously
+general" utility questions. Rolling your own is a recurring miss-
+pattern: the agent searches for their mental-model keyword, doesn't
+find it because the toolset filed the primitive under different
+nomenclature, and reaches for a third-party library or hand-rolls a
+shim. The pattern is reliable; the cost of a 30-second consult is
+much lower than the cost of a future migration.
+
+## The reflex
+
+Before writing any utility, consult the FGV canonical capability
+inventory at
+[`LIBRARY_CAPABILITIES.md`](https://github.com/ErikFortune/fgv/blob/release/.agents/LIBRARY_CAPABILITIES.md).
+
+If the inventory clearly names the primitive — use it.
+
+If you don't see your mental-model keyword in the inventory —
+**check the translation table below before concluding the toolset
+doesn't have it**. The recurring miss-pattern is "agent searched for
+`password hashing`, didn't find it, rolled bcrypt — but the toolset
+has PBKDF2 filed under key derivation." Nomenclature mismatch is
+the dominant failure mode.
+
+If you've checked both and the toolset genuinely doesn't have it —
+surface in `state.md` (or `brief.md`) before adding a new
+dependency. The toolset's maintainers can extend the inventory if
+the gap is real; proceed with a v1 fallback (e.g. the platform
+standard library) in the meantime.
+
+## Translation table — common dev-ese → FGV primitive
+
+| Want to do… | Use… | Lives in… |
+|---|---|---|
+| Read / write files; walk directories; browser FS; in-memory FS; zip files | `FileTree` | `@fgv/ts-json-base` (also `@fgv/ts-web-extras` for browser; `@fgv/ts-extras` for zip) |
+| Emit log / diagnostic / observability output; structured logging; boot-time buffering | `Logging` (`ConsoleLogger`, `InMemoryLogger`, `NoOpLogger`, `BootLogger`, `LogReporter`) | `@fgv/ts-utils` |
+| Compute a structural hash of an object (cache key, dedup key, content-addressed id) | `Hash.Crc32Normalizer.computeHash` | `@fgv/ts-utils` |
+| "Are these two objects structurally equal?" / dedup an array of objects / use object as Map key | Same — hash both and compare | `@fgv/ts-utils` |
+| Result-aware Jest matchers | `toSucceedWith`, `toFailWith`, `toSucceedAndSatisfy` etc. | `@fgv/ts-utils-jest` |
+| Convert `unknown` → typed; validate input; type guards | `Converters` / `Validators` | `@fgv/ts-utils` |
+| Mustache template substitution (`{{name}}` placeholders) | `Mustache.MustacheTemplate.create + validateAndRender` | `@fgv/ts-extras` |
+| Password hashing at rest (PBKDF2) — Node side | `NodeCryptoProvider.deriveKey(password, salt, iterations)` | `@fgv/ts-extras` `crypto-utils` |
+| Password hashing at rest (PBKDF2) — Browser side | `BrowserCryptoProvider.deriveKey(...)` (same interface) | `@fgv/ts-web-extras` `crypto-utils` |
+| Symmetric encryption (AES-256-GCM) — Node | `NodeCryptoProvider.encrypt / decrypt` | `@fgv/ts-extras` `crypto-utils` |
+| Symmetric encryption (AES-256-GCM) — Browser | `BrowserCryptoProvider.encrypt / decrypt` | `@fgv/ts-web-extras` `crypto-utils` |
+| Random bytes / random tokens | `<provider>.generateRandomBytes(N)` returning `Result<Uint8Array>` | `@fgv/ts-extras` / `@fgv/ts-web-extras` |
+| AES-256 key generation | `<provider>.generateKey()` | `@fgv/ts-extras` / `@fgv/ts-web-extras` |
+| Asymmetric keypair (Ed25519, ECDSA P-256) | `NodeCryptoProvider.generateKeyPair(algorithm, extractable)` | `@fgv/ts-extras` `crypto-utils` |
+| Wrap / unwrap bytes for transmission | `wrapBytes` / `unwrapBytes` | both providers |
+| Keystore (password-unlocked secret container) | `Keystore` | `@fgv/ts-extras` `crypto-utils/keystore` |
+| `ICryptoProvider` interface | `ICryptoProvider` | `@fgv/ts-extras` `crypto-utils/model.ts` |
+| String hashing (SHA-256 — content integrity, not passwords) | `<provider>.sha256` / `BrowserHashProvider.hashString` | `@fgv/ts-extras` / `@fgv/ts-web-extras` |
+| Resource management with qualifier-driven variant selection (i18n, prompts, …) | `ts-res` | `@fgv/ts-res` |
+| BCP-47 language tag parsing / matching | `@fgv/ts-bcp47` | `@fgv/ts-bcp47` |
+| Record-jar parsing (RFC-5322-style `key: value` entries) | `RecordJar` | `@fgv/ts-extras` |
+| CSV parsing | `Csv` | `@fgv/ts-extras` |
+| YAML parsing | `Yaml` | `@fgv/ts-extras` |
+| Zip file exposed as a FileTree | `ZipFileTree` | `@fgv/ts-extras` |
+| Browser File API types | `file-api-types` | `@fgv/ts-web-extras` |
+| URL parsing / manipulation | `url-utils` | `@fgv/ts-web-extras` |
+| Generic helpers (deferred / debounced / throttled) | `helpers` | `@fgv/ts-web-extras` |
+| Composite-key parsing — delimiter-separated structured strings | toolset's composite-key helpers / `Converters` | `@fgv/ts-utils` |
+
+## Naming gotchas
+
+- **Password hashing** is filed under **key derivation** (`deriveKey`) — PBKDF2, not bcrypt/argon2.
+- **Random bytes** is filed under the **crypto provider** (`generateRandomBytes`) — don't reach for `crypto.randomBytes` or `getRandomValues` directly.
+- **Structural equality** is filed under **hashing** — compute structural hashes; equal hashes ↔ structurally equal values.
+- **Boot-time logging** is filed under **logging** (`BootLogger`) — buffers until pinned to a real logger.
+- **Template substitution** is filed under **Mustache** — the spec-compliant primitive, not a custom `{{...}}` regex.
+- **Two crypto providers, one interface.** `ICryptoProvider` lives in `@fgv/ts-extras`; Node consumers use `NodeCryptoProvider`; Browser consumers use `BrowserCryptoProvider`. Both implement the same interface.
+
+## When the toolset doesn't have it
+
+Proceed with a v1 fallback and surface in `state.md` so the choice is auditable — "toolset doesn't have X; using Node's `crypto.randomBytes` because Y." Don't add a new dependency without flagging it.
+
+## When to load this skill
+
+Load **before** any of the following:
+
+- Writing `fs.readFile`, `fs.writeFile`, `fs.readdir`, `fs.mkdir`, `path.join`, `glob`, or any importer/exporter signature.
+- Writing `console.log`, `console.error`, `console.warn`, or constructing your own logger.
+- Writing `JSON.stringify(a) === JSON.stringify(b)`, a recursive `deepEqual`, `lodash.isEqual`, or `new Map<SomeObjectShape, ...>` keyed by an object.
+- Writing a `{{...}}` regex-based string replacer or custom Handlebars knockoff.
+- Importing `bcrypt`, `argon2`, `crypto.pbkdf2`, or wrapping `crypto.subtle.deriveBits` directly.
+- Adding a new dependency to a `package.json` for a utility that "feels like someone must have written this already."
+
+If you're already wondering "should I be checking the toolset for this?" — yes. Stop, consult, then proceed.
+
+## Deeper skill companions
+
+- `/filetree-io` — file-I/O-specific patterns
+- `/ts-utils-logging` — logging-specific patterns
+- `/value-hashing` — structural-equality-specific patterns
+- `/result-pattern` — all toolset primitives return `Result<T>`; consuming them goes through the Result chain
+- `/type-safe-validation` — `Converters` / `Validators` are the canonical `unknown → typed` primitive

--- a/.claude/skills/result-pattern/SKILL.md
+++ b/.claude/skills/result-pattern/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: result-pattern
+description: Use when writing, reviewing, or refactoring TypeScript code that returns Result<T> from @fgv/ts-utils. Covers chaining patterns, mapResults for arrays, withErrorFormat for error context, .asResult for DetailedResult, MessageAggregator for collecting errors, the factory pattern for fallible construction, and the Result<void> anti-pattern. Load this skill before writing any function that can fail, before refactoring imperative error-handling into Result chains, or when reviewing code that uses succeed()/fail()/captureResult().
+---
+
+# Result Pattern
+
+> Source: `<repo>/.claude/skills/result-pattern/SKILL.md` in the source
+> corpus. Toolset binding: `@fgv/ts-utils`.
+
+All fallible operations in projects using the FGV toolset return
+`Result<T>` from `@fgv/ts-utils`. Errors are explicit values, not
+exceptions.
+
+## Creating Results
+
+```typescript
+import { Result, succeed, fail, captureResult } from '@fgv/ts-utils';
+
+function divide(a: number, b: number): Result<number> {
+  if (b === 0) {
+    return fail('Division by zero');
+  }
+  return succeed(a / b);
+}
+
+// Wrap throwing code with captureResult
+function parseJson(text: string): Result<unknown> {
+  return captureResult(() => JSON.parse(text));
+}
+```
+
+## Extracting values
+
+| Method | Use when |
+|--------|---------|
+| `.orThrow()` | **Setup / initialization only** — constructors, `beforeEach`, top-level boot |
+| `.orDefault(value)` | Safe fallback to a constant |
+| `.orDefaultLazy(() => …)` | Fallback is expensive to compute |
+
+Never `.orThrow()` in business logic — return a `Result<T>` instead.
+
+## Chaining vs intermediate variables
+
+Prefer chaining when it improves clarity:
+
+```typescript
+// GOOD — chain
+function processData(input: string): Result<Output> {
+  return parseInput(input)
+    .onSuccess((parsed) => validate(parsed))
+    .onSuccess((valid) => transform(valid));
+}
+
+// AVOID — unnecessary intermediate variables
+function processData(input: string): Result<Output> {
+  const parsed = parseInput(input);
+  if (parsed.isFailure()) return parsed;
+  const valid = validate(parsed.value);
+  if (valid.isFailure()) return valid;
+  return transform(valid.value);
+}
+```
+
+Exception: when conditional logic is genuinely complex, intermediate
+variables can be clearer. Prioritize readability.
+
+### Coverage-gap smell — `c8 ignore` around `isFailure` is a refactor signal
+
+If you're about to add a `c8 ignore` directive around an `isFailure()`
+propagation block — the imperative shape above — **stop and try
+chaining first.** Roughly:
+
+```typescript
+const fooResult = doFoo();
+/* c8 ignore next 3 */         // ← this is the smell
+if (fooResult.isFailure()) {
+  return fail(fooResult.message);
+}
+// ... use fooResult.value ...
+```
+
+The branch is uncovered because it's *structurally redundant* in the
+chained form — `.onSuccess()` makes the failure flow implicit and
+removes the `if`-block entirely. Refactor first; the coverage gap
+usually disappears with the branch.
+
+**Chaining isn't applicable everywhere** — probably **more than half**
+of these sites refactor cleanly, but the rest legitimately stay
+imperative. Cases where the intermediate-variable shape genuinely
+fits better:
+
+- The intermediate value is used multiple times in subsequent
+  operations (chaining would force multiple re-extractions or
+  awkward closures).
+- Branching based on the intermediate value where the branches
+  diverge significantly (chaining flattens; an `if` inside
+  `.onSuccess()` reads worse).
+- Side effects between steps that don't compose into the chain
+  (logging via `.report()` does compose; arbitrary mutation usually
+  doesn't).
+- Multi-Result fan-in where you need values from several sources
+  (`mapResults` is the right tool when uniform; bespoke composition
+  stays imperative).
+
+When the imperative form is the right shape AND the failure branch is
+structurally unreachable in v1 (e.g. a defensive check against a
+freshly-minted ID that can't collide, or a defensive guard on a
+brand whose Converter already validates), `c8 ignore` with a
+one-line rationale is fine. The order of operations matters: **try
+chaining first, accept c8 ignore only after determining the
+imperative form is the right shape.**
+
+The source corpus repeatedly hit this pattern: a phase-3 stream
+implementation refactor cut a propagation-coverage gap from ~7% to
+0% AND removed ~30 lines of imperative checks. A subsequent
+chore-batch coverage-closure item hit it again on different files.
+The smell is reliable.
+
+## Adding error context
+
+Use `.withErrorFormat()` to layer context as errors propagate:
+
+```typescript
+function loadUserProfile(userId: string): Result<UserProfile> {
+  return loadUser(userId)
+    .withErrorFormat((e) => `user ${userId}: ${e}`)
+    .onSuccess((user) => loadProfile(user.profileId)
+      .withErrorFormat((e) => `user ${userId} profile: ${e}`)
+    );
+}
+```
+
+## DetailedResult → Result
+
+`MaterializedLibrary.get()` returns `DetailedResult`. Use `.asResult`
+to strip detail before chaining:
+
+```typescript
+// CORRECT
+function resolveItem(id: ItemId): Result<ResolvedItem> {
+  return this._context.items.get(id)
+    .asResult
+    .withErrorFormat((msg) => `item ${id}: ${msg}`)
+    .onSuccess((item) => succeed({ id, item }));
+}
+```
+
+Without `.asResult`, `withErrorFormat` will fail to type-check.
+
+## Array processing — `mapResults` with per-item helpers
+
+```typescript
+import { mapResults } from '@fgv/ts-utils';
+
+// EXCELLENT — declarative, per-item helper, contextualized errors
+function getOptions(): Result<ReadonlyArray<IResolvedOption>> {
+  if (this._resolvedOptions === undefined) {
+    const slots = this._version.options ?? [];
+    return mapResults(slots.map((slot) => this._resolveOption(slot)))
+      .onSuccess((resolved) => {
+        this._resolvedOptions = resolved;
+        return succeed(resolved);
+      });
+  }
+  return succeed(this._resolvedOptions);
+}
+
+private _resolveOption(slot: IOptionEntity): Result<IResolvedOption> {
+  return this._resolveOptionValue(slot.value)
+    .withErrorFormat((msg) => `option ${slot.name}: ${msg}`)
+    .onSuccess((value) => succeed({ slotId: slot.slotId, name: slot.name, value }));
+}
+```
+
+Per-item helpers isolate logic, improve error context, and are easier
+to unit-test than imperative loops with manual error handling.
+
+## Early-return for optional fields, then chain
+
+```typescript
+function getCoating(): Result<IResolvedCoating | undefined> {
+  if (this._resolvedCoating === undefined) {
+    const spec = this._version.coating;
+    if (!spec) {
+      this._resolvedCoating = null;
+      return succeed(undefined);
+    }
+    return this._context.materials.getWithAlternates(spec)
+      .withErrorFormat((msg) => `entity ${this._id}: coating: ${msg}`)
+      .onSuccess((resolved) => {
+        if (!resolved.primary.isCoatingMaterial()) {
+          return fail(`entity ${this._id}: primary material is not coating-grade`);
+        }
+        this._resolvedCoating = {
+          material: resolved.primary,
+          alternates: resolved.alternates.filter((m) => m.isCoatingMaterial()),
+          entity: spec
+        };
+        return succeed(this._resolvedCoating);
+      });
+  }
+  return succeed(this._resolvedCoating ?? undefined);
+}
+```
+
+## Avoid `Result<void>` — anti-pattern
+
+Operations should return something meaningful:
+
+```typescript
+// ANTI-PATTERN
+function updateUser(id: string, data: UserData): Result<void> { … }
+
+// CORRECT — return the updated entity
+function updateUser(id: string, data: UserData): Result<User> { … }
+
+// CORRECT — return achieved-vs-target value
+function scaleToTargetWeight(target: Measurement): Result<Measurement> {
+  // …actual achieved weight may differ from target
+  return succeed(actualWeight);
+}
+```
+
+## Aggregating errors across multiple operations
+
+```typescript
+import { MessageAggregator } from '@fgv/ts-utils';
+
+function validateAll(data: Data): Result<ValidatedData> {
+  const aggregator = new MessageAggregator();
+  validateField1(data.field1).aggregateError(aggregator);
+  validateField2(data.field2).aggregateError(aggregator);
+  validateField3(data.field3).aggregateError(aggregator);
+
+  if (aggregator.hasMessages) {
+    return fail(aggregator.toString('; '));
+  }
+  return succeed(createValidatedData(data));
+}
+```
+
+## Factory pattern for fallible construction
+
+Constructors that might throw should be private/protected. Expose a
+static `create` returning `Result<T>`:
+
+```typescript
+class ResourceManager {
+  private constructor(private config: Config) {
+    if (!config.name) throw new Error('Config name is required');
+  }
+
+  public static create(params: Params): Result<ResourceManager> {
+    return validateParams(params)
+      .onSuccess((valid) => loadConfig(valid))
+      .onSuccess((config) => captureResult(() => new ResourceManager(config)));
+  }
+}
+
+const manager = ResourceManager.create(params).orThrow(); // setup
+const result = ResourceManager.create(params);            // app code
+```
+
+### Reference example — async multi-stage factory with per-step error context
+
+A representative production-scale factory for an encrypted store
+demonstrates the pattern:
+
+```typescript
+public static async create(params: ISecretStoreCreateParams): Promise<Result<SecretStore>> {
+  const privateKeyStorage = new InMemoryPrivateKeyStorage();
+  const algorithm: SigningAlgorithm = params.algorithm ?? DEFAULT_SIGNING_ALGORITHM;
+  const storeId = params.storeId;
+
+  return CryptoUtils.KeyStore.KeyStore.create({
+    cryptoProvider: CryptoUtils.nodeCryptoProvider,
+    privateKeyStorage
+  })
+    .thenOnSuccess(async (keyStore) =>
+      (await keyStore.initialize(params.masterPassword))
+        .withErrorFormat((m) => `initialize failed: ${m}`)
+        .onSuccess(() => succeed(keyStore))
+    )
+    .thenOnSuccess(async (keyStore) =>
+      (await keyStore.addKeyPair(signingKeySlot, { algorithm }))
+        .withErrorFormat((m) => `addKeyPair failed: ${m}`)
+        .onSuccess(() => succeed(keyStore))
+    )
+    .thenOnSuccess(async (keyStore) =>
+      (await keyStore.getKeyPair(signingKeySlot))
+        .withErrorFormat((m) => `getKeyPair failed: ${m}`)
+        .onSuccess((keyPair) => succeed({ keyStore, keyPair }))
+    )
+    .thenOnSuccess(async ({ keyStore, keyPair }) =>
+      (await exportPublicKeyAsMultibaseSpki(keyPair.publicKey))
+        .withErrorFormat((m) => `SPKI export failed: ${m}`)
+        .onSuccess((spki) => succeed({ keyStore, spki }))
+    )
+    .thenOnSuccess(async ({ keyStore, spki }) =>
+      (await SecretStore._importExternalKeys(keyStore, params.externalKeys))
+        .onSuccess(() => succeed(new SecretStore(storeId, keyStore, spki)))
+    )
+    .withErrorFormat((m) => `SecretStore.create: ${m}`);
+}
+```
+
+Properties worth internalizing — these are the load-bearing reasons
+the chain shape is preferred over an imperative version:
+
+- **Linear chain via `.thenOnSuccess` (async-aware)** — every step
+  composes; no `if (foo.isFailure()) return fail(foo.message)` ladder.
+  The chain shape doesn't expose the defensive branches the imperative
+  form would, so no `c8 ignore` is needed (see § Coverage-gap smell).
+- **Per-step `.withErrorFormat` with operation-named prefixes** —
+  `initialize failed: ...`, `addKeyPair failed: ...`, `SPKI export
+  failed: ...`. Each layer adds context the layer above couldn't have
+  known. A failure surfaces as a real ladder: `SecretStore.create:
+  SPKI export failed: <upstream message>`. **Skipping the per-step
+  prefixes is the most common drift**; the inner labels are what
+  makes the error message actionable at the call site.
+- **Outer `.withErrorFormat('SecretStore.create: ...')` at the
+  bottom** — wraps every error in the chain with the factory's name.
+  Two-level error contextualization: factory outside, operation
+  inside.
+- **Accumulator pattern for forward-carried context** — the chain's
+  value type shifts from `KeyStore` → `{ keyStore, keyPair }` →
+  `{ keyStore, spki }` → `SecretStore`. Each step gets exactly what
+  it needs without re-fetching.
+- **Deliberate omission of per-step prefix on `_importExternalKeys`**
+  — that helper already returns contextualized errors of its own.
+  The omission is a thoughtful choice, not a missed prefix; "does
+  this helper already give actionable context?" is the question to
+  ask before wrapping.
+
+When a constructor's setup is async, multi-step, and has multiple
+distinct failure modes, this is the shape to reach for.
+
+## Error-message hygiene
+
+Include enough context to be actionable:
+
+```typescript
+// GOOD
+return fail(`index ${index} out of bounds for array of length ${arr.length}`);
+return fail(`${resourceId}: failed to load: ${underlyingError.message}`);
+
+// AVOID
+return fail('invalid index');
+return fail('load failed');
+```

--- a/.claude/skills/result-tests/SKILL.md
+++ b/.claude/skills/result-tests/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: result-tests
+description: Use when writing, reviewing, or refactoring Jest tests in projects using the FGV toolset. Covers the Result-pattern matchers from @fgv/ts-utils-jest (toSucceed, toFail, toSucceedWith, toFailWith, toSucceedAndSatisfy), test structure (orThrow in setup, matchers in assertions), the never-paper-over-failures rule, TypeScript-in-tests rules, and coverage-gap resolution. Load this skill before writing a new test file, before adding tests to an existing file, or when reviewing tests that use jest matchers.
+---
+
+# Result-Pattern Tests
+
+> Source: `<repo>/.claude/skills/result-tests/SKILL.md` in the source
+> corpus. Toolset binding: `@fgv/ts-utils-jest`.
+
+Tests in projects using the FGV toolset use Jest with custom Result
+matchers from `@fgv/ts-utils-jest`. These let you assert on
+`Result<T>` directly without manually unwrapping.
+
+## Always import the matchers
+
+```typescript
+import '@fgv/ts-utils-jest';
+```
+
+This registers the matchers on Jest's `expect`. Forget this and
+`toSucceed()` won't exist.
+
+## Matcher reference
+
+| Matcher | Use when |
+|---------|---------|
+| `toSucceed()` | Only care that the operation succeeded |
+| `toFail()` | Only care that the operation failed |
+| `toSucceedWith(value)` | Testing simple value equality on success |
+| `toFailWith(/pattern/i)` | Testing error messages — use a **regex**, not a string |
+| `toSucceedAndSatisfy((v) => …)` | Complex objects, multiple property checks, nested Results |
+
+## Test structure — `orThrow` in setup, matchers in assertions
+
+The convention is `test()`, not `it()`. Both are jest aliases for the
+same function; **always use `test()`** to match the broader
+fgv-and-this-corpus convention. New test files use `test()`; existing
+`it()` clusters get converted opportunistically when the file is
+touched.
+
+```typescript
+describe('MyClass', () => {
+  let instance: MyClass;
+
+  // GOOD — orThrow in setup
+  beforeEach(() => {
+    instance = MyClass.create(testParams).orThrow();
+  });
+
+  // GOOD — matchers in assertions
+  test('handles operations', () => {
+    expect(instance.operation()).toSucceedAndSatisfy((result) => {
+      expect(result.value).toBe(expected);
+    });
+    expect(instance.failingOp()).toFailWith(/expected error/i);
+  });
+});
+```
+
+```typescript
+// BAD — don't use matchers in setup
+beforeEach(() => {
+  expect(MyClass.create(params)).toSucceedAndSatisfy((instance) => {
+    testInstance = instance; // wrong place for matchers
+  });
+});
+```
+
+## Error testing — regex over exact strings
+
+```typescript
+// GOOD — flexible regex
+expect(parser.parse('')).toFailWith(/empty input/i);
+expect(parser.parse('{')).toFailWith(/syntax error/i);
+
+// AVOID — brittle exact match
+expect(parser.parse('')).toFailWith('Empty input');
+```
+
+## Complex assertions with `toSucceedAndSatisfy`
+
+```typescript
+expect(SomeClass.create(params)).toSucceedAndSatisfy((instance) => {
+  expect(instance.property).toBe(expectedValue);
+  expect(instance.method()).toSucceed();
+
+  // Nested Result assertions are fine
+  expect(instance.getChild('id')).toSucceedAndSatisfy((child) => {
+    expect(child.value).toBe(42);
+  });
+});
+```
+
+## TypeScript in tests — no `any`, ever
+
+```typescript
+// GOOD — proper assertion through unknown
+const corruptedData = {
+  id: 'invalid' as unknown as SomeId,
+  type: 999 as unknown as SomeTypeIndex
+};
+
+// BAD — fails lint
+const corruptedData = {
+  id: 'invalid' as any,
+  type: 999 as any
+};
+
+// ALSO BAD — `as never` is convention drift, not the rule
+const corruptedData = {
+  id: 'invalid' as never,        // works, but doesn't name the brand
+  type: 999 as never
+};
+```
+
+The `any`-type ban applies in test code too. Branded-type assertions
+go through `as unknown as <BrandedType>` — naming the target brand is
+the load-bearing property (the assertion documents *which* brand is
+being constructed for the test). `as never` works at the type-checker
+level but loses that signal; the convention is the explicit form.
+
+## Never paper over real failures
+
+If a test fails because functionality is broken, **report the bug —
+don't hide it**.
+
+```typescript
+// NEVER hide broken functionality
+// TODO: Add test when method is fixed
+expect(typeof brokenMethod.convert).toBe('function');
+
+// NEVER mock to bypass real failures
+jest.mock('./brokenModule', () => ({
+  brokenMethod: jest.fn().mockReturnValue(mockResult)
+}));
+```
+
+When tests reveal bugs:
+1. Confirm it's a real bug (not a test issue).
+2. Stop and report the failure to the user with the exact error.
+3. Fix the underlying code before continuing.
+4. Never mock around it.
+
+## Test through public APIs
+
+```typescript
+// GOOD — public API
+expect(SomeLibrary.Runtime.validator.validate(data)).toSucceed();
+
+// OK when needed — direct internal import
+// eslint-disable-next-line import/no-internal-modules
+import { InternalClass } from '../../../packlets/internal/module';
+
+// AVOID — don't add exports just for testing
+// AVOID — don't change production APIs to make tests easier
+```
+
+## Coverage gaps
+
+Aim for 100% coverage. Gap-resolution process:
+
+1. Run the project's coverage command and identify uncovered lines.
+2. Categorize each gap:
+   - **Business logic** — must test.
+   - **Validation logic** — usually testable.
+   - **Defensive coding** — may need `c8 ignore` directive.
+3. Resolve in priority order; only add `c8 ignore` for genuinely
+   unreachable defensive code, with a comment explaining why.
+
+```typescript
+/* c8 ignore next 2 - defensive coding: internal consistency check */
+if (this.internalState.isCorrupted()) {
+  throw new Error('Internal state corrupted');
+}
+```
+
+**Get user approval before adding `c8 ignore` directives.**
+
+For the imperative-`isFailure` flavor of coverage gap, see
+`skill.toolset.fgv.result-pattern § Coverage-gap smell` — refactor to
+chain shape first; suppress only after determining the imperative
+form is genuinely correct.
+
+## Test file location
+
+Tests mirror source structure under `src/test/unit/`:
+
+```
+src/
+├── packlets/feature/component.ts
+└── test/unit/packlets/feature/component.test.ts
+```

--- a/.claude/skills/triage-cycle/SKILL.md
+++ b/.claude/skills/triage-cycle/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: triage-cycle
+description: Use when about to draft a triage-agent kickoff prompt for the design → triage → implement cycle. Pass a feature id plus the implementing stream id and this skill walks you through verifying phase B is complete, confirming the streams-ledger handoff section, drafting the kickoff with the three-inputs / three-outputs contract, and staking out the phase-C completion gate. Required step before invoking the triage agent on a substantial design bundle. Mirrors the workstream-brief skill's role for streams.
+---
+
+# Triage Cycle
+
+This skill turns the four-phase design → triage → implement cycle
+into a paste-ready kickoff prompt for the triage agent (phase C).
+Use before any triage-agent invocation that follows phase B (bundle
+drop) and precedes phase D (implementing stream).
+
+The project's design-process doc (`docs/DESIGN_PROCESS.md`) is the
+procedural reference for the triage agent itself. This skill is the
+procedural reference for the **orchestrator** drafting the kickoff
+prompt.
+
+## Inputs
+
+- **Feature id** (required): kebab-case identifier matching the
+  bundle path. The bundle lives at `design/pages/<feature>/`, the
+  staging tree will land at `design/staging/<feature>/`, the boneyard
+  at `design/boneyard/<feature>/`, the recommendation at
+  `design/pages/<feature>/PACKAGING.md`.
+- **Implementing stream id** (required): the stream that will
+  consume the triage outputs. Must have an entry in `docs/WORKSTREAMS.md`.
+- **Optional flag** `--write`: if set, persist the kickoff prompt
+  in `.ai/tasks/active/triage-<feature>/brief.md`.
+
+## Procedure
+
+### 1. Verify phase B is complete
+
+The bundle must already be committed under the drop path. Confirm:
+
+- Drop path exists and contains the raw export.
+- The bundle's own README is intact — typically a "READ THIS FIRST"
+  from the design tool.
+- No agent-produced artifacts in the bundle directory yet (no
+  `PACKAGING.md`, no agent-written prose). If those exist already,
+  phase C may have been started informally — check with the user
+  before drafting a fresh kickoff.
+
+If the bundle isn't committed cleanly, **stop**. Phase B is the
+user's responsibility; the triage agent shouldn't repair it.
+
+### 2. Confirm the streams-ledger handoff section
+
+Open `docs/WORKSTREAMS.md` and find the implementing stream's entry.
+The triage agent's outputs are useless if the implementing stream's
+brief doesn't point at them.
+
+The stream entry should have (or will get during phase C) a
+**Design handoff** subsection naming:
+
+- `docs/DESIGN_PROCESS.md`
+- The packaging recommendation (`design/pages/<feature>/PACKAGING.md`)
+- The staging tree (`design/staging/<feature>/`)
+- The architectural design docs the cycle updated
+
+If the section doesn't exist, flag it to the user. The triage agent
+can land the section as part of phase C, but the orchestrator should
+know going in whether they're commissioning the stream-brief update
+or expecting it preexisting.
+
+### 3. Identify the architectural-doc surface
+
+Skim the bundle's README and a few of its source files. Make a
+quick inventory of features the bundle implies that may not yet be
+in the architectural surface docs:
+
+- New entity / surface concepts
+- New configuration concepts
+- New auth / trust concepts
+- New interactions with existing surfaces
+
+You don't need to resolve these — the triage agent will. The point
+of skimming is to size the triage scope and to flag anything the
+implementing stream depends on that isn't documented anywhere yet.
+
+### 4. Draft the kickoff prompt
+
+Use the template below. Be specific — the triage agent is a fresh
+session, has no context, and works from this prompt + the
+design-process doc.
+
+```markdown
+You are the triage agent for the `<feature>` design cycle. The
+implementing stream is `<stream-id>`. Your three inputs are:
+
+1. `docs/DESIGN_PROCESS.md` — read it in full. Especially
+   "What gets captured at triage time" and "The staging area." This
+   cycle uses **variant A** (you populate staging) [or variant B
+   if applicable].
+2. The raw design bundle at `design/pages/<feature>/` — read it in
+   full; follow imports.
+3. `docs/WORKSTREAMS.md` § `<stream-id>` — the implementing stream's
+   brief. Read it in full to understand what the stream is
+   committing to deliver.
+
+Then produce, in this order:
+
+1. **Architectural-doc updates** for emergent capabilities — anything
+   the design implies that isn't currently in the architectural
+   surface docs. Write the doc updates with rationale, alternatives
+   considered, and parking-lot references where appropriate. These
+   land as commitments, not proposals. Likely candidates surfaced at
+   orchestrator pre-skim: <list 2–4 specific concepts you noticed
+   during step 3>.
+
+2. **Staging tree** at `design/staging/<feature>/` — mirror the
+   target paths. Every staged file gets a `STAGED:` header naming
+   what's binding (interface name, file path, exported symbol) vs.
+   revisable (default values, content, prose). What goes in staging
+   vs. what does not is defined in `docs/DESIGN_PROCESS.md` § The
+   staging area.
+
+3. **Recommendation doc** at `design/pages/<feature>/PACKAGING.md` —
+   enumerative, not pattern-matching. Sections: Already canonical
+   (don't port); Staged (walk-and-decide); Not staged (implementer's
+   first deliverable); Discarded (don't port); Architectural docs
+   landed during triage; End-of-stream checklist; What this triage
+   left for the implementer to decide.
+
+Also surface follow-ups via the four-bucket sort defined in
+`docs/DESIGN_PROCESS.md`: chore-shaped → `docs/CHORES.md`; tech-
+debt-shaped → `docs/TECH_DEBT.md`; future-shaped → `docs/FUTURE.md`;
+genuinely-implementer-decision → packaging doc § What this triage
+left for the implementer to decide.
+
+Update `docs/WORKSTREAMS.md` § `<stream-id>` with a **Design handoff**
+section pointing at this cycle's outputs <or note "section already
+exists, verify it points at the actual outputs you produced" if it
+preexisted>.
+
+**Do not** touch production code (`apps/` or `libraries/` source).
+**Do not** write tests, build-tool-validated assets, lint-passable
+code, or anything that requires the project's validation tooling
+to run — that's the implementing stream's work.
+
+Stop when the four outputs above (architectural docs, staging tree,
+packaging recommendation, handoff section) are complete and
+committed. The orchestrator presents the outputs to the user for
+sign-off (the phase-C completion gate); phase D launches off that
+gate.
+
+## Artifact protocol
+
+Maintain `.ai/tasks/active/triage-<feature>/` throughout the run:
+
+- `brief.md` — this kickoff prompt, persisted.
+- `state.md` — live checkpoint at every meaningful boundary.
+- `result.md` — exit artifact (per-output summary, decisions
+  surfaced for the user's sign-off, follow-ups routed per the
+  four-bucket sort).
+
+**Pre-merge migration is the rule.** Before the cycle's commits
+merge, migrate the active-tasks directory to the completed-tasks
+tree with a polished `README.md`. See
+`.ai/conventions/workflow/artifact-protocol.md`.
+```
+
+### 5. Stake out the phase-C completion gate
+
+In your message to the user delivering the kickoff prompt,
+explicitly note that **you'll present the four outputs to the user
+for sign-off** when the triage agent returns, before phase D
+launches. The sign-off gate is the load-bearing discipline of the
+cycle.
+
+Sign-off targets:
+
+1. Architectural-doc updates read clean against the rest of the
+   design system.
+2. The packaging recommendation is enumerative — every staged item
+   has a fate-recommendation; every "already canonical" entry names
+   the canonical location; every "discard" entry has a one-line WHY.
+3. The staging tree mirrors target paths; every staged code/data
+   file carries a `STAGED:` header with binding-vs-revisable
+   explicit.
+4. `docs/WORKSTREAMS.md` § implementing stream has a Design handoff
+   section pointing at the cycle outputs.
+
+If sign-off surfaces a gap, the same triage agent (if available)
+closes it and re-presents. The gate is a forcing function, not a
+blocker.
+
+### 6. (Optional) Persist the kickoff
+
+If `--write` was passed, create `.ai/tasks/active/triage-<feature>/`
+and save the kickoff as `brief.md`. Also stub an empty `state.md`.
+
+### 7. Hand off
+
+Output the kickoff prompt to the user paste-ready. The orchestrator's
+role through phase C is done at this point; the next orchestrator
+action is the sign-off review when the triage agent returns.
+
+## Quality bar for the kickoff
+
+A good kickoff is one where the triage agent can:
+
+- Start work within 30 seconds of reading.
+- Know exactly which three inputs to read in what order.
+- Know exactly what four outputs to produce and where they land.
+- Know what's out of scope (production code, tests, build-tooling-
+  passing artifacts).
+- Know that phase D launches off a gate the orchestrator owns, not
+  the triage agent.
+
+## Anti-patterns
+
+- **Don't draft a kickoff before phase B is clean.** A bundle still
+  being curated isn't ready for triage.
+- **Don't skip the architectural-doc surface skim** in step 3. The
+  triage agent will find the emergent capabilities anyway, but
+  flagging them in the kickoff seeds the work.
+- **Don't promise the user a phase-D launch alongside the kickoff.**
+  The completion gate is real — its whole purpose is that the user
+  might surface a change before phase D.
+- **Don't let the triage agent touch production code.** That's the
+  implementing stream's job.
+- **Don't bundle multiple features into one triage cycle.** Each
+  cycle is one bundle, one staging directory, one packaging
+  recommendation.

--- a/.claude/skills/ts-utils-logging/SKILL.md
+++ b/.claude/skills/ts-utils-logging/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: ts-utils-logging
+description: Use when writing or reviewing any code that emits diagnostic output, observability signals, or error/failure messages in projects using the FGV toolset. The convention is to use the `logging` packlet from `@fgv/ts-utils` (`ILogger`, `BootLogger`, `LogReporter`) plus the Result-integration helpers in `@fgv/ts-utils`'s `base` packlet (`.report()`, `.orThrow(logger)`, `aggregateError(...)`) — never `console.log` / `console.error` in business logic, never construct a logger inside a component. Load this skill BEFORE adding any `console.*` call, before writing a class that wants to emit diagnostics, before writing a service-bootstrap path, or when reviewing code that throws-without-logging or constructs its own logger. Covers the boot-buffer-then-pin pattern, dependency-injection idiom, Result integration, MessageAggregator integration, and test patterns with `InMemoryLogger`.
+---
+
+# ts-utils Logging
+
+> Source: `<repo>/.claude/skills/ts-utils-logging/SKILL.md` in the
+> source corpus. Toolset binding: `@fgv/ts-utils`.
+
+Projects using the FGV toolset use the `logging` packlet from
+`@fgv/ts-utils` for all diagnostic output, paired with the
+Result-integration helpers in its `base` packlet. Never `console.log`
+/ `console.error` in business logic. Never construct a logger inside
+a component — inject it.
+
+The benefit is the same one you get from `Result<T>` and `FileTree`:
+a uniform shape that works across boot, runtime, tests, in-process
+consumers, and (eventually) durable observability backends without
+business logic noticing the difference.
+
+## Mental model
+
+Logging in this toolset is a **two-phase substrate**:
+
+1. **Boot phase** — a `BootLogger` buffers every log call to memory
+   until durable infrastructure is up. Components created during boot
+   (config readers, catalog loaders, keystore unwrap, etc.) receive
+   the `BootLogger` like any other `ILogger` and have no idea they're
+   talking to a buffer.
+2. **Pin phase** — once the durable logger exists (`ConsoleLogger`,
+   file logger, structured-output logger, whatever), call
+   `bootLogger.ready(realLogger)`. The buffer flushes to the real
+   logger in order, and every subsequent call forwards directly. No
+   data loss, no dropped early errors, no "I'd love to log this but
+   the logger isn't constructed yet."
+
+Components downstream of boot just take an `ILogger` (or
+`IResultReporter`) and don't care which phase they're in.
+
+This is the **boot-buffer-then-pin** pattern; see
+`convention.toolset.fgv.boot-buffer-then-pin` for the convention
+spelled out separately.
+
+## API surface
+
+The convention is to import the `Logging` namespace from
+`@fgv/ts-utils` and access types/classes through it:
+
+```typescript
+import { Logging, type MessageLogLevel } from '@fgv/ts-utils';
+
+const boot = new Logging.BootLogger();
+const reporter = new Logging.LogReporter<MyValue>({ logger });
+const visible = Logging.shouldLog(level, threshold);
+```
+
+### `ILogger` and concrete implementations
+
+```typescript
+interface ILogger {
+  readonly logLevel: ReporterLogLevel;     // 'all' | 'detail' | 'info' | 'warning' | 'error' | 'silent'
+  log(level, message?, ...parameters): Success<string | undefined>;
+  detail(message?, ...parameters): Success<string | undefined>;
+  info(message?, ...parameters): Success<string | undefined>;
+  warn(message?, ...parameters): Success<string | undefined>;
+  error(message?, ...parameters): Success<string | undefined>;
+}
+```
+
+`IDetailLogger` extends with `errorWithDetail(message, detail)` and
+`warnWithDetail(message, detail)` — short summary at the named level,
+full detail at `detail` level.
+
+| Implementation | When |
+|----------------|------|
+| `Logging.ConsoleLogger(level?)` | The durable logger in node v1 |
+| `Logging.InMemoryLogger(level?)` | Tests. Stores `logged` and `suppressed` arrays |
+| `Logging.NoOpLogger()` | Components that require an `ILogger` but the caller doesn't care (rare; usually a smell) |
+| `Logging.BootLogger(level?)` | Boot phase only. Buffers until `ready(realLogger)` is called |
+| `Logging.shouldLog(level, threshold)` | Predicate — true if `level` would be emitted at `threshold` |
+
+### `BootLogger`
+
+```typescript
+const boot = new Logging.BootLogger('detail');    // buffers everything
+boot.info('starting service');                     // → buffer
+const real = new Logging.ConsoleLogger('info');
+boot.ready(real);                                  // flushes buffer, then forwards
+boot.error('keystore unlock failed');              // → real (forwarded)
+```
+
+`isReady` reflects connection status. After `ready()`, the
+`BootLogger` is essentially a thin pass-through.
+
+### `LogReporter` — Result-pattern bridge
+
+```typescript
+const reporter = new Logging.LogReporter<MyValue>({
+  logger,
+  valueFormatter: (v) => `Processed: ${v.name}`,
+  messageFormatter: (msg) => `[service] ${msg}`
+});
+
+reporter.reportSuccess('info', value);
+reporter.reportFailure('error', 'load failed', errorDetail);
+
+// Derive a reporter for a different value type, same logger + message formatter
+const otherReporter = reporter.withValueFormatter<OtherType>((v) => `Other: ${v.id}`);
+```
+
+`LogReporter` implements **both** `IDetailLogger` and
+`IResultReporter<T, TD>`, so it can be passed wherever either is
+required.
+
+### Result integration in `base`
+
+```typescript
+import type { IResultReporter } from '@fgv/ts-utils';
+
+interface IResult<T> {
+  // Report through a reporter without unwrapping; passes through unchanged.
+  report(reporter?: IResultReporter<T>, options?: IResultReportOptions<unknown>): Result<T>;
+
+  // orThrow with logger: log the error before throwing.
+  orThrow(logger?: IResultLogger): T;
+  orThrow(cb: ErrorFormatter): T;
+
+  // Accumulate errors across many fallible operations without short-circuiting.
+  aggregateError(errors: IMessageAggregator, formatter?: ErrorFormatter): this;
+}
+```
+
+## Canonical patterns
+
+### Boot path — module-scope logger + reporter, pinned once durable infrastructure is up
+
+```typescript
+// At module scope — created once, used by every helper in this module.
+const _bootLogger = new Logging.BootLogger();
+const _bootReporter = new Logging.LogReporter<unknown>({ logger: _bootLogger });
+
+async function _buildWorkspace(): Promise<IBuildResult> {
+  // Module-level helpers can log directly through the boot logger…
+  _bootLogger.warn(`Ignoring invalid config namespace '${raw}'`);
+
+  // …and downstream factories accept the reporter as a parameter named `logger`.
+  const platformInit = await initializeBrowserPlatform({
+    userLibraryPath: 'localStorage',
+    logger: _bootReporter
+  });
+
+  if (platformInit.isFailure()) {
+    _bootReporter.error(`Cloud storage could not be loaded: ${platformInit.message}`);
+    return platformInit.orThrow();
+  }
+
+  // Real reporter exists once durable infrastructure is up.
+  // Pin the boot logger; buffered entries flush in order, future calls forward.
+  const realReporter = createDurableReporter(platformInit.value);
+  _bootLogger.ready(realReporter.logger);
+
+  return /* … */;
+}
+```
+
+The two-line module preamble is the canonical shape. **Don't
+construct the boot logger inside `_buildWorkspace`** — module-level
+helpers need to log too, and they shouldn't take a logger parameter
+for what is fundamentally module-startup diagnostics.
+
+### Business-logic component takes a `logger`, then exposes `.logger`
+
+```typescript
+export interface IServiceCatalogCreateParams {
+  config: IServiceConfig;
+  keystore: IKeystore;
+  logger: ILogger;
+}
+
+export class ServiceCatalog {
+  public readonly logger: ILogger;
+
+  private constructor(params: IServiceCatalogCreateParams, /* … */) {
+    this.logger = params.logger;
+  }
+
+  public static fromConfig(params: IServiceCatalogCreateParams): Result<ServiceCatalog> {
+    return /* … */;
+  }
+
+  public resolve(ref: ServiceRef): Result<IServiceConfig> {
+    return this._lookup(ref).onFailure((err) => {
+      this.logger.warn(`unknown ref: ${ref}`, { available: this._knownRefs() });
+    });
+  }
+}
+```
+
+Two things matter here:
+
+- **Constructor takes the logger** — never `new ConsoleLogger()`
+  inside the class. Tests inject `InMemoryLogger`; boot injects the
+  boot reporter; production injects the durable reporter.
+- **Expose `.logger` as a public property** so callers downstream of
+  this component can use `workspace.serviceCatalog.logger.error(...)`
+  rather than threading the original logger through every layer.
+
+### Result integration with `.report()`
+
+`.report()` is for "log this outcome but don't change control flow."
+The Result passes through unchanged.
+
+```typescript
+return loadConfig(path)
+  .report(reporter, { success: 'detail', failure: 'error' })
+  .onSuccess((cfg) => validateConfig(cfg))
+  .onSuccess((cfg) => buildCatalog(cfg));
+```
+
+Use `.report()` at boundaries where you want a record of what
+happened (success or failure) without disturbing the chain.
+
+### `.orThrow()` at the boot edge — log first, then throw
+
+Boot code that genuinely cannot recover — bad config, missing master
+key — logs the failure explicitly through the boot reporter, *then*
+`.orThrow()`s.
+
+```typescript
+const result = loadConfig(path);
+if (result.isFailure()) {
+  _bootReporter.error(`Config load failed: ${result.message}`);
+  return result.orThrow();
+}
+```
+
+`.orThrow(logger)` (the overload that takes a logger and logs
+internally) is also fine. Pick one and be consistent within a module.
+
+**Never `.orThrow()` without having logged the failure** — a thrown
+bootstrap error with no diagnostic is the "process died with no clue
+why" pattern.
+
+### `aggregateError` for multi-step validation
+
+```typescript
+import { MessageAggregator, mapResults } from '@fgv/ts-utils';
+
+const errors = new MessageAggregator();
+const validated = entries
+  .map((e) => validateEntry(e).aggregateError(errors, (msg) => `entry ${e.id}: ${msg}`));
+
+if (errors.hasMessages) {
+  errors.messages.forEach((m) => logger.warn(m));
+  return fail(`catalog has ${errors.messages.length} bad entries`);
+}
+return mapResults(validated);
+```
+
+### Filtering by level — `Logging.shouldLog`
+
+```typescript
+const filteredToasts = toasts.filter((msg) =>
+  Logging.shouldLog(msg.level, toastLevel)
+);
+```
+
+### Tests
+
+```typescript
+import { Logging } from '@fgv/ts-utils';
+
+describe('ServiceCatalog', () => {
+  let logger: Logging.InMemoryLogger;
+  let catalog: ServiceCatalog;
+
+  beforeEach(() => {
+    logger = new Logging.InMemoryLogger('all');
+    catalog = ServiceCatalog.fromConfig({ config, keystore, logger }).orThrow();
+  });
+
+  test('warns on unknown ref', () => {
+    expect(catalog.resolve(unknownRef)).toFailWith(/unknown ref/);
+    expect(logger.logged.some((m) => m.includes('unknown ref'))).toBe(true);
+  });
+});
+```
+
+For tests that don't care about logs, inject `new Logging.NoOpLogger()`
+rather than skipping the parameter.
+
+## Anti-patterns
+
+| Anti-pattern | Why it's wrong | Fix |
+|---|---|---|
+| `console.log(...)` / `console.error(...)` in business logic | No level control, no test capture, no boot buffer, no Result integration | Inject an `ILogger`; call `logger.info/warn/error`. |
+| `private _logger = new Logging.ConsoleLogger('info')` inside a class | Untestable, fixes log level at class scope, ignores boot phase | Take `logger` as a constructor / factory parameter. |
+| `result.orThrow()` with no preceding log at the boot edge | Process exits with no diagnostic | Log explicitly, *then* `.orThrow()`. |
+| `result.orThrow()` in business logic | Throws in fallible code; violates the Result-pattern rule | Return `Result<T>`. |
+| `try { … } catch (e) { logger.error(e); throw e; }` around Result-returning code | Re-introduces exceptions | `result.report(reporter, { failure: 'error' }).onFailure(...)`. |
+| Logging the same failure at every layer of a chain | Duplicate noise, hard to trace | Log once at the layer with most context. |
+| `if (X.isFailure()) { logger.error(X.message); return X; }` | Imperative propagation the Result chain handles cleanly | `X.onFailure((m) => logger.error(m))` or `X.report(reporter, { failure: 'error' })`. |
+| Boot logger constructed inside the bootstrap function | Module-level helpers can't log without a parameter | Module-scope `const _bootLogger = new Logging.BootLogger();`. |
+| Component takes `logger` but doesn't expose `.logger` | Callers thread the original logger past the component | `public readonly logger: ILogger` — set in constructor. |
+| Tests that swallow logs | Lose the ability to verify diagnostic behavior | Inject `Logging.InMemoryLogger`; assert on `.logged`. |
+
+## When to load this skill
+
+- Writing a new component / class / factory that emits any diagnostic
+  output.
+- Writing a service-bootstrap or boot-time path.
+- Reviewing code that calls `console.*`, constructs
+  `new ConsoleLogger(...)` mid-component, or has bare `.orThrow()` at
+  a boot edge.
+- Adding observability to existing code.
+- Writing a test that needs to assert on diagnostic behavior.
+
+## Where this couples to other skills
+
+- **`result-pattern`** — `.report()`, `.orThrow(logger)`, and
+  `aggregateError` are Result-pattern integrations.
+- **`result-tests`** — `InMemoryLogger` + `toSucceedAndSatisfy` is
+  the canonical pattern for asserting "the operation succeeded AND
+  emitted the right warning."

--- a/.claude/skills/type-safe-validation/SKILL.md
+++ b/.claude/skills/type-safe-validation/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: type-safe-validation
+description: Use when writing or reviewing code that converts unknown data into typed values — Converters, Validators, type guards, or any code that takes `unknown` and returns a typed Result. Covers when to use Converters.object vs Validators.object vs Converters.generic, the manual-type-check anti-pattern (CI-blocking), and how to write custom converters safely. Load this skill before authoring a new converter, before refactoring legacy `if (typeof x === 'string')` code, or when reviewing Priority-1 type-safety violations.
+---
+
+# Type-Safe Validation
+
+> Source: `<repo>/.claude/skills/type-safe-validation/SKILL.md` in
+> the source corpus. Toolset binding: `@fgv/ts-utils`.
+
+Converters and Validators from `@fgv/ts-utils` give you type safety
+without unsafe casts. The patterns below are **mandatory** — manual
+type checking with `as` casts is a Priority-1 review block.
+
+## Anti-patterns (will be rejected in review)
+
+```typescript
+// ANTI-PATTERN 1 — manual checks then unsafe cast
+Converters.generic<unknown, MyType>((from: unknown) => {
+  if (typeof from !== 'object' || from === null) return fail('…');
+  const obj = from as Record<string, unknown>;
+  if (typeof obj.field !== 'string') return fail('…');
+  return succeed(obj as MyType); // UNSAFE
+});
+
+// ANTI-PATTERN 2 — property check then cast
+if ('id' in obj && 'name' in obj) {
+  return succeed(obj as IUser); // properties could have wrong types
+}
+
+// ANTI-PATTERN 3 — double cast through Record
+const value = someValue as Record<string, unknown> as TargetType; // never
+```
+
+## Converters — for plain data structures
+
+Use `Converters.object` when transforming JSON-shaped data into typed
+structures:
+
+```typescript
+import { Converters } from '@fgv/ts-utils';
+
+const configConverter = Converters.object<IConfig>({
+  name: Converters.string,
+  port: Converters.number,
+  options: Converters.jsonObject.optional()    // <- per-field .optional()
+});
+
+return configConverter.convert(input); // Result<IConfig>
+```
+
+Converters compose: `Converters.arrayOf`, `Converters.recordOf`,
+`Converters.oneOf`, plus the `.optional()` method on any converter.
+
+### Optional fields — `.optional()`, not `optionalFields:`
+
+`Converters.object` accepts a legacy `optionalFields: ['name', ...]`
+config parameter that flags fields as optional in a separate location
+from their type definition. **Don't use it.** The convention is
+`.optional()` on the property converter:
+
+```typescript
+// GOOD — optionality lives in the type system at declaration
+Converters.object<IConfig>({
+  name: Converters.string,
+  bio: Converters.string.optional()
+});
+
+// BAD — optionality split into a separate config param
+Converters.object<IConfig>({
+  name: Converters.string,
+  bio: Converters.string
+}, { optionalFields: ['bio'] });
+```
+
+Both forms work at runtime; `.optional()` is strongly preferred
+because **it surfaces optionality to the type system;
+`optionalFields:` does not.**
+
+Concrete failure mode the type-system path catches and the legacy
+path doesn't — using `strictObject` with a type that has a *required*
+field:
+
+```typescript
+interface IFoo { requiredString: string; }
+
+// GOOD — TS error: 'requiredString' is required on IFoo but the converter
+// is producing string | undefined. Caught at compile time.
+const fooConverter = Converters.strictObject<IFoo>({
+  requiredString: Converters.string.optional()  // mismatch with IFoo
+});
+
+// BAD — compiles fine. Type system thinks the converter satisfies IFoo
+// because the converter for requiredString is just `Converters.string`;
+// the optionalFields flag is invisible to TS. Runtime allows missing
+// requiredString; production hit comes from a parsed-but-incomplete object.
+const fooConverter = Converters.strictObject<IFoo>({
+  requiredString: Converters.string
+}, { optionalFields: ['requiredString'] });
+```
+
+So the preference is not just stylistic — `optionalFields:` is a
+**type-safety hole**: it lets you silently mark a required field as
+optional and the type system has no way to flag it. The `.optional()`
+form encodes optionality where the compiler can see it.
+
+PR-review reflex: `optionalFields:` in new code is a real finding,
+not a stylistic nit — it's bypassing a type-safety check.
+
+## Validators — for objects with class instances or runtime guarantees
+
+Use `Validators.object` when fields include class instances, branded
+types, or other runtime-guaranteed values that converters can't
+reconstruct:
+
+```typescript
+import { Validators } from '@fgv/ts-utils';
+
+const resourceValidator = Validators.object<IResource>({
+  id: Convert.resourceId,
+  type: Validators.isA((v): v is ResourceType => v instanceof ResourceType),
+  items: Validators.arrayOf(itemValidator)
+});
+
+return resourceValidator.validate(from); // Result<IResource>
+```
+
+## Custom logic — `Converters.generic`, *without* manual type checks
+
+`Converters.generic` is fine when you genuinely need custom
+conversion logic — but only if the inner work itself uses converters
+or trusted typed APIs, not manual `typeof` checks:
+
+```typescript
+const customConverter = Converters.generic<SourceShape, TargetShape>((from) => {
+  // `from` is already typed as SourceShape — don't re-check
+  return innerConverter.convert(from.field).onSuccess((v) => succeed(transform(v)));
+});
+```
+
+If you find yourself writing `if (typeof from !== 'object' …) return
+fail(…)` inside `Converters.generic`, you should be using
+`Converters.object` instead.
+
+## Decision matrix
+
+| Shape | Use |
+|-------|-----|
+| Plain object / JSON-shaped data | `Converters.object` |
+| Object containing class instances or branded values | `Validators.object` |
+| Array of items | `Converters.arrayOf` / `Validators.arrayOf` |
+| `Record<string, T>` | `Converters.recordOf` / `Validators.recordOf` |
+| Discriminated union | `Converters.discriminatedObject` |
+| Genuinely custom transform with no manual type checks | `Converters.generic` |
+
+## Branded type assertions
+
+For branded types (where the runtime value is just a string/number
+but the type is branded), assert through `unknown`:
+
+```typescript
+const id = 'user-123' as unknown as UserId;
+
+// Test data with intentionally invalid types
+const corrupted = {
+  id: 'invalid' as unknown as ValidId,
+  type: 999 as unknown as TypeIndex
+};
+```
+
+Never `as Record<string, unknown> as TargetType` — that's a double
+cast and is rejected in review.
+
+## When in doubt
+
+If a piece of validation code has more than one `if (typeof …)`
+branch followed by an `as`, it's almost certainly the wrong
+approach. Stop and pick the right tool from the table above.

--- a/.claude/skills/value-hashing/SKILL.md
+++ b/.claude/skills/value-hashing/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: value-hashing
+description: Use when writing or reviewing code that needs structural equality on objects — comparing two objects for "are these the same value", deduplicating an array of objects, using an object as a `Map` / `Set` key, or building a cache key from a request shape. Projects using the FGV toolset use the `Hash` namespace from `@fgv/ts-utils` (`Crc32Normalizer.computeHash`) instead of `JSON.stringify(a) === JSON.stringify(b)`, hand-rolled property walks, lodash `isEqual`, or `fast-deep-equal`. Load this skill BEFORE writing any of the following: `JSON.stringify(...)===JSON.stringify(...)`, a recursive `function deepEqual(...)` walker, `new Map<SomeObjectShape, ...>` keyed by an object, `Set<SomeObjectShape>`, or anything that says "these two objects are structurally the same." Covers the `computeHash` API, the four canonical usage patterns, the edge cases the normalizer handles vs doesn't, and the anti-patterns it replaces.
+---
+
+# Value Hashing
+
+> Source: `<repo>/.claude/skills/value-hashing/SKILL.md` in the source
+> corpus. Toolset binding: `@fgv/ts-utils`.
+
+Structural equality / dedup / object-as-key in projects using the
+FGV toolset goes through `@fgv/ts-utils`'s `Hash` namespace —
+specifically `Crc32Normalizer`. It produces a stable,
+key-order-independent hash of any JSON-shaped value. Don't roll your
+own; don't reach for `JSON.stringify` or `lodash.isEqual`.
+
+## Mental model
+
+`Crc32Normalizer.computeHash(value)` walks the value, normalizes its
+shape (object keys sorted, type tags applied to disambiguate `null` /
+`undefined` / `Date` / `RegExp` / `Map` / `Set`), joins the parts,
+and CRC32-hashes them. Returns `Result<string>` — eight hex digits.
+
+Same hash → almost certainly the same value (CRC32 collisions exist
+but are vanishingly rare for typical structured data; if you need
+cryptographic-grade collision resistance, this isn't the tool).
+
+```typescript
+import { Hash } from '@fgv/ts-utils';
+
+const normalizer = new Hash.Crc32Normalizer();
+
+const h1 = normalizer.computeHash({ name: 'atlas', kind: 'agent' }).orThrow();
+const h2 = normalizer.computeHash({ kind: 'agent', name: 'atlas' }).orThrow();
+// h1 === h2 (key order doesn't matter)
+```
+
+Reuse a single normalizer instance — they're stateless beyond the
+configured hash function.
+
+## The four canonical usage patterns
+
+### 1. Compare two objects for structural equality
+
+```typescript
+function isSame(a: unknown, b: unknown): Result<boolean> {
+  const normalizer = new Hash.Crc32Normalizer();
+  return normalizer.computeHash(a).onSuccess((ha) =>
+    normalizer.computeHash(b).onSuccess((hb) => succeed(ha === hb))
+  );
+}
+```
+
+### 2. Deduplicate an array of objects
+
+```typescript
+function dedupe<T>(items: ReadonlyArray<T>): Result<T[]> {
+  const normalizer = new Hash.Crc32Normalizer();
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const item of items) {
+    const hashResult = normalizer.computeHash(item);
+    if (hashResult.isFailure()) return fail(`dedupe: ${hashResult.message}`);
+    if (!seen.has(hashResult.value)) {
+      seen.add(hashResult.value);
+      out.push(item);
+    }
+  }
+  return succeed(out);
+}
+```
+
+### 3. Object as a `Map` / `Set` key
+
+JavaScript's `Map<K, V>` keys by reference for object keys, which is
+rarely what you want. Hash first, key on the hash:
+
+```typescript
+class StructuralMap<K, V> {
+  private readonly _normalizer = new Hash.Crc32Normalizer();
+  private readonly _store = new Map<string, V>();
+
+  public set(key: K, value: V): Result<this> {
+    return this._normalizer.computeHash(key).onSuccess((h) => {
+      this._store.set(h, value);
+      return succeed(this);
+    });
+  }
+
+  public get(key: K): Result<V | undefined> {
+    return this._normalizer.computeHash(key).onSuccess((h) => succeed(this._store.get(h)));
+  }
+}
+```
+
+### 4. Cache key for a derived computation
+
+```typescript
+class ComputationCache<TInput, TOutput> {
+  private readonly _normalizer = new Hash.Crc32Normalizer();
+  private readonly _cache = new Map<string, TOutput>();
+
+  public lookupOrCompute(input: TInput, compute: (i: TInput) => TOutput): Result<TOutput> {
+    return this._normalizer.computeHash(input).onSuccess((key) => {
+      const hit = this._cache.get(key);
+      if (hit !== undefined) return succeed(hit);
+      const value = compute(input);
+      this._cache.set(key, value);
+      return succeed(value);
+    });
+  }
+}
+```
+
+## Anti-patterns (replace these)
+
+- **`JSON.stringify(a) === JSON.stringify(b)`** — fails on key order
+  (`{a:1,b:2}` vs `{b:2,a:1}` stringify differently), drops
+  `undefined` properties silently, can't represent `Map` / `Set` /
+  `Date` / `RegExp` / `BigInt`, and throws on circular refs. The
+  normalizer fixes the first three; flags the fourth.
+- **Hand-rolled `function deepEqual(a, b)`** — bug magnet. Optional
+  fields, nested arrays, sparse arrays, prototype-pollution risk,
+  NaN handling, Date comparison, RegExp comparison — every case has
+  a subtle gotcha. The normalizer encodes all of them once,
+  correctly, in one place.
+- **Reference equality (`===` / `Object.is`)** for value-typed
+  records — only works when you know the producer returned the same
+  instance.
+- **`lodash.isEqual` / `fast-deep-equal`** — extra dependency,
+  doesn't return `Result<T>`, has its own opinions about
+  Date/RegExp/class-instance handling. Use the in-house tool so the
+  rest of the codebase has a single semantic.
+- **`new Map<SomeObject, V>()` keyed by reference** — silently
+  broken if you ever look up by an object built from the same data.
+  Use a `StructuralMap` (pattern 3 above) keyed on the hash.
+
+## Edge cases the normalizer handles
+
+- **Object key order**: keys sorted before hashing. ✓
+- **Array order**: positions preserved (arrays are ordered, this is
+  correct). ✓
+- **`null` vs `undefined`**: distinguished. ✓
+- **`{a: undefined}` vs `{}`**: distinct hashes (the explicit
+  `undefined` property is preserved). Differs from `JSON.stringify`,
+  which silently drops them.
+- **`Date`**: serialized via `valueOf()` (timestamp). ✓
+- **`RegExp`**: serialized via `.toString()`. ✓
+- **`Map` / `Set`**: handled via type prefix plus normalized
+  entries. ✓
+- **`NaN`**: every `NaN` hashes the same way — different from `===`
+  semantics where `NaN !== NaN`. This is correct for structural
+  equality. ✓
+- **`bigint`, `boolean`, `number`, `symbol`**: typed wrapping
+  prevents cross-type collisions. ✓
+
+## Edge cases the normalizer does NOT handle
+
+- **Circular references**: not protected against. Break the cycle
+  before hashing.
+- **Class instances**: only own string-keyed enumerable properties
+  are walked. Class methods, prototype-defined properties, and
+  symbol-keyed properties are stripped. Two instances of different
+  classes with the same own data hash identically. If class identity
+  matters, include a discriminator field.
+- **Functions**: `computeHash` returns `fail(...)` for
+  `typeof === 'function'`. Strip functions before passing in.
+- **Symbol keys**: ignored entirely.
+
+## Result-typed, not throwing
+
+`computeHash` returns `Result<string>` and never throws. Use it like
+any other Result API:
+
+```typescript
+return normalizer.computeHash(input)
+  .onSuccess((hash) => /* use hash */)
+  .withErrorFormat((msg) => `cache key: ${msg}`);
+```
+
+In setup / `beforeEach` / boot only, `.orThrow()` is acceptable.
+
+## TypeScript surface
+
+```typescript
+import { Hash } from '@fgv/ts-utils';
+
+// Concrete normalizer — 99% of consumers want this:
+const normalizer = new Hash.Crc32Normalizer();
+
+// Custom hash function (e.g. SHA-256) — extend HashingNormalizer:
+class Sha256Normalizer extends Hash.HashingNormalizer {
+  public constructor() {
+    super((parts) => /* your SHA-256 */ '');
+  }
+}
+```
+
+Public API:
+
+| Name | Shape | Use |
+|------|-------|-----|
+| `Hash.Crc32Normalizer` | `class extends HashingNormalizer` (no-arg constructor) | Default. Use this. |
+| `Hash.HashingNormalizer` | `class extends Normalizer` | Subclass to plug in a different hash. |
+| `Hash.HashFunction` | `(parts: string[]) => string` | The hash plugin signature. |
+| `.computeHash(from: unknown)` | `Result<string>` | Primary API. |
+| `.normalize<T>(from: T)` | `Result<T>` | Returns a normalized value (sorted keys etc.) when you want the canonical *shape*, not a hash. Rare. |
+
+If you need normalized canonical *values* rather than hashes (e.g.
+to write a stable JSON file representation), use `.normalize()`
+instead of `.computeHash()`. Otherwise, default to `computeHash`.

--- a/.claude/skills/workstream-brief/SKILL.md
+++ b/.claude/skills/workstream-brief/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: workstream-brief
+description: Use to extract a tight operational brief for a parallel workstream from the project's streams ledger (docs/WORKSTREAMS.md). Pass a workstream id and this skill walks you through reading the source brief, the linked reading list, and the cross-stream dependencies to produce a kickoff document that a fresh agent can pick up cold. Required step before kicking off any parallel cloud-agent run on a workstream — also useful in the IDE to scope a session. The brief explicitly stakes out which files the stream may modify, which it must NOT touch (collision avoidance with other parallel streams), the acceptance criteria, and the handoff contract for downstream streams.
+---
+
+# Workstream Brief
+
+This skill turns the multi-page streams-ledger design doc into a
+self-contained kickoff brief for one stream. Use it before any
+parallel run — the brief is the contract. If the brief turns out
+wrong, update the streams ledger before deviating.
+
+## Inputs
+
+- **Workstream ID** (required): the stream identifier per the
+  project's convention. The user (or invoking agent) provides this.
+- **Optional flag** `--write`: if set, the brief is written to the
+  active-tasks directory for resumption later.
+
+## Procedure
+
+### 1. Read the source brief
+
+Open `docs/WORKSTREAMS.md` and locate the section for the requested
+workstream id. Read its **full** entry: track, status today, v1
+deliverable, stop point, reading list, dependencies, publishes-for-
+downstream, open design questions.
+
+### 2. Read the reading list
+
+Each workstream lists required reading. Open every file/section it
+names and load enough context to write the brief without re-reading
+the linked docs while operating. **Don't skim.** This is the moment
+you trade depth for later speed.
+
+### 3. Identify file-level boundaries
+
+The brief must answer two questions every parallel agent needs to
+know **before touching anything**:
+
+- **In-scope paths** — what this workstream is allowed to modify. Be
+  explicit. If the workstream's deliverable is fuzzy (e.g. "design
+  spike"), list the files the spike will likely touch.
+- **Out-of-scope paths** — what other streams own. Cross-reference
+  the streams ledger's Dependencies and Publishes-for-downstream
+  sections. Anything another active stream will modify is **out of
+  scope**, even if it would seem natural to touch it. If you must
+  touch a shared file, pause and escalate to the user before
+  proceeding.
+
+If you can't cleanly separate in-scope from out-of-scope, that's a
+finding — report it and ask the user how to proceed before kicking
+off the work.
+
+### 4. Capture the handoff contract
+
+Each workstream **publishes** something for downstream streams (an
+interface, a data model, a doc). Translate the source doc's
+"Publishes for downstream" bullets into concrete artifacts: file
+paths, exported type names, doc sections. Downstream streams will
+rely on these — they need to be unambiguous.
+
+### 5. Emit the brief
+
+Use the template below. Be terse. Every line should be load-bearing.
+
+```markdown
+# Workstream Brief: <id> — <name>
+
+## Mission
+<1–2 sentences summarizing what this stream achieves>
+
+## Status entering
+<one line: what exists today, what's missing>
+
+## In-scope paths (you may modify)
+- <path>
+- <path>
+
+## Out-of-scope paths (you must NOT modify — owned by other streams)
+- <path> — owned by <other stream id>
+- <path> — owned by <other stream id>
+
+## Required reading (load before writing code)
+- <file or doc§section>
+- <file or doc§section>
+
+## Missing-input rule (non-negotiable)
+
+If any required-reading file or other declared input doesn't exist or
+you can't access it: **STOP**. Surface the gap to the user.
+
+Do NOT:
+- Recreate the missing input from your own analysis or codebase
+  exploration.
+- Re-derive followups / state / brief content from scratch.
+- Improvise or guess at what the input was supposed to contain.
+
+Missing required-reading is an orchestrator-level provisioning gap,
+not an agent-level workaround.
+
+## Dependencies
+**Hard** (cannot start without): <list, or "none">
+**Soft** (can stub if upstream not ready): <list, or "none">
+
+## v1 deliverables (in order)
+1. <numbered item from the streams ledger, terse>
+2. …
+
+## Acceptance criteria (the "stop point")
+- [ ] <criterion derived from the streams ledger's stop point>
+- [ ] Build passes (`rush build` from repo root, or `rushx build` from project dir)
+- [ ] Tests pass (`rush test` or `rushx test`)
+- [ ] Lint clean in any modified project (`rushx lint`)
+- [ ] No ad-hoc `console.*` in business logic — use `@fgv/ts-utils` Logging
+
+## Handoff contract (what you publish for downstream streams)
+- <artifact> — consumed by <downstream stream id(s)>
+- <artifact> — consumed by <downstream stream id(s)>
+
+## Open questions to resolve
+- <question> — recommended approach: <option>
+- <question> — escalate to user
+
+## Findings-inbox convention
+Findings surfaced during the stream go to per-file inbox entries at
+`.ai/tasks/active/<id>/findings/inbox/<timestamp>-<slug>.md` — one
+finding per file. The orchestrator periodically drains the inbox
+into the consolidated `followups.md`. Don't write to `followups.md`
+directly during the stream.
+
+## Required exit artifact
+
+On completion, write `.ai/tasks/active/<id>/result.md` with:
+
+- Branch name
+- One-paragraph summary
+- Files changed (list)
+- Build / test / lint status (pass/fail per command)
+- **Observability self-audit**: grep in-scope paths for `console.*`
+  in business logic; confirm zero hits or document each kept-as-is
+  site with explicit rationale.
+- **Convention-compliance sweep**: check for known anti-patterns
+  (see `.ai/instructions/CODE_REVIEW_CHECKLIST.md`).
+- **Sibling-sweep pass** on new surfaces: for each new surface,
+  ask "what siblings did I asymmetrically diverge from?"
+  (see `.ai/conventions/workflow/sibling-sweep-lens.md`)
+- Open questions or follow-ups for downstream
+- Any deviation from this brief (and why)
+
+## Resume protocol
+If interrupted, before resuming:
+1. Read this brief in full again.
+2. Read `.ai/tasks/active/<id>/state.md` for the most recent checkpoint.
+3. Confirm with the user that scope and boundaries still apply.
+```
+
+### 6. (Optional) Persist the brief
+
+If `--write` was passed, create `.ai/tasks/active/<stream-id>/` and
+save the brief as `brief.md`. Also create an empty `state.md` with
+a header so the directory is structurally ready for the resume
+protocol.
+
+### 7. Hand off
+
+Output the brief to the user. The brief is the contract for the
+parallel run. If kicking off a cloud agent, hand it the brief
+verbatim — the brief should be sufficient to start cold, without
+re-reading the streams ledger.
+
+## Quality bar for the brief
+
+A good brief is one where a fresh agent can:
+
+- Start work within 30 seconds of reading.
+- Know exactly which files are theirs.
+- Know exactly what to deliver to call it done.
+- Know exactly what to write at the end so the next stream can
+  pick up.
+
+If you can't say yes to all four, the brief isn't tight enough —
+go back to the source doc and refine.
+
+## Anti-patterns
+
+- **Don't synthesize fiction.** If the streams ledger is silent on
+  something the brief needs (e.g. file-level scope), say so and
+  ask. Don't fabricate.
+- **Don't paraphrase the design.** The brief is operational — file
+  paths, criteria, contracts. Design rationale stays in the
+  streams ledger.
+- **Don't skip the out-of-scope list.** That's the whole point of
+  doing this for parallel runs.
+- **Don't ship a brief without the observability compliance line.**
+  When the rule isn't in the brief at the authoring moment, the
+  pattern doesn't reach the implementing agent and ad-hoc
+  diagnostic sites accumulate.
+- **Don't ship a brief without the missing-input rule.** Agents
+  will try to reconstruct missing inputs from codebase exploration
+  — that's scope deviation disguised as helpfulness. The
+  missing-input rule explicitly prohibits this.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,20 +75,44 @@ expect(operation()).toSucceedAndSatisfy((result) => {
 });
 ```
 
+## When to load which skill
+
+Load skills just-in-time when the relevant work surface is touched:
+
+| Work surface | Skill |
+|---|---|
+| Any file I/O, directory walk, importer/exporter | `/filetree-io` |
+| Any diagnostic output, logger construction, boot path | `/ts-utils-logging` |
+| Any structural equality, dedup, object-as-map-key | `/value-hashing` |
+| Any utility-shaped code ("feels general") | `/published-primitives-reflex` |
+| Writing or reviewing `Result<T>`-returning code | `/result-pattern` |
+| Writing or reviewing tests | `/result-tests` |
+| Writing or reviewing converters, validators, type guards | `/type-safe-validation` |
+| Extracting a stream brief for a parallel run | `/workstream-brief` |
+| Drafting a design-triage-cycle kickoff | `/triage-cycle` |
+
 ## Complex Task Orchestration
 
-For complex multi-phase tasks (new features, major refactoring), the task-master workflow system is available in `.claude/agents/`. This provides:
+For coordinating parallel workstreams, the **orchestrator** is available in `.claude/agents/orchestrator.md`. It maintains the artifact substrate, selects workflow shapes, composes kickoff briefs for worker agents, and closes the lessons loop. The orchestrator is designed for frontier-model sessions where the agent is coordinating, not implementing.
 
-- Structured requirements analysis with confirmation gates
-- Design review phases
-- Implementation coordination with specialized agents
-- Automated and manual testing phases
-- Artifact preservation for future reference
+Three workflow shapes:
 
-Workflow templates are in `.ai/workflows/`. Use task-master for:
-- Multi-step features requiring coordination
-- Major refactoring with behavior preservation
-- Tasks benefiting from structured documentation
+| Shape | When |
+|---|---|
+| `stream` | Substantial feature with a known shape — use `/workstream-brief` |
+| `chore-batch` | Sequential walk through 3–6 small unrelated cleanup items |
+| `design-triage-implement` | Feature needing design exploration first — use `/triage-cycle` |
+
+Artifact substrate (maintained by the orchestrator):
+- `docs/WORKSTREAMS.md` — in-flight and completed streams
+- `docs/CHORES.md` — cleanup batches
+- `docs/TECH_DEBT.md` + `docs/FUTURE.md` — deferred work
+- `.ai/tasks/active/<id>/` → `.ai/tasks/completed/<YYYY-MM>/<id>/` — per-stream artifacts
+- `.ai/BASELINE.md` — pinned baseline commit for the current wave
+
+Workflow conventions are in `.ai/conventions/workflow/`.
+
+For single-agent structured tasks (requirements → design → implementation → review), the **task-master** is in `.claude/agents/task-master.md`. Workflow templates are in `.ai/workflows/`.
 
 ## Claude-Specific Notes
 

--- a/docs/CHORES.md
+++ b/docs/CHORES.md
@@ -1,0 +1,72 @@
+# Chores — fgv
+
+Scheduled cleanup batches. Different from TECH_DEBT (long-running
+structural debt) and FUTURE (parking lot of ideas). A chore batch
+is a focused agent run that closes several small items at once,
+typically tied to a specific transition — between waves of
+workstreams, between phases, after a major refactor lands. Each
+batch is bounded, agent-shaped, and usually 3–6 items.
+
+---
+
+## What goes here vs. TECH_DEBT vs. FUTURE
+
+| Doc | Captures | Shape | Closed by |
+|-----|----------|-------|-----------|
+| **Batch register (this doc)** | Scheduled cleanup tied to a specific transition | Time-bounded, batched, 3–6 items | A focused agent run |
+| **TECH_DEBT** | Long-running structural debt | Priority-ranked (P1–P4) | Opportunistically — when the right surface area is touched |
+| **FUTURE** | Parking-lot ideas, not on roadmap, not non-goals | Captured with rationale | Promoted to roadmap when concrete demand surfaces |
+
+Items can move between docs. A TECH_DEBT entry that becomes
+time-critical can be promoted into the active chore batch.
+
+## Process notes
+
+### When to open a new batch
+
+- **Between waves of streams.** Two streams just merged; they
+  surfaced N items that all want to land before the next wave.
+- **After a major refactor.** A refactor that ships green but leaves
+  test-only paths or `TODO`-marked follow-ups.
+- **Pre-phase transitions.** When a phase closes and the next phase
+  begins, items that don't belong to either are chore-shaped.
+
+### Kickoff-prompt shape for chore agents
+
+Reference: `.ai/conventions/workflow/kickoff-prompt-shape.md` §
+interleaved-per-item. A chore batch is a **sequential walk** through
+3–6 small items, not a single coherent feature. **Don't** give the
+agent a single upfront "Read everything before coding" list spanning
+all items.
+
+### Coverage-closure items — explicit smell guidance
+
+Any chore item that includes "close coverage gaps" needs explicit
+guidance to **load `/result-pattern` before reaching for coverage-
+suppression**, plus a one-line description of the smell:
+
+> If you're about to add a coverage-suppression directive around an
+> imperative `isFailure()` propagation block, that's a refactor
+> signal. Try chaining first — it usually closes the gap
+> structurally. Accept suppression only after determining the
+> imperative form is genuinely the right shape. See
+> `.claude/skills/result-pattern/SKILL.md` § Coverage-gap smell.
+
+### Artifact migration is pre-merge
+
+Same rule as workstreams. The chore-batch agent migrates
+`.ai/tasks/active/<batch-id>/` → `.ai/tasks/completed/<YYYY-MM>/<batch-id>/`
+and writes the polished `README.md` **as part of the PR, before
+merge**, not as a post-merge follow-up.
+
+---
+
+## Active batch
+
+*(No active batch.)*
+
+---
+
+## Completed batches
+
+*(No completed batches yet.)*

--- a/docs/DESIGN_PROCESS.md
+++ b/docs/DESIGN_PROCESS.md
@@ -1,0 +1,155 @@
+# Design Process — fgv
+
+Candidate pattern for design → triage → implement cycles. The
+process bridges high-fidelity design prototypes (HTML/CSS/JS,
+Figma, Claude Design output, etc.) to implementation contracts.
+
+---
+
+## Premise
+
+Design tools produce high-fidelity prototypes that look essentially
+final. Implementing agents work best when they have **clear
+contracts** — what's binding, what's revisable, what already exists
+upstream. The gap between "delightful prototype" and "implementable
+contract" is where this process lives.
+
+The recurring failure modes when that gap isn't bridged:
+
+- **Implementers copy prototypes literally** — including idioms that
+  don't fit the target codebase (browser-babel, inline styles,
+  untyped JS).
+- **Implementers ignore prototypes** — and the visual intent is lost
+  in translation.
+- **Implementers face a multi-thousand-LOC bundle with no priority
+  signal** — and their first hour is spent re-discovering what
+  already exists in shared libraries.
+- **Pre-positioning creates apparent contracts** — implementers
+  treat planted artifacts as immutable when they were meant as
+  starters.
+- **Emergent capabilities** show up during implementation instead
+  of being captured in design docs before implementation starts.
+
+## Workflow
+
+```
+A · Design   →   B · Drop   →   C · Triage   →   D · Implement
+designer         commit         triage agent     implementing
+produces a       the raw        produces the     stream consumes
+prototype        bundle to      architectural    the triage
+                 design path    doc updates,     outputs and
+                 (no agent)     staging tree,    builds the
+                                packaging        feature
+                                recommendation
+```
+
+For the full workflow procedure see
+`.ai/conventions/workflow/` and the orchestrator's `/triage-cycle`
+skill.
+
+Use `/triage-cycle` to draft the phase-C kickoff prompt.
+
+## What gets captured at triage time
+
+Four buckets, each with a different home:
+
+1. **Visuals → component plan** — enumerative inventory: already-
+   canonical / promote-to-shared-library / app-local / discard.
+2. **Assets → package destinations** — assets sorted by *role*,
+   not current content fidelity. Placeholder and final assets share
+   the same package because the *interface* (an SVG at this aspect
+   ratio) is what consumers depend on.
+3. **Emergent capabilities → architectural docs** — features the
+   design implies that aren't currently documented. Captured during
+   triage as commitments, not proposals. The implementing stream
+   finds them already documented, with rationale and alternatives
+   considered.
+4. **Followups → batch register / TECH_DEBT / FUTURE** — items
+   that don't fit the other buckets, routed via
+   `.ai/conventions/workflow/lessons-codification-triage.md`.
+
+## The staging area
+
+Proposed artifacts live in a parallel directory tree mirroring their
+proposed final paths (`design/staging/<feature>/`). Production code
+is never touched during triage. The implementer chooses what to
+promote, what to revise-and-promote, and what to reject.
+
+### Why staging beats annotations
+
+**Structural constraint vs. procedural convention.** A separate
+directory tree is a structural fact — staged artifacts physically
+aren't in production paths, so the implementer has to *decide-to-
+move* rather than *decide-to-keep*. Default behavior is "do nothing
+→ nothing happens to the codebase," which is the right default for
+proposals.
+
+### What goes in staging
+
+- Asset files (copies of new assets ready to move to canonical homes)
+- Content data (themes, presets, configuration arrays)
+- Type definitions the implementer will consume — when genuinely
+  settled at triage time
+- Doc fragments (READMEs for new directories, scaffolding for
+  component-library docs)
+
+### What does NOT go in staging
+
+- Components requiring tests / build-tool-validation / lint passes
+- Anything depending on in-flight wire shapes not yet shipped
+- Style decisions the implementer should own
+- Architectural docs — those land in `docs/` directly during triage
+
+### Staged file headers
+
+Every staged code/data file carries a `STAGED:` header naming what's
+binding (interface name, file path, exported symbol) vs. revisable
+(default values, content arrays, prose).
+
+### Boneyard
+
+Items the implementer rejects move to
+`design/boneyard/<feature>/<staged-path-mirrored>` with a one-line
+WHY annotation. Preserved, not deleted — signal for the next triager
+about what didn't fly and why.
+
+### End-of-stream discipline
+
+When the implementing stream closes, every staged item has one fate:
+
+| Fate | What happened | Where the file lives |
+|------|---------------|----------------------|
+| Promoted | Implementer accepted (and possibly revised) | Production tree |
+| Boneyarded | Implementer rejected with documented reason | Boneyard tree |
+| Process bug | Anything still in staging | Needs cleanup before stream close |
+
+## Variant: who populates staging?
+
+- **Variant A** — the triage agent populates staging. Standard for
+  substantial bundles. Forces architectural questions to surface
+  early.
+- **Variant B** — staging starts empty; the implementing agent
+  extracts as their first deliverable. Lighter; useful when the
+  bundle is small or the implementing agent has the domain expertise
+  to do the extraction without losing triage value.
+
+The boneyard mechanism works identically either way.
+
+## Phase-C completion gate
+
+Phase C is **not** complete when the triage agent stops. It's
+complete when the user signs off on the three outputs:
+
+1. Architectural-doc updates read clean against the rest of the
+   design system.
+2. The packaging recommendation is enumerative — every staged item
+   has a fate-recommendation; every "already canonical" entry names
+   the canonical location; every "discard" entry has a one-line WHY.
+3. The staging tree mirrors target paths; every staged code/data
+   file carries a `STAGED:` header with binding-vs-revisable
+   explicit.
+4. `docs/WORKSTREAMS.md` § implementing stream has a Design handoff
+   section pointing at the cycle outputs.
+
+If sign-off surfaces a gap, the triage agent closes it and re-
+presents. The gate is a forcing function, not a blocker.

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -1,0 +1,26 @@
+# Future — fgv
+
+Parking-lot ideas that aren't current work, aren't non-goals, but
+need concrete demand or design before they can be scheduled. Items
+here get promoted to `docs/WORKSTREAMS.md` when a real use case
+surfaces.
+
+---
+
+## Entry format
+
+```markdown
+## Idea title
+
+Description with the user's framing expanded with the design space.
+
+**Why deferred**: why this isn't current work.
+
+**Dependencies**: what would unblock it.
+
+**Reference**: session / observation context.
+```
+
+---
+
+*(No entries yet.)*

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -1,0 +1,46 @@
+# Tech Debt — fgv
+
+Already-shipped imperfections. Priority-ranked; addressed
+opportunistically when the right surface area is touched.
+
+---
+
+## Priority key
+
+- **P1** — blocking / structural; address before resuming major feature work.
+- **P2** — fix before the next major feature in the affected area.
+- **P3** — opportunistic cleanup.
+- **P4** — doc / minor consistency.
+
+## Entry format
+
+```markdown
+- **[Pn] Title.**
+  Description with file pointers.
+
+  **Trigger**: when this should be addressed.
+
+  **Scope sketch**: one-paragraph fix shape.
+
+  **Not a P(n+1)**: why this priority and not lower.
+
+  **Reference**: PR / commit / session context that surfaced it.
+```
+
+---
+
+## P1 — Blocking
+
+*(None.)*
+
+## P2 — Fix before next major feature in affected area
+
+*(None.)*
+
+## P3 — Opportunistic cleanup
+
+*(None.)*
+
+## P4 — Doc / minor consistency
+
+*(None.)*

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -1,0 +1,70 @@
+# Workstreams — fgv
+
+The canonical doc for in-flight and completed parallel workstreams.
+Each entry is a kickoff brief — designed so a fresh agent (or fresh
+human) can pick it up cold from this doc plus the linked reading
+list, without re-creating any of the design discussion that produced
+it.
+
+---
+
+## Status conventions
+
+- 🟢 ready to start (all hard dependencies met)
+- 🟡 ready but trailing on a soft dependency
+- 🔵 in flight (active design or implementation)
+- 🔴 blocked (hard dependency unmet)
+- ✅ shipped (merged to the buffer line)
+
+## Branch model
+
+Feature branches PR into `release`. The orchestrator gates
+buffer→main promotions via a unified automated-review pass.
+See `.ai/conventions/workflow/branch-buffer-and-promotion.md`.
+
+## Baseline check before kickoff
+
+Every workstream session verifies its branch base against `.ai/BASELINE.md`
+before doing any work. The baseline pins the minimum release-branch
+commit a new branch must descend from so a wave of parallel streams
+shares the same foundation; bumped when a new wave launches.
+
+## Stream versions
+
+Used when a stream's deliverable splits into independently-shippable
+phases. Each version has its own brief, status, dependencies, PR,
+and task-artifact directory. Reserve for streams where the phases
+are genuinely separable shipping units.
+
+## Shared types between parallel streams
+
+When two parallel streams share a type, pick exactly one pattern:
+
+1. **Coordination commit**: land the shared type as a small commit
+   before either stream branches.
+2. **Narrower consumer interface**: consumer defines a smaller,
+   distinctly-named interface exposing only the methods it needs.
+3. **Lock ownership in kickoff prompts**: exactly one stream owns
+   each shared symbol; the other is told explicitly NOT to define it.
+
+Never have two parallel streams publishing the same symbol.
+
+## Artifact protocol
+
+Every workstream maintains live artifacts at
+`.ai/tasks/active/<stream-id>/{brief.md, state.md, result.md}`
+throughout the run. **Migrate to `.ai/tasks/completed/<YYYY-MM>/<stream-id>/`
+and write a polished `README.md` as part of the PR — before merge,
+not as a follow-up.** See `.ai/conventions/workflow/artifact-protocol.md`.
+
+---
+
+## Active workstreams
+
+*(No active workstreams yet.)*
+
+---
+
+## Completed workstreams
+
+*(No completed workstreams yet.)*


### PR DESCRIPTION
## Summary

- Adds the full orchestrator substrate for coordinating parallel workstreams: streams ledger (`docs/WORKSTREAMS.md`), chore batch register (`docs/CHORES.md`), tech-debt and future parking lots, design-process doc, and baseline pin file
- Adds eight workflow conventions under `.ai/conventions/workflow/` (artifact protocol, branch model, inbox/drain, kickoff-prompt shape, lessons triage, long-PR review, sibling-sweep, stale-marker scan)
- Adds nine just-in-time skills under `.claude/skills/` (filetree-io, ts-utils-logging, value-hashing, published-primitives-reflex, result-pattern, result-tests, type-safe-validation, workstream-brief, triage-cycle)
- Adds orchestrator agent definition at `.claude/agents/orchestrator.md`
- Updates `CLAUDE.md` to reference the orchestrator and adds the skill dispatch table

## Test plan

- [ ] Substrate docs present and internally consistent (cross-references verified)
- [ ] All 9 skills present with `SKILL.md` content
- [ ] All 8 convention files present
- [ ] `CLAUDE.md` skill dispatch table matches skills corpus
- [ ] No production code changed — all additions are AI workflow infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)