### PR TITLE
docs: adapt orchestrator substrate to fgv repo shape

### DIFF
--- a/.ai/BASELINE.md
+++ b/.ai/BASELINE.md
@@ -1,18 +1,44 @@
 # Baseline
 
-The minimum `release` branch commit that all branches in the current
-wave must descend from. Bumped by the orchestrator when a new wave
-launches or when a cleanup batch lands that must be in the base
-going forward.
+Pins the **last `release` → `main` promotion** — i.e. the last
+published lockstep version. Bumped by the orchestrator only when
+a promotion lands, not when a new stream starts.
+
+## What it's for
+
+- **Recovery referent.** "Last known shipped state" if we need to
+  reason about what's actually in the wild vs. what's accumulated
+  on `release`.
+- **Blast-radius sizing.** When scoping a stream, the delta between
+  this commit and current `release` HEAD is the unreleased surface
+  the stream sits on top of. A bigger delta means more interaction
+  risk.
+
+## What it's NOT for
+
+- Not a stream-start gate. Streams branch from current `release`
+  HEAD; collision avoidance with parallel streams is by package
+  surface and out-of-scope declarations in the stream entry, not
+  by shared base commit.
+- Not a wave base. There are no waves — work is reactive,
+  consumer-driven, and feature-shaped.
+
+## When to bump
+
+On every `release` → `main` promotion. Update both the commit sha
+and the date; include the lockstep version that promotion published
+(or "not yet published" if the promotion preceded the next publish
+event).
 
 ---
 
-**Current baseline**: *(not yet pinned — pin with the first wave's
-base commit when you launch the first workstream)*
+**Current baseline**: `ffde48ad` — 2026-05-10 — orchestrator
+workflow infrastructure installed (provisional pin; pre-dates the
+first real `release` → `main` promotion under this substrate).
 
-To pin:
+To bump:
 ```
-git log --oneline -1 release   # get the commit sha
-# then update this file:
-# **Current baseline**: <sha> — <YYYY-MM-DD> — <one-line description>
+git log --oneline -1 release   # get the commit sha after the promotion merge
+# then update the line above:
+# **Current baseline**: <sha> — <YYYY-MM-DD> — <lockstep version or context>
 ```

--- a/.ai/conventions/workflow/branch-buffer-and-promotion.md
+++ b/.ai/conventions/workflow/branch-buffer-and-promotion.md
@@ -41,39 +41,56 @@ line only advances via deliberate orchestrator-gated promotions.
 
 ## The promotion gate
 
-Invoked at clean stream-close moments after the buffer has
-accumulated a coherent batch of merged PRs:
+Invoked as a release event, not a routine operation. In this repo
+the promotion delta is typically large (months of accumulated
+feature work) — too large for meaningful code review, and each
+constituent PR was reviewed on its way into the buffer. The
+gate is therefore **test / docs / sibling-sweep**, not unified
+code review:
 
 1. Confirm the buffer is in known-good state — all in-flight
    followups closed or explicitly deferred; no in-progress PRs
-   blocking; baseline doc reflects the buffer's current state.
-2. Open a PR `<buffer> → <canonical>`. The PR's diff is whatever
-   has accumulated on the buffer since the last promotion.
-3. **Run one explicit automated-review pass on the unified buffer
-   state.** Even though each constituent PR was reviewed
-   individually when it landed, the unified diff can surface
-   **fix-interaction findings** — fixes that held in isolation but
-   interact when combined. Address those before merging.
-4. Merge with **merge-commit** method (preserves the constituent
-   PRs' history; squash would collapse the audit trail; rebase
-   would rewrite SHAs that other docs reference).
-5. Bump the pinned baseline file to capture the new canonical head.
-   The buffer continues to advance from the same point.
+   blocking.
+2. Confirm CI green: tests pass, coverage gates met, lint clean
+   on the buffer's current HEAD.
+3. Confirm generated docs are caught up (api-extractor output and
+   doc-update PRs reflect the current buffer state).
+4. **Run a sibling-sweep as a fresh agent** against the unified
+   buffer delta. The per-PR reviews catch within-PR issues; the
+   sibling-sweep catches **fix-interaction findings** — fixes
+   that held in isolation but interact when combined — plus
+   cross-stream inconsistencies (drifted conventions, duplicated
+   primitives, naming clashes). See
+   `.ai/conventions/workflow/sibling-sweep-lens.md`.
+   - Critical findings (production-blocking, data-corruption,
+     security, recovery-path-broken) get inline fixes before merge.
+   - Everything else routes to followups — TECH_DEBT, FUTURE, or
+     the next chore batch.
+5. Open a PR `<buffer> → <canonical>`. Merge with **merge-commit**
+   method (preserves the constituent PRs' history; squash would
+   collapse the audit trail; rebase would rewrite SHAs that other
+   docs reference).
+6. Bump the pinned baseline file to capture the new canonical head.
+   Include the lockstep version this promotion will publish (or
+   "pre-publish" if the promotion precedes the next publish event).
 
-Promotion frequency: at natural stream-close moments. Don't promote
-on every PR (defeats the buffer); don't let the buffer drift
-indefinitely (loses the "canonical is current canonical" property).
+Promotion frequency in this repo is **release-event-driven, not
+continuous** — production publish only when stability-via-
+consumption is established (at least one consumer has applied
+recent features end-to-end). Alpha publishes from the prerelease
+mirror happen independently and don't gate or require promotion.
 
-## Why the promotion needs its own review pass
+## Why the sibling-sweep, not a unified code review
 
-The per-PR automated reviews catch within-PR issues. **Cross-PR
-fix-interactions only surface when the combined state is reviewed
-together.** Per the source corpus's review-cycle data, fix-
-interactions are uncommon but real. Catching them at promotion is
-cheaper than discovering them in production. The cost of the
-promotion review pass is one automated pass on the unified PR;
-orchestrator triage of its findings is the real cost — typically
-modest.
+In smaller-delta topologies, a unified automated code-review pass
+at promotion catches fix-interactions cheaply. In this repo the
+delta is too large for that to produce useful signal — re-reviewing
+months of already-reviewed code costs a lot and finds little.
+The sibling-sweep is a different lens: it looks across PRs for
+cross-stream interaction, convention drift, and primitive
+duplication, which **is** the class of issue per-PR review can't
+catch. Net: cheaper than a full re-review, catches the things
+that actually escape per-PR review.
 
 ## Alternatives the orchestrator workflow family is compatible with
 
@@ -120,8 +137,8 @@ semantic-by-convention. Other projects may prefer `develop`,
 
 - **Direct agent merges to the canonical line.** Defeats the
   buffer's purpose.
-- **Promotion without an automated-review pass.** Skips the
-  fix-interaction catch.
+- **Promotion without a sibling-sweep.** Skips the fix-interaction
+  and cross-stream-drift catch.
 - **Squash-merge at promotion.** Collapses the audit trail of
   constituent PRs.
 - **Promotion on every PR.** Buffer becomes a passthrough; loses

--- a/.ai/conventions/workflow/stale-marker-scan.md
+++ b/.ai/conventions/workflow/stale-marker-scan.md
@@ -44,9 +44,9 @@ The orchestrator runs the scan as part of post-merge bookkeeping:
 
 ## Anti-patterns
 
-- **Skipping the scan after a non-wave-close merge.** Markers can
-  rot at any merge, not just at wave boundaries. Run the scan as
-  part of every post-merge bookkeeping pass.
+- **Skipping the scan after a "small" merge.** Markers can rot at
+  any merge. Run the scan as part of every post-merge bookkeeping
+  pass.
 - **Flipping markers but not updating the sequencing summary.**
   The summary is its own surface and rots independently.
 - **Trusting "I just looked at the ledger yesterday" as proof of

--- a/.ai/instructions/ACTIVE_DEVELOPMENT.md
+++ b/.ai/instructions/ACTIVE_DEVELOPMENT.md
@@ -1,25 +1,35 @@
 # Active Development Guidelines
 
-This document covers guidelines specific to the libraries and applications currently under active development. These rules supplement the general coding standards.
+This document covers guidelines specific to the libraries and surfaces currently under active development. These rules supplement the general coding standards.
 
-## Active Development Scope
+## How to read this doc
 
-### Actively Developed Libraries
-| Library | Path | Purpose |
-|---------|------|---------|
-| `ts-http-storage` | `libraries/ts-http-storage` | HTTP storage provider abstraction |
-| `ts-app-shell` | `libraries/ts-app-shell` | Shared React app shell primitives |
+This repo is a set of utility libraries with independent roadmaps but a **lockstep version policy** — when we publish, we publish everything. Most libraries see at least some reactive maintenance, but a handful (and specific packlets within them) are the current frontier and accept breakage freely; the rest carry stability obligations.
 
-### Other Libraries (production, handle with care)
-Everything else under `libraries/` is in production. See [Compatibility Rules](#compatibility-rules).
+The active/production split is therefore **per-surface, not per-library**. A library can have both an established surface that needs compatibility care and an actively-developed packlet that doesn't. The lists below name the surfaces currently in the "free hand" zone; everything else is "handle with care" by default.
+
+## Currently active surfaces
+
+| Library | Active surface(s) | Notes |
+|---------|-------------------|-------|
+| `ts-extras` | `ai-assist`, `crypto-utils` | Established packlets (csv, record-jar, yaml, mustache, hash, conversion, zip-file-tree) are stable — handle with care |
+| `ts-app-shell` | All packlets | New library, no consumers yet outside this repo |
+| `ts-http-storage` | All | New library |
+| `ts-web-extras` | All | New library |
+
+Anything not listed above — including production libraries like `ts-utils`, `ts-res`, `ts-bcp47`, `ts-json`, `ts-json-base`, `ts-random`, `ts-utils-jest`, `ts-res-ui-components` — carries stability obligations. See [Compatibility Rules](#compatibility-rules).
+
+## Out-of-scope packages
+
+The sudoku packages (`ts-sudoku-lib`, `ts-sudoku-ui`) are slated to move to their own monorepo. Don't queue active development against them in this repo's workflow substrate.
 
 ---
 
 ## Compatibility Rules
 
-### New Libraries: No Compatibility Burden
+### Active surfaces: No Compatibility Burden
 
-The active-development packages (`ts-http-storage`, `ts-app-shell`) are **all new code**. Compatibility is **not** a consideration:
+Code on the active surfaces listed above is **new enough that compatibility is not a consideration**:
 
 - **Do not** preserve deprecated values, types, or re-exports
 - **Do not** add backwards-compatibility shims or renamed aliases
@@ -27,14 +37,18 @@ The active-development packages (`ts-http-storage`, `ts-app-shell`) are **all ne
 - If a change is necessary or appropriate, **break compatibility and fix consumers** rather than accumulating cruft
 - Trying to preserve compatibility in new code leads to bloat and confusion
 
-### Production Libraries: Be Careful
+### Established surfaces: Be Careful
 
-All other libraries under `libraries/` are in production:
+Everything else carries stability obligations:
 
 - Breaking changes require careful consideration of downstream impact
 - **When in doubt, ask** before making breaking changes
-- Follow semantic versioning principles
+- Follow semantic versioning principles within the lockstep policy (a breaking change anywhere bumps everyone — that's a real cost)
 - Check for consumers before removing or renaming exports
+
+### The lockstep-version wrinkle
+
+Because we publish everything together, a breaking change on an established surface is more expensive than it looks: every package's version moves, every consumer integrates a delta that includes things they didn't ask for. Prefer additive or aliased changes on established surfaces when feasible; reserve genuine breaks for cases where the new shape is materially better and the migration cost is justified.
 
 ---
 

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -37,9 +37,9 @@ Your job is **not** primarily to write code — it's to:
 Before doing anything, read these — they carry the conventions your predecessor codified:
 
 - `CLAUDE.md` and `.ai/instructions/ACTIVE_DEVELOPMENT.md`
-- `docs/WORKSTREAMS.md` preamble (status conventions, stream versions, shared types, baseline check, artifact protocol)
-- `docs/CHORES.md` (current active batch shape + completed precedents)
-- `.ai/BASELINE.md` (pinned baseline commit — verify before any new branch)
+- `docs/WORKSTREAMS.md` preamble (repo shape, branch flow, status conventions, stream entry shape, shared types, artifact protocol)
+- `docs/CHORES.md` (current active batch shape + completed precedents; trigger taxonomy)
+- `.ai/BASELINE.md` (last `release` → `main` promotion — used for blast-radius sizing, not as a stream-start gate)
 - Cross-cutting design docs in `docs/` relevant to the work in flight
 
 Then check `.ai/tasks/active/` for in-flight task artifacts before starting any new orchestration work.
@@ -65,10 +65,10 @@ Full workflow procedures: `.ai/conventions/workflow/` and `docs/DESIGN_PROCESS.m
 ### Stream kickoff
 
 1. Load `/workstream-brief` for the stream ID.
-2. Verify file-boundary collision avoidance against any other in-flight parallel streams.
-3. Verify the branch base against `.ai/BASELINE.md`.
+2. Verify package-surface / file-boundary collision avoidance against any other in-flight parallel streams.
+3. Branch base is current `release` HEAD (no shared "wave base" — see WORKSTREAMS.md preamble).
 4. Commit `brief.md` + empty `state.md` to `.ai/tasks/active/<stream-id>/`.
-5. Deliver kickoff prompt paste-ready: mission, in/out-of-scope paths, required reading, skills to load (with trigger conditions), missing-input rule, phases, acceptance criteria, exit artifact shape, resume protocol.
+5. Deliver kickoff prompt paste-ready: mission, package surface, in/out-of-scope paths, required reading, skills to load (with trigger conditions), missing-input rule, phases, acceptance criteria, exit artifact shape, resume protocol.
 
 ### Chore-batch kickoff
 
@@ -85,15 +85,18 @@ Compose following the interleaved-per-item shape from `.ai/conventions/workflow/
 1. Flip the stream's status marker in `docs/WORKSTREAMS.md` to ✅.
 2. Run a stale-marker scan (`.ai/conventions/workflow/stale-marker-scan.md`): anything in the ledger now stale?
 3. Drain stream followups (`.ai/conventions/workflow/inbox-and-drain.md`) — route each to FUTURE / TECH_DEBT / next chore batch / next stream.
-4. Bump `.ai/BASELINE.md` if this stream is the last in its wave.
-5. Triage any surfaced lessons (`.ai/conventions/workflow/lessons-codification-triage.md`).
+4. Triage any surfaced lessons (`.ai/conventions/workflow/lessons-codification-triage.md`).
 
-### Pre-wave chore batch assembly
+`.ai/BASELINE.md` is **not** bumped on stream merge — only on `release` → `main` promotion.
 
-1. Read each completed stream's polished `README.md` in `.ai/tasks/completed/`.
-2. Extract every chore-shaped item, follow-up, or deferred note.
+### Chore batch assembly
+
+Triggered by a concrete transition (see `docs/CHORES.md` § When to open a new batch — post-feature followup, adjacent-feature prep, pre-alpha tidy, post-consumer-integration sweep).
+
+1. Read recent completed streams' polished `README.md` in `.ai/tasks/completed/` (scope to streams whose surface is relevant to the trigger).
+2. Extract every chore-shaped item, follow-up, or deferred note tied to the trigger.
 3. Categorize each: **chore batch** / **stream** / **TECH_DEBT** / **FUTURE**.
-4. Compile proposed batch (3–6 items, tied to a concrete transition trigger).
+4. Compile proposed batch (3–6 items, all sharing the same trigger).
 5. Present to user for sign-off before landing in `docs/CHORES.md`.
 
 ### Babysitting a long PR review cycle
@@ -111,9 +114,19 @@ Post-merge: run sibling-sweep as a **fresh agent**, not the implementing agent. 
 
 When the user is doing manual testing or posting batches of findings: suggest spinning up a fresh sub-agent session in scribe mode — mirrors the four-bucket sort, writes per-file inbox entries, proposes routings. Token-cheap. Delegate rather than handling each finding inline.
 
-### Buffer-and-main promotion
+### `release` → `main` promotion
 
-When the buffer line has accumulated a coherent batch of merged PRs: confirm known-good state → open PR buffer→main → run unified automated-review pass (catches fix-interaction findings) → merge with merge-commit → bump `.ai/BASELINE.md`. See `.ai/conventions/workflow/branch-buffer-and-promotion.md`.
+A release event, not a routine operation — the delta is typically too large for meaningful code review, and each constituent PR was reviewed individually on its way into `release`. Gate is **test/docs/sibling-sweep**, not unified code review:
+
+1. Confirm CI green on `release`; tests + coverage gates pass.
+2. Confirm generated docs are caught up (api-extractor / `update generated docs` PRs current).
+3. Run a sibling-sweep as a fresh agent against the unified delta — catches fix-interaction findings that escaped per-PR review. Critical findings only get inline fixes; everything else routes to followups.
+4. Open PR `release` → `main`, merge with merge-commit (preserves audit trail).
+5. Bump `.ai/BASELINE.md` to the new `main` HEAD with the lockstep version published (or "pre-publish" if promotion precedes the next publish event).
+
+See `.ai/conventions/workflow/branch-buffer-and-promotion.md`.
+
+Note: `prerelease` mirrors `release` immediately (with version/changelog deltas only) and is the alpha-publish source. Alpha cuts are independent of promotion — alphas can ship from `release`-as-mirrored-to-`prerelease` long before any `release` → `main` promotion. Stability-via-consumption is the gate on promotion, not alpha cadence.
 
 ## Kickoff prompt checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Artifact substrate (maintained by the orchestrator):
 - `docs/CHORES.md` — cleanup batches
 - `docs/TECH_DEBT.md` + `docs/FUTURE.md` — deferred work
 - `.ai/tasks/active/<id>/` → `.ai/tasks/completed/<YYYY-MM>/<id>/` — per-stream artifacts
-- `.ai/BASELINE.md` — pinned baseline commit for the current wave
+- `.ai/BASELINE.md` — last `release` → `main` promotion (blast-radius sizing referent, not a stream-start gate)
 
 Workflow conventions are in `.ai/conventions/workflow/`.
 

--- a/docs/CHORES.md
+++ b/docs/CHORES.md
@@ -3,9 +3,11 @@
 Scheduled cleanup batches. Different from TECH_DEBT (long-running
 structural debt) and FUTURE (parking lot of ideas). A chore batch
 is a focused agent run that closes several small items at once,
-typically tied to a specific transition — between waves of
-workstreams, between phases, after a major refactor lands. Each
-batch is bounded, agent-shaped, and usually 3–6 items.
+typically tied to a specific transition — after a feature ships
+with surface-local followups, before an adjacent feature starts on
+the same surface, or after a consumer-integration round closes and
+the open items become legible. Each batch is bounded, agent-shaped,
+and usually 3–6 items.
 
 ---
 
@@ -24,12 +26,26 @@ time-critical can be promoted into the active chore batch.
 
 ### When to open a new batch
 
-- **Between waves of streams.** Two streams just merged; they
-  surfaced N items that all want to land before the next wave.
-- **After a major refactor.** A refactor that ships green but leaves
-  test-only paths or `TODO`-marked follow-ups.
-- **Pre-phase transitions.** When a phase closes and the next phase
-  begins, items that don't belong to either are chore-shaped.
+A chore batch needs a concrete transition trigger. Recognized
+triggers in this repo:
+
+- **Post-feature followup batch.** A feature stream just shipped
+  to `release` and left N small followups on its surface (test-only
+  paths, deferred coverage closures, TODO-marked cleanups).
+- **Adjacent-feature prep.** Another stream is about to start on a
+  surface adjacent to one that's been accumulating debt — clean it
+  up before the new stream touches it, so the new stream isn't
+  fighting old smells.
+- **Pre-alpha tidy.** Before cutting an alpha (i.e. before mirroring
+  `release` → `prerelease` for a publish), sweep for changelog
+  rot, doc-rot, and obvious cross-package inconsistencies that the
+  alpha would otherwise carry.
+- **Post-consumer-integration sweep.** After a consumer applies a
+  feature end-to-end, the friction they hit usually surfaces a
+  cluster of small fixes worth batching.
+
+Items that don't have a concrete trigger belong in TECH_DEBT or
+FUTURE, not here.
 
 ### Kickoff-prompt shape for chore agents
 

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -8,26 +8,87 @@ it.
 
 ---
 
+## Repo shape (load-bearing context)
+
+This repo is a set of related but distinct utility libraries under
+`libraries/` (plus CLI tools under `tools/`), not a single coherent
+product. Work is mostly **reactive, consumer-driven, feature-shaped**:
+external consumers batch up feature requests as they do major work;
+we service those batches and publish an alpha; consumers integrate;
+once at least one consumer has applied a feature end-to-end, we
+treat that surface as validated. A feature commonly touches 1–3
+packages, so the unit of work is the **feature**, not the package.
+
+**Lockstep version policy.** When we publish, we publish everything.
+Independent roadmaps per library, single shared version. Sizing the
+blast radius of any stream needs to account for this — a change in
+one package ships in the same alpha as every other package's changes.
+
+**Stability-via-consumption.** We presume instability until at least
+one consumer has applied a feature end-to-end. `release` and the
+alphas published from `prerelease` are post-feature-PR but
+pre-validation. Production promotion is gated on observed consumer
+use, not just CI green. Case in point: a -25 → -26 type-tightening
+that would have been a production regression if -25 had shipped to
+main.
+
+## Branch flow
+
+```
+agent feature branches ─PR─▶ release ──mirror──▶ prerelease ──npm-publish─▶ alpha
+                                │
+                                └── promote (test/docs gate, not code review) ──▶ main
+```
+
+- **`release`** is the buffer line. Feature PRs merge here. Iterative
+  review cycles, followups, and slips are absorbed here.
+- **`prerelease`** mirrors `release` immediately. The only deltas vs.
+  `release` are `package.json` / version-policy files and Rush
+  changelogs. Alphas publish from `prerelease` via the
+  `npm-publish` GitHub workflow.
+- **`main`** is the canonical line. Promotion `release` → `main` is
+  a release event — it accumulates a long delta and is gated on
+  **test/docs/sibling-sweep, not code review** (each constituent PR
+  was reviewed on its way into `release`; the unified delta is too
+  large for meaningful re-review).
+
+A branch-model evolution to a more conventional "main is tip,
+hotfix branches off main" topology is on the roadmap; see the
+relevant entry in this file when it's drafted.
+
 ## Status conventions
 
 - 🟢 ready to start (all hard dependencies met)
-- 🟡 ready but trailing on a soft dependency
+- 🟡 ready but trailing on a soft dependency, or trigger TBD
 - 🔵 in flight (active design or implementation)
 - 🔴 blocked (hard dependency unmet)
-- ✅ shipped (merged to the buffer line)
+- ✅ shipped (merged to `release`)
 
-## Branch model
+## Stream entry shape
 
-Feature branches PR into `release`. The orchestrator gates
-buffer→main promotions via a unified automated-review pass.
-See `.ai/conventions/workflow/branch-buffer-and-promotion.md`.
+Every stream entry declares, at minimum:
 
-## Baseline check before kickoff
+- **Mission** — 1–2 sentences.
+- **Package surface** — explicit list of packages this stream
+  expects to modify (e.g. `ts-extras/ai-assist`, `ts-app-shell/ai-assist`).
+  This is both the reading-aid and the collision-avoidance metadata
+  for parallel streams.
+- **Out-of-scope** — paths this stream will NOT touch, when
+  collision avoidance with another stream depends on it.
+- **Acceptance criteria** — exit gates.
+- **Artifact pointer** — `.ai/tasks/active/<stream-id>/`.
 
-Every workstream session verifies its branch base against `.ai/BASELINE.md`
-before doing any work. The baseline pins the minimum release-branch
-commit a new branch must descend from so a wave of parallel streams
-shares the same foundation; bumped when a new wave launches.
+Full kickoff-prompt shape: `.ai/conventions/workflow/kickoff-prompt-shape.md`.
+
+## Branch base
+
+New streams branch from current `release` HEAD. There is no shared
+"wave base" — streams are mostly independent, and the few real
+file-boundary conflicts are caught by the package-surface and
+out-of-scope declarations in the stream entry. `.ai/BASELINE.md`
+pins the last `release` → `main` promotion (i.e. the last
+published lockstep version), used as a recovery referent and for
+sizing blast radius, not as a stream-start gate.
 
 ## Stream versions
 
@@ -56,6 +117,12 @@ Every workstream maintains live artifacts at
 throughout the run. **Migrate to `.ai/tasks/completed/<YYYY-MM>/<stream-id>/`
 and write a polished `README.md` as part of the PR — before merge,
 not as a follow-up.** See `.ai/conventions/workflow/artifact-protocol.md`.
+
+## Out-of-scope packages
+
+The sudoku packages (`ts-sudoku-lib`, `ts-sudoku-ui`) are slated to
+move to their own monorepo and are out of scope for the workflow
+substrate. Don't queue streams against them here.
 
 ---
 


### PR DESCRIPTION
## Summary

Rework the orchestrator workflow substrate inherited from #321 to fit this repo's actual shape: a set of utility libraries with independent roadmaps, lockstep version policy, consumer-driven reactive feature cadence, and stability-via-consumption gating on production promotion.

The core change is **dropping the "wave" concept** — it was load-bearing in the source corpus (single product, coordinated cadence) but doesn't fit here, where work is mostly small reactive feature streams that span 1–3 packages and ship on independent roadmaps within a lockstep version envelope.

## Substantive changes

- **`docs/WORKSTREAMS.md`** — new preamble: repo-shape framing (utility libraries, lockstep version policy, stability-via-consumption), branch flow diagram (`release` ↔ `prerelease` mirror → alpha; `release` → `main` promotion on stability gate), stream-entry shape now requires explicit **package surface** declaration as collision-avoidance metadata. Wave concept removed; sudoku noted as out-of-scope.
- **`.ai/BASELINE.md`** — redefined as the last `release` → `main` promotion pin. Used for blast-radius sizing and recovery referent, not as a stream-start gate. Provisionally pinned to `ffde48ad` with a note that this pre-dates the first real promotion under the substrate.
- **`docs/CHORES.md`** — new trigger taxonomy: post-feature followup / adjacent-feature prep / pre-alpha tidy / post-consumer-integration sweep. "Between waves" trigger removed.
- **`.ai/instructions/ACTIVE_DEVELOPMENT.md`** — active/established split reframed as **per-surface, not per-library**. `ts-extras`'s `ai-assist` and `crypto-utils` packlets called out as active while the rest of `ts-extras` stays "handle with care." `ts-web-extras` added. Sudoku noted as out-of-scope/migrating. New section on the lockstep-version wrinkle for breaking-change cost.
- **`.ai/conventions/workflow/branch-buffer-and-promotion.md`** — promotion gate rewritten as **test / docs / sibling-sweep**, not unified code review. Reflects reality: months-long delta is too large for meaningful re-review, and each constituent PR was already reviewed on its way into `release`. Sibling-sweep is the right lens for the fix-interaction and cross-stream-drift class of finding that escapes per-PR review.

## Minor

- `.claude/agents/orchestrator.md` — stream kickoff branches from `release` HEAD (not BASELINE); post-merge bookkeeping no longer bumps BASELINE; chore-batch assembly retriggered; promotion gate aligned with new convention.
- `.ai/conventions/workflow/stale-marker-scan.md` — wave-boundary phrasing dropped.
- `CLAUDE.md` — one BASELINE description line refreshed.

## Test plan

- [ ] Skim each modified doc end-to-end for internal consistency
- [ ] Verify branch-flow diagram in `WORKSTREAMS.md` matches actual `release`/`prerelease`/`main` semantics
- [ ] Sanity-check that the `ACTIVE_DEVELOPMENT.md` per-surface split aligns with how you actually think about which packlets accept breakage vs. carry stability obligations
- [ ] Confirm the `BASELINE.md` provisional pin to `ffde48ad` makes sense, or note the better commit to pin to

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_