### PR TITLE
docs(ai-assist-image-generation): phase A signoff + phase B brief

### DIFF
--- a/.ai/tasks/active/ai-assist-image-generation/brief-phase-b.md
+++ b/.ai/tasks/active/ai-assist-image-generation/brief-phase-b.md
@@ -1,0 +1,352 @@
+# Stream Brief: ai-assist-image-generation (phase B — implementation)
+
+**Stream ID:** ai-assist-image-generation
+**Phase:** B — implementation
+**Sequencing:** Phase A signed off. Phase B starts immediately. `ai-assist-thinking-config` phase B is queued strictly after this stream lands.
+
+---
+
+## Context
+
+Phase A produced `.ai/tasks/active/ai-assist-image-generation/design.md` (read it in full — it is the inventory and rationale, not the contract). The orchestrator and user reviewed it and signed off with substantial modifications to the type architecture and scope. **This brief is the binding contract** — where it conflicts with `design.md`, this brief wins.
+
+This is a feature-completion stream on an active-development surface (`@fgv/ts-extras/ai-assist`). Per `.ai/instructions/ACTIVE_DEVELOPMENT.md`, you have a free hand on breaking changes. The lockstep version policy means breaking changes ship in the same alpha as everything else, so design for the right shape, not the most-compatible shape.
+
+---
+
+## Mission
+
+Implement the layered options architecture, the registry simplifications, the wire-encoder corrections, and the deprecated-model removals. Land the result as a single PR against the integration branch with 100% test coverage and updated `LIBRARY_CAPABILITIES.md`.
+
+---
+
+## Signed-off design decisions (binding)
+
+The following decisions override `design.md` where they conflict.
+
+### D1. Type architecture: layered options, no provider-middle-layer
+
+The unified-type approach (design's Approach A) is rejected. The discriminated-union approach (design's Approach B) was rejected as too restrictive (model selection is dispatcher-driven, not caller-driven). The signed-off approach is **layered options with model-family blocks**:
+
+```typescript
+interface IAiImageGenerationOptions {
+  // Generic — top-level. Most callers stay here.
+  size?: AiImageSize;
+  count?: number;
+  quality?: AiImageQuality;
+  seed?: number;
+  // ... other genuinely-cross-provider general knobs
+  
+  // Optional precision — array of model-family-scoped blocks
+  // The config is the union of all configs; the resolver picks
+  // applicable blocks dynamically based on the resolved model.
+  models?: IModelFamilyConfig[];
+}
+
+type IModelFamilyConfig =
+  | IDallEModelOptions          // provider: 'openai'
+  | IGptImageModelOptions       // provider: 'openai'
+  | IGrokImagineModelOptions    // provider: 'xai'
+  | IImagen4ModelOptions        // provider: 'google'
+  | IGeminiFlashImageModelOptions  // provider: 'google'
+  | IOtherModelOptions;         // provider: 'other' (escape hatch)
+
+interface IDallEModelOptions {
+  provider: 'openai';
+  models?: DallEModelNames[];   // optional; omit = applies to all DallE family models
+  config: IDallEImageGenerationConfig;
+}
+
+// ... analogous shapes for the other named-family variants
+
+interface IOtherModelOptions {
+  provider: 'other';
+  models: string[];             // REQUIRED — no implicit "all" for unknown
+  config: JsonObject;           // untyped passthrough escape hatch
+}
+```
+
+**Discriminator field** is `provider`, with values `'openai' | 'xai' | 'google' | 'other'`. Coarser than the registry's full provider IDs (`'openai-compat'` users still write `provider: 'openai'` blocks; the discriminator is about model-family lineage, not dispatcher identity).
+
+**Family-config shape** (`IDallEImageGenerationConfig`, etc.) is the **loose union** of what any model in that family accepts. Per-model validity (e.g. `style` only on `dall-e-3`, not `dall-e-2`) is enforced at runtime via the registry, not at the type level. This is a deliberate tradeoff: we get sharing across family members at the cost of TypeScript not catching every per-model mismatch. The runtime validator catches what the types don't.
+
+**Per-family `models?` field type** uses scoped name unions (`DallEModelNames = 'dall-e-2' | 'dall-e-3'`, etc.) so that `models: ['gpt-image-1']` on a DallE block is a TypeScript error. For `IOtherModelOptions`, `models` is `string[]` — unconstrained, since the escape hatch's whole purpose is unknown models.
+
+### D2. Merge precedence
+
+Application order, building from the resolved-model wire-shape canvas:
+
+1. **Generic top-level** options (caller's `size`, `count`, `quality`, etc.) → mapped onto the resolved model's wire shape
+2. **Family-generic blocks** (entries in `models?` matching the resolved model's family with `models` field omitted) → applied in declaration order
+3. **Model-specific blocks** (entries with `models` array including the resolved model name) → applied in declaration order
+4. **Other blocks** (entries with `provider: 'other'` whose `models` array includes the resolved model name) → applied in declaration order, **same precedence tier as model-specific** (D1 confirmed answer to "Other-precedence" question)
+
+Within each tier, declaration order — later wins. Across tiers, later tier wins. Net precedence: Other ≈ model-specific > family-generic > generic.
+
+**Provider-mismatch handling.** If a block's `provider` does not match the dispatcher's provider lineage (e.g., `provider: 'openai'` block with an xAI dispatcher), the block is silently skipped during filtering. No error — the union-config semantics make this a normal "this block doesn't apply to this resolution path" case.
+
+**JSDoc on the merge function** must document precedence explicitly. Caller surprise risk is highest when both `options.size` (generic) and a model-specific `config.size` are set with different values; document that model-specific wins.
+
+### D3. Drop deprecated models
+
+Remove from registry, types, examples, docs, and test fixtures:
+
+- `imagen-3.0-generate-002` and any `imagen-3.*` references (deprecates June 24-30, 2026)
+- `grok-2-image-1212` (deprecated Feb 28, 2026 — already past)
+- `grok-imagine-image-pro` (deprecates May 15, 2026)
+- The `imagen.negativePrompt` field (Imagen 3 only; obsolete with Imagen 3 removal)
+
+**Active models the implementation supports:**
+
+- **OpenAI:** `dall-e-2`, `dall-e-3`, `gpt-image-1`
+- **xAI:** `grok-imagine-image`, `grok-imagine-image-quality`
+- **Google:** `imagen-4.0-generate-001`, `imagen-4.0-ultra-generate-001`, `imagen-4.0-fast-generate-001`, `gemini-2.5-flash-image`
+
+**Pre-existing correctness fix:** xAI `defaultModel.image` currently points at the deprecated `grok-2-image-1212`. Update to `grok-imagine-image-quality`.
+
+### D4. Add xAI reference image support
+
+xAI `/v1/images/edits` accepts JSON bodies with `{ "type": "image_url", "url": <data URI or URL> }` objects — different wire format from OpenAI's multipart/form-data. Implement a **dedicated xAI edits adapter** (likely a new `AiImageApiFormat` value `'xai-images-edits'` or branch within an extended `'xai-images'` adapter — implementer's choice). Set `acceptsImageReferenceInput: true` on the xAI registry entry.
+
+Up to 3 source images per call, per current xAI docs.
+
+### D5. Skip Gemini `responseModalities`
+
+The phase A design's Q1 finding (`callGeminiImageOutGeneration` doesn't set `responseModalities: ["IMAGE"]`, supposedly required per Google docs) is **rejected as wrong**. User has empirically verified Gemini Flash Image works in production without setting this parameter. The Google docs are stale. Do not add `responseModalities` to the Gemini Flash request.
+
+(**Lessons-codification candidate** — captured separately. No action in this stream.)
+
+### D6. OpenAI live-verification (phase B step zero)
+
+The phase A OpenAI inventory is from training data (the agent's `docs.openai.com` fetches returned 403). Before encoding registry constants for OpenAI models, **verify each model's accepted values via live API calls**. Use:
+
+- **Documentation source:** `https://developers.openai.com/` (the `platform.openai.com` URL the phase A agent tried is login-gated; this is the public docs endpoint)
+- **Test harness:** the existing image-generation sample app in this repo (path TBD by you — search for it; the user has confirmed it exists and reproduces the gpt-image-1 `response_format` failure)
+- **Verify per model** (`dall-e-2`, `dall-e-3`, `gpt-image-1`):
+  - Accepted size strings
+  - Accepted quality vocabulary
+  - Accepted parameter names (e.g. is it `output_format` or `response_format` for gpt-image-1)
+  - Reference-image endpoint behavior (mask requirement for dall-e-2; maskless for gpt-image-1)
+
+Capture verified specifics in `state.md` (Decisions log) before encoding them as registry constants. If any specific differs from the design's `[training-data]` inventory, **the live-verified value wins**.
+
+This is non-optional and should be the first work in phase B. Estimated cost: ~30-60 minutes of live test calls.
+
+### D7. Registry simplifications
+
+With the layered type architecture handling family dispatch:
+
+- **Drop:** `acceptsGptImageExtensions` (replaced by GptImage being its own family), `acceptsStyle` (DallE family-config has `style?` which only validates for dall-e-3), `usesAspectRatio` (xAI's `IGrokImagineImageGenerationConfig` has `aspectRatio?` natively)
+- **Replace `acceptedQualities: []` → `supportsQualityParam?: boolean`**. Self-documenting; `[]` as "don't send" is opaque (the agent's design Q4 acknowledged this; we picked the boolean alternative)
+- **Keep:** `modelPrefix`, `format`, `acceptsImageReferenceInput`, `acceptedSizes`, `acceptedQualities`, `maxCount`, `outputParamStyle`, `defaultOutputMimeType`
+- **Add:** any new registry fields the implementation surfaces as needed (e.g. for xAI's new edits format dispatch). Document in JSDoc.
+
+The registry's role narrows under the layered design: pre-validation gates that the type system cannot enforce (per-model size limits, per-model count limits, family-loose-union shape mismatches caught at runtime). It is no longer the primary surface for caller-facing options.
+
+### D8. Other-block as runtime-untyped escape hatch
+
+`IOtherModelOptions.config` is `JsonObject` — opaque to the type system. The merge function passes through Other-block fields verbatim into the wire request, with no validation. This is the deliberate "trust me, I know what I'm doing" path for callers who need to send wire params our typed configs don't yet expose (e.g. a future OpenAI param we haven't added).
+
+Per D2 precedence, Other blocks land at the model-specific tier (or after — implementer's choice within "model-specific or later"). User's framing: "if OpenAI added a parameter to one of the models and our library hadn't caught up, the caller wants Other to push it through."
+
+---
+
+## Package surface (read + write)
+
+### In-scope (modify)
+
+- `libraries/ts-extras/src/packlets/ai-assist/`
+  - `model.ts` — type definitions (the layered options shape, family configs, model-name unions, `JsonObject` import)
+  - `registry.ts` — entry simplifications, deprecated-model removals, default-model corrections
+  - `apiClient.ts` — wire encoders (OpenAI gens + edits, xAI gens + edits new, Imagen, Gemini Flash)
+  - Possibly new file `imageOptionsResolver.ts` (or similar) for the merge logic + runtime validation
+  - `index.ts` — export new types if needed
+- `libraries/ts-extras/src/test/unit/ai-assist/` — comprehensive test coverage for new types, merge logic, validation, wire encoders
+- `libraries/ts-extras/etc/ts-extras.api.md` — regenerate via api-extractor
+- `.ai/instructions/LIBRARY_CAPABILITIES.md` — expand the ai-assist image generation section with the new layered options shape, escape hatch, deprecated-model notes
+- `.ai/tasks/active/ai-assist-image-generation/state.md` — update at phase milestones
+
+### Out-of-scope (do not modify)
+
+- `libraries/ts-app-shell/src/packlets/ai-assist/` — consumer-side wiring may need a follow-up, but that's a separate stream
+- The chat-completion path (`chatRequestBuilders.ts`, `streamingClient.ts`, `streamingAdapters/*`) — covered by `ai-assist-thinking-config` (parallel stream)
+- Any package outside `ts-extras/ai-assist`
+- Sudoku packages — vestigial
+- The `responseModalities` Gemini change — see D5
+
+---
+
+## Required reading (priority order)
+
+1. **`.ai/tasks/active/ai-assist-image-generation/design.md`** — full phase A inventory and rationale. Read in full. This brief overrides decisions where they conflict; the inventory is otherwise authoritative.
+2. **`.ai/tasks/active/ai-assist-image-generation/brief.md`** — original phase A brief; still the source of provider scope and goals.
+3. **`.ai/tasks/active/ai-assist-image-generation/state.md`** — phase A agent's terminal state and decisions log.
+4. **`libraries/ts-extras/src/packlets/ai-assist/model.ts`, `registry.ts`, `apiClient.ts`** — current implementation; the diff target.
+5. **`libraries/ts-extras/etc/ts-extras.api.md`** — current public API surface; understand what changes when.
+6. **`docs/WORKSTREAMS.md`** preamble — repo shape, lockstep policy, stability-via-consumption framing (load-bearing).
+7. **`.ai/instructions/ACTIVE_DEVELOPMENT.md`** — `ai-assist` is on the active-surface list; free hand on breaking changes is explicit.
+8. **`.ai/instructions/CODING_STANDARDS.md`** — Result pattern usage, no-`any` rule, factory pattern, `mapResults` for arrays.
+9. **`.ai/instructions/TESTING_GUIDELINES.md`** — Result matchers from `@fgv/ts-utils-jest`, 100% coverage requirement.
+
+---
+
+## Skills to load (when conditions trigger)
+
+- `/result-pattern` — before writing any function returning `Result<T>` (the validator, the merge function, all wire encoders).
+- `/result-tests` — before writing test files. Test all paths via Result matchers, never `.orThrow()` in assertions.
+- `/published-primitives-reflex` — before writing utility-shaped helpers (e.g. deep merge, value normalization). Check `@fgv/*` first; the merge logic should not reinvent something `@fgv/ts-utils` already exposes.
+- `/type-safe-validation` — before writing the runtime validator. Use Converters/Validators from `@fgv/ts-utils`; never manual `typeof` + cast.
+- `/filetree-io` — N/A here (no file I/O in this stream); do not load.
+
+---
+
+## Phases (with checkpoints)
+
+### B.0 — OpenAI live-verification (per D6)
+
+Verify accepted values for `dall-e-2`, `dall-e-3`, `gpt-image-1` via:
+- `developers.openai.com` documentation review
+- Live test calls via the existing in-repo image-gen sample app
+
+Capture verified specifics in `state.md` (Decisions log). Compare against `design.md` `[training-data]` annotations; flag any divergence.
+
+**Checkpoint:** state.md updated with verified-specifics table.
+
+### B.1 — Type definitions
+
+Implement the layered options shape per D1:
+- Generic `IAiImageGenerationOptions` with top-level fields and `models?: IModelFamilyConfig[]`
+- Per-family option interfaces (`IDallEModelOptions`, `IGptImageModelOptions`, `IGrokImagineModelOptions`, `IImagen4ModelOptions`, `IGeminiFlashImageModelOptions`, `IOtherModelOptions`)
+- Per-family config shapes (`IDallEImageGenerationConfig`, etc.)
+- Model-name unions (`DallEModelNames`, `GptImageModelNames`, etc.)
+- The full `IModelFamilyConfig` discriminated union
+
+JSDoc on every exported type. Document the precedence rules on the merge function's docstring (per D2).
+
+**Checkpoint:** types compile; api-extractor surface reviewed.
+
+### B.2 — Registry simplifications
+
+Apply D3 (deprecated-model removals), D4 (xAI ref-image flag), D7 (registry-shape simplifications). Update default models. Concrete entries per the verified specifics from B.0.
+
+**Checkpoint:** registry compiles, includes only active models, default-model fields point at non-deprecated models.
+
+### B.3 — Merge logic + runtime validator
+
+Implement the merge function per D2 precedence. Implement the runtime validator (resolved-model + merged-config → Result, per registry capability constraints). Failure messages follow the design's §5.4 format ("model X: field Y value Z is not accepted; accepted values: [...]").
+
+**Checkpoint:** merge + validate functions complete; unit tests for merge precedence and validation gates pass.
+
+### B.4 — Wire encoders
+
+Update `apiClient.ts` adapters to use the merge function output:
+- OpenAI gens / edits (conditional `response_format` per `outputParamStyle`)
+- xAI gens (`aspect_ratio` not `size`; default model already corrected in B.2)
+- xAI edits (NEW adapter — JSON body with `{ type: "image_url" }` objects per D4)
+- Imagen `:predict` (Imagen 4 params; `imagenOptions.*` from family config; `negativePrompt` removed per D3)
+- Gemini Flash `:generateContent` (no `responseModalities` change per D5; `imageConfig.aspectRatio` from `IGeminiFlashImageGenerationConfig`)
+
+**Checkpoint:** all encoders compile; integration tests against mocked HTTP endpoints pass.
+
+### B.5 — Tests + coverage
+
+Functional test breadth first, then coverage gap closure (per `.ai/instructions/TESTING_GUIDELINES.md`):
+- Type-shape tests (compile-time via `// @ts-expect-error` for known invalid combinations)
+- Merge precedence tests (every tier interaction)
+- Runtime validation tests (per-model accepted values, family-loose-union mismatch rejection)
+- Wire encoder tests (one per provider/endpoint, mocked HTTP)
+- Other-block escape hatch test (passthrough verification)
+- Existing tests updated for the new type shape
+
+100% coverage required.
+
+**Checkpoint:** `rushx test` passes with 100% coverage in `ts-extras`.
+
+### B.6 — Documentation
+
+Update `LIBRARY_CAPABILITIES.md` ai-assist section:
+- Layered options shape with concrete examples (casual caller; power caller using family-specific config; escape hatch caller)
+- Per-provider supported models (not deprecated ones)
+- Reference-image support matrix (which models accept refs, which provider+model combinations)
+- Note the no-silent-translation policy
+
+**Checkpoint:** docs reflect implementation; api-extractor regenerated.
+
+---
+
+## Acceptance criteria
+
+- [ ] B.0 verification table in state.md
+- [ ] All deprecated models removed (no string references in code or fixtures except in deletion-explanatory comments if any)
+- [ ] Layered options types compile and pass api-extractor
+- [ ] Merge function passes precedence tests for all four tiers
+- [ ] Runtime validator rejects each known per-model invalid value with contextual error
+- [ ] Wire encoders produce correct request bodies for all 9 active models × supported endpoints
+- [ ] xAI reference-image edits adapter produces a JSON body with `{ type: "image_url" }` objects
+- [ ] `gpt-image-1` requests do NOT include `response_format`
+- [ ] Gemini Flash requests do NOT include `responseModalities` (per D5)
+- [ ] `rushx build` passes in `ts-extras`
+- [ ] `rushx test` passes with 100% coverage in `ts-extras`
+- [ ] No `any` types
+- [ ] All fallible operations return `Result<T>`
+- [ ] `LIBRARY_CAPABILITIES.md` ai-assist section updated
+- [ ] PR opened to `claude/ai-assist-features` (NOT `release`)
+
+---
+
+## Phase B exit artifact (state.md)
+
+At completion, `state.md` should record:
+- Phase A done; Phase B done
+- B.0 OpenAI live-verification table (specifics confirmed; deltas from design.md noted)
+- Any implementation decisions that differed from this brief or the design (with rationale)
+- Test coverage status per file
+- PR number and merge commit
+- Any open questions or blockers surfaced (none expected; flag if you find them)
+- Followups that should land as TECH_DEBT, FUTURE, or a future chore batch — the orchestrator drains these post-merge
+
+---
+
+## Branch + PR posture
+
+- **Base branch:** `claude/ai-assist-features` (the integration branch)
+- **Work branch:** `claude/ai-assist-image-generation-impl` (or yours to pick — note: if your harness appends a random suffix, that's fine, but please document the actual branch name in state.md so the orchestrator can find your PR)
+- **PR target:** `claude/ai-assist-features` (NOT `release`)
+- One PR for all of B.0–B.6 unless something forces a split (it shouldn't)
+- The integration branch will merge to `release` at the end of the cluster, after `ai-assist-thinking-config` also lands
+
+---
+
+## Pre-merge artifact migration
+
+Per the artifact-protocol convention (`.ai/conventions/workflow/artifact-protocol.md`), migration to `.ai/tasks/completed/` is **pre-merge**, not post-merge. Specifically:
+
+- Migrate `.ai/tasks/active/ai-assist-image-generation/` to `.ai/tasks/completed/2026-05/ai-assist-image-generation/` (or whatever YYYY-MM matches your merge month)
+- Write a polished `README.md` in the completed dir capturing what shipped, key decisions, acceptance status, and any followups
+- Include the migration in your PR
+
+The orchestrator will spot-check the migration during PR review. The auth-primitives stream missed this step and required a follow-up cleanup PR; do not repeat that pattern.
+
+---
+
+## Resume protocol
+
+If the session ends mid-phase: read `brief-phase-b.md` (this file), `brief.md` (phase A), `design.md`, and `state.md` to resume. State.md records which checkpoints are done.
+
+---
+
+## Missing-input rule
+
+If a required-reading file is missing, has a shape that conflicts with this brief, or if your B.0 live verification surfaces a structural mismatch you can't resolve (e.g., `gpt-image-1` API has fundamentally restructured since this brief was written), **STOP and report**. Do not improvise.
+
+---
+
+## Out of scope
+
+- The `ai-assist-thinking-config` stream (queued strictly after this stream)
+- Consumer-side updates in `ts-app-shell/ai-assist` — separate stream if needed
+- Any package outside `ts-extras/ai-assist`
+- Sudoku packages — vestigial
+- New providers or new models beyond the active-models list in D3
+- Image-gen streaming — confirmed sync across all providers (design §7); if any provider has added streaming since, defer
+- Audio / video generation

--- a/.ai/tasks/active/ai-assist-image-generation/design.md
+++ b/.ai/tasks/active/ai-assist-image-generation/design.md
@@ -1,0 +1,893 @@
+# Design: ai-assist Image Generation (Phase A)
+
+**Stream:** ai-assist-image-generation  
+**Phase:** A — research and design  
+**Date:** 2026-05-11  
+**Status:** draft for orchestrator/user signoff
+
+---
+
+## 1. Provider Capability Inventory
+
+> **Research note:** OpenAI's platform docs (`platform.openai.com`) returned HTTP 403 (login-gated). The OpenAI section uses training-data knowledge (cutoff August 2025) with `[training-data]` markers on specific values that should be live-verified before encoding as registry constants. xAI and Google sections used live-fetched documentation; sources cited by URL.
+
+---
+
+### 1.1 OpenAI `dall-e-2` [training-data — verify]
+
+**Reference:** https://platform.openai.com/docs/api-reference/images/create
+
+**Endpoints:**
+- `POST /v1/images/generations` — text-to-image
+- `POST /v1/images/edits` — inpainting; **requires PNG with alpha-channel mask** (different from gpt-image-1's maskless reference-image edits)
+- `POST /v1/images/variations` — generate variations of an input image
+
+**Parameters:**
+
+| Parameter | Accepted values | Default | Notes |
+|---|---|---|---|
+| `model` | `"dall-e-2"` | — | |
+| `prompt` | string (max ~1000 chars) | required | |
+| `n` | 1–10 | 1 | Up to 10 images per call |
+| `size` | `"256x256"`, `"512x512"`, `"1024x1024"` | `"1024x1024"` | Only square; three choices |
+| `response_format` | `"url"`, `"b64_json"` | `"url"` | |
+| `quality` | not supported | — | Ignored or errors |
+| `style` | not supported | — | |
+| `seed` | not supported | — | |
+
+**Reference image support:** Yes, via `/v1/images/edits` — but requires an alpha-channel mask. Our current reference-image path sends maskless multipart; this would fail for dall-e-2.
+
+**Response:** `data[].b64_json` or `data[].url`. No `revised_prompt`.
+
+**Quirks:**
+- Oldest model; lowest cost.
+- The `/edits` and `/variations` endpoints are unique to dall-e-2.
+- Mask requirement on edits makes our current maskless reference-image path incompatible.
+
+---
+
+### 1.2 OpenAI `dall-e-3` [training-data — verify]
+
+**Reference:** https://platform.openai.com/docs/api-reference/images/create
+
+**Endpoints:** `POST /v1/images/generations` only.
+
+**Parameters:**
+
+| Parameter | Accepted values | Default | Notes |
+|---|---|---|---|
+| `model` | `"dall-e-3"` | — | |
+| `prompt` | string (max ~4000 chars) | required | |
+| `n` | **1 only** | 1 | `n=2` returns an error — hard limit |
+| `size` | `"1024x1024"`, `"1792x1024"`, `"1024x1792"` | `"1024x1024"` | |
+| `quality` | `"standard"`, **`"hd"`** | `"standard"` | **`"hd"` not `"high"` — source of the quality-mismatch bug** |
+| `style` | `"vivid"`, `"natural"` | `"vivid"` | `"vivid"` = hyper-real; `"natural"` = more realistic |
+| `response_format` | `"url"`, `"b64_json"` | `"url"` | |
+| `seed` | not officially supported | — | |
+
+**Reference image support:** None.
+
+**Response:** `data[].b64_json` or `data[].url` plus `data[].revised_prompt` (unique to dall-e-3 — model rewrites prompts; this field shows what was actually sent).
+
+**Quirks:**
+- `n=1` hard limit; call multiple times for multiple images.
+- `"hd"` quality runs a second pass; ~2× cost.
+- `style` parameter is dall-e-3-only and has meaningful visual impact.
+- Prompt rewriting is aggressive; `revised_prompt` often differs substantially from input.
+
+---
+
+### 1.3 OpenAI `gpt-image-1` [training-data — verify; ** = high-priority live verification]
+
+**Reference:** https://platform.openai.com/docs/api-reference/images/create
+
+**Endpoints:**
+- `POST /v1/images/generations`
+- `POST /v1/images/edits` — maskless reference-image-guided generation (visual context, not inpainting)
+
+**Parameters:**
+
+| Parameter | Accepted values | Default | Notes |
+|---|---|---|---|
+| `model` | `"gpt-image-1"` | — | |
+| `prompt` | string | required | |
+| `n` | 1–10 | 1 | |
+| `size` | `"1024x1024"`, `"1536x1024"`, `"1024x1536"`, `"auto"` ** | `"auto"` | Different from dall-e-3's `1792x...` sizes |
+| `quality` | `"low"`, `"medium"`, `"high"`, `"auto"` | `"auto"` | Entirely different from dall-e-3's vocabulary |
+| `background` | `"transparent"`, `"opaque"`, `"auto"` | `"auto"` | `"transparent"` requires `output_format: "png"` |
+| `moderation` | `"low"`, `"auto"` | `"auto"` | |
+| `output_format` | `"png"`, `"jpeg"`, `"webp"` | `"png"` | Replaces `response_format` — see quirks |
+| `output_compression` | integer 0–100 | 100 | JPEG/WebP compression; irrelevant for PNG |
+| `response_format` | **NOT ACCEPTED** | — | **Root cause of the 400 bug.** Model rejects this. |
+| `style` | not supported | — | |
+| `seed` | not documented as stable | — | |
+
+**Reference image support:** Yes, via `/v1/images/edits`. Maskless multipart form-data. gpt-image-1 uses reference images as visual context, not inpainting targets.
+
+**Response:** `data[].b64_json` always. No URL mode available via public API. No `revised_prompt`.
+
+**Quirks:**
+- **`response_format` is rejected with a 400.** Our code unconditionally sends `response_format: 'b64_json'` — confirmed root cause of the bug.
+- `output_format` replaces `response_format` for output format control. For base64 retrieval, send `output_format: "png"` (or desired format); response always returns `b64_json`.
+- `background: "transparent"` only with `output_format: "png"`.
+- Requires organization-level API approval.
+
+---
+
+### 1.4 Google Imagen 4 (Gemini API `:predict`)
+
+**References (live-fetched):**
+- https://ai.google.dev/gemini-api/docs/models/imagen
+- https://ai.google.dev/gemini-api/docs/imagen
+- https://cloud.google.com/vertex-ai/generative-ai/docs/models/imagen/4-0-generate-001
+
+> **Critical deprecation notice:** `imagen-3.0-generate-002` is deprecated and **shuts down June 24–30, 2026** (within weeks of this writing). The registry currently uses this model. Phase B must migrate to Imagen 4 models immediately.
+
+**Current GA models:**
+- `imagen-4.0-generate-001` — standard; 1–4 images; supports 2K output
+- `imagen-4.0-ultra-generate-001` — highest quality; **max 1 image per call**
+- `imagen-4.0-fast-generate-001` — fast/cheap; 1–4 images
+
+**Endpoint:**
+```
+POST https://generativelanguage.googleapis.com/v1beta/models/{model}:predict
+```
+
+Auth: `x-goog-api-key` header. Body: `{ instances: [{ prompt: string }], parameters: { ... } }`.
+
+**Parameters (`parameters` block):**
+
+| Parameter | Accepted values | Notes |
+|---|---|---|
+| `sampleCount` | 1–4 (standard/fast); **1 only (ultra)** | Number of images |
+| `aspectRatio` | `"1:1"` (default), `"3:4"`, `"4:3"`, `"9:16"`, `"16:9"` | No pixel dimensions |
+| `imageSize` | `"1K"` (default), `"2K"` | Standard and Ultra support 2K; not all models |
+| `addWatermark` | boolean | Default `true` (SynthID). Must be `false` to use `seed` |
+| `seed` | integer 1–2147483647 | Only works when `addWatermark: false` |
+| `enhancePrompt` | boolean | LLM-based prompt rewriting before generation |
+| `personGeneration` | `"allow_all"`, `"allow_adult"`, `"dont_allow"` | Content safety |
+| `safetySetting` | `"block_low_and_above"`, `"block_medium_and_above"` (default), `"block_only_high"` | |
+| `outputOptions` | `{ mimeType: "image/jpeg"\|"image/png", compressionQuality: int }` | Output format control |
+| `includeRaiReason` | boolean | Include Responsible AI reason in response |
+
+**Parameters REMOVED in Imagen 4 (vs Imagen 3):**
+- `negativePrompt` — **no longer supported** in standard Imagen 4 generate endpoint. (Was in Imagen 3; currently exposed in our `imagen` escape hatch — this field is now stale.)
+- `sampleImageStyle` — not a current Imagen 4 parameter.
+
+**Reference image support:** None via `:predict`. Reference images require Gemini Flash Image.
+
+**Response:** `predictions[].bytesBase64Encoded` + optional `predictions[].mimeType`.
+
+**Quirks:**
+- `seed` requires `addWatermark: false` — attempting seed with watermark enabled silently ignores it or errors.
+- `negativePrompt` is gone from Imagen 4; our current `imagen.negativePrompt` field is silently ignored (or may error) with current models.
+- Ultra model is capped at 1 image per call.
+- Imagen 3 deprecation is imminent; any production use of `imagen-3.0-generate-002` will break end of June 2026.
+
+---
+
+### 1.5 Google Gemini 2.5 Flash Image (`:generateContent`, "Nano Banana")
+
+**References (live-fetched):**
+- https://ai.google.dev/gemini-api/docs/image-generation
+- https://ai.google.dev/gemini-api/docs/models/gemini-2.5-flash-image
+- https://developers.googleblog.com/gemini-2-5-flash-image-now-ready-for-production-with-new-aspect-ratios/
+
+**Endpoint:**
+```
+POST https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent
+```
+
+**Current model:** `gemini-2.5-flash-image`
+
+**Request body:**
+```json
+{
+  "contents": [{ "role": "user", "parts": [...] }],
+  "generationConfig": {
+    "responseModalities": ["IMAGE"],
+    "imageConfig": { "aspectRatio": "16:9" },
+    "candidateCount": 1
+  }
+}
+```
+
+**Key parameters:**
+
+| Parameter | Location | Accepted values | Notes |
+|---|---|---|---|
+| `responseModalities` | `generationConfig` | `["IMAGE"]`, `["IMAGE", "TEXT"]`, `["TEXT"]` | **Required** for image output. If omitted, model may return text-only. |
+| `imageConfig.aspectRatio` | `generationConfig` | `"1:1"`, `"3:2"`, `"2:3"`, `"3:4"`, `"4:3"`, `"4:5"`, `"5:4"`, `"9:16"`, `"16:9"`, `"21:9"` | Wider range than Imagen 4 |
+| `candidateCount` | `generationConfig` | 1 (currently) | Multiple images theoretically possible; SDK has reported bugs |
+| Reference images | `contents[].parts[]` | `inlineData: { mimeType, data }` | Up to 3 input images for composition/editing |
+
+**Output format:** Currently **JPEG only**. There is no documented way to request PNG or WebP output from this model. Live-fetched GitHub issues confirm `outputMimeType` as an `imageConfig` parameter is not yet working. Our current code captures `part.inlineData.mimeType` from the response, which will correctly be `"image/jpeg"`.
+
+**Response:** `candidates[].content.parts[]` with `inlineData` blocks (images) and/or `text` parts.
+
+**Quirks:**
+- **`responseModalities: ["IMAGE"]` is required** but our current `callGeminiImageOutGeneration` does NOT set this. This is likely causing silent text-only responses or generation failures. **High priority fix.**
+- `candidateCount > 1` has reported SDK-level bugs (Extra inputs are not permitted). Effectively 1 image per call.
+- `seed` not supported.
+- Output is JPEG regardless of request; `mimeType` in response will say `image/jpeg`.
+- The model can query Google Search during generation (a unique capability vs Imagen).
+- Each generated image costs 1,290 output tokens (pricing/rate-limit impact).
+
+---
+
+### 1.6 xAI Image Generation
+
+**References (live-fetched):**
+- https://docs.x.ai/developers/model-capabilities/images/generation
+- https://docs.x.ai/docs/guides/image-generations
+- https://docs.x.ai/developers/models/grok-2-image-1212
+
+> **Critical deprecation notice:** `grok-2-image-1212` is **deprecated as of February 28, 2026.** The registry currently uses this as the default image model — it must be updated.
+
+**Current models:**
+- `grok-imagine-image` — standard generation model (replaces `grok-2-image-1212`)
+- `grok-imagine-image-quality` — higher quality (recommended for new requests)
+- ~~`grok-imagine-image-pro`~~ — deprecated May 15, 2026; use `grok-imagine-image-quality` instead
+
+**Endpoint:**
+- `POST https://api.x.ai/v1/images/generations` — text-to-image
+- `POST https://api.x.ai/v1/images/edits` — reference-image editing (**new — not supported on the deprecated model**)
+
+**Parameters (new Imagine models):**
+
+| Parameter | Accepted values | Notes |
+|---|---|---|
+| `model` | `"grok-imagine-image"`, `"grok-imagine-image-quality"` | |
+| `prompt` | string | required |
+| `n` | 1–10 | |
+| `aspect_ratio` | `"1:1"`, `"3:4"`, `"4:3"`, `"9:16"`, `"16:9"`, `"2:3"`, `"3:2"`, `"9:19"`, `"19.5:9"`, `"9:20"`, `"20:9"`, `"1:2"`, `"2:1"`, `"auto"` | Replaces OpenAI-style `size` strings |
+| `resolution` | `"2k"`, `"720p"` (model-dependent) | Optional |
+| `response_format` | `"url"`, `"b64_json"` | Accepted (unlike gpt-image-1) |
+| `size` | not accepted | OpenAI-style pixel strings are not supported |
+| `quality` | not accepted | No quality parameter |
+| `seed` | not documented | |
+
+**Reference image support (new Imagine models):** Yes, via `/v1/images/edits`. Up to 3 source images as `{ "type": "image_url", "url": "<public URL or base64 data URI>" }` objects — a **JSON body format**, not multipart form-data. This is a different wire format from OpenAI's edits endpoint.
+
+**Response:** `data[].b64_json` or `data[].url`. Output is JPEG.
+
+**Quirks:**
+- **Wire format divergence from OpenAI:** New xAI Imagine models use `aspect_ratio` (aspect ratio strings) instead of `size` (pixel dimension strings). Current code passes `size` from options — this parameter is silently ignored by xAI, which means the size control our callers expect doesn't work.
+- **Reference image wire format is different from OpenAI:** xAI edits use JSON with `{ "type": "image_url" }` objects; OpenAI uses multipart form-data. Our current `callOpenAiImagesEdits` would not work for xAI edits.
+- `grok-2-image-1212` is deprecated and should be removed from the registry default model.
+- CORS restriction means browser callers need a proxy (already handled).
+
+---
+
+### 1.7 openai-compat (self-hosted)
+
+The `openai-compat` descriptor has no `imageGeneration` entries — it declares no image-generation capabilities. This is correct. Self-hosted servers rarely expose image endpoints, and claiming support would break callers who configure openai-compat against a server that doesn't have them. Leave as-is.
+
+---
+
+## 2. Current Implementation Gap Analysis
+
+### 2.1 Wire encoding wrong (provider rejects values we send)
+
+| Gap | Affected model(s) | Current behavior | Provider behavior |
+|---|---|---|---|
+| `response_format: 'b64_json'` sent unconditionally | `gpt-image-1` | `callOpenAiImagesGenerations` and `callOpenAiImagesEdits` always send this | Provider returns HTTP 400 |
+| `quality: 'high'` sent to dall-e-3 | `dall-e-3` | Type accepts `'high'`; code passes through | dall-e-3 expects `'hd'` not `'high'` |
+| `quality: 'standard'` sent to gpt-image-1 | `gpt-image-1` | Type accepts `'standard'`; code passes through | gpt-image-1 expects `'low'\|'medium'\|'high'\|'auto'` |
+| `size: '1792x1024'` sent to gpt-image-1 | `gpt-image-1` | Type allows `'1792x1024'`; code passes through | gpt-image-1 uses `'1536x1024'` for landscape |
+| `size: '1024x1792'` sent to gpt-image-1 | `gpt-image-1` | Type allows `'1024x1792'`; code passes through | gpt-image-1 uses `'1024x1536'` for portrait |
+| `size` passed to xAI Imagine models | `grok-imagine-*` | Code passes `size` through; silently ignored | xAI uses `aspect_ratio`, not pixel strings |
+| `negativePrompt` in Imagen request | `imagen-4.*` | Sent in `parameters` block | Not supported in Imagen 4; may error or be ignored |
+
+### 2.2 Capability not exposed (provider supports it, our type doesn't)
+
+| Gap | Affected model(s) |
+|---|---|
+| `dall-e-2` sizes `256x256`, `512x512` | `dall-e-2` |
+| `dall-e-3` `style` param (`'vivid'` / `'natural'`) | `dall-e-3` |
+| `gpt-image-1` portrait/landscape sizes (`1536x1024`, `1024x1536`) | `gpt-image-1` |
+| `gpt-image-1` quality tiers `'low'`, `'medium'`, `'auto'` | `gpt-image-1` |
+| `gpt-image-1` `background`, `moderation`, `output_format`, `output_compression` | `gpt-image-1` |
+| xAI `aspect_ratio` parameter | `grok-imagine-*` |
+| Imagen 4 `imageSize`, `addWatermark`, `enhancePrompt`, `outputOptions` | `imagen-4.*` |
+| Gemini Flash Image `imageConfig.aspectRatio` | `gemini-*-image` |
+
+### 2.3 Validation gap (caller can pass invalid values, we don't catch them)
+
+| Gap | Trigger |
+|---|---|
+| `dall-e-3` + `count > 1` | Caller passes `count: 2`; provider errors |
+| Quality value for wrong model | `'hd'` to gpt-image-1; `'high'` to dall-e-3 |
+| Size value for wrong model | `'1792x1024'` to gpt-image-1 |
+| `dall-e-2` + non-square size | `'1792x1024'` to dall-e-2 |
+| Imagen Ultra + `count > 1` | `count: 2` to `imagen-4.0-ultra-generate-001` |
+
+### 2.4 Pre-emptive over-send (always-sent param that some models reject)
+
+| Gap | Code location | Affected model(s) |
+|---|---|---|
+| `response_format: 'b64_json'` always appended | `callOpenAiImagesGenerations` ~L1067; `callOpenAiImagesEdits` ~L1108 | `gpt-image-1` (400); safe for dall-e-2, dall-e-3, xAI |
+
+### 2.5 Coverage gap (provider surface broken or unsupported)
+
+| Gap | Notes |
+|---|---|
+| `responseModalities: ["IMAGE"]` not set in Gemini Flash path | `callGeminiImageOutGeneration` doesn't set `responseModalities`. The model may return text-only or fail silently. **Likely already broken in production.** |
+| xAI default model is deprecated | Registry has `grok-2-image-1212` as default; deprecated Feb 28 2026 |
+| Imagen 3 deprecation | Registry uses `imagen-3.0-generate-002` implicitly (via `modelPrefix: 'imagen-'`); Imagen 3 shuts down June 24–30, 2026 |
+| xAI reference image wire format incompatible | Even if `acceptsImageReferenceInput` were enabled for xAI, our multipart form-data path would not work — new xAI edits use JSON body |
+| `callGeminiImageOutGeneration` missing `generationConfig` | No `generationConfig` block at all in the request body means `responseModalities`, `imageConfig.aspectRatio`, `candidateCount` are all inaccessible |
+| `dall-e-2` reference images blocked correctly but for undocumented reason | Currently blocked because `acceptsImageReferenceInput` is absent (false). The real reason — mask requirement incompatibility — is not documented in the registry. |
+
+---
+
+## 3. Type-Shape Recommendation
+
+### 3.1 Three approaches
+
+**Approach A — Single unified type, registry-driven runtime validation**
+
+`IAiImageGenerationOptions` expands to include the full union of all parameters. Registry entries enumerate accepted values per model. The dispatcher validates before building the wire request.
+
+Tradeoffs:
+- ✅ Simple caller API; one type; additive changes don't break callers
+- ✅ Matches library's existing philosophy (provider abstraction, thin caller layer)
+- ✅ Migration cost: near-zero for callers who don't use quality/size params
+- ⚠️ TypeScript can't prevent passing `style` to gpt-image-1; runtime validation required
+- ⚠️ `quality` union becomes heterogeneous (`'standard' | 'hd' | 'low' | 'medium' | 'high' | 'auto'`) without TypeScript-level per-model fidelity
+
+**Approach B — Discriminated union per model**
+
+`IAiImageGenerationParams` becomes a discriminated union on model name. Full type-level fidelity.
+
+Tradeoffs:
+- ✅ TypeScript catches `style` on gpt-image-1 at compile time
+- ❌ Breaking change for all callers; immediate migration required across all consumers
+- ❌ Model name in the params type conflicts with model resolution (model is currently resolved from registry/defaultModel, not provided by the caller)
+- ❌ New provider model requires new union arm + new per-model options interface
+- ❌ Heavy migration cost under lockstep versioning policy
+
+**Approach C — Common subset + per-provider escape hatch**
+
+Minimal type with `provider?: Record<string, unknown>` escape hatches.
+
+Tradeoffs:
+- ✅ Stable cross-provider surface
+- ❌ Escape hatch is untyped; callers lose all type safety for provider-specific params
+- ❌ Even `size` and `quality` would land in the untyped escape hatch
+- ❌ Doesn't solve the problem
+
+### 3.2 Recommendation: Approach A
+
+**Approach A** is recommended. Justification:
+
+1. The library is a provider abstraction layer — callers pass params; the dispatcher routes. Adding per-model type branching (Approach B) undermines this.
+2. `ts-app-shell/useAiAssist` passes `IAiImageGenerationParams` through without inspecting it; it doesn't need model-specific types.
+3. Under lockstep versioning, Approach B forces all consumers to update immediately. Approach A's additive changes require only targeted quality-value fixes.
+4. The active-surface clause gives us a free hand on breaking changes, but the lockstep cost is real. The one breaking change (quality `'high'` → `'hd'` for dall-e-3) is narrow and grep-findable.
+5. xAI's move to `aspect_ratio` instead of `size` is a bigger concern: callers who pass `size` to xAI get silent no-ops. Approach A lets us surface this as a validated field with clear semantics rather than a silent divergence. Adding an `aspectRatio` field alongside `size` in the unified type is cleaner than duplicating types per-provider.
+
+**Migration impact of Approach A:** See §8.
+
+---
+
+## 4. Registry-Shape Recommendation
+
+### 4.1 Proposed new `IAiImageModelCapability` fields
+
+```typescript
+export interface IAiImageModelCapability {
+  // Existing fields
+  readonly modelPrefix: string;
+  readonly format: AiImageApiFormat;
+  readonly acceptsImageReferenceInput?: boolean;
+
+  // --- New fields ---
+
+  /**
+   * Accepted `size` string values for this model. When defined, the
+   * dispatcher pre-validates and returns Result.fail if caller's size is
+   * not in this set. When undefined, no size validation.
+   */
+  readonly acceptedSizes?: ReadonlyArray<AiImageSize>;
+
+  /**
+   * Accepted `quality` values. When defined, pre-validates. An empty array
+   * means "this model has no quality parameter — don't send it."
+   */
+  readonly acceptedQualities?: ReadonlyArray<AiImageQuality>;
+
+  /**
+   * Maximum count (n). When defined, pre-validates count <= maxCount.
+   */
+  readonly maxCount?: number;
+
+  /**
+   * How to encode the output format parameter on the wire:
+   * - `'response-format'`: send `response_format: 'b64_json'` (dall-e-2, dall-e-3, xAI legacy)
+   * - `'output-format'`: send `output_format: <caller's outputFormat ?? 'png'>` (gpt-image-1)
+   * - `'none'`: send neither (Imagen, Gemini Flash — format is in request params, not a wire field)
+   */
+  readonly outputParamStyle?: 'response-format' | 'output-format' | 'none';
+
+  /**
+   * Default MIME type for response images when the provider doesn't include
+   * it in the response body. Used to populate IAiGeneratedImage.mimeType.
+   */
+  readonly defaultOutputMimeType?: string;
+
+  /**
+   * Whether this model accepts the `style` parameter (dall-e-3 only).
+   */
+  readonly acceptsStyle?: boolean;
+
+  /**
+   * Whether this model accepts gpt-image-1 extension params:
+   * background, moderation, output_format, output_compression.
+   */
+  readonly acceptsGptImageExtensions?: boolean;
+
+  /**
+   * Whether this model uses aspect_ratio (xAI Imagine style) instead of
+   * size pixel strings. When true, the dispatcher sends `aspect_ratio`
+   * from options.aspectRatio and ignores options.size.
+   */
+  readonly usesAspectRatio?: boolean;
+}
+```
+
+Also propose adding `AiImageApiFormat` value for xAI's updated wire format. The key question (see §9, Q5) is whether to add `'xai-images-v2'` or update the existing `'xai-images'` format handling. **Recommendation:** Update the existing `callOpenAiImageGeneration` adapter rather than adding a new format — the format name documents the API shape, not the model generation; both old and new xAI models route through the same adapter with different registry capability entries.
+
+### 4.2 Concrete registry entries
+
+**openai provider:**
+```typescript
+imageGeneration: [
+  {
+    modelPrefix: 'gpt-image-',
+    format: 'openai-images',
+    acceptsImageReferenceInput: true,
+    acceptedSizes: ['1024x1024', '1536x1024', '1024x1536', 'auto'],
+    acceptedQualities: ['low', 'medium', 'high', 'auto'],
+    maxCount: 10,
+    outputParamStyle: 'output-format',    // rejects response_format; use output_format
+    defaultOutputMimeType: 'image/png',   // default; override-able via outputFormat option
+    acceptsGptImageExtensions: true
+  },
+  {
+    modelPrefix: 'dall-e-3',
+    format: 'openai-images',
+    acceptsImageReferenceInput: false,    // explicit: no edits endpoint for dall-e-3
+    acceptedSizes: ['1024x1024', '1792x1024', '1024x1792'],
+    acceptedQualities: ['standard', 'hd'],
+    maxCount: 1,                          // hard limit
+    outputParamStyle: 'response-format',
+    defaultOutputMimeType: 'image/png',
+    acceptsStyle: true
+  },
+  {
+    modelPrefix: 'dall-e-2',
+    format: 'openai-images',
+    acceptsImageReferenceInput: false,    // edits need mask; our maskless path incompatible
+    acceptedSizes: ['256x256', '512x512', '1024x1024'],
+    acceptedQualities: [],                // no quality param — don't send it
+    maxCount: 10,
+    outputParamStyle: 'response-format',
+    defaultOutputMimeType: 'image/png'
+  },
+  {
+    modelPrefix: '',                      // catch-all for unknown openai models
+    format: 'openai-images',
+    outputParamStyle: 'response-format',
+    defaultOutputMimeType: 'image/png'
+  }
+]
+```
+
+**xai-grok provider:**
+```typescript
+// Update defaultModel.image to a current model
+defaultModel: {
+  base: 'grok-4-1-fast',
+  tools: 'grok-4-1-fast-reasoning',
+  image: 'grok-imagine-image-quality'  // was: 'grok-2-image-1212' (deprecated)
+},
+imageGeneration: [
+  {
+    modelPrefix: '',
+    format: 'xai-images',
+    acceptsImageReferenceInput: false,   // edits wire format incompatible with our path
+    acceptedQualities: [],               // no quality param
+    maxCount: 10,
+    outputParamStyle: 'response-format',
+    defaultOutputMimeType: 'image/jpeg',
+    usesAspectRatio: true               // uses aspect_ratio, not size pixel strings
+  }
+]
+```
+
+> **Note on xAI reference images:** The new xAI Imagine models DO support reference images via `/images/edits`, but the wire format (JSON body with `{ type: "image_url" }` objects) is different from OpenAI's multipart form-data. We should block reference images for xAI until a dedicated adapter is implemented. The `acceptsImageReferenceInput: false` flag handles this.
+
+**google-gemini provider:**
+```typescript
+imageGeneration: [
+  {
+    modelPrefix: 'imagen-',
+    format: 'gemini-imagen',
+    acceptsImageReferenceInput: false,
+    acceptedQualities: [],
+    outputParamStyle: 'none',
+    defaultOutputMimeType: 'image/png'
+    // No acceptedSizes — Imagen uses aspectRatio not pixel dimensions
+  },
+  {
+    modelPrefix: '',
+    format: 'gemini-image-out',
+    acceptsImageReferenceInput: true,
+    maxCount: 1,
+    acceptedQualities: [],
+    outputParamStyle: 'none',
+    defaultOutputMimeType: 'image/jpeg'  // Flash Image currently outputs JPEG only
+  }
+]
+```
+
+> **Note on rule ordering:** `resolveImageCapability` picks longest `modelPrefix` match. `imagen-` (7 chars) wins over `''` (0 chars) for any `imagen-*` model. This is correct. The empty string catch-all for gemini correctly routes `gemini-2.5-flash-image` to `gemini-image-out`.
+
+---
+
+## 5. Failure Semantics Policy
+
+### 5.1 Where pre-validation kicks in
+
+Pre-validation runs in `callProviderImageGeneration` after capability resolution, before request build:
+
+1. `supportsImageGeneration(descriptor)` — fail fast
+2. Resolve model string
+3. Resolve `IAiImageModelCapability`
+4. Check `acceptsImageReferenceInput`
+5. **(NEW)** `validateImageOptions(model, capability, options)` — validates size, quality, count against registry fields
+6. Build wire request using the validated options
+
+**New `validateImageOptions` function:**
+```typescript
+function validateImageOptions(
+  model: string,
+  capability: IAiImageModelCapability,
+  options: IAiImageGenerationOptions | undefined
+): Result<IAiImageGenerationOptions>
+```
+
+Returns the original options object on success. On first violation, returns `Result.fail` with contextual message. Fail-fast (no aggregation) — image generation is a single request.
+
+### 5.2 Where we let providers 400
+
+Parameters not expressed in the registry (novel values, future additions) surface as provider 400s through the failure path, same as today. The goal is to catch enumerable, known-bad values at the client; not to be a comprehensive validator.
+
+### 5.3 Silent translation policy
+
+**No silent translation.** Specific cases:
+
+- `quality: 'high'` → NOT silently translated to `'hd'` for dall-e-3. Registry lists `'hd'` as accepted; validator rejects `'high'` with a clear message.
+- `size: '1792x1024'` for gpt-image-1 → rejected, not silently mapped to `'1536x1024'`.
+- `size` for xAI → NOT silently mapped to `aspect_ratio`. If caller passes `size`, it's ignored (with a note in docs); the `aspectRatio` field is the right field for xAI.
+
+**Exception (output normalization):** MIME type assignment is output normalization, not input translation, and is acceptable.
+
+### 5.4 Error message format
+
+```
+model "dall-e-3": quality "high" is not accepted; accepted values: ["standard", "hd"]
+model "dall-e-3": count 4 exceeds maximum of 1
+model "gpt-image-1": size "1792x1024" is not accepted; accepted values: ["1024x1024", "1536x1024", "1024x1536", "auto"]
+model "imagen-4.0-ultra-generate-001": count 2 exceeds maximum of 1
+```
+
+Format: `model "${model}": ${field} ${JSON.stringify(value)} is not accepted; accepted values: ${JSON.stringify(accepted)}`
+
+---
+
+## 6. Output Shape Unification
+
+### 6.1 Current output shape
+
+```typescript
+interface IAiGeneratedImage extends IAiImageData {
+  readonly mimeType: string;
+  readonly base64: string;
+  readonly revisedPrompt?: string;
+}
+interface IAiImageGenerationResponse {
+  readonly images: ReadonlyArray<IAiGeneratedImage>;
+}
+```
+
+This shape is already good. No structural changes recommended.
+
+### 6.2 Provider-to-shape mapping
+
+| Provider | Response shape | Current normalization | Issue |
+|---|---|---|---|
+| OpenAI `/generations` + `/edits` | `data[].b64_json` | `base64: item.b64_json`, `mimeType: 'image/png'` (hardcoded) | gpt-image-1 MIME type should reflect `output_format` |
+| xAI `/generations` | `data[].b64_json` (JPEG) | `base64: item.b64_json`, `mimeType: 'image/jpeg'` | Correct; new models also JPEG |
+| Imagen `:predict` | `predictions[].bytesBase64Encoded` + `mimeType?` | `base64: pred.bytesBase64Encoded`, `mimeType: pred.mimeType ?? 'image/png'` | Correct |
+| Gemini Flash `:generateContent` | `candidates[].content.parts[].inlineData` | `base64: part.inlineData.data`, `mimeType: part.inlineData.mimeType` | Correct; JPEG from response |
+
+**Fix needed:** When gpt-image-1 is called with `outputFormat: 'jpeg'` or `outputFormat: 'webp'`, the response MIME type should be `'image/jpeg'` or `'image/webp'`, not `'image/png'`. The current architecture passes `defaultMimeType` as a constant at the dispatch level; this needs to become dynamic for gpt-image-1.
+
+**Fix:** Thread the effective `output_format` value from options into `callOpenAiImageGeneration` and use it to set the MIME type in the response normalizer.
+
+### 6.3 Provider-specific output fields
+
+| Field | Provider | Disposition |
+|---|---|---|
+| `revised_prompt` | dall-e-3 only | Already in `revisedPrompt?` — keep |
+| Safety metadata | Imagen | Not surfaced; omit (filtered calls fail before we parse) |
+| Gemini candidate `finishReason` | Gemini Flash | Already ignored; correct |
+| Google Search grounding metadata | Gemini Flash | Not surfaced; omit |
+
+**No additions to `IAiGeneratedImage`.** A `providerExtras?: Record<string, unknown>` bag is explicitly deferred until a concrete consumer need exists.
+
+---
+
+## 7. Streaming
+
+Image generation is synchronous across all four providers as of 2026-05-11:
+
+| Provider | Streaming image gen? |
+|---|---|
+| OpenAI (dall-e-2, dall-e-3, gpt-image-1) | No. `/images/generations` is synchronous. |
+| xAI (grok-imagine-*) | No. Same synchronous OpenAI-compatible format. |
+| Google Imagen `:predict` | No. Synchronous request-response. |
+| Google Gemini Flash `:generateContent` | No streaming image output. The `:generateContent` endpoint supports streaming for text, but image `inlineData` parts are only present in the non-streaming response. |
+
+No streaming integration needed in phase B. If streaming image generation is added by any provider in the future, the architecture accommodates it cleanly — a new `AiImageApiFormat` value and a new adapter in the dispatch switch.
+
+---
+
+## 8. Migration Impact
+
+### 8.1 `IAiImageGenerationOptions.quality` field
+
+**Current type:** `quality?: 'standard' | 'high'`  
+**New type:** `quality?: 'standard' | 'hd' | 'low' | 'medium' | 'high' | 'auto'`
+
+**Breaking for:** Callers using `quality: 'high'` targeting dall-e-3 (was already broken at the wire level; `dall-e-3` wanted `'hd'`). They must change to `quality: 'hd'`.
+
+**Blast radius:** `ts-app-shell` (1 in-repo consumer — passes params through; likely doesn't set `quality`); `personaility` (1 known external consumer). Grep for `quality.*high` in both repos. **Verify before claiming blast radius is zero.**
+
+**Migration:** Change `quality: 'high'` → `quality: 'hd'` in callers that target dall-e-3. Callers targeting gpt-image-1 with `quality: 'high'` are already correct.
+
+### 8.2 `IAiImageGenerationOptions.size` field
+
+**Current type:** `size?: '1024x1024' | '1024x1792' | '1792x1024' | 'auto'`  
+**New type:** Superset with additional values added.
+
+**Breaking for:** None — additive.
+
+### 8.3 `IAiImageGenerationOptions` new optional fields
+
+New: `style?`, `background?`, `moderation?`, `outputFormat?`, `outputCompression?`, `aspectRatio?`
+
+**Breaking for:** None — all optional.
+
+### 8.4 `IAiImageGenerationOptions.imagen.negativePrompt` field
+
+**Current:** `imagen.negativePrompt` accepted and sent to Imagen.  
+**New:** Should be removed or marked deprecated. Imagen 4 doesn't support it; Imagen 3 shuts down June 2026.
+
+**Breaking for:** Any caller using `imagen.negativePrompt`. Since `ai-assist` is on the active-surface list, we can remove it.
+
+**Blast radius:** Unknown. Grep for `negativePrompt` in consumer code. Likely low usage.
+
+**Migration:** Remove the field; callers who use it need to drop it.
+
+### 8.5 Registry `IAiImageModelCapability` new optional fields
+
+All new optional fields; no breaking change for code that constructs capability objects.
+
+### 8.6 xAI default model update
+
+`defaultModel.image` changes from `'grok-2-image-1212'` (deprecated) to `'grok-imagine-image-quality'`.
+
+**Breaking for:** Callers who pass no model override and use xAI image generation. The wire format is compatible; the model name changes. If the new model has different visual characteristics, that's an expected change.
+
+**Blast radius:** Any active xAI image callers. The deprecated model may already be throwing errors (it was deprecated Feb 28 2026). **This is a correctness fix.**
+
+### 8.7 Imagen 3 → Imagen 4 migration
+
+The registry currently uses `modelPrefix: 'imagen-'` as a catch-all, so any `imagen-3.*` or `imagen-4.*` model routes through `gemini-imagen` format. No code change needed at the format level. The `defaultModel.image` for `google-gemini` is `'gemini-2.5-flash-image'` (not an Imagen model), so the imagen path is only reached via explicit `modelOverride`.
+
+**If any consumer explicitly overrides to `imagen-3.0-generate-002`:** They will break when Imagen 3 shuts down June 24–30, 2026. **Notify consumers to switch to `imagen-4.0-generate-001`.**
+
+### 8.8 `imagen.negativePrompt` removal
+
+See §8.4 above.
+
+### 8.9 Behavior change — pre-validation
+
+Callers who previously passed invalid options (e.g. `count: 5` to dall-e-3) will now get `Result.fail` from `callProviderImageGeneration` rather than a provider 400. Error message changes from provider-shaped to our format (see §5.4). Both are `Result.fail`; the calling code is unaffected.
+
+### 8.10 Summary of breaking changes
+
+| Change | Action required | Blast radius |
+|---|---|---|
+| `quality: 'high'` → `'hd'` for dall-e-3 | Grep consumer code; change dall-e-3 callers | 1 in-repo + 1 known external |
+| `imagen.negativePrompt` removal | Drop from callers | Likely low; verify |
+| xAI default model update | None (correctness fix; deprecated model already broken) | xAI image callers |
+| Imagen 3 deprecation | Switch to `imagen-4.0-generate-001` in overrides | Any consumer using Imagen explicitly |
+
+All other changes are additive. Total callsite changes: 0–3 lines across known consumers (estimate pending grep verification).
+
+---
+
+## 9. Open Questions for Signoff
+
+### Q1: Gemini Flash Image — `responseModalities` already broken?
+
+`callGeminiImageOutGeneration` doesn't set `responseModalities: ["IMAGE"]` in the request body. Per live-fetched Gemini docs, this is required to get image output. If the model defaults to text-only or rejects the request without it, **all Gemini Flash Image calls are currently broken** with "no image parts in response."
+
+**Need to know before phase B:** Is Gemini Flash Image currently returning images in production, or is this already broken? A live test call would resolve this. If it's broken, this is the highest-priority fix (higher than the gpt-image-1 `response_format` issue, since that at least fails loudly with a 400).
+
+### Q2: xAI reference image wire format
+
+New xAI Imagine models support `/v1/images/edits` but use a JSON body with `{ "type": "image_url" }` objects, not multipart form-data. Our current `callOpenAiImagesEdits` would not work for xAI even if we enabled `acceptsImageReferenceInput`.
+
+**Decision:** Keep `acceptsImageReferenceInput: false` for xAI in phase B, and defer a dedicated xAI edits adapter to a later stream. This is an additive future change; it doesn't block the core fixes.
+
+**Confirm:** Is there a known consumer need for xAI reference images now? If yes, scope it into phase B.
+
+### Q3: gpt-image-1 MIME type tracking for non-PNG output
+
+When a caller requests `outputFormat: 'jpeg'`, the response `mimeType` should be `'image/jpeg'`. The current dispatcher passes `defaultMimeType: 'image/png'` as a constant. Two options:
+
+- **Option A:** Thread effective `outputFormat` from options into `callOpenAiImageGeneration` and use it to set MIME type.
+- **Option B:** Use `defaultOutputMimeType` from the capability entry for gpt-image-1 (set to `'image/png'`) but override based on caller's `outputFormat` option.
+
+**Recommendation:** Option A is cleaner. The MIME type is determined by the request, so it should be threaded with the request parameters. **Confirm this is acceptable.**
+
+### Q4: `acceptedQualities: []` semantics
+
+Proposed: `acceptedQualities: []` means "no quality parameter — don't send it." An alternative is an explicit `supportsQualityParam?: boolean` flag.
+
+**Decision needed:** Is the dual interpretation (`[]` = don't send; `undefined` = don't validate) clear enough, or should there be a separate boolean? The current proposal uses `[]` for dall-e-2 and xAI. **Confirm preferred approach.** Recommendation: `[]` is adequate for a library-internal registry; add a comment in the interface JSDoc explaining the semantics.
+
+### Q5: xAI `usesAspectRatio` flag vs new `AiImageApiFormat` value
+
+xAI Imagine models use `aspect_ratio` instead of `size`. Two implementation approaches:
+
+- **Option A:** Add `usesAspectRatio?: boolean` to the capability entry and branch within the existing `callOpenAiImageGeneration` adapter.
+- **Option B:** Add a new `AiImageApiFormat` value (`'xai-images-v2'`?) and a dedicated adapter.
+
+**Recommendation:** Option A for phase B. The difference is one field name (`size` vs `aspect_ratio`); a small branch in the adapter is less overhead than a new format value and new adapter. Option B is appropriate if xAI's API diverges further in the future.
+
+**Confirm:** Is adding `aspectRatio?: string` to `IAiImageGenerationOptions` the right UX for xAI callers (instead of overloading `size`)? Since Imagen also uses aspect ratios (in the `imagen.aspectRatio` field), there's prior art for per-provider aspect ratio fields. **Recommendation:** Add a top-level `aspectRatio` field to `IAiImageGenerationOptions` alongside `size`, with docs noting which providers use each.
+
+### Q6: Imagen `imagen` field — rename, restructure, or expand?
+
+The current `imagen` escape hatch has `negativePrompt` (now obsolete) and `aspectRatio` (Imagen-specific). With Imagen 4 adding `imageSize`, `addWatermark`, `enhancePrompt`, `outputOptions`, the `imagen` bag will grow.
+
+**Options:**
+- Expand `imagen` with new fields (keeping it as a per-provider escape hatch)
+- Move `imagen.aspectRatio` to top-level (since xAI now also uses aspect ratios) and keep `imagen` for Imagen-only knobs
+- Rename `imagen` to something more descriptive (e.g. `imagenOptions`)
+
+**Recommendation:** Move `aspectRatio` to top-level (shared by xAI and Imagen). Keep `imagen` for the Imagen-specific knobs (`imageSize`, `addWatermark`, `enhancePrompt`, `outputOptions`) renamed to `imagenOptions` for clarity. Remove `negativePrompt` from this bag. **Confirm.**
+
+### Q7: Imagen Ultra `maxCount: 1` handling
+
+`imagen-4.0-ultra-generate-001` only supports 1 image per call. The registry uses prefix-matching (`modelPrefix: 'imagen-'` catches all Imagen models). To enforce the Ultra constraint, we'd need either:
+- A separate registry entry with `modelPrefix: 'imagen-4.0-ultra-'` and `maxCount: 1`
+- Or rely on the provider's error (which is a 400 from the API)
+
+**Recommendation:** Add an explicit `imagen-4.0-ultra-` entry with `maxCount: 1`. The prefix matching already handles this correctly since `imagen-4.0-ultra-generate-001` (22 chars) matches `imagen-4.0-ultra-` (18 chars) before `imagen-` (7 chars).
+
+**Confirm:** Should we add the Ultra-specific entry in phase B, or accept the provider 400 for now?
+
+### Q8: xAI `resolution` parameter
+
+xAI Imagine models accept a `resolution` parameter (`"2k"`, `"720p"`). Should this be exposed? It's a new capability not currently expressible.
+
+**Recommendation:** Add `resolution?: string` to the xAI-specific section (or top-level with a provider-specific note) if there's a near-term consumer need. Otherwise defer. **Confirm priority.**
+
+### Q9: Consumer verification of `quality` usage
+
+The `quality: 'high'` → `'hd'` rename is the only non-additive breaking change. Before phase B finalizes the type, grep `personaility` and `ts-app-shell` for any usage of `quality` in image generation contexts. If neither uses it, the blast radius is zero and no callsite migration is needed.
+
+**Action:** Orchestrator/user should verify quality field usage in consumer repos before accepting the migration path as zero-cost.
+
+### Q10: Gemini Flash `candidateCount` vs multiple calls
+
+The Gemini Flash Image model theoretically supports multiple images via `candidateCount` but the Python SDK has reported bugs with `number_of_images`. Our TypeScript implementation uses raw `fetch` calls, not the SDK, so SDK bugs don't apply. However, the model documentation is ambiguous about whether `candidateCount > 1` is actually supported.
+
+**Decision:** For phase B, use `maxCount: 1` in the registry and make multiple calls at the application level if multiple images are needed. Revisit if Google stabilizes multiple-image support in the API spec.
+
+---
+
+## Appendix A: Proposed Type Additions
+
+```typescript
+// New aliases
+export type AiImageSize =
+  | '256x256' | '512x512'            // dall-e-2
+  | '1024x1024'                       // all models
+  | '1024x1792' | '1792x1024'        // dall-e-3
+  | '1024x1536' | '1536x1024'        // gpt-image-1
+  | 'auto';                           // gpt-image-1
+
+export type AiImageQuality =
+  | 'standard' | 'hd'                // dall-e-3
+  | 'low' | 'medium' | 'high' | 'auto'; // gpt-image-1
+
+// Updated IAiImageGenerationOptions
+export interface IAiImageGenerationOptions {
+  /**
+   * Pixel dimensions for OpenAI image models. Each model has its own accepted
+   * set; the dispatcher pre-validates against the registry.
+   * Note: xAI uses `aspectRatio` instead; Imagen uses `imagenOptions.aspectRatio`.
+   */
+  readonly size?: AiImageSize;
+  /** Number of images. Default 1. Some models enforce a maximum (dall-e-3: 1). */
+  readonly count?: number;
+  /**
+   * Quality tier. Accepted values differ per model:
+   * - dall-e-3: 'standard' | 'hd'
+   * - gpt-image-1: 'low' | 'medium' | 'high' | 'auto'
+   * Other models ignore this field.
+   */
+  readonly quality?: AiImageQuality;
+  /** Reproducibility seed, where supported. */
+  readonly seed?: number;
+  /**
+   * Aspect ratio for xAI Imagine models. Ignored by OpenAI and Google models.
+   * xAI ignores `size`; pass `aspectRatio` for dimension control with xAI.
+   */
+  readonly aspectRatio?: string;
+  /** dall-e-3 only. 'vivid' = hyper-real; 'natural' = more realistic. */
+  readonly style?: 'vivid' | 'natural';
+  /** gpt-image-1 only. Background transparency control. */
+  readonly background?: 'transparent' | 'opaque' | 'auto';
+  /** gpt-image-1 only. Content moderation strictness. */
+  readonly moderation?: 'low' | 'auto';
+  /** gpt-image-1 only. Output encoding format (replaces response_format). */
+  readonly outputFormat?: 'png' | 'jpeg' | 'webp';
+  /** gpt-image-1 only. JPEG/WebP compression level 0–100. */
+  readonly outputCompression?: number;
+  /** Imagen-specific options. Ignored by other providers. */
+  readonly imagenOptions?: {
+    readonly aspectRatio?: '1:1' | '3:4' | '4:3' | '9:16' | '16:9';
+    readonly imageSize?: '1K' | '2K';
+    readonly addWatermark?: boolean;
+    readonly enhancePrompt?: boolean;
+    readonly outputMimeType?: 'image/jpeg' | 'image/png';
+    readonly outputCompressionQuality?: number;
+  };
+}
+```
+
+---
+
+## Appendix B: Implementation Checklist for Phase B
+
+The following are discrete implementation units for scope estimation. This is not the phase B brief.
+
+1. **`model.ts`** — Add `AiImageSize`, `AiImageQuality` type aliases; update `IAiImageGenerationOptions`; add new fields to `IAiImageModelCapability`.
+
+2. **`registry.ts`** — Replace 2 openai entries with 4 per-model entries; update xai-grok (model name + new capability fields); update google-gemini; update xai `defaultModel.image`.
+
+3. **`imageValidation.ts`** (new file) or inline — `validateImageOptions(model, capability, options): Result<IAiImageGenerationOptions>`.
+
+4. **`apiClient.ts`** — Multiple changes:
+   - Add validation call in `callProviderImageGeneration`
+   - Fix `callOpenAiImagesGenerations` for `outputParamStyle` switching
+   - Fix `callOpenAiImagesEdits` same
+   - Add `generationConfig.responseModalities: ["IMAGE"]` to `callGeminiImageOutGeneration`
+   - Add `generationConfig.imageConfig.aspectRatio` to Gemini Flash path
+   - Handle `usesAspectRatio` in the openai-images adapter for xAI models
+   - Handle model-specific params: `style` for dall-e-3, gpt-image-1 extensions
+   - Thread MIME type correctly for gpt-image-1 `outputFormat`
+   - Update Imagen request builder to use Imagen 4 params (`imagenOptions.*`)
+
+5. **Tests** — 100% coverage required on all new code; update existing tests for new validation behavior.
+
+6. **`LIBRARY_CAPABILITIES.md`** — Expand ai-assist section for image generation.

--- a/.ai/tasks/active/ai-assist-image-generation/state.md
+++ b/.ai/tasks/active/ai-assist-image-generation/state.md
@@ -1,7 +1,7 @@
 # Stream State: ai-assist-image-generation
 
-**Status:** 🔵 phase A complete — awaiting orchestrator/user signoff before phase B
-**Last updated:** 2026-05-11 (phase A agent — design.md complete)
+**Status:** 🟢 phase B (implementation) ready to start — phase A signed off
+**Last updated:** 2026-05-11 (orchestrator — phase A signoff + phase B prep)
 
 ---
 
@@ -9,12 +9,41 @@
 
 | Phase | Status | Notes |
 |-------|--------|-------|
-| A — research and design | ✅ complete | `design.md` written; PR open against `claude/ai-assist-features` |
-| B — implementation | ⏸ blocked on phase A signoff | Brief to be written by orchestrator post-signoff |
+| A — research and design | ✅ complete | `design.md` written; signed off with substantial modifications. PR consolidated into the phase B prep PR (this branch). |
+| B — implementation | 🟢 ready | Brief: `brief-phase-b.md`. Awaiting agent kickoff. |
+
+---
+
+## Phase A signoff summary
+
+The phase A design provided a comprehensive provider inventory and gap analysis (the value of the research). Its recommendation (Approach A — unified type + registry-driven validation) was rejected by the orchestrator/user review for over-indexing on compatibility on a surface that's explicitly "free hand on breaking changes" per `.ai/instructions/ACTIVE_DEVELOPMENT.md`. Substantive modifications detailed below.
+
+### Decisions overriding the design
+
+| ID | Topic | Design recommendation | Signoff decision |
+|---|---|---|---|
+| D1 | Type architecture | Approach A (unified) | Layered options: generic top-level + optional `models?: IModelFamilyConfig[]` array of family-scoped blocks with `provider` discriminator and `IOtherModelOptions` escape hatch |
+| D2 | Merge precedence | Implicit | Explicit: generic → family-generic → model-specific ≈ Other; declaration order within tier; provider-mismatch silently skipped |
+| D3 | Deprecated models | Migrate to current | Drop entirely: `imagen-3.*`, `grok-2-image-1212`, `grok-imagine-image-pro`, `imagen.negativePrompt`. Plus correctness fix for xAI default model. |
+| D4 | xAI reference images | Defer (Q2) | In scope for phase B — dedicated xAI edits adapter (JSON body with `{ type: "image_url" }` objects) |
+| D5 | Gemini `responseModalities` | Add as required (urgent fix per Q1) | Skip — user empirically verified Gemini works without it; the Google docs are stale |
+| D6 | OpenAI live-verification | Implicit (`[training-data]` markers) | Phase B step zero: verify each OpenAI model's accepted values via `developers.openai.com` + the in-repo image-gen sample app |
+| D7 | Registry shape | 7 new optional fields | Simplified: drop `acceptsGptImageExtensions`, `acceptsStyle`, `usesAspectRatio` (the layered types handle dispatch). Replace `acceptedQualities: []` semantics with `supportsQualityParam?: boolean`. Keep size/quality/count accepted-value fields. |
+| D8 | Other-block precedence | n/a (escape hatch not in design) | Other blocks participate in merge with model-specific tier precedence; passthrough to wire request |
+
+Detail in `brief-phase-b.md`. **`brief-phase-b.md` is the binding contract; `design.md` is the inventory and rationale.**
+
+### Lessons-codification candidates (parked for orchestrator triage post-merge)
+
+- **Cloud-agent harness branch-name suffix.** Phase A agent's branch was `claude/ai-image-generation-research-gtE2l` (not the brief's specified `claude/ai-assist-image-generation-design`) due to harness-appended random suffix. Briefs should accommodate this rather than specifying exact names.
+- **Don't trust docs over observed behavior on "is this currently broken" claims.** Phase A surfaced the Gemini `responseModalities` issue from docs; user empirically confirmed it's a non-issue. Design phases should include live-test verification for "broken" claims before flagging them as urgent.
+- **Phase A briefs should suggest fallback doc URLs.** OpenAI section was `[training-data]` because `platform.openai.com` is login-gated; `developers.openai.com` is the public alternative. Future briefs touching provider docs should list known fallbacks.
 
 ---
 
 ## Decisions log
+
+### Phase A (cloud agent's working branch: `claude/ai-image-generation-research-gtE2l`)
 
 - Working branch: `claude/ai-image-generation-research-gtE2l` (session-designated; branched from `claude/ai-assist-features`)
 - PR target: `claude/ai-assist-features`
@@ -25,36 +54,26 @@
 - `response_format: 'b64_json'` confirmed as root cause of gpt-image-1 400 bug (§2.4). Fix: conditional on `outputParamStyle: 'output-format'` capability flag.
 - dall-e-3 quality is `'hd'` not `'high'`; our current type `'standard' | 'high'` is wrong for both dall-e-3 (`'hd'`) and gpt-image-1 (`'low'|'medium'|'high'|'auto'`).
 - `grok-2-image-1212` is **deprecated as of February 28, 2026** (registry is stale). New models: `grok-imagine-image`, `grok-imagine-image-quality`.
-- `imagen-3.0-generate-002` is **deprecated; shuts down June 24–30, 2026** (within weeks). Migration to Imagen 4 (`imagen-4.0-generate-001`) is urgent.
+- `imagen-3.0-generate-002` is **deprecated; shuts down June 24–30, 2026**. Migration to Imagen 4 is urgent.
 - xAI Imagine models use `aspect_ratio` (not `size` pixel strings). Our current code silently ignores the `size` param for xAI — callers have no dimension control.
-- `responseModalities: ["IMAGE"]` is **required** in Gemini Flash Image requests but our code doesn't set it — all Gemini Flash Image calls may be producing text-only responses or failing silently. **Highest-priority bug** (worse than the gpt-image-1 400, which at least fails loudly).
-- xAI new Imagine models support reference images but via JSON body (not multipart) — incompatible with our current `callOpenAiImagesEdits`. Blocked until a dedicated adapter is written.
+- ~~`responseModalities: ["IMAGE"]` is required in Gemini Flash Image requests~~ — **user empirically refuted; docs are stale (D5).**
+- xAI new Imagine models support reference images but via JSON body (not multipart) — incompatible with our current `callOpenAiImagesEdits`. Will be addressed in phase B (D4).
 - Gemini Flash Image currently outputs **JPEG only** regardless of request; `outputMimeType` config is not functional per live community reports.
 
-**Excluded from design and why:**
-- xAI reference image implementation — wire format (JSON body with `image_url` objects) is different from OpenAI multipart; scoped out to avoid bloating phase B. `acceptsImageReferenceInput: false` blocks the call up front. (§9, Q2)
-- `dall-e-2` `/images/variations` endpoint — our reference-image path requires maskless input; dall-e-2's edits need a mask. Blocked via `acceptsImageReferenceInput: false`. Variations endpoint not exposed (no caller need identified).
-- Gemini Flash multiple images (`candidateCount > 1`) — SDK bugs reported; `maxCount: 1` for now. (§9, Q10)
-- `openai-compat` image generation — no known consumer need; correct to leave without `imageGeneration` entries.
-- Audio/video generation — out of scope per brief.
+### Phase A signoff (orchestrator + user, 2026-05-11)
+
+See "Decisions overriding the design" table above.
 
 ---
 
 ## Open questions / blockers
 
-See `design.md` §9. Key questions requiring orchestrator/user input before phase B:
-
-1. **Is Gemini Flash Image already broken?** (`responseModalities` missing) — needs live test call.
-2. **xAI reference images in phase B scope?** — currently blocked; defer or include?
-3. **gpt-image-1 MIME type threading** — Option A (thread `outputFormat`) vs Option B (static default). Recommend Option A; confirm.
-4. **`acceptedQualities: []` semantics** — vs explicit `supportsQualityParam?: boolean` flag.
-5. **xAI `usesAspectRatio`** vs new `AiImageApiFormat` value — recommend flag, confirm.
-6. **`imagen`/`imagenOptions` rename** — recommend rename + move `aspectRatio` to top-level.
-7. **Imagen Ultra `maxCount: 1`** — explicit registry entry or let provider 400?
-8. **Consumer quality-field verification** — grep `personaility` and `ts-app-shell` for `quality` usage before accepting zero-cost blast radius.
+*(none — phase B unblocked; brief-phase-b.md captures all binding decisions)*
 
 ---
 
 ## PR
 
-*(to be opened — `design.md` + `state.md` targeting `claude/ai-assist-features`)*
+- **Phase A research:** committed to `claude/ai-image-generation-research-gtE2l`; merged into the orchestrator's phase B prep branch via `git merge --no-ff` to consolidate the phase-A→B transition into a single PR against the integration branch.
+- **Phase A + B prep PR:** `claude/ai-image-generation-phase-b-prep` → `claude/ai-assist-features` (open after orchestrator commits the brief + state.md + WORKSTREAMS update)
+- **Phase B implementation PR:** TBD by phase B agent; target `claude/ai-assist-features`

--- a/.ai/tasks/active/ai-assist-image-generation/state.md
+++ b/.ai/tasks/active/ai-assist-image-generation/state.md
@@ -1,7 +1,7 @@
 # Stream State: ai-assist-image-generation
 
-**Status:** 🟢 phase A ready to start
-**Last updated:** 2026-05-11 (orchestrator — substrate prep)
+**Status:** 🔵 phase A complete — awaiting orchestrator/user signoff before phase B
+**Last updated:** 2026-05-11 (phase A agent — design.md complete)
 
 ---
 
@@ -9,23 +9,52 @@
 
 | Phase | Status | Notes |
 |-------|--------|-------|
-| A — research and design | 🟢 ready | Brief committed; awaiting agent kickoff |
-| B — implementation | ⏸ blocked on phase A signoff | Brief written by orchestrator post-signoff |
+| A — research and design | ✅ complete | `design.md` written; PR open against `claude/ai-assist-features` |
+| B — implementation | ⏸ blocked on phase A signoff | Brief to be written by orchestrator post-signoff |
 
 ---
 
 ## Decisions log
 
-*(empty — populated by implementing agent)*
+- Working branch: `claude/ai-image-generation-research-gtE2l` (session-designated; branched from `claude/ai-assist-features`)
+- PR target: `claude/ai-assist-features`
+- Recommendation: **Approach A** (unified type + registry-driven validation). Defends against Approaches B and C in §3.
+- Registry shape: `IAiImageModelCapability` gains 7 new optional fields; concrete per-model entries proposed in §4.
+
+**Key research findings:**
+- `response_format: 'b64_json'` confirmed as root cause of gpt-image-1 400 bug (§2.4). Fix: conditional on `outputParamStyle: 'output-format'` capability flag.
+- dall-e-3 quality is `'hd'` not `'high'`; our current type `'standard' | 'high'` is wrong for both dall-e-3 (`'hd'`) and gpt-image-1 (`'low'|'medium'|'high'|'auto'`).
+- `grok-2-image-1212` is **deprecated as of February 28, 2026** (registry is stale). New models: `grok-imagine-image`, `grok-imagine-image-quality`.
+- `imagen-3.0-generate-002` is **deprecated; shuts down June 24–30, 2026** (within weeks). Migration to Imagen 4 (`imagen-4.0-generate-001`) is urgent.
+- xAI Imagine models use `aspect_ratio` (not `size` pixel strings). Our current code silently ignores the `size` param for xAI — callers have no dimension control.
+- `responseModalities: ["IMAGE"]` is **required** in Gemini Flash Image requests but our code doesn't set it — all Gemini Flash Image calls may be producing text-only responses or failing silently. **Highest-priority bug** (worse than the gpt-image-1 400, which at least fails loudly).
+- xAI new Imagine models support reference images but via JSON body (not multipart) — incompatible with our current `callOpenAiImagesEdits`. Blocked until a dedicated adapter is written.
+- Gemini Flash Image currently outputs **JPEG only** regardless of request; `outputMimeType` config is not functional per live community reports.
+
+**Excluded from design and why:**
+- xAI reference image implementation — wire format (JSON body with `image_url` objects) is different from OpenAI multipart; scoped out to avoid bloating phase B. `acceptsImageReferenceInput: false` blocks the call up front. (§9, Q2)
+- `dall-e-2` `/images/variations` endpoint — our reference-image path requires maskless input; dall-e-2's edits need a mask. Blocked via `acceptsImageReferenceInput: false`. Variations endpoint not exposed (no caller need identified).
+- Gemini Flash multiple images (`candidateCount > 1`) — SDK bugs reported; `maxCount: 1` for now. (§9, Q10)
+- `openai-compat` image generation — no known consumer need; correct to leave without `imageGeneration` entries.
+- Audio/video generation — out of scope per brief.
 
 ---
 
 ## Open questions / blockers
 
-*(empty — phase A agent populates as research surfaces them)*
+See `design.md` §9. Key questions requiring orchestrator/user input before phase B:
+
+1. **Is Gemini Flash Image already broken?** (`responseModalities` missing) — needs live test call.
+2. **xAI reference images in phase B scope?** — currently blocked; defer or include?
+3. **gpt-image-1 MIME type threading** — Option A (thread `outputFormat`) vs Option B (static default). Recommend Option A; confirm.
+4. **`acceptedQualities: []` semantics** — vs explicit `supportsQualityParam?: boolean` flag.
+5. **xAI `usesAspectRatio`** vs new `AiImageApiFormat` value — recommend flag, confirm.
+6. **`imagen`/`imagenOptions` rename** — recommend rename + move `aspectRatio` to top-level.
+7. **Imagen Ultra `maxCount: 1`** — explicit registry entry or let provider 400?
+8. **Consumer quality-field verification** — grep `personaility` and `ts-app-shell` for `quality` usage before accepting zero-cost blast radius.
 
 ---
 
 ## PR
 
-*(none yet)*
+*(to be opened — `design.md` + `state.md` targeting `claude/ai-assist-features`)*

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -132,17 +132,17 @@ substrate. Don't queue streams against them here.
 
 ### `ai-assist-image-generation` 🟢
 
-**Status:** 🟢 phase A (research + design) ready to start
-**Phase B sequencing:** strictly after this stream's design signoff
+**Status:** 🟢 phase B (implementation) ready to start; phase A complete + signed off
+**Phase B sequencing:** strictly before `ai-assist-thinking-config` phase B (serial implementation; same packlet)
 **Branch base:** `claude/ai-assist-features` (integration branch off `release`)
-**Package surface:** `@fgv/ts-extras/ai-assist`, `@fgv/ts-app-shell/ai-assist`, `.ai/instructions/LIBRARY_CAPABILITIES.md`
-**Out-of-scope:** sudoku packages, audio/video generation, the thinking-config surface (parallel stream)
+**Package surface:** `@fgv/ts-extras/ai-assist`, `.ai/instructions/LIBRARY_CAPABILITIES.md` (consumer-side `ts-app-shell/ai-assist` updates deferred to a follow-up if needed)
+**Out-of-scope:** sudoku packages, audio/video generation, the thinking-config surface (queued separately), chat-completion path
 
-**Mission.** Complete the image-generation feature properly across all four providers (OpenAI dall-e-2/3 + gpt-image-1; Google Imagen + Gemini Flash Image; xAI Grok image; openai-compat). Inventory current per-model capability divergences (size sets, quality vocabularies, reference-image support, response-format handling), design a coherent caller-facing API and registry shape, document migration impact under lockstep version policy. Phase A produces a design doc; orchestrator/user gate before phase B implementation is commissioned.
+**Mission.** Complete the image-generation feature properly across all four providers (OpenAI dall-e-2/3 + gpt-image-1; Google Imagen 4 + Gemini Flash Image; xAI grok-imagine-image/-quality; openai-compat). Phase A produced the inventory and design; signoff modified the type architecture (layered options with model-family blocks instead of unified type) and dropped deprecated models. Phase B implements per `brief-phase-b.md`.
 
-**Origin.** Personaility integration surfaced two concrete failures (`gpt-image-1` + `response_format` → 400; `dall-e-3` + `count > 1` → silent provider error) — symptoms of partial provider-surface modeling, not fix-shaped bugs.
+**Origin.** Personaility integration surfaced two concrete failures (gpt-image-1 + `response_format` → 400; dall-e-3 + `count > 1` → silent provider error) — symptoms of partial provider-surface modeling, not fix-shaped bugs.
 
-**Phase A artifacts:** `.ai/tasks/active/ai-assist-image-generation/{brief.md, state.md}` → produces `design.md`.
+**Phase B artifacts:** `.ai/tasks/active/ai-assist-image-generation/{brief.md (phase A), brief-phase-b.md (binding contract), design.md (inventory), state.md}` → produces implementation PR.
 
 ### `ai-assist-thinking-config` 🟢
 


### PR DESCRIPTION
## Summary

Closes phase A and opens phase B for `ai-assist-image-generation`. Consolidated PR: phase-A research merge (the agent's `design.md` + state.md updates from `claude/ai-image-generation-research-gtE2l`) plus the orchestrator's signoff bookkeeping (decisions log, phase-B brief, WORKSTREAMS update).

Targets the integration branch (`claude/ai-assist-features`), not `release` directly, per the cluster's integration-branch convention.

## Phase A signoff modifications

The agent's design recommended **Approach A** (unified type + registry-driven validation). The orchestrator/user review rejected this for over-indexing on compatibility on a surface that's explicitly "free hand" per `ACTIVE_DEVELOPMENT.md`. Substantive modifications:

| ID | Decision |
|---|---|
| D1 | **Layered options architecture** — generic top-level + optional `models?: IModelFamilyConfig[]` array of family-scoped blocks with `provider` discriminator and `IOtherModelOptions` escape hatch |
| D2 | **Explicit merge precedence** — generic → family-generic → model-specific ≈ Other; declaration order within tier |
| D3 | **Drop deprecated models entirely** — `imagen-3.*`, `grok-2-image-1212`, `grok-imagine-image-pro`, `imagen.negativePrompt`. Fix xAI default model. |
| D4 | **Add xAI reference image support** — new edits adapter (JSON body with `{ type: "image_url" }` objects) |
| D5 | **Skip Gemini `responseModalities`** — user empirically verified Gemini works without it; docs are stale |
| D6 | **Phase B step zero: OpenAI live-verification** via `developers.openai.com` + the in-repo image-gen sample app (the agent's training-data inventory needs confirmation) |
| D7 | **Registry simplifications** — drop several flags now handled by the layered types; replace `acceptedQualities: []` semantics with `supportsQualityParam?: boolean` |
| D8 | **Other-block precedence** — participates in merge with model-specific tier; passthrough to wire request |

`brief-phase-b.md` is the binding contract for the phase B implementing agent. `design.md` is the inventory and rationale.

## Files changed

- `.ai/tasks/active/ai-assist-image-generation/design.md` (new, from phase A merge — 893 lines)
- `.ai/tasks/active/ai-assist-image-generation/brief-phase-b.md` (new — phase B kickoff contract)
- `.ai/tasks/active/ai-assist-image-generation/state.md` (updated — phase A signoff + decisions log)
- `docs/WORKSTREAMS.md` (image-gen entry status flipped to phase-B-ready)

## Lessons-codification candidates (parked for post-merge triage)

In state.md:
- Cloud-agent harness sometimes appends random suffixes to branch names (agent's branch was `claude/ai-image-generation-research-gtE2l`, not the brief's specified name). Briefs should accommodate this.
- Don't trust docs over observed behavior on "is this currently broken" claims. Phase A flagged Gemini `responseModalities` as urgent based on docs; user empirically refuted.
- Phase A briefs should suggest fallback doc URLs (the agent hit 403 on `platform.openai.com`; `developers.openai.com` is the public alternative).

## Test plan

- [ ] Confirm `design.md` is intact (893 lines from the agent's commit)
- [ ] Confirm `brief-phase-b.md` reflects the signoff decisions accurately
- [ ] Confirm `state.md` decision-overrides table maps cleanly to the brief
- [ ] Confirm WORKSTREAMS entry shows phase-B-ready
- [ ] No production code changed in this PR (orchestrator artifacts only)

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_