### PR TITLE
docs(workflow): adopt doc-graduation discipline

### DIFF
--- a/.ai/conventions/workflow/doc-graduation.md
+++ b/.ai/conventions/workflow/doc-graduation.md
@@ -1,0 +1,144 @@
+# Convention — `convention.workflow.doc-graduation`
+
+> Adapted from the personaility-side orchestrator's doc-graduation discipline (2026-05).
+> Cross-repo consistency intentional: both orchestrators follow the same model so
+> the user only has one mental model to reason about across the two repos.
+
+A discipline for which orchestrator-authored docs graduate to `release` and which stay on a working branch. The goal is to reduce `release` history noise (every cluster shouldn't bring along every Q&A note the orchestrator produced) while keeping load-bearing artifacts findable on `release` for future readers.
+
+---
+
+## Vocabulary
+
+| fgv | personaility | Role |
+|---|---|---|
+| `release` | `working` | The shared canonical line. Buffer for clusters before promotion to `main`. |
+| `claude/orchestrator-session` | session branch | Long-lived working branch where orchestrator-authored docs accumulate before graduating (if they graduate at all). |
+| `claude/<stream>-substrate-prep` | `chore/stream-<id>-prep` | Per-stream prep branch that cherry-picks the docs the implementing agent needs. |
+| `claude/<cluster>-features` | (none — finer grain) | Cluster integration branch absorbing multiple streams' substrate before cluster-level promotion. |
+| `chore/<scope>` | same | Bookkeeping branches (cleanup batches, sweeps, amendments). |
+| `.ai/notes/cross-repo-handoffs/` | `.ai/notes/fgv-share/` | Cross-repo handoff content (inbound for fgv, outbound for personaility — same content, different home repos). |
+
+---
+
+## Default: docs stay where they're authored
+
+The orchestrator writes lots of docs in the course of a session: decision-tracks, pre-spec scoping notes, Q&A logs, lessons-codification candidates, intermediate research. **Most of these don't need to live on `release`.** They serve the current session and the next orchestrator who picks up cold; they don't need a stable URL for any downstream consumer.
+
+The defaults:
+
+- **Cross-cutting decision-tracks, Q&A logs, lessons-codification candidates** → live on `claude/orchestrator-session` under `.ai/notes/orchestrator/`. Sweep to `release` periodically (see below).
+- **Per-stream substrate** (`brief.md`, `state.md`) → live on the cluster integration branch (`claude/<cluster>-features`) via a substrate-prep PR. This IS graduation — the implementing agent reads from there.
+- **Cross-repo handoff content the other side authored** → live at `.ai/notes/cross-repo-handoffs/<topic>.md` on the integration branch where the relevant cluster lives. Graduates with the cluster.
+
+---
+
+## When a doc SHOULD graduate to `release`
+
+Three triggers:
+
+1. **A named downstream consumer needs a stable URL.** The implementing agent kicking off a stream is the canonical example — they read `brief.md` from the integration branch. Cross-repo orchestrators (when the other repo can reach this one) also count. Future-orchestrator-reading-the-substrate is a weaker case; usually they read from `release` (and may not be able to reach a working branch).
+2. **Long-term canonical architectural reference.** Load-bearing design docs future readers will need (e.g. `LIBRARY_CAPABILITIES.md`, the workflow conventions themselves). These are part of the project's public-ish surface.
+3. **Cluster close.** When a cluster's integration branch merges to `release`, all the cluster's substrate graduates with it. This is the bulk-graduation event.
+
+---
+
+## When a doc should NOT graduate
+
+- **Orchestrator-to-orchestrator handoff notes between sessions.** Live on `claude/orchestrator-session`; the next orchestrator reads them from there at session start.
+- **Pre-spec scoping drafts.** Live on session branch until they harden into a spec the implementing agent will consume (at which point the spec graduates; the deliberation that produced it does not).
+- **Decision-track notes** (Q&A with the user that resolved into committed positions). The resolution graduates with the spec; the deliberation stays on session branch.
+- **Research scratch / option-space surveys.** Live on a research agent's branch or on the session branch until a downstream consumer surfaces.
+- **Internal handoff notes** orchestrator-to-implementing-agent-via-the-user. Live on session branch; the user pulls the content into the implementing agent's kickoff prompt.
+- **Per-orchestrator-session lessons-pending notes.** Stay on session branch until they're codified (graduating to convention/skill/agent prompt) or aged out.
+
+---
+
+## Per-stream prep branch mechanic
+
+This is the main graduation path for stream kickoff docs.
+
+1. **Identify the docs the implementing agent actually needs.** Spec, stream plan, kickoff brief, any referenced design artifacts. Be precise — only what the stream consumes. Other orchestrator-side artifacts stay where they are.
+2. **Create `claude/<stream>-substrate-prep` off the cluster integration branch.** (Or `claude/<stream>-substrate-prep` off `release` if there's no cluster.)
+3. **Cherry-pick or copy the specific files / commits** for the chosen docs from the orchestrator session branch (or write them fresh on the prep branch).
+4. **Open a PR** `claude/<stream>-substrate-prep` → integration branch (or `release`). Docs-only. Merge.
+5. **The implementing agent forks their work branch** off the integration branch (now with the seeded substrate).
+6. **Once the prep PR merges, freeze the session-branch copies** if any existed. Treat the working copy as canonical. Amendments go through a follow-up PR, not edits to the session-branch copy.
+
+This pattern is already in place under the existing integration-branch model. The convention codifies it explicitly.
+
+---
+
+## Background-doc sweep pattern
+
+Docs that accumulate on `claude/orchestrator-session` with no specific consumer but represent a coherent durable record get periodic batched sweeps to `release`.
+
+Mechanic:
+
+1. Identify the set of session-branch docs that deserve graduation (lessons-codification candidates that have been codified into stable form; decision-tracks for shipped clusters; cross-stream rationale that future orchestrators will need).
+2. Create `chore/orchestrator-sweep-<date>` off `release`.
+3. Cherry-pick / copy the chosen docs onto the chore branch.
+4. Open PR `chore/orchestrator-sweep-<date>` → `release`. Squash-merge (the goal is one logical commit on release, not the per-doc commit history).
+5. Document on the session branch which docs swept and when (so future orchestrators can find what's already on release).
+
+**Sweep frequency:** at natural moments. Cluster closes; quarter ends; orchestrator hands off; convention-codification batch completes. Not on a schedule.
+
+---
+
+## Edit-during-fork risk and mitigation
+
+Once an implementing agent has forked their work branch off an integration branch (post-prep-merge), edits to the docs they're consuming on either the orchestrator-session branch or the integration branch don't reach them automatically.
+
+**Mitigation:**
+
+- After the substrate-prep PR merges, treat the session-branch copy (if any) as historical. The integration-branch copy is canonical.
+- If a mid-stream amendment is needed:
+  - Open a small follow-up PR `chore/<stream>-amend` (or `claude/<stream>-amend-substrate`) off the integration branch.
+  - Amend the doc; merge.
+  - Tell the agent to pull / merge integration into their branch.
+- Silent drift between session-branch copy and integration-branch copy is the main hazard. Discipline: after prep PR merges, edits live on integration-based branches, not session.
+
+---
+
+## Cross-repo-handoffs category
+
+When a cross-repo orchestrator (e.g. the personaility orchestrator) needs to read content that fgv produces but personaility's tooling can't reach this repo, the staging location is `.ai/notes/cross-repo-handoffs/<topic>.md` and the user copies content out via whatever cross-repo mechanism is available (chat paste, manual copy, etc.).
+
+The mirror case (fgv consuming what personaility produces) lands the inbound handoff at the same path on fgv's side, sanitized to remove consumer-specific naming where appropriate.
+
+Either direction: the doc is committed and durable; cross-repo orchestrators reference it via the user as the transport.
+
+---
+
+## Where docs live — quick reference
+
+| Doc type | Lives on |
+|---|---|
+| Per-stream `brief.md`, `state.md` | Cluster integration branch (graduated via substrate-prep PR) |
+| `design.md` produced by phase-A agent | Cluster integration branch (graduated when phase-A PR merges) |
+| `WORKSTREAMS.md` entries | Cluster integration branch (or `release` for non-cluster streams) |
+| Cross-repo handoff received | Cluster integration branch under `.ai/notes/cross-repo-handoffs/` |
+| Orchestrator session-state, decision-tracks | `claude/orchestrator-session` under `.ai/notes/orchestrator/` |
+| Lessons-codification candidates (pre-codification) | `claude/orchestrator-session` |
+| Convention docs (codified) | `release` (via `chore/` PR) |
+| Skill definitions (codified) | `release` (via `chore/` PR) |
+| Orchestrator agent prompt (`.claude/agents/orchestrator.md`) | `release` |
+| Completed-stream archive (`.ai/tasks/completed/`) | `release` (graduated with the cluster's integration-branch merge) |
+
+---
+
+## Anti-patterns
+
+- **Graduating every orchestrator doc.** `release` history balloons; future readers can't tell which docs were load-bearing vs scratch.
+- **Editing session-branch copies after their integration-branch graduation.** Silent drift; edits don't reach the consumer.
+- **Sweeping research scratch to release.** Use the sweep pattern only for durable artifacts that future orchestrators will benefit from. Scratch stays on session branch until aged out.
+- **Skipping the cross-repo-handoffs/ archive.** Inbound handoffs that aren't archived become unrecoverable when the originating cluster closes.
+
+---
+
+## Relationship to other conventions
+
+- **`branch-buffer-and-promotion.md`** — the buffer-and-canonical-line model; this convention is about WHAT lives on the buffer, not the mechanics of promoting it.
+- **`artifact-protocol.md`** — task-artifact lifecycle (`.ai/tasks/active/` → `completed/`); this convention overlaps for stream substrate but covers broader doc categories too.
+- **`kickoff-prompt-shape.md`** — what a stream kickoff prompt contains; this convention is about where it lives before / after handoff.
+- **`lessons-codification-triage.md`** — what to do with lessons; this convention is about where lessons-pending notes live before they're triaged.

--- a/.ai/notes/orchestrator/README.md
+++ b/.ai/notes/orchestrator/README.md
@@ -1,0 +1,52 @@
+# Orchestrator session notes
+
+This directory exists on the long-lived branch `claude/orchestrator-session` (branched off `release`), not on `release` itself. On `release`, this README serves as the structural marker — future orchestrators reading from a `release` checkout know where to find the live working notes.
+
+## What lives here (on the session branch)
+
+Cross-cutting orchestrator-authored content that doesn't have a named downstream consumer requiring a stable URL on `release`:
+
+- **Decision-tracks** — Q&A logs and deliberation that resolved into committed positions. The resolution graduates with the relevant spec or convention; the deliberation that produced it stays here.
+- **Pre-spec scoping drafts** — early framing notes for streams not yet substrate-prepped.
+- **Lessons-codification candidates** — items observed during stream runs that are candidates for becoming conventions, skills, or agent-prompt updates. Live here until triaged; triage either codifies them (graduating to `release` via a `chore/` PR) or ages them out.
+- **Cross-stream rationale** — design choices that span multiple streams and don't fit cleanly in any one stream's `state.md`.
+- **Orchestrator handoff notes** between sessions — context for the next orchestrator session to read at start.
+
+## What does NOT live here
+
+- Per-stream substrate (lives on cluster integration branch via substrate-prep PR)
+- Cross-repo handoffs (live at `.ai/notes/cross-repo-handoffs/` on the relevant cluster integration branch)
+- Codified conventions (live at `.ai/conventions/workflow/` on `release`)
+- Codified skills (live at `.claude/skills/` on `release`)
+
+## Lifecycle
+
+Notes live on the session branch until one of:
+
+1. **Codified** — promoted into a stable form (convention doc, skill, agent-prompt update); graduates to `release` via a `chore/` PR; the session-branch copy can be marked obsolete or removed.
+2. **Aged out** — no longer relevant; eventually pruned.
+3. **Swept** — durable historical record (e.g. cluster-close decision-track) batched-graduated to `release` via `chore/orchestrator-sweep-<date>` PR. Squash-merged so the per-doc commit history doesn't pollute `release`.
+
+See `.ai/conventions/workflow/doc-graduation.md` for the full discipline.
+
+## Finding the session branch
+
+```bash
+git fetch origin claude/orchestrator-session
+git checkout claude/orchestrator-session
+ls .ai/notes/orchestrator/
+```
+
+If the branch doesn't exist on the remote, no notes have been written yet (or the previous orchestrator session never created/pushed it). Future orchestrators may create the branch on first use.
+
+## Naming conventions
+
+Files in this directory:
+
+- `lessons-pending.md` — single rolling document of lessons-codification candidates
+- `decision-tracks/<topic>.md` — per-topic Q&A and deliberation
+- `pre-spec/<feature>.md` — early framing for streams not yet substrate-prepped
+- `cross-stream/<topic>.md` — design rationale spanning multiple streams
+- `handoffs/<YYYY-MM>-to-<role>.md` — orchestrator-session handoff notes
+
+Not prescriptive — adapt as needed. Subdirectories or flat structure both fine.

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -40,9 +40,13 @@ Before doing anything, read these — they carry the conventions your predecesso
 - `docs/WORKSTREAMS.md` preamble (repo shape, branch flow, status conventions, stream entry shape, shared types, artifact protocol)
 - `docs/CHORES.md` (current active batch shape + completed precedents; trigger taxonomy)
 - `.ai/BASELINE.md` (last `release` → `main` promotion — used for blast-radius sizing, not as a stream-start gate)
+- `.ai/conventions/workflow/doc-graduation.md` (which docs live where; the discipline for what graduates to `release` vs stays on `claude/orchestrator-session`)
 - Cross-cutting design docs in `docs/` relevant to the work in flight
 
-Then check `.ai/tasks/active/` for in-flight task artifacts before starting any new orchestration work.
+Then check both surfaces for in-flight context:
+
+- `.ai/tasks/active/` for in-flight task artifacts
+- `claude/orchestrator-session` branch (if it exists on remote) for orchestrator-side decision-tracks, lessons-pending, and handoff notes from the previous session. See `.ai/notes/orchestrator/README.md` (on `release`) for the structure.
 
 ## Workflow shapes
 
@@ -66,8 +70,8 @@ Full workflow procedures: `.ai/conventions/workflow/` and `docs/DESIGN_PROCESS.m
 
 1. Load `/workstream-brief` for the stream ID.
 2. Verify package-surface / file-boundary collision avoidance against any other in-flight parallel streams.
-3. Branch base is current `release` HEAD (no shared "wave base" — see WORKSTREAMS.md preamble).
-4. Commit `brief.md` + empty `state.md` to `.ai/tasks/active/<stream-id>/`.
+3. Branch base is current `release` HEAD (no shared "wave base" — see WORKSTREAMS.md preamble) or cluster integration branch if the stream is part of a cluster.
+4. Commit `brief.md` + empty `state.md` to `.ai/tasks/active/<stream-id>/` via a substrate-prep branch + PR per `.ai/conventions/workflow/doc-graduation.md` § "Per-stream prep branch mechanic". After the prep PR merges, treat the substrate as canonical on the integration branch; later amendments use a follow-up `chore/<stream>-amend` PR, not edits to a session-branch copy.
 5. Deliver kickoff prompt paste-ready: mission, package surface, in/out-of-scope paths, required reading, skills to load (with trigger conditions), missing-input rule, phases, acceptance criteria, exit artifact shape, resume protocol.
 
 ### Chore-batch kickoff
@@ -113,6 +117,14 @@ Post-merge: run sibling-sweep as a **fresh agent**, not the implementing agent. 
 ### Delegating capture to a scribe session
 
 When the user is doing manual testing or posting batches of findings: suggest spinning up a fresh sub-agent session in scribe mode — mirrors the four-bucket sort, writes per-file inbox entries, proposes routings. Token-cheap. Delegate rather than handling each finding inline.
+
+### Doc graduation and session-branch hygiene
+
+Per `.ai/conventions/workflow/doc-graduation.md`: the default is that orchestrator-authored docs stay on `claude/orchestrator-session`, not on `release`. Only docs with a named downstream consumer requiring a stable URL graduate to `release` (or to a cluster integration branch). Substrate (`brief.md`, `state.md`) graduates via substrate-prep PR; cross-cutting decision-tracks, lessons-pending notes, and pre-spec drafts live on the session branch under `.ai/notes/orchestrator/`.
+
+Periodic sweeps from session branch to `release` via `chore/orchestrator-sweep-<date>` (squash-merged) at natural moments (cluster close; orchestrator handoff; codification batch complete).
+
+After a substrate-prep PR merges, the integration-branch copy is canonical. Subsequent amendments use a follow-up `chore/<stream>-amend` PR; don't edit the session-branch copy and expect those edits to reach the agent.
 
 ### `release` → `main` promotion
 


### PR DESCRIPTION
## Summary

Adopt the personaility-side orchestrator's doc-graduation discipline, adapted to fgv-side vocabulary. Cross-repo consistency intentional: both orchestrators follow the same model so you have one mental model when context-switching.

## What changes

| Aspect | Before | After |
|---|---|---|
| Cross-cutting decision-tracks | Lived only in chat; no durable home | Live on `claude/orchestrator-session` under `.ai/notes/orchestrator/` |
| Lessons-pending notes | Buried in per-stream `state.md` files | Centralized on session branch; periodic sweep to `release` when codified |
| Pre-spec scoping drafts | Same | Live on session branch until they harden into a substrate |
| Per-stream substrate-prep | Already substrate-prep → integration-branch pattern | Codified explicitly with vocabulary aligned to personaility's convention |
| Edit-during-fork hazard | Implicit risk; sometimes I'd amend state.md after agent forked | Explicit discipline: after substrate-prep merges, use `chore/<stream>-amend` PRs; don't edit session copy |
| Background-doc sweep | No formal pattern | `chore/orchestrator-sweep-<date>` squash-merged at natural moments |

## Vocabulary

| fgv | personaility |
|---|---|
| `release` | `working` |
| `claude/orchestrator-session` | session branch |
| `claude/<stream>-substrate-prep` | `chore/stream-<id>-prep` |
| `claude/<cluster>-features` | (not directly; finer-grain on their side) |
| `.ai/notes/cross-repo-handoffs/` | `.ai/notes/fgv-share/` (mirror image) |

## Files

- `.ai/conventions/workflow/doc-graduation.md` — the convention itself
- `.ai/notes/orchestrator/README.md` — structural marker on `release` pointing at where session-branch notes live
- `.claude/agents/orchestrator.md` — updated read-on-session-start list, stream-kickoff procedure, new "doc graduation" common-operation section

## Follow-up after merge

- Create `claude/orchestrator-session` branch off post-merge `release` HEAD; push to origin
- First content: a `.ai/notes/orchestrator/lessons-pending.md` draft capturing the lessons-codification candidates accumulated across the ai-assist + crypto-batch-2 cluster work so far (parallel-phase-A-when-pattern-feeds-each-other; cloud-agent-branch-name-suffix; don't-trust-docs-over-observed-behavior; cross-repo-handoff-shape)
- Eventual sweep to `release` when the clusters close

## Test plan

- [ ] Read the convention end-to-end for internal consistency
- [ ] Confirm the vocabulary table maps cleanly to existing fgv-side branch naming
- [ ] Confirm `.claude/agents/orchestrator.md` updates don't conflict with existing workflow shapes

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_