### PR TITLE
chore(ai-assist-cluster): cluster-close prep

### DIFF
--- a/.ai/tasks/completed/2026-05/ai-assist-image-generation/README.md
+++ b/.ai/tasks/completed/2026-05/ai-assist-image-generation/README.md
@@ -1,0 +1,103 @@
+# ai-assist-image-generation — completed
+
+**Stream ID:** ai-assist-image-generation
+**Bucket:** 2026-05
+**PR:** [#329](https://github.com/ErikFortune/fgv/pull/329) — `feat(ai-assist): layered image generation options architecture (Phase B)`
+**Merge commit:** `e936fd15f` (into `claude/ai-assist-features` integration branch)
+**Phase B branch:** `claude/implement-image-generation-m7xMi`
+**Cross-repo consumer:** the consumer project surfaced the originating bugs; published once `claude/ai-assist-features` lands on `release` (cluster close) and is mirrored to `prerelease` for the next alpha cut
+
+## What shipped
+
+Complete reshape of the image-generation feature across all four providers (OpenAI, Google, xAI, openai-compat). The reshape was triggered by two concrete bugs reported by the consumer (`gpt-image-1` + `response_format` → 400; `dall-e-3` + `count > 1` → silent provider error) but the underlying cause was partial provider-surface modeling — the existing types and registry didn't capture per-model capability divergence. The fix is structural.
+
+### Core architecture: layered options
+
+`IAiImageGenerationOptions` gains an optional `models?: ReadonlyArray<IModelFamilyConfig>` array of family-scoped config blocks discriminated on `provider` + `family`. The merge function applies four precedence tiers:
+
+1. Generic top-level options (`size`, `count`, `quality`, etc.)
+2. Family-generic blocks (provider+family match, `models` field omitted)
+3. Model-specific blocks (`models` array includes the resolved model)
+4. Other-blocks (escape hatch via `IOtherModelOptions`, raw `JsonObject` passthrough)
+
+Later tier wins; within tier, declaration order wins. Provider/family-mismatch blocks silently skipped during filtering. The merge function returns `Result<IResolvedImageOptions>` for caller-side Result-chaining.
+
+### Per-family config types
+
+- `IDallEImageGenerationConfig` — DallE-family (dall-e-2, dall-e-3): style, response_format vocabulary
+- `IGptImageGenerationConfig` — gpt-image-1 family: output_format, background, moderation
+- `IGrokImagineImageGenerationConfig` — xAI Imagine family: aspect_ratio (not size pixel strings)
+- `IImagen4GenerationConfig` — Google Imagen 4 family
+- `IGeminiFlashImageGenerationConfig` — Gemini Flash Image
+- `IOtherModelOptions` — escape hatch for unknown models; `models: string[]` required, `config: JsonObject` untyped passthrough
+
+### Registry simplifications
+
+`IAiImageModelCapability` shape on `IAiProviderDescriptor.imageGeneration` carries: `modelPrefix`, `format`, `acceptsImageReferenceInput`, `acceptedSizes`, `supportsQualityParam` (replaces opaque `acceptedQualities: []` semantics), `acceptedQualities`, `maxCount`, `outputParamStyle` (`'response-format' | 'output-format' | 'none'`), `defaultOutputMimeType`. Dispatcher pre-validates caller params against capability fields and fails fast with contextual messages.
+
+### Wire encoder changes
+
+- **OpenAI `/images/generations` + `/images/edits`**: conditional `response_format` vs `output_format` based on `outputParamStyle` (fixes `gpt-image-1` 400)
+- **xAI new adapter** (`callXaiImageGeneration` + `callXaiImagesEdits`): sends `aspect_ratio` not `size`; edits use JSON body with `{type: "image_url"}` objects (NOT multipart — different wire format from OpenAI's edits)
+- **Gemini `:generateContent`**: `aspectRatio` in `generationConfig` when set
+- **Imagen `:predict`**: full Imagen 4 params; `negativePrompt` removed (Imagen 3 feature; deprecated with Imagen 3 retirement)
+
+### Deprecated models dropped (D3)
+
+- `imagen-3.*` — slated for shutdown June 24-30, 2026
+- `grok-2-image-1212` — already deprecated Feb 28, 2026
+- `grok-imagine-image-pro` — deprecated May 15, 2026
+- `imagen.negativePrompt` field — obsolete with Imagen 3 retirement
+
+xAI `defaultModel.image` updated `grok-2-image-1212` → `grok-imagine-image-quality` (the previous default was already broken).
+
+## Key decisions (signed off pre-implementation)
+
+| ID | Decision |
+|---|---|
+| D1 | Layered options architecture (NOT Approach A unified; NOT Approach B per-model discrimination) |
+| D2 | 4-tier merge precedence: generic → family-generic → model-specific ≈ Other |
+| D3 | Drop deprecated models entirely (no migration path) |
+| D4 | xAI reference images via JSON body, dedicated edits adapter |
+| D5 | Do NOT add `responseModalities: ["IMAGE"]` to Gemini Flash — user empirically verified the docs are stale on this point |
+| D6 | OpenAI live-verification step zero before encoding registry constants (training-data inventory needed confirmation) |
+| D7 | `supportsQualityParam?: boolean` replaces `acceptedQualities: []` for self-documenting registry shape |
+| D8 | `IOtherModelOptions` escape hatch with `JsonObject` passthrough |
+
+## Acceptance status
+
+- [x] All four providers implemented (OpenAI dall-e-2/3, gpt-image-1; Google Imagen 4 + Gemini Flash; xAI Imagine; openai-compat)
+- [x] Layered options types compile, pass api-extractor
+- [x] 4-tier merge precedence: 57 tests in `imageOptionsResolver.test.ts`
+- [x] Runtime validator rejects per-model invalid values with contextual messages
+- [x] Wire encoders for all active models × supported endpoints (43 tests in `apiClient.imageGeneration.test.ts`)
+- [x] xAI reference-image edits adapter produces correct JSON body shape
+- [x] `gpt-image-1` no longer 400s on `response_format`
+- [x] Gemini Flash does NOT include `responseModalities` (per D5)
+- [x] `rushx build` + `rushx test` pass; 100% coverage in `ts-extras`
+- [x] No `any` types; all fallible operations return `Result<T>`
+- [x] `LIBRARY_CAPABILITIES.md` updated
+- [x] Pre-merge artifact migration done (this PR finishes that with the README)
+- [x] PR merged to `claude/ai-assist-features` (integration branch)
+
+## Tech debt surfaced during code review (logged to TECH_DEBT.md)
+
+Reviewer pass on PR #329 absolved pre-existing patterns from this stream's scope but recorded them for future cleanup:
+
+- **P2**: `try/catch` + `instanceof-Error` boilerplate at apiClient.ts lines ~158, 217, 272, 316. Each carries a `c8 ignore` directive suppressing untestable catch branches. `captureAsyncResult()` is the right replacement; the `c8 ignore` becomes unnecessary. **Trigger**: next time apiClient.ts is open for substantive changes.
+- **P3**: `resolveImageCapability` in `registry.ts:328-339` returns `| undefined` instead of `Result<IAiImageModelCapability>`. Returning Result with a contextual error would let callers chain off failure cleanly. **Trigger**: next substantive change to the provider registry or capability resolution path.
+
+Both entries landed as part of cluster-close prep, alongside this README.
+
+## Followups / lessons for orchestration
+
+- Cloud-agent harness auto-suffixes work-branch names (`claude/implement-image-generation-m7xMi`). Briefs should accommodate this rather than specifying exact names.
+- The signed-off layered architecture differs substantially from the phase A agent's Approach A recommendation. Signoff modifications can be substantial when the design is correct on inventory but off on architecture; the orchestrator+user review pass is what catches this. Lesson: trust the orchestrator review gate even when the design looks polished.
+- `responseModalities` ghost finding (phase A flagged it as urgent based on docs; user empirically refuted): don't trust docs over observed behavior on "is this currently broken" claims. Future design phases should include live-test verification for any "broken path" claim before flagging urgency.
+
+## Source artifacts
+
+- [`brief.md`](./brief.md) — phase A kickoff brief
+- [`brief-phase-b.md`](./brief-phase-b.md) — phase B binding contract (post-signoff)
+- [`design.md`](./design.md) — phase A research and design inventory
+- [`state.md`](./state.md) — implementing agent terminal state

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -35,11 +35,29 @@ opportunistically when the right surface area is touched.
 
 ## P2 — Fix before next major feature in affected area
 
-*(None.)*
+- **[P2] Replace try/catch + instanceof-Error boilerplate in `ai-assist/apiClient.ts` with `captureAsyncResult`.**
+  Four identical `catch (err: unknown) { const detail = err instanceof Error ? err.message : String(err); return fail(...detail...); }` blocks at lines ~158, 217, 272, 316. Each carries a `/* c8 ignore next 1 - defensive: fetch errors are always Error instances in practice */` directive to suppress the untestable catch branch — a signal that `captureAsyncResult()` is the right replacement. `captureAsyncResult` handles the `Error`-vs-string normalisation internally and makes the `c8 ignore` directives unnecessary.
+
+  **Trigger**: next time `apiClient.ts` is open for substantive changes (e.g. adding a new provider).
+
+  **Scope sketch**: wrap each `try { response = await fetch(...) } catch` block with `captureAsyncResult(() => fetch(...))`, then chain `.withErrorFormat((msg) => \`AI API request failed: ${msg}\`)`. The `c8 ignore` directives on the catch lines can be removed once the blocks are gone.
+
+  **Not a P3**: the `c8 ignore` directives are suppressing real untestability; the boilerplate pattern appears four times and will grow with each new provider endpoint.
+
+  **Reference**: PR #329 review — patterns pre-existed the PR, absolved from that review.
 
 ## P3 — Opportunistic cleanup
 
-*(None.)*
+- **[P3] `resolveImageCapability` in `ai-assist/registry.ts` returns `| undefined` instead of `Result<IAiImageModelCapability>`.**
+  `registry.ts:328–339`. The function returns `undefined` when no capability matches `modelId`, silently swallowing the "unknown model" case. Callers must null-check rather than chain. Returning `Result<IAiImageModelCapability>` with a contextual error message would let callers propagate the failure cleanly.
+
+  **Trigger**: next substantive change to the provider registry or capability resolution path.
+
+  **Scope sketch**: change return type to `Result<IAiImageModelCapability>`; return `fail(\`model '${modelId}' not found in provider '${descriptor.name}' image capabilities\`)` when the reduce produces `undefined`; update call sites (primarily in `apiClient.ts`) to chain off the result.
+
+  **Not a P2**: the function is currently only called in contexts that already handle `undefined` defensively; behaviour is correct, just non-idiomatic.
+
+  **Reference**: PR #329 review — pattern pre-existed the PR, absolved from that review.
 
 ## P4 — Doc / minor consistency
 

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -128,40 +128,10 @@ substrate. Don't queue streams against them here.
 
 ## Active workstreams
 
-*(No active workstreams.)*
-
-### `ai-assist-image-generation` 🟢
-
-**Status:** 🟢 phase B (implementation) ready to start; phase A complete + signed off
-**Phase B sequencing:** strictly before `ai-assist-thinking-config` phase B (serial implementation; same packlet)
-**Branch base:** `claude/ai-assist-features` (integration branch off `release`)
-**Package surface:** `@fgv/ts-extras/ai-assist`, `.ai/instructions/LIBRARY_CAPABILITIES.md` (consumer-side `ts-app-shell/ai-assist` updates deferred to a follow-up if needed)
-**Out-of-scope:** sudoku packages, audio/video generation, the thinking-config surface (queued separately), chat-completion path
-
-**Mission.** Complete the image-generation feature properly across all four providers (OpenAI dall-e-2/3 + gpt-image-1; Google Imagen 4 + Gemini Flash Image; xAI grok-imagine-image/-quality; openai-compat). Phase A produced the inventory and design; signoff modified the type architecture (layered options with model-family blocks instead of unified type) and dropped deprecated models. Phase B implements per `brief-phase-b.md`.
-
-**Origin.** Personaility integration surfaced two concrete failures (gpt-image-1 + `response_format` → 400; dall-e-3 + `count > 1` → silent provider error) — symptoms of partial provider-surface modeling, not fix-shaped bugs.
-
-**Phase B artifacts:** `.ai/tasks/active/ai-assist-image-generation/{brief.md (phase A), brief-phase-b.md (binding contract), design.md (inventory), state.md}` → produces implementation PR.
-
-### `ai-assist-thinking-config` 🟢
-
-**Status:** 🟢 phase B (implementation) ready — v2 design signed off and merged ([#332](https://github.com/ErikFortune/fgv/pull/332))
-**Phase B sequencing:** strictly after `ai-assist-image-generation` phase B (#329) merges to the integration branch (collision avoidance — same packlet)
-**Branch base:** `claude/ai-assist-features` (integration branch off `release`)
-**Package surface:** `@fgv/ts-extras/ai-assist`, `.ai/instructions/LIBRARY_CAPABILITIES.md` (consumer-side `ts-app-shell/ai-assist` updates deferred to a follow-up if needed)
-**Out-of-scope:** sudoku packages, image-generation surface (predecessor stream), thinking-event surfacing (followup stream `ai-assist-thinking-events`)
-
-**Mission.** Complete thinking/reasoning-model support across all four providers. Phase A v2 produced the layered-architecture design (analogous to image-gen's pattern); phase B implements it. Includes: layered `IThinkingConfig` types, merge function + runtime validator, per-provider wire encoders, registry signaling additions, unconditional Anthropic non-streaming validator fix, xAI registry staleness cleanup. Step zero is live verification of three provider-API specifics (xAI temperature rejection, Gemini token budget defaults, Anthropic Sonnet 4.5 wire format).
-
-**Origin.** Cross-repo consumer integration surfaced thinking-model 400s; downstream of completing the feature properly across all providers.
-
-**Phase B artifacts:** `.ai/tasks/active/ai-assist-thinking-config/{brief.md (phase A v1 contract), brief-phase-a-v2.md (v2 commission), brief-phase-b.md (binding phase B contract), design.md (v2 layered architecture), design-v1.md (archived research reference), state.md}` → produces implementation PR.
-
 ### `ai-assist-thinking-events` 🟡
 
 **Status:** 🟡 ready; sequencing after `ai-assist-thinking-config` phase B lands
-**Branch base:** `claude/ai-assist-features` (integration branch off `release`) or a future cluster integration branch if this one merges first
+**Branch base:** `release` HEAD after the ai-assist cluster lands (`.ai/tasks/completed/2026-05/ai-assist-thinking-config/` and `ai-assist-image-generation/` available as reference)
 **Package surface:** `@fgv/ts-extras/ai-assist` (streaming adapters, model.ts, apiClient.ts), `@fgv/ts-app-shell/ai-assist`, `.ai/instructions/LIBRARY_CAPABILITIES.md`
 **Out-of-scope:** the core thinking-config architecture (already shipped via `ai-assist-thinking-config`); sudoku packages
 
@@ -178,13 +148,27 @@ Design-triage-implement shape is likely; new public API has real consequences. S
 
 **Phase A artifacts:** TBD when stream is commissioned; will live at `.ai/tasks/active/ai-assist-thinking-events/`.
 
-### Integration branch convention (active for the ai-assist cluster)
-
-Both ai-assist streams (and any followups within the cluster) share an integration branch `claude/ai-assist-features` based off `release`. Each phase PRs into the integration branch, not `release`, to keep `release` history grouped at one cohesive cluster-level merge. The integration branch merges to `release` at the end of the cluster after all stream artifacts have migrated to `completed/`. This is a per-cluster pattern, not a default — single-stream features can continue to PR directly to `release`.
-
 ---
 
 ## Completed workstreams
+
+### `ai-assist-thinking-config` ✅
+
+**Status:** ✅ shipped — merged in [#334](https://github.com/ErikFortune/fgv/pull/334) into `claude/ai-assist-features` integration branch; phase A v2 design in [#332](https://github.com/ErikFortune/fgv/pull/332); commission prep in [#330](https://github.com/ErikFortune/fgv/pull/330) + [#333](https://github.com/ErikFortune/fgv/pull/333); phase B branch `claude/ai-assist-thinking-phase-b-aIY1Y`
+**Package surface:** `@fgv/ts-extras/ai-assist`, `.ai/instructions/LIBRARY_CAPABILITIES.md`
+
+**What shipped.**
+- Layered thinking-config architecture: `IThinkingConfig` with generic `effort?: 'low' | 'medium' | 'high'` + `providers?: ReadonlyArray<IThinkingProviderConfig>` array of per-provider blocks (Anthropic, OpenAI, Google, xAI, Other escape hatch). Per-provider configs expose full provider knobs first-class (Anthropic `'max'`, OpenAI `'xhigh'`/`'none'`/`'minimal'`, Gemini `thinkingBudget`, xAI `'none'`)
+- `thinkingOptionsResolver.ts`: 4-tier merge logic + `checkTemperatureConflict` (temperature + thinking = `Result.fail` on Anthropic / OpenAI non-'none' / xAI conservative; Gemini accepts both)
+- Registry signaling: `AiModelCapability` + `ModelSpecKey` gain `'thinking'`; `IAiProviderDescriptor.thinkingMode` (`'optional'`/`'required'`/`'unsupported'`); capability rules per provider
+- xAI registry staleness fix: retired `grok-4-1-fast`/`grok-4-1-fast-reasoning` removed; defaults updated to `grok-4.3`
+- Anthropic non-streaming validator fix: `extractAnthropicText` used unconditionally (handles thinking blocks, tools, plain text)
+- All four chat-completion paths (non-streaming + streaming) updated with thinking wire encoding; proxy passthrough wired
+- OpenAI `'none'` edge case correctly handled: setting `effort: 'none'` on gpt-5.x disables reasoning AND accepts temperature
+
+**Followup**: `ai-assist-thinking-events` (queued; thinking-event surfacing to callers; the `includeThoughts?: boolean` field placed but inert in this stream gets wired up there)
+
+**Artifacts:** `.ai/tasks/completed/2026-05/ai-assist-thinking-config/`
 
 ### `ai-assist-image-generation` ✅
 


### PR DESCRIPTION
## Summary

Final cluster-close prep for the ai-assist cluster before opening the `claude/ai-assist-features → release` PR. Three items:

1. **Polished `README.md` for `.ai/tasks/completed/2026-05/ai-assist-image-generation/`** — the image-gen agent migrated brief/design/state but didn't write the separate README per artifact-protocol. Lands the polished entry-point doc for future readers. Compare with the `ai-assist-thinking-config` README that the thinking-config agent did write.

2. **`docs/WORKSTREAMS.md` bookkeeping** — Active section was carrying stale entries:
   - Removed duplicate `ai-assist-image-generation` Active 🟢 entry (already in Completed ✅ since #329's merge)
   - Moved `ai-assist-thinking-config` from Active 🟢 to Completed ✅ with #334 merge details
   - Removed the integration-branch convention note (cluster is closing; the convention generalizes via `.ai/conventions/workflow/doc-graduation.md` pending #331's merge to release)
   - Kept `ai-assist-thinking-events` 🟡 in Active (carries forward as the queued followup)

3. **Tech-debt cherry-pick from #329 review** — cherry-picked `63865a4cd` (the reviewer-authored TECH_DEBT entries from `claude/review-ai-image-generation-BKpOu`). Reviewer cited:
   - **P2**: try/catch + `instanceof-Error` boilerplate at `apiClient.ts` lines ~158, 217, 272, 316 — verified still present post-#329's iteration; the implementer's P2 fixes during review addressed other items, not this pattern
   - **P3**: `resolveImageCapability` returning `| undefined` instead of `Result<T>` at `registry.ts:328-339` — verified still present
   
   Preserved as a distinct commit (separate from my orchestrator commit) so authorship is clean.

## Files changed

- `.ai/tasks/completed/2026-05/ai-assist-image-generation/README.md` (new)
- `docs/WORKSTREAMS.md` (Active/Completed restructure)
- `docs/TECH_DEBT.md` (via the cherry-picked tech-debt commit)

## Next

After this merges, I open `claude/ai-assist-features → release` as the cluster's final merge PR. You push the merge button on that one.

## Test plan

- [ ] image-gen README content reflects what shipped
- [ ] WORKSTREAMS Active section now contains only `ai-assist-thinking-events` 🟡
- [ ] WORKSTREAMS Completed section has all three: image-gen, thinking-config, auth-primitives-batch1
- [ ] TECH_DEBT P2 and P3 entries are present
- [ ] No production code changed in this prep PR

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_