### PR TITLE
docs(workflow): tighten lint gate as first-class acceptance criterion

### DIFF
--- a/.ai/instructions/CODING_STANDARDS.md
+++ b/.ai/instructions/CODING_STANDARDS.md
@@ -507,3 +507,47 @@ const value = input || 'default'; // Wrong if 0 or '' are valid
 - Look for similar code in the codebase and follow its patterns
 - Use existing helper functions rather than creating new ones
 - Check if a Converter, Validator, or type guard already exists
+
+---
+
+## Pre-PR Validation Checklist
+
+**Before opening any PR, run the full local validation suite** in every modified package:
+
+```bash
+rushx build    # compile + emit
+rushx lint     # ESLint
+rushx test     # Jest with coverage gates
+```
+
+All three must pass. CI catches what's left, but the local feedback loop is faster and catches issues before reviewers see them.
+
+### `rushx lint` is a first-class gate
+
+`rushx build` does **not** transitively run lint in this monorepo's Heft config. Lint is a separate gate. PRs have repeatedly merged with passing build + tests but failing lint, blocking downstream cluster merges. Treat lint as mandatory, not optional.
+
+If `rushx lint` reports rule violations:
+- **Run `rushx fixlint` first.** It autofixes the mechanical class of errors (formatting, unused-import sort, missing semicolons, many style rules).
+- For violations the autofix can't resolve, fix manually — **do not disable rules to make lint pass**. If a rule genuinely shouldn't apply, surface as an open question to the orchestrator rather than adding an inline disable directive.
+
+### Acceptance criteria for any stream's exit
+
+Every stream's acceptance criteria list must include:
+
+- [ ] `rushx build` passes in every modified package
+- [ ] **`rushx lint` passes in every modified package** *(load-bearing — not transitively run by build)*
+- [ ] `rushx test` passes with 100% coverage in every modified package
+- [ ] **`rushx fixlint` was run before the final commit** *(catches the mechanical class)*
+- [ ] No `any` types; all fallible operations return `Result<T>`
+
+The bolded items above are the gap recently codified — multiple recent streams had lint failures escape into PR-open state, blocking cluster merges.
+
+### Why this gate is load-bearing
+
+Lint errors break CI. When a cluster integration branch tries to merge to `release`, a single per-stream lint failure blocks the whole cluster. The cost compounds: the cluster-close prep PR can't merge, the integration-to-release PR can't merge, and any downstream consumer waiting for the alpha gets delayed.
+
+The local cost of running lint is ~5-10 seconds per package. The downstream cost of skipping it is potentially hours of orchestrator + agent time unwinding a blocked merge.
+
+### For orchestrators
+
+When reviewing an implementing agent's PR before merge (or before bundling into a cluster-close prep), call `mcp__github__pull_request_read` with `method: get_check_runs` and refuse to advance the workflow if any check is `conclusion: failure`. Do this **before** opening downstream prep/promotion PRs — once a failed-CI commit is in the integration branch, unwinding is painful.

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -84,6 +84,16 @@ Compose following the interleaved-per-item shape from `.ai/conventions/workflow/
 2. Verify phase B (bundle drop) is clean before drafting the kickoff.
 3. Hold the phase-C completion gate: present all four triage outputs to the user for sign-off before launching phase D. Gate is real — the user may surface a change.
 
+### Reviewing an agent PR before merge / bundling
+
+Before advancing the workflow (merging the PR, bundling it into a cluster-close prep, opening the cluster→release promotion PR):
+
+1. **Call `mcp__github__pull_request_read` with `method: get_check_runs`.** Refuse to advance if any check is `conclusion: failure`. This catches lint failures, test failures, or coverage-gate breaks that the agent may have missed in their local run. Lint is a particular hot spot — `rushx build` does NOT transitively run lint in this monorepo, so an agent's "build passes" claim doesn't cover it.
+2. **If CI is red**: send back to the agent with the failing check's URL. The fix is the agent's, not the orchestrator's (unless the lint failure is one-line-mechanical and the agent has otherwise wrapped up the stream).
+3. **Once CI is green**: proceed with the merge / bundling / promotion as planned.
+
+This is a hard precondition because once a failed-CI commit is in the integration branch, unwinding (revert, re-prep, re-promote) is painful. Pre-merge gating is the cheap path.
+
 ### Post-merge bookkeeping
 
 1. Flip the stream's status marker in `docs/WORKSTREAMS.md` to ✅.
@@ -152,10 +162,11 @@ Every kickoff prompt (stream or chore-batch) must include:
 - [ ] Missing-input rule: STOP if a required input is missing; do NOT recreate it from codebase exploration
 - [ ] Dependencies (hard and soft)
 - [ ] Phases with sub-steps
-- [ ] Acceptance criteria (exit gates)
+- [ ] Acceptance criteria (exit gates) — **must include `rushx build`, `rushx lint`, AND `rushx test` per `.ai/instructions/CODING_STANDARDS.md` § Pre-PR Validation Checklist. Lint is NOT transitively run by build; it's a separate gate that has repeatedly escaped acceptance criteria when only build+test were listed.**
 - [ ] Required exit artifact (`result.md` shape)
 - [ ] Resume protocol (read brief + state.md)
 - [ ] Branch + PR posture
+- [ ] Pre-PR `rushx fixlint` run noted as an implementer-aid (catches the mechanical class of lint errors automatically)
 
 ## Artifact substrate
 


### PR DESCRIPTION
## Summary

Tightens guidance to prevent the lint-failure-escapes-acceptance pattern that just blocked the ai-assist cluster merge (PR #336). Multiple recent streams (#329, #334) and now the cluster have had lint failures slip into PR-open or post-merge state because acceptance criteria only required `rushx build` and `rushx test`. `rushx build` does **not** transitively run lint in this monorepo's Heft config — lint is a separate gate.

Compounding cost: a single per-stream lint failure on an integration branch blocks the cluster→release promotion PR. Unwinding is much more expensive than catching at the agent's local feedback loop.

## Changes

### `.ai/instructions/CODING_STANDARDS.md` — new "Pre-PR Validation Checklist" section

- Lists the three commands every agent must run locally before opening a PR: `rushx build`, `rushx lint`, `rushx test`
- Explicitly calls out that `rushx build` does NOT transitively run lint
- Notes `rushx fixlint` as the autofix tool for the mechanical class of violations
- Standard acceptance-criteria template with `rushx lint` as a separate bullet
- **Forbids inline rule-disable directives** as a workaround; surface to orchestrator instead
- Orchestrator-facing section: gate workflow advancement on CI green via `get_check_runs`

### `.claude/agents/orchestrator.md` — kickoff checklist + new common operation

- Kickoff prompt checklist notes that acceptance criteria must include `rushx lint` as a separate gate (cross-refs the new CODING_STANDARDS section)
- New common-operation section "Reviewing an agent PR before merge / bundling" — makes the CI-green precondition explicit. Before advancing the workflow (merging, bundling into cluster-close prep, opening the cluster→release promotion PR), the orchestrator calls `get_check_runs` on the PR and refuses to advance if any check is `conclusion: failure`.

## What this fixes going forward

- Future implementing agents see lint in their acceptance criteria explicitly, not as an implicit assumption rolled into "build passes"
- Future orchestrator sessions inherit the CI-green gate as standard procedure rather than implicit best-practice
- The implementer-aid (`rushx fixlint`) is surfaced so agents don't have to manually fix mechanical errors

## Follow-up

The four crypto-batch-2 phase-A briefs are on the still-open substrate-prep PR (#328). They land before #328 merges, so they pre-date this convention update. I'll amend those briefs to include the new acceptance-criteria items in a separate commit before they go to agents.

## Test plan

- [ ] Read the new CODING_STANDARDS § Pre-PR Validation Checklist for clarity
- [ ] Confirm orchestrator.md changes don't conflict with existing workflow shapes
- [ ] No code changes; docs-only

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_