### PR TITLE
docs(crypto-batch-2-misc): add lint acceptance criteria to brief

### DIFF
--- a/.ai/tasks/active/crypto-batch-2-misc/brief.md
+++ b/.ai/tasks/active/crypto-batch-2-misc/brief.md
@@ -149,12 +149,15 @@ Add `sign`, `verify`, and `timingSafeEqual` to the `crypto-utils` § listing of 
 - [ ] Browser `timingSafeEqual` implementation is constant-time (no early-return)
 - [ ] 100% coverage in both packages
 - [ ] `rushx build` passes in both packages
+- [ ] **`rushx lint` passes in both packages** *(load-bearing — NOT transitively run by build; see `.ai/instructions/CODING_STANDARDS.md` § Pre-PR Validation Checklist)*
 - [ ] `rushx test` passes with 100% coverage in both
+- [ ] **`rushx fixlint` was run before the final commit** *(autofixes the mechanical class — formatting, unused-import sort, missing semicolons, many style rules)*
 - [ ] No `any` types
+- [ ] No inline lint-rule-disable directives added to make lint pass — if a rule genuinely shouldn't apply, surface to the orchestrator
 - [ ] api-extractor regenerated (`ts-extras.api.md`, `ts-web-extras.api.md`)
 - [ ] `LIBRARY_CAPABILITIES.md` updated
 - [ ] PR opened against `claude/crypto-batch-2-features` (NOT `release`)
-- [ ] Pre-merge artifact migration to `.ai/tasks/completed/2026-05/crypto-batch-2-misc/` with polished `README.md`
+- [ ] Pre-merge artifact migration to `.ai/tasks/completed/2026-05/crypto-batch-2-misc/` with polished `README.md` *(write a separate polished README — migrated state.md alone does not fulfill this)*
 
 ---
 
@@ -201,3 +204,4 @@ If a required-reading file is missing or has a conflicting shape (e.g. `crypto.s
 - Don't add `timingSafeEqual` variants (lengths-known, prefix-equality, etc.); the basic primitive is what's asked for
 - Don't pull in dependencies for `timingSafeEqual` browser implementation; a 5-line XOR walk is correct and minimal
 - Don't touch the HPKE, Argon2id, or WebAuthn surfaces — those are parallel streams
+- **Don't open the PR until `rushx build && rushx lint && rushx test` all pass locally** in both modified packages. `rushx build` does NOT transitively run lint; lint is a separate gate. Run `rushx fixlint` before the final commit to autofix the mechanical class of violations.


### PR DESCRIPTION
## Summary

Folds the new lint-gate guidance from [#337](https://github.com/ErikFortune/fgv/pull/337) into the `crypto-batch-2-misc` brief. The other three crypto-batch-2 briefs (HPKE, Argon2id, WebAuthn) are phase-A design-only and don't produce code; their phase B briefs will be drafted post-signoff and inherit the new acceptance criteria.

This is the kind of `chore/<stream>-amend` PR the new doc-graduation discipline (`.ai/conventions/workflow/doc-graduation.md`) describes: a substrate-prep PR amending a brief that already landed on integration, so the eventual implementing agent sees the corrected acceptance criteria when they fork their work branch.

## Changes

In `.ai/tasks/active/crypto-batch-2-misc/brief.md`:

**Acceptance criteria** — added four items:
- `rushx lint` passes in both packages (load-bearing, separate from `rushx build`)
- `rushx fixlint` was run before the final commit
- No inline lint-rule-disable directives as workarounds (surface to orchestrator)
- Polished README in the completed dir is a separate file, not just the migrated state.md (lessons-codification from the auth-primitives + image-gen pattern: agents have been treating "state.md migrated to completed/" as fulfilling the polished-README requirement; the convention says they're distinct artifacts)

**"Don't" section** — added one item:
- Don't open the PR until `rushx build && rushx lint && rushx test` all pass locally in both modified packages

## Why now

The misc stream is implementation-only and uses Sonnet — the same class of agent that's been letting lint failures slip through recent streams. Catching this in the brief before kickoff means the agent has the explicit acceptance criteria from the start, no retro-fitting needed.

## Test plan

- [ ] Confirm the misc brief acceptance criteria match the standard pre-PR validation checklist in `.ai/instructions/CODING_STANDARDS.md` (after #337 lands)
- [ ] No production code; docs-only

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_