### PR TITLE
docs(tech-debt): add cross-runtime entry-point export parity

### DIFF
--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -46,6 +46,19 @@ opportunistically when the right surface area is touched.
 
   **Reference**: PR #329 review — patterns pre-existed the PR, absolved from that review.
 
+- **[P2] Cross-runtime entry-point export parity is not systematically tested.**
+  Libraries with both Node (`src/index.ts`) and browser (`src/index.browser.ts`) entry points can drift in export names without CI catching it. api-extractor runs only on the Node entry point, so a typo or rename in the browser entry slips through. Pattern has bitten the team several times; most recent instance: `@fgv/ts-extras` exported `Crypto` instead of `CryptoUtils` from `index.browser.ts`, surfacing as `CryptoUtils.Keystore undefined` in the personaility web app. Fixed with a one-off test for that specific import; no general practice.
+
+  Comprehensive per-export coverage on every library is too expensive given the API surface. The right scope is opportunistic per-library micro-tests.
+
+  **Trigger**: anytime a library's `index.browser.ts` is touched substantively (new exports added, namespace renames, refactors). Also: anytime a cross-runtime export bug is reported, expand the affected library's micro-test rather than just patching the single export.
+
+  **Scope sketch**: a tiny test file per library — `src/test/unit/browserEntry.test.ts` (or similar) — that imports from `index.browser.ts` and asserts the top-level exported names match a minimal expected list (the major namespaces, not every symbol). Renaming a Node export then breaks the browser test if the browser entry wasn't updated in lockstep. Per-library cost: ~15 lines. No commitment to backfill across all libraries; just add when the library's browser entry is touched.
+
+  **Not a P3**: the pattern has recurred multiple times across the team; the consumer-impact cost (production-visible undefined exports) is real. P2 trigger ("next time the browser entry is touched") puts it on a natural cadence.
+
+  **Reference**: bug reported via personaility web app integration; one-off test added in the fix PR (see `@fgv/ts-extras` browser entry).
+
 ## P3 — Opportunistic cleanup
 
 - **[P3] `resolveImageCapability` in `ai-assist/registry.ts` returns `| undefined` instead of `Result<IAiImageModelCapability>`.**


### PR DESCRIPTION
## Summary

Records a P2 tech-debt item for cross-runtime entry-point export parity. Surfaced via the recent `ts-extras` bug where `index.browser.ts` exported `Crypto` instead of `CryptoUtils`, breaking the personaility web app integration with `CryptoUtils.Keystore undefined`.

api-extractor runs only on the Node entry point, so export divergence between Node and browser entries slips through CI. Pattern has recurred several times across the team.

## Scope (honestly)

Comprehensive per-export coverage on every library is too expensive given the API surface. The entry scopes the preventive measure as **opportunistic per-library micro-tests**:
- Tiny test file (`src/test/unit/browserEntry.test.ts` or similar) per library
- Imports from `index.browser.ts` and asserts top-level export names match expected
- Renaming a Node export then breaks the browser test if the browser entry wasn't updated in lockstep
- Per-library cost ~15 lines
- No commitment to backfill across all libraries — added when the library's browser entry is touched

## Trigger

P2 trigger: anytime a library's `index.browser.ts` is touched substantively, add or expand the micro-test. Also: anytime a cross-runtime export bug is reported, expand the affected library's micro-test rather than just patching the single export.

## Files

- `docs/TECH_DEBT.md` — new P2 entry

## Test plan

- [ ] Confirm entry is appropriately scoped (P2 with trigger condition, not comprehensive backfill)
- [ ] Confirm cost framing matches what's actually feasible
- [ ] No code changed

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_