### PR TITLE
docs(crypto-batch-2): consolidated phase B briefs for HPKE, Argon2id, WebAuthn

### DIFF
--- a/.ai/tasks/active/crypto-batch-2-argon2id/brief-phase-b.md
+++ b/.ai/tasks/active/crypto-batch-2-argon2id/brief-phase-b.md
@@ -1,0 +1,398 @@
+# Stream Brief: crypto-batch-2-argon2id (phase B — implementation)
+
+**Stream ID:** crypto-batch-2-argon2id
+**Phase:** B — implementation
+**Sequencing:** Phase A signed off. Phase B can run in parallel with `crypto-batch-2-hpke` and `crypto-batch-2-webauthn` phase B. Minor potential file collision with HPKE on `@fgv/ts-extras/crypto-utils/model.ts` (Argon2id adds the `IArgon2idProvider` + `IArgon2idParams` + `IKeyDerivationParams` discriminated union; HPKE doesn't need model.ts edits — collision risk is low and handled by file-level discipline below).
+
+---
+
+## Context
+
+Phase A produced `.ai/tasks/active/crypto-batch-2-argon2id/design.md` (read it in full — library survey + composition rationale + KeyStore integration design). Orchestrator/user signed off **as designed** with two resolutions on Open Questions:
+
+- **Q1 (parameter naming):** keep the readable form (`memoryKiB`, `iterations`, `parallelism`, `outputBytes`). Do NOT collapse to RFC's `m`/`t`/`p`.
+- **Q2 (parallelism > 1 on WASM):** JSDoc warning is sufficient — no runtime logged warning needed.
+
+Plus one orchestrator-flagged precondition (ARGON-1): live `hash-wasm` repository activity check at phase B step zero.
+
+**This brief is the binding contract** — where it conflicts with `design.md`, this brief wins.
+
+This is feature work on an active-development surface (new packages `@fgv/ts-extras-argon2` and `@fgv/ts-web-extras-argon2`, plus model additions in `@fgv/ts-extras/crypto-utils`). Per `.ai/instructions/ACTIVE_DEVELOPMENT.md`, free hand on breaking changes.
+
+---
+
+## Mission
+
+Ship two new monorepo packages — `@fgv/ts-extras-argon2` (Node, wraps `argon2`) and `@fgv/ts-web-extras-argon2` (Browser + Node-compatible, wraps `hash-wasm`) — implementing a shared `IArgon2idProvider` interface defined in `@fgv/ts-extras/crypto-utils/model.ts`. Extend `KeyStore` with `addSecretFromPasswordArgon2id` / `verifySecretFromPasswordArgon2id`. Convert `IKeyDerivationParams` to a discriminated union. 100% test coverage, lint pass, `LIBRARY_CAPABILITIES.md` update, pre-merge artifact migration.
+
+---
+
+## Signed-off design decisions (binding)
+
+The decisions baked into `design.md` stand unless overridden below.
+
+### D1. Library choices (design §1)
+
+- Node: **`argon2` v0.45.0+** (kelektiv/ranisalt). Default variant is `argon2id`. Raw bytes via `raw: true`. Node ≥ 22 matches repo's `nodeSupportedVersionRange`.
+- Browser (and Node test-side equivalence): **`hash-wasm` v4.12.0+**. Pure WASM — runs identically in both runtimes. `outputType: 'binary'` → `Uint8Array`.
+
+Rejected: `@node-rs/argon2` (no raw or PHC output); `argon2-browser` (effectively abandoned).
+
+### D2. Package structure (design §2)
+
+Two new packages registered in `rush.json` under `libraries/`:
+
+- `libraries/ts-extras-argon2/` — `@fgv/ts-extras-argon2`, depends on `@fgv/ts-extras`, `@fgv/ts-utils`, `argon2`.
+- `libraries/ts-web-extras-argon2/` — `@fgv/ts-web-extras-argon2`, depends on `@fgv/ts-extras`, `@fgv/ts-utils`, `hash-wasm`. **Does NOT depend on `@fgv/ts-web-extras`** — `hash-wasm` has no Web Crypto coupling, so the browser package can stand alone.
+
+Both `shouldPublish: true`, `versionPolicyName: "base-utils"`, `tags: ["libraries"]`.
+
+Class names follow the existing convention: `NodeArgon2Provider` and `BrowserArgon2Provider` (parallels `NodeCryptoProvider` / `BrowserCryptoProvider`).
+
+### D3. Interface shape (design §3, Q1 resolved)
+
+Add to `@fgv/ts-extras/src/packlets/crypto-utils/model.ts`:
+
+```typescript
+export interface IArgon2idParams {
+  readonly memoryKiB: number;     // OWASP 2023 min: 19456 (19 MiB). Constraint: >= 8.
+  readonly iterations: number;    // OWASP min: 2. Constraint: >= 1.
+  readonly parallelism: number;   // 1..255. WASM path computes sequentially but value affects output bytes.
+  readonly outputBytes: number;   // typical 32 (AES-256 key). Constraint: >= 4.
+}
+
+export const ARGON2ID_OWASP_MIN: IArgon2idParams = {
+  memoryKiB: 19456, iterations: 2, parallelism: 1, outputBytes: 32
+} as const;
+
+export const ARGON2ID_PASSPHRASE: IArgon2idParams = {
+  memoryKiB: 65536, iterations: 3, parallelism: 1, outputBytes: 32
+} as const;
+
+export interface IArgon2idProvider {
+  argon2id(
+    password: Uint8Array | string,
+    salt: Uint8Array,
+    params: IArgon2idParams
+  ): Promise<Result<Uint8Array>>;
+}
+```
+
+Parameter naming locked to the readable form (signoff Q1). Do NOT rename to RFC's `m`/`t`/`p`.
+
+Class shape follows the fgv factory pattern — private constructor + static `create(...): Result<NodeArgon2Provider>` (or `BrowserArgon2Provider`). Use `captureResult(() => new ...)`. The classes don't take constructor arguments today; if `hash-wasm` ever requires init plumbing, surface as state.md decision.
+
+### D4. `IKeyDerivationParams` becomes a discriminated union (design §3, Q3)
+
+Replace the existing single shape with:
+
+```typescript
+export interface IPbkdf2KeyDerivationParams {
+  readonly kdf: 'pbkdf2';
+  readonly salt: string;        // base64
+  readonly iterations: number;
+}
+
+export interface IArgon2idKeyDerivationParams {
+  readonly kdf: 'argon2id';
+  readonly salt: string;        // base64
+  readonly memoryKiB: number;
+  readonly iterations: number;
+  readonly parallelism: number;
+}
+
+export type IKeyDerivationParams =
+  | IPbkdf2KeyDerivationParams
+  | IArgon2idKeyDerivationParams;
+
+export type KeyDerivationFunction = 'pbkdf2' | 'argon2id';
+```
+
+**Migration impact** (design §9 — verify in phase B):
+- `keystore/converters.ts` — the `IKeyDerivationParams` converter must handle both union arms. This is the main code-change site.
+- `verifySecretFromPassword()` — its existing `if (keyDerivation.kdf !== 'pbkdf2') return fail(...)` guard becomes the narrowing expression. No logic change.
+- `keyStore.ts` `unlock()` — `keyDerivation.iterations` access remains valid (both arms have `iterations`).
+
+The discriminated-union arms share `kdf` and `salt`; narrowing is additive. Audit + verify, don't speculate.
+
+### D5. Composition idiom (design §4) — option (b): standalone `IArgon2idProvider`
+
+- `ICryptoProvider` does **not** know about Argon2id.
+- `IArgon2idProvider` is a fully independent interface.
+- `KeyStore` methods that need Argon2id take an `IArgon2idProvider` as an explicit parameter (D6 below).
+- Consumers compose: instantiate `NodeArgon2Provider` (or `BrowserArgon2Provider`) themselves and pass it in.
+
+Rejected: optional field on `ICryptoProvider`; extends-shape; generalizing `addSecretFromPassword` with a `kdf?` parameter.
+
+### D6. `KeyStore` integration (design §5) — two new dedicated methods
+
+Add to `KeyStore`:
+
+```typescript
+public async addSecretFromPasswordArgon2id(
+  name: string,
+  password: string,
+  argon2idProvider: IArgon2idProvider,
+  options?: IAddSecretFromPasswordArgon2idOptions
+): Promise<Result<IAddSecretFromPasswordResult>>;
+
+public async verifySecretFromPasswordArgon2id(
+  name: string,
+  password: string,
+  argon2idProvider: IArgon2idProvider,
+  keyDerivation: IArgon2idKeyDerivationParams
+): Promise<Result<boolean>>;
+```
+
+Where:
+
+```typescript
+export interface IAddSecretFromPasswordArgon2idOptions {
+  readonly params?: IArgon2idParams;    // defaults to ARGON2ID_OWASP_MIN
+  readonly description?: string;
+  readonly replace?: boolean;
+}
+```
+
+Reuse `IAddSecretFromPasswordResult`; its `keyDerivation` field is typed as the discriminated union (D4) — Argon2id callers get `IArgon2idKeyDerivationParams` back. Constant-time comparison in verify (use the existing helper).
+
+Do NOT generalize `addSecretFromPassword` with a `kdf?` discriminator. The two-method shape makes the KDF choice explicit and audit-traceable (design §5 rejection reasoning).
+
+### D7. Cross-runtime equivalence test placement (design §6, Q5 resolved)
+
+The cross-runtime equivalence test lives **in `libraries/ts-extras-argon2/`** with a `devDependency` on `@fgv/ts-web-extras-argon2`. `hash-wasm` is pure WASM and runs identically under Node and browsers, so the test is a **plain Jest test** running in Node — **no browser runner needed**. The unusual cross-package devDependency is acceptable; document it in the test file's header comment.
+
+If the cross-package devDependency causes a Rush dependency-cycle complaint, fall back to placing the cross-runtime test in `libraries/ts-web-extras-argon2/` instead (it can import `@fgv/ts-extras-argon2` as a devDependency). Either direction works; surface the resolution in state.md.
+
+### D8. JSDoc-only warning for `parallelism > 1` on WASM (Q2 resolved)
+
+`BrowserArgon2Provider.argon2id`'s JSDoc explicitly notes:
+
+- WASM computes sequentially regardless of `parallelism`.
+- The `parallelism` value IS still wired into the hash; output bytes differ for different values.
+- Recommendation: use `parallelism: 1` unless interoperating with a server-side derivation that uses a different value.
+
+**No runtime logged warning** — JSDoc is the contract.
+
+### D9. Test vectors (design §6)
+
+- RFC 9106 Appendix B test vector for Argon2id v1.3 (`password` / `somesalt`, m=32, t=3, p=4, hashLength=32). Phase B implementer copies the exact hex from RFC 9106 §B.3 directly — do not transcribe from the design (which contained a placeholder).
+- Parameter sweep covering: OWASP min, OWASP stronger, low-memory boundary, min-iterations, parallelism > 1, output 16 / 32 / 64 (design §6 sweep table).
+- Pass/fail criterion: byte-identical output (`expect(Array.from(nodeBytes)).toEqual(Array.from(browserBytes))`).
+
+---
+
+## Phase B step zero (B.0) — live `hash-wasm` activity check (orchestrator-flagged)
+
+The design's library survey records `hash-wasm` last published November 2024 (~6 months at design time). The orchestrator condition is non-optional:
+
+1. Fetch `https://github.com/Daninet/hash-wasm` (or `https://www.npmjs.com/package/hash-wasm`).
+2. Check most recent commit / release date and open-issue count.
+3. **If maintenance has materially deteriorated** (e.g. unresolved security-relevant issues, last commit > 12 months, maintainer publicly inactive), STOP and surface to the orchestrator. Do NOT pivot to `argon2-browser` unilaterally — the orchestrator may want to re-scope or hold the stream.
+4. If maintenance is steady (low issues are fine — `hash-wasm` is a low-activity, focused library), proceed with `hash-wasm` per D1.
+5. Record the activity-check outcome in `state.md` (Decisions log).
+
+---
+
+## Phase B implementation phases
+
+### B.1 — Model additions in `@fgv/ts-extras`
+
+In `libraries/ts-extras/src/packlets/crypto-utils/model.ts`:
+
+- Add `IArgon2idParams`, `ARGON2ID_OWASP_MIN`, `ARGON2ID_PASSPHRASE`, `IArgon2idProvider` (D3)
+- Convert `IKeyDerivationParams` to the discriminated union (D4)
+- Update `KeyDerivationFunction` to `'pbkdf2' | 'argon2id'`
+
+Audit and update `keystore/converters.ts` to handle both union arms. Audit `keyStore.ts` for any `IKeyDerivationParams` access sites; verify each compiles and is semantically correct under the new union. Run `rushx build && rushx lint && rushx test` in `ts-extras` to confirm the model changes pass before moving on.
+
+**Checkpoint:** `ts-extras` compiles + lints + tests pass with new model surface (Argon2id provider impl not yet present; existing PBKDF2 paths still 100% covered).
+
+### B.2 — Create `@fgv/ts-extras-argon2`
+
+- `rush add` is for adding deps to an existing package; for a new package, follow the existing pattern: copy the structure of a small existing package (e.g. `libraries/ts-bcp47` or another minimal lib) and modify, then run `rush update`.
+- New package contents per design §2.
+- `NodeArgon2Provider` class with private constructor + static `create()`. `argon2id` method wraps the upstream `argon2.hash(password, { type: argon2.argon2id, salt, memoryCost: params.memoryKiB, timeCost: params.iterations, parallelism: params.parallelism, hashLength: params.outputBytes, raw: true })` inside `captureAsyncResult`, returning `Result<Uint8Array>`.
+- Parameter validation (per design §3 "Parameter Constraints"): `memoryKiB >= 8`, `iterations >= 1`, `parallelism` in `1..255`, `outputBytes >= 4`. Failure messages prefixed `argon2id:`.
+- Re-export `IArgon2idProvider` and `IArgon2idParams` from `@fgv/ts-extras` for consumer convenience (per design §2 "Exported surface").
+- Register in `rush.json`.
+- Add per-package `tsconfig.json`, `jest.config.json`, `package.json`, `README.md` (stub OK — README content can be added at B.6).
+
+**Checkpoint:** `@fgv/ts-extras-argon2` builds, lints, and has at least roundtrip + RFC-vector tests passing with 100% coverage of its own code.
+
+### B.3 — Create `@fgv/ts-web-extras-argon2`
+
+- Same structure as B.2.
+- `BrowserArgon2Provider` class with private constructor + static `create()`. `argon2id` method wraps `hash-wasm.argon2id({ password, salt, iterations: params.iterations, parallelism: params.parallelism, memorySize: params.memoryKiB, hashLength: params.outputBytes, outputType: 'binary' })` inside `captureAsyncResult`, returning `Result<Uint8Array>`.
+- JSDoc on `argon2id` per D8: WASM is sequential, parallelism still affects bytes, recommend `parallelism: 1`.
+- Parameter validation identical to Node path (D3).
+- Re-export `IArgon2idProvider`, `IArgon2idParams` from `@fgv/ts-extras` for consumer convenience.
+- Register in `rush.json`.
+
+**Checkpoint:** `@fgv/ts-web-extras-argon2` builds, lints, and has roundtrip + RFC-vector tests passing with 100% coverage.
+
+### B.4 — KeyStore extension
+
+In `libraries/ts-extras/src/packlets/crypto-utils/keystore/`:
+
+- Add `addSecretFromPasswordArgon2id` and `verifySecretFromPasswordArgon2id` methods per D6.
+- Existing `verifySecretFromPassword` keeps its `if (keyDerivation.kdf !== 'pbkdf2') return fail(...)` guard — that's the narrowing expression now.
+- Tests in `keystore` test suite: derivation roundtrip; verify happy path; verify wrong-password path; replace flag; storage of `IArgon2idKeyDerivationParams` in entries.
+- For these tests, instantiate `NodeArgon2Provider` from `@fgv/ts-extras-argon2`. This makes `@fgv/ts-extras-argon2` a `devDependency` of `@fgv/ts-extras` for tests. If that creates a Rush dependency-cycle warning, instead use a minimal in-test mock `IArgon2idProvider` that returns deterministic bytes — surface the choice in state.md.
+
+**Checkpoint:** KeyStore has 100% coverage for both Argon2id methods; the existing PBKDF2 paths remain at 100% coverage.
+
+### B.5 — Cross-runtime equivalence test
+
+Per D7. New test file in `libraries/ts-extras-argon2/src/test/unit/crossRuntime.test.ts` (or equivalent path). Imports both `NodeArgon2Provider` and `BrowserArgon2Provider`. For each test vector + the parameter sweep, asserts byte-identical output:
+
+```typescript
+const nodeBytes = (await nodeProvider.argon2id(password, salt, params)).orThrow();
+const browserBytes = (await browserProvider.argon2id(password, salt, params)).orThrow();
+expect(Array.from(nodeBytes)).toEqual(Array.from(browserBytes));
+```
+
+Document at the top of the file why the cross-package devDependency exists (link this brief).
+
+**Checkpoint:** All test vectors + sweep cases produce byte-identical output across providers.
+
+### B.6 — Documentation
+
+Update `.ai/instructions/LIBRARY_CAPABILITIES.md`:
+
+- Add new decision shortcut: **"Need to derive a key from a password using Argon2id (RFC 9106)?"** → `NodeArgon2Provider` from `@fgv/ts-extras-argon2` (Node) or `BrowserArgon2Provider` from `@fgv/ts-web-extras-argon2` (browser, also runs in Node for tests). Both implement `IArgon2idProvider` from `@fgv/ts-extras/crypto-utils`. Use `ARGON2ID_OWASP_MIN` as starting params; `ARGON2ID_PASSPHRASE` for user-typed passphrases.
+- Add **"Need to back a password-protected KeyStore entry with Argon2id?"** → `KeyStore.addSecretFromPasswordArgon2id(name, password, argon2idProvider, { params })` / `verifySecretFromPasswordArgon2id(...)`.
+- Update the `crypto-utils` packlet entry to mention `IArgon2idProvider`, `IArgon2idParams`, `ARGON2ID_OWASP_MIN`/`PASSPHRASE`, and the new KeyStore methods. Mention the discriminated `IKeyDerivationParams` union.
+- Update the package table at the top of the doc to add the two new packages.
+- Update the cross-runtime interfaces table to add `IArgon2idProvider` (Node impl: `NodeArgon2Provider`, Browser impl: `BrowserArgon2Provider`).
+
+Regenerate api-extractor for `ts-extras`, `ts-extras-argon2`, `ts-web-extras-argon2`.
+
+Polish each new package's `README.md` with usage examples and the `IArgon2idProvider` interface link.
+
+**Checkpoint:** docs reflect implementation; api-extractor regenerated.
+
+### B.7 — Pre-merge artifact migration
+
+Migrate `.ai/tasks/active/crypto-batch-2-argon2id/` → `.ai/tasks/completed/2026-05/crypto-batch-2-argon2id/`. Write a **separate polished `README.md`** capturing:
+
+- What shipped (two new packages, `IArgon2idProvider`, KeyStore methods, discriminated union)
+- Key decisions (library choices; package split; standalone interface; cross-runtime via pure WASM)
+- B.0 `hash-wasm` activity-check outcome
+- Acceptance status
+- Followups: TECH_DEBT / FUTURE candidates
+
+Pre-merge migration is mandatory per `.ai/conventions/workflow/artifact-protocol.md`. **Separate polished README.md** — not just the migrated state.md.
+
+---
+
+## Package surface
+
+### In-scope (modify / create)
+
+- `libraries/ts-extras/src/packlets/crypto-utils/model.ts` — add types per D3, convert `IKeyDerivationParams` to union per D4
+- `libraries/ts-extras/src/packlets/crypto-utils/keystore/converters.ts` — handle both union arms
+- `libraries/ts-extras/src/packlets/crypto-utils/keystore/keyStore.ts` — add `addSecretFromPasswordArgon2id` and `verifySecretFromPasswordArgon2id`
+- `libraries/ts-extras/etc/ts-extras.api.md` — regenerate
+- `libraries/ts-extras/src/test/unit/crypto/keystore.test.ts` (or wherever the KeyStore tests live) — new cases for Argon2id paths
+- `libraries/ts-extras-argon2/` — new package (full structure per design §2)
+- `libraries/ts-web-extras-argon2/` — new package (full structure per design §2)
+- `rush.json` — register both new packages
+- `.ai/instructions/LIBRARY_CAPABILITIES.md` — new decision shortcuts + entries
+- `.ai/tasks/active/crypto-batch-2-argon2id/state.md` — checkpoint updates
+- Pre-merge: migrate `.ai/tasks/active/crypto-batch-2-argon2id/` → `.ai/tasks/completed/2026-05/crypto-batch-2-argon2id/` with polished `README.md`
+
+### Out-of-scope
+
+- `ICryptoProvider` modifications (Argon2id is standalone; D5)
+- Generalization of `addSecretFromPassword` with `kdf?` parameter (rejected in D6)
+- HPKE, WebAuthn surfaces (parallel streams)
+- Browser smoke test via `apps/ts-utils-browser-test` (optional per design §6; skip unless something forces it)
+- Sudoku packages
+
+### Parallel-stream awareness
+
+HPKE phase B introduces a new file in `crypto-utils/` (`hpkeProvider.ts`) and only modifies `crypto-utils/index.ts`. Argon2id modifies `crypto-utils/model.ts` and `crypto-utils/keystore/`. Direct file collisions are unlikely. If both streams independently want to edit `crypto-utils/index.ts` (HPKE: add `HpkeProvider` export; Argon2id: re-export new Argon2id types via the index), use checkpoint discipline and a clean rebase. Coordinate via state.md if a real conflict surfaces.
+
+---
+
+## Required reading (priority order)
+
+1. `.ai/tasks/active/crypto-batch-2-argon2id/brief-phase-b.md` (this file) — binding contract
+2. `.ai/tasks/active/crypto-batch-2-argon2id/design.md` — phase A inventory + composition rationale
+3. `.ai/tasks/active/crypto-batch-2-argon2id/brief.md` — phase A contract
+4. `.ai/notes/cross-repo-handoffs/fgv-batch-2-handoff-2026-05.md` — consumer context (recovery rows + passphrase rows)
+5. `libraries/ts-extras/src/packlets/crypto-utils/keystore/` — existing PBKDF2 paths, factory pattern, `IKeyDerivationParams` consumer sites
+6. `libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts` and `browserCryptoProvider.ts` — class-with-create-factory shape; naming pattern
+7. `rush.json` and an existing small library's `package.json` / `tsconfig.json` / `jest.config.json` (e.g. `libraries/ts-bcp47`) — new-package boilerplate template
+8. RFC 9106 (Argon2id) — at least §3.1 (algorithm) and §B (test vectors); skim §4 (parameter selection)
+9. `argon2` npm docs (https://github.com/ranisalt/node-argon2) — confirm parameter names + `raw: true` behavior
+10. `hash-wasm` docs (https://github.com/Daninet/hash-wasm) — confirm `argon2id()` API + `outputType: 'binary'`
+11. `.ai/instructions/CODING_STANDARDS.md` § Pre-PR Validation Checklist — lint discipline
+12. `.ai/instructions/TESTING_GUIDELINES.md` — Result matchers, 100% coverage
+
+---
+
+## Skills to load (when conditions trigger)
+
+- `/result-pattern` — load before writing any function returning `Result<T>` (all public methods)
+- `/result-tests` — load before writing tests
+- `/type-safe-validation` — load when implementing parameter validation in `IArgon2idProvider.argon2id`
+- `/published-primitives-reflex` — load before writing utility helpers
+
+---
+
+## Acceptance criteria
+
+- [ ] B.0 `hash-wasm` activity-check outcome captured in state.md
+- [ ] `IArgon2idProvider`, `IArgon2idParams`, `ARGON2ID_OWASP_MIN`, `ARGON2ID_PASSPHRASE` added to `model.ts`
+- [ ] `IKeyDerivationParams` converted to discriminated union; `keystore/converters.ts` updated to handle both arms
+- [ ] `NodeArgon2Provider` shipped in `@fgv/ts-extras-argon2` with private constructor + static `create` factory
+- [ ] `BrowserArgon2Provider` shipped in `@fgv/ts-web-extras-argon2` with private constructor + static `create` factory
+- [ ] `KeyStore.addSecretFromPasswordArgon2id` and `verifySecretFromPasswordArgon2id` implemented
+- [ ] Cross-runtime byte-identical output verified for the RFC 9106 §B.3 vector + the parameter sweep (design §6)
+- [ ] `parallelism > 1` JSDoc warning present on `BrowserArgon2Provider.argon2id`
+- [ ] `rushx build` passes in `ts-extras`, `ts-extras-argon2`, `ts-web-extras-argon2`
+- [ ] **`rushx lint` passes in all modified packages** (load-bearing — NOT transitively run by build; see CODING_STANDARDS § Pre-PR Validation Checklist)
+- [ ] `rushx test` passes with 100% coverage in all modified packages
+- [ ] **`rushx fixlint` was run before the final commit**
+- [ ] No `any` types; all fallible operations return `Result<T>`
+- [ ] No inline lint-rule-disable directives added to make lint pass
+- [ ] api-extractor regenerated (`ts-extras.api.md`, `ts-extras-argon2.api.md`, `ts-web-extras-argon2.api.md`)
+- [ ] `LIBRARY_CAPABILITIES.md` updated with new decision shortcuts + packlet entry + package table + cross-runtime table
+- [ ] Pre-merge artifact migration to `.ai/tasks/completed/2026-05/crypto-batch-2-argon2id/` with **separate polished README.md**
+- [ ] PR opened against `claude/crypto-batch-2-features` (NOT `release`)
+
+---
+
+## Branch + PR posture
+
+- **Base branch:** `claude/crypto-batch-2-features` (cluster integration)
+- **Work branch:** `claude/crypto-batch-2-argon2id-impl` (or harness-auto-suffix; document the actual branch in state.md)
+- **PR target:** `claude/crypto-batch-2-features`
+- One PR for all of B.0–B.7 unless something forces a split.
+
+---
+
+## Don't
+
+- Don't open the PR until `rushx build && rushx lint && rushx test` all pass locally. `rushx build` does NOT transitively run lint; lint is a separate gate. Run `rushx fixlint` before the final commit.
+- Don't add Argon2id to `ICryptoProvider` — standalone interface only (D5).
+- Don't generalize `addSecretFromPassword` with a `kdf?` parameter — two-method shape (D6).
+- Don't rename `IArgon2idParams` fields to RFC's `m`/`t`/`p` — readable form locked (D3 / Q1).
+- Don't add a runtime logged warning for `parallelism > 1` on WASM — JSDoc only (D8 / Q2).
+- Don't pivot to `argon2-browser` unilaterally if `hash-wasm` activity check shows mild slowness — surface to orchestrator (B.0).
+- Don't add `@fgv/ts-web-extras` as a dependency of `@fgv/ts-web-extras-argon2` — it's not needed (D2).
+- Don't skip B.0. The orchestrator condition stands.
+
+---
+
+## Resume protocol
+
+If the session ends mid-phase: read `brief-phase-b.md` (this file), `design.md`, and `state.md` to resume. State.md records which checkpoints (B.0–B.7) are done.
+
+---
+
+## Missing-input rule
+
+If a required-reading file is missing or has a shape that conflicts with this brief, or if B.0 activity-check finds `hash-wasm` materially deteriorated, **STOP and report**. Do not improvise.

--- a/.ai/tasks/active/crypto-batch-2-argon2id/state.md
+++ b/.ai/tasks/active/crypto-batch-2-argon2id/state.md
@@ -1,7 +1,7 @@
 # Stream State: crypto-batch-2-argon2id
 
-**Status:** 🟡 phase A complete — awaiting orchestrator signoff before phase B
-**Last updated:** 2026-05-12 (implementing agent — claude/argon2id-package-split-EhzDh)
+**Status:** 🟢 phase A signed off; phase B ready to start
+**Last updated:** 2026-05-12 (orchestrator — phase B brief authored)
 
 ---
 
@@ -9,8 +9,23 @@
 
 | Phase | Status | Notes |
 |-------|--------|-------|
-| A — research and design | 🟡 complete, awaiting signoff | design.md written; PR open targeting claude/crypto-batch-2-features |
-| B — implementation | ⏸ blocked on phase A signoff | Brief to be written by orchestrator post-signoff |
+| A — research and design | ✅ done | design.md merged into `claude/crypto-batch-2-features` |
+| B — implementation | 🟢 ready | `brief-phase-b.md` is the binding contract; assignable to implementing agent |
+
+---
+
+## Phase A signoff summary (orchestrator)
+
+Design approved **as designed**. Open question resolutions:
+
+- **OQ1 (parameter naming):** keep readable form (`memoryKiB` / `iterations` / `parallelism` / `outputBytes`). Do not collapse to RFC's `m`/`t`/`p`.
+- **OQ2 (parallelism > 1 on WASM):** JSDoc warning is sufficient — no runtime logged warning.
+- **OQ3 (discriminated union for `IKeyDerivationParams`):** proceed with the union approach. Phase B audits `keystore/converters.ts` and `keyStore.ts` access sites.
+- **OQ5 (cross-runtime test placement):** in `libraries/ts-extras-argon2/` with a `devDependency` on `@fgv/ts-web-extras-argon2`. Plain Jest in Node — no browser runner needed because `hash-wasm` is pure WASM.
+
+Orchestrator-flagged precondition (B.0): live `hash-wasm` GitHub activity check before kickoff. If maintenance has materially deteriorated, STOP and surface — do not pivot to `argon2-browser` unilaterally.
+
+Phase B contract is baked into `.ai/tasks/active/crypto-batch-2-argon2id/brief-phase-b.md`. Where the brief conflicts with the design, the brief wins.
 
 ---
 

--- a/.ai/tasks/active/crypto-batch-2-hpke/brief-phase-b.md
+++ b/.ai/tasks/active/crypto-batch-2-hpke/brief-phase-b.md
@@ -1,0 +1,330 @@
+# Stream Brief: crypto-batch-2-hpke (phase B — implementation)
+
+**Stream ID:** crypto-batch-2-hpke
+**Phase:** B — implementation
+**Sequencing:** Phase A signed off. Phase B can run in parallel with `crypto-batch-2-argon2id` and `crypto-batch-2-webauthn` phase B (no file collision — Argon2id and WebAuthn build new packages; only minor potential overlap with Argon2id on `crypto-utils/model.ts`, handled by file-level discipline below).
+
+---
+
+## Context
+
+Phase A produced `.ai/tasks/active/crypto-batch-2-hpke/design.md` (read it in full — inventory + rationale, not the contract). Orchestrator/user signed off with **one significant modification** to the API surface: the design's "subtle as first parameter" function-based API is replaced with a **class-based `HpkeProvider` pattern**. The rest of the design stands.
+
+**This brief is the binding contract** — where it conflicts with `design.md`, this brief wins.
+
+This is feature work on an active-development surface (`@fgv/ts-extras/crypto-utils` + `@fgv/ts-web-extras/crypto-utils`). Per `.ai/instructions/ACTIVE_DEVELOPMENT.md`, free hand on breaking changes; lockstep version policy means changes ship in the same alpha as everything else.
+
+---
+
+## Mission
+
+Implement HPKE base mode (RFC 9180, `DHKEM(X25519, HKDF-SHA256) + HKDF-SHA256 + AES-256-GCM`) as a class-based `HpkeProvider` in `@fgv/ts-extras/crypto-utils`, re-exported via `@fgv/ts-web-extras/crypto-utils` for browser callers. Plus HKDF as an exposed primitive on the same class. 100% test coverage, lint pass, `LIBRARY_CAPABILITIES.md` update, pre-merge artifact migration.
+
+---
+
+## Signed-off design decisions (binding)
+
+The decisions baked into `design.md` stand unless overridden below.
+
+### D1. Cipher suite (from design)
+
+- KEM: `DHKEM(X25519, HKDF-SHA256)` (KEM_ID = `0x0020`)
+- KDF: `HKDF-SHA256` (KDF_ID = `0x0001`)
+- AEAD: `AES-256-GCM` (AEAD_ID = `0x0002`)
+
+### D2. API surface — CLASS shape (overrides design §2)
+
+**Replaces the design's standalone-function-with-subtle-first-param pattern.** The signoff-modified shape:
+
+```typescript
+export class HpkeProvider {
+  private readonly _subtle: SubtleCrypto;
+
+  private constructor(subtle: SubtleCrypto) {
+    this._subtle = subtle;
+  }
+
+  public static create(subtle: SubtleCrypto): Result<HpkeProvider> {
+    return captureResult(() => new HpkeProvider(subtle));
+  }
+
+  public async sealBase(
+    recipientPublicKey: CryptoKey,
+    info: Uint8Array,
+    aad: Uint8Array,
+    plaintext: Uint8Array
+  ): Promise<Result<IHpkeSealResult>>;
+
+  public async openBase(
+    recipientPrivateKey: CryptoKey,
+    info: Uint8Array,
+    aad: Uint8Array,
+    enc: Uint8Array,
+    ciphertext: Uint8Array
+  ): Promise<Result<Uint8Array>>;
+
+  public async hkdf(
+    secret: Uint8Array,
+    salt: Uint8Array,
+    info: Uint8Array,
+    length: number
+  ): Promise<Result<Uint8Array>>;
+}
+
+// envelope helpers stay as static methods on the class OR as namespace-level exports
+// (implementer's choice; both fine — they don't need subtle):
+export namespace HpkeProvider {
+  export function encodeEnvelope(result: IHpkeSealResult): Uint8Array;
+  export function decodeEnvelope(envelope: Uint8Array): Result<{ enc: Uint8Array; ciphertext: Uint8Array }>;
+}
+```
+
+**Why class-based:**
+- Matches existing fgv crypto-utils pattern (`NodeCryptoProvider`, `BrowserCryptoProvider`, `KeyStore`, `DirectEncryptionProvider` — all classes with `create` factories)
+- Captures `subtle` once at construction; no per-call cognitive overhead at consumer call sites
+- Standard fgv factory pattern (private constructor + static `create` returning `Result`)
+- Stays separate from `ICryptoProvider` per D1 (architectural intent preserved — HPKE is its own provider class, not a method on the crypto provider)
+- Test injection still trivial (pass mock subtle into `create`)
+
+**Naming:** Class is `HpkeProvider` (or just `Hpke` if the design's namespace name is preserved as the class name — implementer's choice; the design's `Hpke` namespace becomes the class). Cross-stream: stays consistent with `NodeCryptoProvider`/`BrowserCryptoProvider` shape.
+
+### D3. Ciphertext format — inclusive auth tag (from design Q2)
+
+`IHpkeSealResult.ciphertext` includes the 16-byte AES-256-GCM authentication tag appended (`plaintext.length + 16` bytes). Matches Web Crypto's natural output; consumers needing separate tag bytes use the envelope encode/decode helpers.
+
+```typescript
+export interface IHpkeSealResult {
+  readonly enc: Uint8Array;          // 32-byte X25519 ephemeral pubkey (raw export)
+  readonly ciphertext: Uint8Array;   // GCM ciphertext + tag concatenated
+}
+```
+
+### D4. HKDF placement — on `HpkeProvider`, NOT on `ICryptoProvider` (from design §4 + signoff)
+
+HKDF lives on the `HpkeProvider` class as the `hkdf(secret, salt, info, length)` method. Not promoted to `ICryptoProvider`. Argument from design: adding to `ICryptoProvider` would be a breaking change for third-party implementations. Argument from signoff: WebAuthn doesn't need HKDF in its boundary; the cross-stream coordination is resolved.
+
+If future demand surfaces for `ICryptoProvider.hkdf`, promote then.
+
+### D5. `info` parameter — `Uint8Array`, no default, first-class (from design §5)
+
+Load-bearing. Callers MUST supply context-binding bytes. JSDoc reiterates the cross-context-replay risk. No convenience helper for context construction — application-specific conventions are caller-determined.
+
+### D6. Cross-runtime strategy — shared test vectors, no separate browser runner (from design §6)
+
+Test-vector constants live in a shared file consumed by both `ts-extras` and `ts-web-extras` Jest suites. Follow the existing `wrapBytes` precedent. Browser-side `HpkeProvider` is **re-exported** from `ts-extras` (the implementation lives in `ts-extras/crypto-utils/hpkeProvider.ts`); `ts-web-extras/crypto-utils/index.ts` re-exports `HpkeProvider` for browser callers.
+
+### D7. Internal primitives stay internal (from design §2)
+
+KEM Encap, KEM Decap, and KeySchedule are NOT exported. Only the five public operations (`sealBase`, `openBase`, `hkdf`, `encodeEnvelope`, `decodeEnvelope`) are public surface. Prevents misuse like shared-secret reuse across multiple seals.
+
+### D8. No context-binding helper (from design)
+
+`info` construction conventions (domain-separation prefixes, separator bytes, length encoding) are application-determined. fgv does not ship a helper; the JSDoc on `info` covers the discipline.
+
+---
+
+## Phase B step zero (B.0) — live RFC verification (orchestrator-flagged)
+
+The phase A agent's research session was rfc-editor.org-blocked (HTTP 403); the protocol details in `design.md §1` are drawn from the agent's training corpus. **B.0 is non-optional.**
+
+Before writing implementation code:
+
+1. Fetch RFC 9180 directly from `https://www.rfc-editor.org/rfc/rfc9180` (or via web-search if direct fetch blocked).
+2. Verify the algorithm pseudocode in design §1 (LabeledExtract, LabeledExpand, DHKEM Encap/Decap, key schedule) matches the RFC.
+3. Verify test vector availability — RFC 9180 Appendix A — check whether the exact cipher suite `DHKEM(X25519, HKDF-SHA256) + HKDF-SHA256 + AES-256-GCM` has canonical vectors. If only `AES-128-GCM` X25519 vectors exist (which the design suggests is the case), commit to self-generated cross-runtime anchors: generate test vectors with one runtime (Node `crypto.webcrypto.subtle`) and validate the browser implementation produces byte-identical output.
+4. Record the verification outcome in `state.md` (Decisions log). If any algorithm detail differs from the design, surface as an orchestrator question rather than improvising.
+
+---
+
+## Phase B implementation phases
+
+### B.1 — Type definitions
+
+In `libraries/ts-extras/src/packlets/crypto-utils/hpkeProvider.ts` (new file):
+
+- `IHpkeSealResult` interface (per D3)
+- `HpkeProvider` class skeleton with private constructor, static `create`, async method signatures
+- `encodeEnvelope` / `decodeEnvelope` as namespace-level static methods (per D2)
+
+JSDoc on every exported type. The `info` parameter's JSDoc spells out the load-bearing nature and the cross-context-replay risk.
+
+Re-export `HpkeProvider` from `crypto-utils/index.ts`. Add browser re-export from `ts-web-extras/crypto-utils/index.ts`.
+
+**Checkpoint:** types compile; api-extractor surface reviewed.
+
+### B.2 — Core primitives (internal)
+
+Private methods on `HpkeProvider` (or internal helpers in `hpkeProvider.ts`):
+
+- DHKEM Encap (ephemeral X25519 keypair gen + DH + LabeledExtract + LabeledExpand → shared_secret + enc)
+- DHKEM Decap (deserialize enc + DH + same LabeledExtract/LabeledExpand path)
+- KeySchedule (psk_id_hash, info_hash, key_schedule_context, secret, then derive AEAD key + base_nonce + exporter_secret per RFC §5.1)
+- LabeledExtract / LabeledExpand (HMAC-based, since Web Crypto's HKDF is combined-only — implement raw HMAC per design §1)
+
+These are NOT exported; they're internal building blocks. Per D7.
+
+**Checkpoint:** internal primitives compile and roundtrip against test vectors from B.0.
+
+### B.3 — Public operations
+
+- `sealBase`: validate recipient pubkey shape; generate ephemeral; encap; KeySchedule; AES-GCM encrypt; return `{enc, ciphertext}` per D3
+- `openBase`: validate recipient privkey shape; decap; KeySchedule; AES-GCM decrypt; return plaintext
+- `hkdf`: implement RFC 5869 Extract-then-Expand via HMAC-SHA256 (Web Crypto's combined HKDF doesn't expose Extract alone; implement raw)
+- `encodeEnvelope` / `decodeEnvelope`: simple concatenation/split (32 enc bytes + variable ciphertext)
+
+All async public methods return `Result<T>` via `captureAsyncResult`. Result.fail messages include enough context for debugging without leaking key material.
+
+**Checkpoint:** end-to-end seal→open roundtrip passes for both Node and browser test vectors.
+
+### B.4 — Tests + coverage
+
+Test files:
+- `libraries/ts-extras/src/test/unit/crypto/hpkeProvider.test.ts` — Node side
+- `libraries/ts-web-extras/src/test/unit/hpkeProvider.test.ts` — Browser side
+- Shared test-vector constants file (placement: per design §6 — likely `libraries/ts-extras/src/test/unit/crypto/hpke-vectors.ts` or similar; both test files import)
+
+Test coverage:
+- Cipher-suite vectors (RFC 9180 if available, or self-generated cross-runtime anchors per B.0)
+- Roundtrip: seal then open with same `info` and `aad` — recovers plaintext
+- `info` mismatch: seal with `info=X`, open with `info=Y` — fails (AEAD verification)
+- `aad` mismatch: seal with `aad=X`, open with `aad=Y` — fails
+- Wrong recipient key: seal to recipient A, open with recipient B's privkey — fails
+- Tampered ciphertext: flip one byte in ciphertext, open fails
+- Tampered enc: flip one byte in enc, open fails
+- Empty plaintext, empty aad — valid; roundtrip works
+- HKDF: known-vector tests (RFC 5869 test vectors A.1, A.2, A.3 if applicable to SHA-256)
+- Cross-runtime equivalence: `ts-extras` and `ts-web-extras` test files import the same vector constants and verify byte-identical output
+- Envelope encode/decode roundtrip
+
+100% coverage required. Per `.ai/instructions/CODING_STANDARDS.md` § Pre-PR Validation Checklist, full `rushx build && rushx lint && rushx test` must pass locally before opening PR.
+
+### B.5 — Documentation
+
+Update `.ai/instructions/LIBRARY_CAPABILITIES.md`:
+
+- Expand the `crypto-utils` packlet entry to mention `HpkeProvider` (RFC 9180 base mode; the cipher suite; the class shape with `create` factory)
+- Add a new decision shortcut: **"Need to wrap material to a recipient via HPKE (RFC 9180)?"** → describe `HpkeProvider.create(subtle).orThrow().sealBase(...)` pattern; note `info` is load-bearing
+- Note that HKDF is exposed on `HpkeProvider.hkdf(...)` (not on `ICryptoProvider`) for now
+
+**Checkpoint:** docs reflect implementation; api-extractor regenerated for both packages.
+
+### B.6 — Pre-merge artifact migration
+
+Migrate `.ai/tasks/active/crypto-batch-2-hpke/` → `.ai/tasks/completed/2026-05/crypto-batch-2-hpke/`. Write a **separate polished `README.md`** (not just the migrated state.md) capturing:
+
+- What shipped (HpkeProvider class, cipher suite, envelope helpers, HKDF)
+- Key decisions including the signoff modification (class-based vs functions)
+- B.0 RFC verification outcome (cited vectors or self-generated anchors)
+- Acceptance status
+- Followups: TECH_DEBT / FUTURE candidates
+
+Pre-merge migration is mandatory per `.ai/conventions/workflow/artifact-protocol.md`. Don't repeat the early-cluster pattern of treating "state.md migrated" as fulfilling the README requirement.
+
+---
+
+## Package surface
+
+### In-scope (modify)
+
+- `libraries/ts-extras/src/packlets/crypto-utils/hpkeProvider.ts` (new file — the class + helpers)
+- `libraries/ts-extras/src/packlets/crypto-utils/index.ts` (export `HpkeProvider`)
+- `libraries/ts-extras/etc/ts-extras.api.md` (regenerate)
+- `libraries/ts-extras/src/test/unit/crypto/hpkeProvider.test.ts` (new)
+- Shared test-vector constants file
+- `libraries/ts-web-extras/src/packlets/crypto-utils/index.ts` (re-export `HpkeProvider`)
+- `libraries/ts-web-extras/etc/ts-web-extras.api.md` (regenerate)
+- `libraries/ts-web-extras/src/test/unit/hpkeProvider.test.ts` (new)
+- `.ai/instructions/LIBRARY_CAPABILITIES.md` (decision shortcut + packlet entry update)
+- `.ai/tasks/active/crypto-batch-2-hpke/state.md` (checkpoint updates)
+- Pre-merge: migrate `.ai/tasks/active/crypto-batch-2-hpke/` → `.ai/tasks/completed/2026-05/crypto-batch-2-hpke/` with polished `README.md`
+
+### Out-of-scope
+
+- `wrapBytes`/`unwrapBytes` (ECIES — separate primitive; D1)
+- `ICryptoProvider` modifications (HpkeProvider is its own class; D2)
+- Argon2id, WebAuthn surfaces (parallel streams)
+- HPKE auth mode, PSK mode, auth-PSK mode (base mode only)
+- Sudoku packages
+
+### Parallel-stream awareness
+
+`crypto-batch-2-argon2id` phase B may touch `crypto-utils/model.ts` (to add the `IKeyDerivationParams` discriminated union). HPKE phase B introduces a new file (`hpkeProvider.ts`) and only modifies `crypto-utils/index.ts` (to add the `HpkeProvider` export). Collision risk on `model.ts` only if HPKE phase B also edits it (it shouldn't — HpkeProvider doesn't need ICryptoProvider type additions). If something forces a model.ts edit, coordinate with the Argon2id agent via state.md checkpoints.
+
+---
+
+## Required reading (priority order)
+
+1. `.ai/tasks/active/crypto-batch-2-hpke/brief-phase-b.md` (this file) — binding contract
+2. `.ai/tasks/active/crypto-batch-2-hpke/design.md` — phase A inventory + algorithm pseudocode (verify at B.0)
+3. `.ai/tasks/active/crypto-batch-2-hpke/brief.md` — phase A contract (still useful for original scope framing)
+4. `.ai/notes/cross-repo-handoffs/fgv-batch-2-handoff-2026-05.md` — consumer context
+5. RFC 9180 (HPKE) — section 5 (key schedule), section 6 (modes; we need §6.1 base mode), section 9 (test vectors), appendix A
+6. `libraries/ts-extras/src/packlets/crypto-utils/` — existing patterns:
+   - `nodeCryptoProvider.ts` and `browserCryptoProvider.ts` for class-with-create-factory shape
+   - `keystore/` for nested-class organization in the packlet
+   - `wrapBytes.ts` for analogous protocol implementation precedent
+7. `libraries/ts-web-extras/src/packlets/crypto-utils/` — browser-side patterns
+8. `.ai/instructions/CODING_STANDARDS.md` § Pre-PR Validation Checklist — lint discipline; full validation suite required before PR
+9. `.ai/instructions/TESTING_GUIDELINES.md` — Result matchers, 100% coverage requirement
+
+---
+
+## Skills to load (when conditions trigger)
+
+- `/result-pattern` — load before writing any function returning `Result<T>` (all public methods)
+- `/result-tests` — load before writing tests; use Result matchers
+- `/published-primitives-reflex` — load before writing utility helpers
+- `/type-safe-validation` — load if input-validation surfaces (likely minimal — primary inputs are typed `CryptoKey` and `Uint8Array`)
+
+---
+
+## Acceptance criteria
+
+- [ ] B.0 RFC verification outcome captured in state.md
+- [ ] `HpkeProvider` class with private constructor + static `create` factory
+- [ ] All five public operations implemented and tested
+- [ ] Cross-runtime byte-identical output verified (Node ↔ browser) via shared test vectors
+- [ ] `info` parameter discipline documented in JSDoc; load-bearing nature called out
+- [ ] `rushx build` passes in `ts-extras` and `ts-web-extras`
+- [ ] **`rushx lint` passes in `ts-extras` and `ts-web-extras`** (load-bearing — NOT transitively run by build; see CODING_STANDARDS § Pre-PR Validation Checklist)
+- [ ] `rushx test` passes with 100% coverage in `ts-extras` and `ts-web-extras`
+- [ ] **`rushx fixlint` was run before the final commit**
+- [ ] No `any` types; all fallible operations return `Result<T>`
+- [ ] No inline lint-rule-disable directives added to make lint pass
+- [ ] api-extractor regenerated (`ts-extras.api.md`, `ts-web-extras.api.md`)
+- [ ] `LIBRARY_CAPABILITIES.md` updated with new decision shortcut + packlet entry
+- [ ] Pre-merge artifact migration to `.ai/tasks/completed/2026-05/crypto-batch-2-hpke/` with **separate polished README.md** (not just migrated state.md)
+- [ ] PR opened against `claude/crypto-batch-2-features` (NOT `release`)
+
+---
+
+## Branch + PR posture
+
+- **Base branch:** `claude/crypto-batch-2-features` (cluster integration)
+- **Work branch:** `claude/crypto-batch-2-hpke-impl` (or harness-auto-suffix; document the actual branch in state.md)
+- **PR target:** `claude/crypto-batch-2-features`
+- One PR for all of B.0–B.6 unless something forces a split.
+
+---
+
+## Don't
+
+- Don't open the PR until `rushx build && rushx lint && rushx test` all pass locally. `rushx build` does NOT transitively run lint; lint is a separate gate. Run `rushx fixlint` before the final commit.
+- Don't expose Encap/Decap/KeySchedule as public surface — internal only (D7)
+- Don't promote `hkdf` to `ICryptoProvider` — stays on `HpkeProvider` (D4)
+- Don't add helpers for `info` construction — caller's responsibility (D8)
+- Don't add HPKE auth mode / PSK mode / auth-PSK mode — base mode only (out of scope)
+- Don't modify `wrapBytes`/`unwrapBytes` — separate primitive (D1)
+- Don't skip B.0. The phase A research was rfc-editor.org-blocked; live verification is required before encoding constants.
+
+---
+
+## Resume protocol
+
+If the session ends mid-phase: read `brief-phase-b.md` (this file), `design.md`, and `state.md` to resume. State.md records which checkpoints (B.0–B.6) are done.
+
+---
+
+## Missing-input rule
+
+If a required-reading file is missing or has a shape that conflicts with this brief, or if B.0 RFC verification surfaces algorithm differences from the design, **STOP and report**. Do not improvise.

--- a/.ai/tasks/active/crypto-batch-2-hpke/state.md
+++ b/.ai/tasks/active/crypto-batch-2-hpke/state.md
@@ -1,7 +1,7 @@
 # Stream State: crypto-batch-2-hpke
 
-**Status:** 🔵 phase A complete; phase B awaiting signoff
-**Last updated:** 2026-05-12 (phase A implementing agent)
+**Status:** 🟢 phase A signed off; phase B ready to start
+**Last updated:** 2026-05-12 (orchestrator — phase B brief authored)
 
 ---
 
@@ -9,8 +9,18 @@
 
 | Phase | Status | Notes |
 |-------|--------|-------|
-| A — research and design | ✅ done | design.md committed; PR open against `claude/crypto-batch-2-features` |
-| B — implementation | ⏸ blocked on phase A signoff | Brief to be written by orchestrator post-signoff |
+| A — research and design | ✅ done | design.md merged into `claude/crypto-batch-2-features` |
+| B — implementation | 🟢 ready | `brief-phase-b.md` is the binding contract; assignable to implementing agent |
+
+---
+
+## Phase A signoff summary (orchestrator)
+
+Design approved with **one significant modification**: the design's "subtle as first parameter" function-based API is replaced with a **class-based `HpkeProvider` pattern** (private constructor + static `create(subtle): Result<HpkeProvider>`), matching the existing `NodeCryptoProvider` / `BrowserCryptoProvider` / `KeyStore` / `DirectEncryptionProvider` shape. The rest of the design (cipher suite; ciphertext format with inclusive auth tag; HKDF placement on the class rather than `ICryptoProvider`; `info` as first-class `Uint8Array`; internal primitives stay internal; no context-binding helper; cross-runtime via re-export with shared test vectors) stands as designed.
+
+Orchestrator added one non-optional precondition (B.0): live RFC 9180 verification. The phase A agent's research session was rfc-editor.org-blocked, so phase B must verify algorithm pseudocode and test-vector availability before encoding constants.
+
+Phase B contract is baked into `.ai/tasks/active/crypto-batch-2-hpke/brief-phase-b.md`. Where the brief conflicts with the design, the brief wins.
 
 ---
 

--- a/.ai/tasks/active/crypto-batch-2-webauthn/brief-phase-b.md
+++ b/.ai/tasks/active/crypto-batch-2-webauthn/brief-phase-b.md
@@ -1,0 +1,367 @@
+# Stream Brief: crypto-batch-2-webauthn (phase B — implementation)
+
+**Stream ID:** crypto-batch-2-webauthn
+**Phase:** B — implementation
+**Sequencing:** Phase A signed off. Phase B can run in parallel with `crypto-batch-2-hpke` and `crypto-batch-2-argon2id` phase B (no file collision — WebAuthn creates two new packages and touches `LIBRARY_CAPABILITIES.md`; that file is also touched by the other two streams, handled by simple section-level discipline).
+
+---
+
+## Context
+
+Phase A produced `.ai/tasks/active/crypto-batch-2-webauthn/design.md` (read it in full — library survey + six-primitive surface + type re-export discipline + abstraction-rejection log). Orchestrator/user signed off **as designed**: six primitive Result-integration wrappers, nothing else.
+
+The design's open questions resolve as follows:
+
+- **OQ-1 (libraries/ vs integrations/):** stay in `libraries/`. The `integrations/` convention question is a separate lessons-codification chore.
+- **OQ-2 (v12 support):** v13+ only. Do not include `@simplewebauthn/types`.
+- **OQ-3 (`VerifyRegistrationResponseOpts` naming):** accept the namespace duplication risk; `Parameters<>` alias guarantees structural identity.
+- **OQ-4 (rejected abstractions):** the four temptations stay rejected. No challenge generator helper, no PRF salt helper, no autofill input validator, no `WebAuthnCredential` builder.
+
+**This brief is the binding contract** — where it conflicts with `design.md`, this brief wins.
+
+This is feature work on an active-development surface (two brand-new packages). Per `.ai/instructions/ACTIVE_DEVELOPMENT.md`, free hand on breaking changes.
+
+---
+
+## Mission
+
+Ship two new monorepo packages — `@fgv/ts-extras-webauthn` (Node, wraps `@simplewebauthn/server`) and `@fgv/ts-web-extras-webauthn` (browser, wraps `@simplewebauthn/browser`). Each exports its primitives as `Promise<Result<T>>` via `captureAsyncResult` over the unmodified upstream functions. Six primitives total, no abstraction beyond the boundary. 100% test coverage via `jest.mock` of upstream, lint pass, `LIBRARY_CAPABILITIES.md` update, pre-merge artifact migration.
+
+---
+
+## Signed-off design decisions (binding)
+
+The decisions baked into `design.md` stand unless overridden below.
+
+### D1. Six primitives — nothing else (design §1, §7)
+
+| Package | Function | Return |
+|---|---|---|
+| `@fgv/ts-extras-webauthn` | `generateRegistrationOptions(opts)` | `Promise<Result<PublicKeyCredentialCreationOptionsJSON>>` |
+| `@fgv/ts-extras-webauthn` | `verifyRegistrationResponse(opts)` | `Promise<Result<VerifiedRegistrationResponse>>` |
+| `@fgv/ts-extras-webauthn` | `generateAuthenticationOptions(opts)` | `Promise<Result<PublicKeyCredentialRequestOptionsJSON>>` |
+| `@fgv/ts-extras-webauthn` | `verifyAuthenticationResponse(opts)` | `Promise<Result<VerifiedAuthenticationResponse>>` |
+| `@fgv/ts-web-extras-webauthn` | `startRegistration(opts)` | `Promise<Result<RegistrationResponseJSON>>` |
+| `@fgv/ts-web-extras-webauthn` | `startAuthentication(opts)` | `Promise<Result<AuthenticationResponseJSON>>` |
+
+Each is a one-line `captureAsyncResult(() => upstream(options))`. No transformation of inputs, no rewrapping of outputs, no error-message prefix, no ceremony orchestration.
+
+### D2. NOT-in-scope (design §7, OQ-4)
+
+Do NOT add (these were considered and explicitly rejected):
+
+- Challenge generator helper
+- PRF salt helper / Uint8Array conversion helper
+- `browserAutofillInput` validator / `autocomplete` attribute helper
+- `WebAuthnCredential` builder from verification output
+- Attestation policy presets
+- Algorithm allowlist presets
+- Challenge state management or challenge stores
+- Session token issuance
+- Registration or authentication ceremony orchestration
+- Credential / user database abstractions
+
+If you find yourself drafting any of these, **stop and surface to the orchestrator**. The Result-integration boundary is the whole product; abstraction creep is the failure mode.
+
+### D3. Upstream version pin (design §6)
+
+- `@simplewebauthn/server` — `^13.0.0` (caret) in `@fgv/ts-extras-webauthn`
+- `@simplewebauthn/browser` — `^13.0.0` (caret) in `@fgv/ts-web-extras-webauthn`
+- Add both to `common/config/rush/common-versions.json` `preferredVersions` with the `^13.0.0` range.
+- v13+ only; do NOT take `@simplewebauthn/types` as a dependency (its content was inlined into the server/browser packages in v13).
+
+### D4. Type re-export discipline (design §5)
+
+Re-export only the types that appear directly in the wrapped function input/output signatures. Deeper types (transports, COSE algorithms, attestation formats, extension client inputs/outputs) are caller's problem — they import from `@simplewebauthn/*` directly if needed.
+
+**Server package re-exports:**
+
+```typescript
+export type {
+  GenerateRegistrationOptionsOpts,
+  PublicKeyCredentialCreationOptionsJSON,
+  VerifiedRegistrationResponse,
+  GenerateAuthenticationOptionsOpts,
+  PublicKeyCredentialRequestOptionsJSON,
+  VerifiedAuthenticationResponse,
+  WebAuthnCredential,
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/server';
+
+// Aliases for upstream-unnamed opts types (Parameters<> keeps them in sync automatically)
+export type VerifyRegistrationResponseOpts = Parameters<typeof _verifyRegistrationResponse>[0];
+export type VerifyAuthenticationResponseOpts = Parameters<typeof _verifyAuthenticationResponse>[0];
+```
+
+**Browser package re-exports:**
+
+```typescript
+export type {
+  StartRegistrationOpts,
+  RegistrationResponseJSON,
+  StartAuthenticationOpts,
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/browser';
+```
+
+Use `Parameters<typeof fn>[0]` for any opts type the upstream doesn't export as a named alias. This is load-bearing for migration discipline (D3 / design §6): when upstream signatures change, the alias auto-updates.
+
+### D5. Error format (design §4) — captureAsyncResult bare
+
+No prefix. Upstream error messages are descriptive and self-identifying. Consumers wanting `"webauthn registration: <upstream>"` add it themselves via `.withErrorFormat()`. This is the correct layer for that concern.
+
+### D6. Test strategy — `jest.mock` upstream entirely (design §9 step 4)
+
+Do NOT use real `@simplewebauthn/*` calls in tests. `jest.mock('@simplewebauthn/server')` (or `'@simplewebauthn/browser'`) at the top of each test file. The thing being tested is the `captureAsyncResult` integration, not the upstream's WebAuthn ceremony correctness.
+
+Minimum 2 tests per primitive: success path (upstream resolves → `Success`) and failure path (upstream rejects → `Failure` with upstream message captured). 12 tests minimum across both packages.
+
+### D7. Package location and naming (design §2)
+
+- `libraries/ts-extras-webauthn/` — `@fgv/ts-extras-webauthn`
+- `libraries/ts-web-extras-webauthn/` — `@fgv/ts-web-extras-webauthn`
+
+Both `shouldPublish: true`, `versionPolicyName: "base-utils"`, `tags: ["libraries"]` (browser package also tagged `"browser"` per design §2).
+
+Browser package uses `testEnvironment: "jsdom"` in `config/jest.config.json` (matches `ts-web-extras`). Server package uses node test environment.
+
+`@fgv/heft-dual-rig` for both — same rig pattern as ts-extras / ts-web-extras.
+
+### D8. Flat structure — no packlets (design §9 step 2/3)
+
+Each package is a single `src/index.ts` file. No packlets, no internal subdirectories beyond `src/test/unit/`. The packages are single-purpose boundaries; flat structure is appropriate.
+
+---
+
+## Phase B implementation phases
+
+### B.1 — Scaffold both packages
+
+1. Register both packages in `rush.json` (entries per design §2).
+2. Create `libraries/ts-extras-webauthn/` tree:
+   - `package.json` — name `@fgv/ts-extras-webauthn`; dependencies `@simplewebauthn/server: ^13.0.0`, `@fgv/ts-utils: workspace:*`; peerDependencies `@fgv/ts-utils`; devDependencies mirror ts-utils-jest / ts-extras patterns (heft, jest, etc.).
+   - `tsconfig.json` extending node rig
+   - `config/rig.json` → `@fgv/heft-dual-rig`
+   - `config/jest.config.json` with 100% coverage threshold; node test environment
+   - `config/api-extractor.json` (copy from existing small library)
+   - `CHANGELOG.json` (empty initial)
+3. Create `libraries/ts-web-extras-webauthn/` tree with the same shape but:
+   - `package.json` depends on `@simplewebauthn/browser: ^13.0.0`
+   - `config/jest.config.json` uses `testEnvironment: "jsdom"`
+4. Add `preferredVersions` entries to `common/config/rush/common-versions.json`.
+5. Run `rush update` and confirm both packages install cleanly.
+
+**Checkpoint:** `rush install` + `rush build` succeeds for both packages (empty src is fine at this checkpoint).
+
+### B.2 — Server package implementation
+
+Single file: `libraries/ts-extras-webauthn/src/index.ts`. Implementation exactly as design §3 (server section):
+
+```typescript
+import {
+  generateRegistrationOptions as _generateRegistrationOptions,
+  verifyRegistrationResponse as _verifyRegistrationResponse,
+  generateAuthenticationOptions as _generateAuthenticationOptions,
+  verifyAuthenticationResponse as _verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import { captureAsyncResult, type Result } from '@fgv/ts-utils';
+
+// type re-exports (per D4)
+
+export async function generateRegistrationOptions(
+  options: GenerateRegistrationOptionsOpts
+): Promise<Result<PublicKeyCredentialCreationOptionsJSON>> {
+  return captureAsyncResult(() => _generateRegistrationOptions(options));
+}
+// ...three more analogous functions
+```
+
+JSDoc on each function: one short line stating "Result-integration wrapper around `@simplewebauthn/server`'s `<name>`. Returns `Promise<Result<T>>`; upstream errors are captured as `Failure` with the original message." Reference upstream docs URL.
+
+Re-export the types per D4.
+
+**Checkpoint:** `rushx build` + `rushx lint` pass.
+
+### B.3 — Browser package implementation
+
+Single file: `libraries/ts-web-extras-webauthn/src/index.ts`. Per design §3 (browser section). Two functions plus re-exports.
+
+**Checkpoint:** `rushx build` + `rushx lint` pass.
+
+### B.4 — Tests for both packages
+
+`libraries/ts-extras-webauthn/src/test/unit/webauthn.test.ts` (server, 4 functions × ≥2 tests each).
+`libraries/ts-web-extras-webauthn/src/test/unit/webauthn.test.ts` (browser, 2 functions × ≥2 tests each).
+
+Per-primitive pattern (design §9 step 4):
+
+```typescript
+import { jest } from '@jest/globals';
+jest.mock('@simplewebauthn/server');
+
+import { generateRegistrationOptions } from '../index';
+import * as upstream from '@simplewebauthn/server';
+
+describe('generateRegistrationOptions', () => {
+  beforeEach(() => { jest.resetAllMocks(); });
+
+  test('returns Success wrapping upstream result on success', async () => {
+    const mockResult = { /* shape */ } as PublicKeyCredentialCreationOptionsJSON;
+    jest.mocked(upstream.generateRegistrationOptions).mockResolvedValueOnce(mockResult);
+    await expect(generateRegistrationOptions(mockOpts)).resolves.toSucceedWith(mockResult);
+  });
+
+  test('returns Failure capturing upstream error message on throw', async () => {
+    jest.mocked(upstream.generateRegistrationOptions).mockRejectedValueOnce(
+      new Error('Challenge is not in the correct format')
+    );
+    await expect(generateRegistrationOptions(mockOpts)).resolves.toFailWith(
+      /challenge is not in the correct format/i
+    );
+  });
+});
+```
+
+Use `@fgv/ts-utils-jest` matchers per `.ai/instructions/TESTING_GUIDELINES.md`. 100% coverage in both packages.
+
+**Checkpoint:** `rushx test` passes with 100% coverage in both packages.
+
+### B.5 — Documentation
+
+Update `.ai/instructions/LIBRARY_CAPABILITIES.md` per design §7. Add a new section (after `@fgv/ts-web-extras`) titled something like:
+
+> ### `@fgv/ts-extras-webauthn` + `@fgv/ts-web-extras-webauthn` — WebAuthn Result boundary
+
+Include the six-primitive table and the explicit "NOT in scope" list from D2. Make the boundary-only positioning unmissable for future readers — the design's framing is exactly right.
+
+Add decision shortcuts:
+
+- **"Need a Result-integrated WebAuthn registration / authentication primitive (server-side)?"** → `generateRegistrationOptions` / `verifyRegistrationResponse` / `generateAuthenticationOptions` / `verifyAuthenticationResponse` from `@fgv/ts-extras-webauthn`. Wraps `@simplewebauthn/server`. Caller still owns ceremony orchestration, challenge management, and credential storage.
+- **"Need to start a WebAuthn ceremony in the browser?"** → `startRegistration` / `startAuthentication` from `@fgv/ts-web-extras-webauthn`. Wraps `@simplewebauthn/browser`.
+- **Note:** these packages do NOT include PRF helpers, challenge generators, attestation policy, or credential storage. For anything beyond the Result boundary, call `@simplewebauthn/*` directly.
+
+Update the package table at the top of the doc to add the two new packages.
+
+Regenerate api-extractor for both new packages.
+
+**Checkpoint:** docs reflect implementation; api-extractor regenerated.
+
+### B.6 — Pre-merge artifact migration
+
+Migrate `.ai/tasks/active/crypto-batch-2-webauthn/` → `.ai/tasks/completed/2026-05/crypto-batch-2-webauthn/`. Write a **separate polished `README.md`** capturing:
+
+- What shipped (two packages, six primitives)
+- The Result-integration-boundary discipline (D1, D2) — the README is the durable record of what fgv did NOT include and why
+- Key decisions (libraries/ placement, v13+ only, `Parameters<>` aliases, jest.mock upstream)
+- Acceptance status
+- Followups: TECH_DEBT / FUTURE candidates (e.g. the `integrations/` convention question from OQ-1)
+
+Pre-merge migration is mandatory per `.ai/conventions/workflow/artifact-protocol.md`. **Separate polished README.md** — not just the migrated state.md.
+
+Note: a phase A draft PR (#342) exists on the WebAuthn agent branch. That PR is being superseded by this consolidated cluster work; the orchestrator will close it when the prep PR merges. Implementer does not need to touch #342.
+
+---
+
+## Package surface
+
+### In-scope (create / modify)
+
+- `libraries/ts-extras-webauthn/` — new package (full structure per design §2)
+- `libraries/ts-web-extras-webauthn/` — new package (full structure per design §2)
+- `rush.json` — register both new packages
+- `common/config/rush/common-versions.json` — add `@simplewebauthn/server` and `@simplewebauthn/browser` to `preferredVersions`
+- `.ai/instructions/LIBRARY_CAPABILITIES.md` — new section + decision shortcuts + package table update
+- `.ai/tasks/active/crypto-batch-2-webauthn/state.md` — checkpoint updates
+- Pre-merge: migrate `.ai/tasks/active/crypto-batch-2-webauthn/` → `.ai/tasks/completed/2026-05/crypto-batch-2-webauthn/` with polished `README.md`
+
+### Out-of-scope
+
+- Any abstraction beyond the six primitives (D2 — the rejected-temptations list is binding)
+- Modifications to `@fgv/ts-extras`, `@fgv/ts-web-extras`, `@fgv/ts-utils`, or any other existing package (zero impact; design §10)
+- HPKE, Argon2id surfaces (parallel streams)
+- Sudoku packages
+
+### Parallel-stream awareness
+
+Both HPKE and Argon2id phase B will also touch `.ai/instructions/LIBRARY_CAPABILITIES.md`. The HPKE stream updates the `crypto-utils` packlet entry plus adds one decision shortcut. The Argon2id stream adds new packages to the table, new decision shortcuts, and updates the `crypto-utils` packlet entry. WebAuthn adds a new top-level section + two decision shortcuts + two table entries. Section-level discipline (each stream owns its added section / decision-shortcut / table-row) keeps merge conflicts minimal. If a real conflict arises, coordinate via state.md checkpoints.
+
+---
+
+## Required reading (priority order)
+
+1. `.ai/tasks/active/crypto-batch-2-webauthn/brief-phase-b.md` (this file) — binding contract
+2. `.ai/tasks/active/crypto-batch-2-webauthn/design.md` — phase A inventory + six-primitive surface
+3. `.ai/tasks/active/crypto-batch-2-webauthn/brief.md` — phase A contract
+4. `.ai/notes/cross-repo-handoffs/fgv-batch-2-handoff-2026-05.md` — consumer context
+5. `libraries/ts-utils-jest/` — small-package structural precedent (package.json / tsconfig / rig / jest config)
+6. `libraries/ts-web-extras/` — browser-package precedent (jsdom test environment, package.json shape)
+7. `libraries/ts-utils/src/packlets/base/result.ts` — `captureAsyncResult` reference (don't re-implement)
+8. `@simplewebauthn/server` v13 docs — https://simplewebauthn.dev/docs/packages/server
+9. `@simplewebauthn/browser` v13 docs — https://simplewebauthn.dev/docs/packages/browser
+10. `.ai/instructions/CODING_STANDARDS.md` § Pre-PR Validation Checklist — lint discipline
+11. `.ai/instructions/TESTING_GUIDELINES.md` — Result matchers, 100% coverage
+12. `.ai/instructions/ACTIVE_DEVELOPMENT.md` — free hand on breaking changes; no compat shims for new packages
+
+---
+
+## Skills to load (when conditions trigger)
+
+- `/result-pattern` — load before writing the wrappers (every function returns `Promise<Result<T>>`)
+- `/result-tests` — load before writing tests; use Result matchers
+- `/published-primitives-reflex` — load if tempted to write any helper beyond the six primitives (this is the kill-switch on abstraction creep)
+
+---
+
+## Acceptance criteria
+
+- [ ] Both new packages registered in `rush.json` and installable via `rush update`
+- [ ] All six primitives implemented as one-line `captureAsyncResult` wrappers
+- [ ] Type re-exports limited to the direct-signature types (D4); `Parameters<>` aliases used for upstream-unnamed opts types
+- [ ] No abstractions beyond the six primitives (no challenge gen / PRF helper / autofill validator / credential builder — D2)
+- [ ] `jest.mock` used for upstream in all tests (no real WebAuthn ceremony)
+- [ ] `rushx build` passes in both new packages
+- [ ] **`rushx lint` passes in both new packages** (load-bearing — NOT transitively run by build; see CODING_STANDARDS § Pre-PR Validation Checklist)
+- [ ] `rushx test` passes with 100% coverage in both new packages
+- [ ] **`rushx fixlint` was run before the final commit**
+- [ ] No `any` types; all fallible operations return `Result<T>`
+- [ ] No inline lint-rule-disable directives added to make lint pass
+- [ ] api-extractor generated for both new packages
+- [ ] `LIBRARY_CAPABILITIES.md` updated with new section, decision shortcuts, and package table rows
+- [ ] `common/config/rush/common-versions.json` `preferredVersions` entries added
+- [ ] Pre-merge artifact migration to `.ai/tasks/completed/2026-05/crypto-batch-2-webauthn/` with **separate polished README.md** that captures the boundary-only discipline
+- [ ] PR opened against `claude/crypto-batch-2-features` (NOT `release`)
+
+---
+
+## Branch + PR posture
+
+- **Base branch:** `claude/crypto-batch-2-features` (cluster integration)
+- **Work branch:** `claude/crypto-batch-2-webauthn-impl` (or harness-auto-suffix; document the actual branch in state.md)
+- **PR target:** `claude/crypto-batch-2-features`
+- One PR for all of B.1–B.6 unless something forces a split.
+- Note: PR #342 (the WebAuthn phase A draft) is being superseded by this work. Orchestrator will close it after the prep PR merges.
+
+---
+
+## Don't
+
+- Don't open the PR until `rushx build && rushx lint && rushx test` all pass locally. `rushx build` does NOT transitively run lint; lint is a separate gate. Run `rushx fixlint` before the final commit.
+- Don't add ANY of the rejected abstractions from D2 / OQ-4. If you find yourself drafting one, STOP and surface to the orchestrator. The Result-integration boundary IS the product.
+- Don't add an error-message prefix in the wrappers — `captureAsyncResult` captures the upstream message bare (D5).
+- Don't take `@simplewebauthn/types` as a dependency — v13+ exports types from server/browser packages directly (D3).
+- Don't use the real `@simplewebauthn/*` in tests — `jest.mock` upstream entirely (D6).
+- Don't add packlets — flat single-file `src/index.ts` per package (D8).
+- Don't re-export types beyond the direct-signature set (D4). Deeper types stay caller-imported.
+
+---
+
+## Resume protocol
+
+If the session ends mid-phase: read `brief-phase-b.md` (this file), `design.md`, and `state.md` to resume. State.md records which checkpoints (B.1–B.6) are done.
+
+---
+
+## Missing-input rule
+
+If a required-reading file is missing or has a shape that conflicts with this brief, or if upstream `@simplewebauthn/*` v13.x has changed signatures since the design (verify `@simplewebauthn/server`'s currently-published v13.x exports if anything looks off), **STOP and report**. Do not improvise.

--- a/.ai/tasks/active/crypto-batch-2-webauthn/design.md
+++ b/.ai/tasks/active/crypto-batch-2-webauthn/design.md
@@ -1,0 +1,687 @@
+# Design: crypto-batch-2-webauthn
+
+**Stream:** crypto-batch-2-webauthn  
+**Phase:** A — research and design  
+**Author:** implementing agent  
+**Date:** 2026-05-12  
+**Status:** draft — awaiting orchestrator signoff
+
+---
+
+## 1. Upstream library survey
+
+### @simplewebauthn/server
+
+- **Current version:** 13.3.0 (released 2026-03-10)
+- **Source:** https://github.com/MasterKale/SimpleWebAuthn
+- **npm:** https://www.npmjs.com/package/@simplewebauthn/server
+- **License:** MIT — compatible with fgv's MIT
+
+**Release cadence:** active and well-maintained. Major version history shows consistent cadence (v4 → v5 → v6 → v7 → v8 → v9 → v10 → v11 → v12 → v13), roughly one to two major versions per year since 2020. Current series (v11–v13) has been stable in surface area; v13.x is primarily refinement.
+
+**Stability of the four server-side primitives across recent majors:**
+
+| Function | Last significant signature change |
+|---|---|
+| `generateRegistrationOptions` | v10 (Base64URLString for excluded credential IDs; random user ID default) |
+| `verifyRegistrationResponse` | v11 (return type restructured: `credential` object replaces individual properties) |
+| `generateAuthenticationOptions` | v10 (`rpID` became required; Base64URLString for allowed credential IDs) |
+| `verifyAuthenticationResponse` | v11 (argument renamed `authenticator` → `credential`; return type gained `authenticationInfo`) |
+
+Since v11, the surface has been stable. v12 added JSR registry support (no API change). v13 added registration hints support and improved attestation trust anchor verification — refinements, not breaks. The v11 → v12 → v13 path has had no signature-level breaking changes to our four primitives.
+
+**Documented breaking-change patterns:**
+- Major versions reliably include breaking changes
+- The changelog at https://github.com/MasterKale/SimpleWebAuthn/blob/master/CHANGELOG.md is comprehensive and explicitly marks breaking changes with `**Breaking**`
+- The pattern since v7 is: functions are async (`Promise<T>` returns); inputs use `Base64URLString` not `Uint8Array`; output types are structured objects
+
+**Notable v13 change:** Types no longer require the separate `@simplewebauthn/types` package — all types are exported directly from `@simplewebauthn/server` and `@simplewebauthn/browser`. This simplifies our wrapper significantly (no three-way dependency).
+
+**Verdict:** Confirmed correct wrap target. Widely used, TypeScript-first, actively maintained, MIT-licensed, stable API in current major.
+
+---
+
+### @simplewebauthn/browser
+
+- **Current version:** 13.3.0 (same versioning as server package — they are released in lockstep)
+- **npm:** https://www.npmjs.com/package/@simplewebauthn/browser
+- **License:** MIT — compatible with fgv's MIT
+
+**Release cadence:** same lockstep cadence as server package.
+
+**Stability of the two browser-side primitives:**
+
+| Function | Last significant signature change |
+|---|---|
+| `startRegistration` | v11 (object argument shape: `{ optionsJSON, useAutoRegister? }`) |
+| `startAuthentication` | v11 (object argument shape: `{ optionsJSON, useBrowserAutofill?, verifyBrowserAutofillInput? }`) |
+
+Stable since v11. No changes in v12 or v13.
+
+**Bundle-size implications:**  
+`@simplewebauthn/browser` is approximately **9.1 KB gzipped** (current v13.x). This is low overhead for a WebAuthn integration library — the entire implementation including crypto helpers is under 10 KB compressed. The library ships two bundles: an ES2021 bundle for modern browsers and an ES5 bundle with polyfills for older targets. The ES5 bundle is larger due to polyfills; consumers targeting modern browsers (which is the correct baseline for WebAuthn) should use the ES2021 build. Our `@fgv/ts-web-extras-webauthn` wrapper adds no material overhead beyond the upstream dependency.
+
+Source: https://simplewebauthn.dev/docs/packages/browser; https://www.npmjs.com/package/@simplewebauthn/browser
+
+**Verdict:** Confirmed correct wrap target. ~9 KB gzipped is acceptable for a browser authentication library. Stable API in current major.
+
+---
+
+## 2. Package structure
+
+### Two new packages
+
+#### `@fgv/ts-extras-webauthn`
+
+```
+libraries/ts-extras-webauthn/
+├── src/
+│   ├── index.ts                  # re-exports; four server-side primitives + types
+│   └── test/
+│       └── unit/
+│           └── webauthn.test.ts  # tests for all four server primitives
+├── package.json
+├── tsconfig.json
+├── config/
+│   ├── rig.json
+│   ├── jest.config.json
+│   └── api-extractor.json
+└── CHANGELOG.json
+```
+
+**Dependencies:**
+- `dependencies`: `@simplewebauthn/server`, `@fgv/ts-utils`
+- `devDependencies`: standard heft/jest/ts toolchain (mirrors ts-extras or ts-utils-jest pattern)
+- `peerDependencies`: `@fgv/ts-utils`
+
+**rush.json entry:**
+```json
+{
+  "packageName": "@fgv/ts-extras-webauthn",
+  "projectFolder": "libraries/ts-extras-webauthn",
+  "shouldPublish": true,
+  "versionPolicyName": "base-utils",
+  "tags": ["libraries"]
+}
+```
+
+**Runtime environment:** Node (server-side). Standard `@fgv/heft-dual-rig` rig, same as ts-extras.
+
+---
+
+#### `@fgv/ts-web-extras-webauthn`
+
+```
+libraries/ts-web-extras-webauthn/
+├── src/
+│   ├── index.ts                  # re-exports; two browser-side primitives + types
+│   └── test/
+│       └── unit/
+│           └── webauthn.test.ts  # tests for both browser primitives
+├── package.json
+├── tsconfig.json
+├── config/
+│   ├── rig.json
+│   ├── jest.config.json
+│   └── api-extractor.json
+└── CHANGELOG.json
+```
+
+**Dependencies:**
+- `dependencies`: `@simplewebauthn/browser`, `@fgv/ts-utils`
+- `devDependencies`: standard heft/jest/ts toolchain; jsdom test environment (same as ts-web-extras)
+- `peerDependencies`: `@fgv/ts-utils`
+
+**rush.json entry:**
+```json
+{
+  "packageName": "@fgv/ts-web-extras-webauthn",
+  "projectFolder": "libraries/ts-web-extras-webauthn",
+  "shouldPublish": true,
+  "versionPolicyName": "base-utils",
+  "tags": ["libraries", "browser"]
+}
+```
+
+**Runtime environment:** browser. Jest configuration uses `testEnvironment: "jsdom"` — same pattern as `ts-web-extras`. The `@simplewebauthn/browser` functions call `navigator.credentials.*`; tests mock the upstream module entirely (see §9), so jsdom's incomplete `navigator.credentials` implementation is not a problem in practice.
+
+---
+
+### Naming and scoping
+
+`@fgv/ts-extras-webauthn` follows the same naming pattern as the Argon2 stream's `@fgv/ts-extras-argon2`: a `ts-extras-*` suffix for Node libraries and `ts-web-extras-*` for browser libraries that are separate packages because of a heavyweight upstream dependency. The naming convention is clear and consistent.
+
+**Import ergonomics for consumers:**
+```typescript
+// Server-side (Node)
+import { generateRegistrationOptions, verifyRegistrationResponse } from '@fgv/ts-extras-webauthn';
+import { generateAuthenticationOptions, verifyAuthenticationResponse } from '@fgv/ts-extras-webauthn';
+
+// Browser-side
+import { startRegistration, startAuthentication } from '@fgv/ts-web-extras-webauthn';
+```
+
+Clean, predictable, no scoping issues.
+
+---
+
+## 3. Exact function signatures
+
+All six primitives follow this shape:
+1. Accept upstream's input type unchanged
+2. Return `Promise<Result<UpstreamReturnType>>`
+3. Implemented as `captureAsyncResult(() => upstream(options))`
+
+### Server package (`@fgv/ts-extras-webauthn`)
+
+```typescript
+import {
+  generateRegistrationOptions as _generateRegistrationOptions,
+  verifyRegistrationResponse as _verifyRegistrationResponse,
+  generateAuthenticationOptions as _generateAuthenticationOptions,
+  verifyAuthenticationResponse as _verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import { captureAsyncResult, type Result } from '@fgv/ts-utils';
+
+// ---- Type re-exports (see §5 for full discipline) ----
+export type {
+  GenerateRegistrationOptionsOpts,
+  PublicKeyCredentialCreationOptionsJSON,
+  VerifiedRegistrationResponse,
+  GenerateAuthenticationOptionsOpts,
+  PublicKeyCredentialRequestOptionsJSON,
+  VerifiedAuthenticationResponse,
+  WebAuthnCredential,
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/server';
+
+// Type aliases for verify functions — upstream does not export named opts types for these.
+// Using Parameters<> keeps these aliases automatically in sync with the upstream signature.
+export type VerifyRegistrationResponseOpts = Parameters<typeof _verifyRegistrationResponse>[0];
+export type VerifyAuthenticationResponseOpts = Parameters<typeof _verifyAuthenticationResponse>[0];
+
+// ---- The four server-side primitives ----
+
+export async function generateRegistrationOptions(
+  options: GenerateRegistrationOptionsOpts
+): Promise<Result<PublicKeyCredentialCreationOptionsJSON>> {
+  return captureAsyncResult(() => _generateRegistrationOptions(options));
+}
+
+export async function verifyRegistrationResponse(
+  options: VerifyRegistrationResponseOpts
+): Promise<Result<VerifiedRegistrationResponse>> {
+  return captureAsyncResult(() => _verifyRegistrationResponse(options));
+}
+
+export async function generateAuthenticationOptions(
+  options: GenerateAuthenticationOptionsOpts
+): Promise<Result<PublicKeyCredentialRequestOptionsJSON>> {
+  return captureAsyncResult(() => _generateAuthenticationOptions(options));
+}
+
+export async function verifyAuthenticationResponse(
+  options: VerifyAuthenticationResponseOpts
+): Promise<Result<VerifiedAuthenticationResponse>> {
+  return captureAsyncResult(() => _verifyAuthenticationResponse(options));
+}
+```
+
+**Key type notes:**
+- `GenerateRegistrationOptionsOpts` and `GenerateAuthenticationOptionsOpts` are exported by `@simplewebauthn/server` as named type aliases (using the `Parameters<typeof fn>[0]` idiom upstream)
+- `VerifyRegistrationResponseOpts` and `VerifyAuthenticationResponseOpts` are NOT exported by upstream — we define them as `Parameters<>` aliases; this guarantees they stay in sync with upstream automatically
+- `RegistrationResponseJSON` and `AuthenticationResponseJSON` appear as the `response` field in the verify opts types; re-exporting them allows consumers to import the full JSON response shape from our package
+- `WebAuthnCredential` is re-exported because it appears as the `credential` field in `VerifyAuthenticationResponseOpts` (callers need this type to shape the credential they pass in from their database)
+
+---
+
+### Browser package (`@fgv/ts-web-extras-webauthn`)
+
+```typescript
+import {
+  startRegistration as _startRegistration,
+  startAuthentication as _startAuthentication,
+} from '@simplewebauthn/browser';
+import { captureAsyncResult, type Result } from '@fgv/ts-utils';
+
+// ---- Type re-exports (see §5 for full discipline) ----
+export type {
+  StartRegistrationOpts,
+  RegistrationResponseJSON,
+  StartAuthenticationOpts,
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/browser';
+
+// ---- The two browser-side primitives ----
+
+export async function startRegistration(
+  options: StartRegistrationOpts
+): Promise<Result<RegistrationResponseJSON>> {
+  return captureAsyncResult(() => _startRegistration(options));
+}
+
+export async function startAuthentication(
+  options: StartAuthenticationOpts
+): Promise<Result<AuthenticationResponseJSON>> {
+  return captureAsyncResult(() => _startAuthentication(options));
+}
+```
+
+**Key type notes:**
+- `StartRegistrationOpts` and `StartAuthenticationOpts` are exported by `@simplewebauthn/browser` (defined as `Parameters<typeof fn>[0]` upstream)
+- `RegistrationResponseJSON` and `AuthenticationResponseJSON` are the concrete return types — consumers need them when pattern-matching on the result
+
+---
+
+### Shared type overlap note
+
+`RegistrationResponseJSON` and `AuthenticationResponseJSON` appear in both packages (server re-exports them from `@simplewebauthn/server`; browser re-exports them from `@simplewebauthn/browser`). In v13+, these types are structurally identical — they represent the same WebAuthn JSON format. Consumers using both packages can import from either; TypeScript's structural type system ensures compatibility. Document this in consumer guidance (§7).
+
+---
+
+## 4. Error context format
+
+### What `captureAsyncResult` already does
+
+```typescript
+export async function captureAsyncResult<T>(func: () => Promise<T>): Promise<Result<T>> {
+  try {
+    return succeed(await func());
+  } catch (err: unknown) {
+    return fail(_errorMessage(err));
+  }
+}
+
+function _errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+```
+
+Behavior:
+- `Error` instances: `err.message` is captured — the human-readable error string
+- Non-Error thrown values: converted to string via `String()`
+- Error class/type is NOT preserved in the Result value (Result is value-shaped, not exception-shaped)
+
+### @simplewebauthn error message quality
+
+The upstream library throws descriptive `Error` instances with human-readable messages. Examples from the codebase and documentation:
+- `"The authenticator response contained invalid attestation"`
+- `"Challenge is not in the correct format"`
+- `"Unexpected authentication response type"`
+- `"Credential counter value for given response must be larger than 0"`
+
+These messages are self-describing; callers do not need a function-name prefix to understand what failed.
+
+### Decision: captureAsyncResult bare — no additional prefix
+
+**Rationale:**
+1. Upstream error messages are descriptive and self-identifying
+2. The D1 principle (Result-integration boundary only, no opinion baked in) argues against adding fgv-level framing around upstream messages
+3. Consumers wrapping these primitives in their own opinionated ceremony orchestration will add their own context via `.withErrorFormat()` — adding a prefix at our layer creates double-wrapping in the common case
+4. Callers pattern-matching on upstream error strings (for specific error handling) should not be broken by a prefix injection
+5. captureAsyncResult's error capture is already the established fgv pattern for this purpose
+
+**What this means for consumers:** if a consumer wants `"webauthn registration: <upstream message>"` as their error format, they write:
+```typescript
+const result = await generateRegistrationOptions(opts)
+  .withErrorFormat((msg) => `webauthn registration: ${msg}`);
+```
+This is the correct layer for that concern — the consumer's opinionated wrapper.
+
+**Error class preservation:** not needed. The class name is not information that flows through Result's value-shaped error model, and callers who need exception-level inspection should not be using this boundary.
+
+---
+
+## 5. Type re-export discipline
+
+**Strategy: re-export all types that appear in the wrapped function signatures (input types and output types, transitively one level).**
+
+Rationale: consumers need to construct inputs and handle outputs without a second `import ... from '@simplewebauthn/*'` statement. But types used inside those types (e.g., `AuthenticatorTransportFuture`, `COSEAlgorithmIdentifier`, `AttestationFormat`) are used in more advanced configuration and are better imported directly from `@simplewebauthn/server` — forcing callers to know that package exists for those types is fine.
+
+### Server package re-exports (`@fgv/ts-extras-webauthn`)
+
+Types appearing directly in our six server-side signatures:
+
+| Type | Used in | Source |
+|---|---|---|
+| `GenerateRegistrationOptionsOpts` | input to `generateRegistrationOptions` | upstream export |
+| `PublicKeyCredentialCreationOptionsJSON` | return from `generateRegistrationOptions` | upstream export |
+| `VerifyRegistrationResponseOpts` | input to `verifyRegistrationResponse` | **our alias** (`Parameters<>`) |
+| `VerifiedRegistrationResponse` | return from `verifyRegistrationResponse` | upstream export |
+| `RegistrationResponseJSON` | field in `VerifyRegistrationResponseOpts.response` | upstream export |
+| `GenerateAuthenticationOptionsOpts` | input to `generateAuthenticationOptions` | upstream export |
+| `PublicKeyCredentialRequestOptionsJSON` | return from `generateAuthenticationOptions` | upstream export |
+| `VerifyAuthenticationResponseOpts` | input to `verifyAuthenticationResponse` | **our alias** (`Parameters<>`) |
+| `VerifiedAuthenticationResponse` | return from `verifyAuthenticationResponse` | upstream export |
+| `AuthenticationResponseJSON` | field in `VerifyAuthenticationResponseOpts.response` | upstream export |
+| `WebAuthnCredential` | field in `VerifyAuthenticationResponseOpts.credential` | upstream export |
+
+Types NOT re-exported (consumers import from `@simplewebauthn/server` directly if needed):
+- `AuthenticatorTransportFuture`, `COSEAlgorithmIdentifier`, `AuthenticatorSelectionCriteria`
+- `AttestationFormat`, `CredentialDeviceType`, `Base64URLString`, `Uint8Array_`
+- `AuthenticationExtensionsClientInputs`, `AuthenticationExtensionsAuthenticatorOutputs`
+- `AttestationConveyancePreference` and other deep option types
+
+### Browser package re-exports (`@fgv/ts-web-extras-webauthn`)
+
+| Type | Used in | Source |
+|---|---|---|
+| `StartRegistrationOpts` | input to `startRegistration` | upstream export |
+| `RegistrationResponseJSON` | return from `startRegistration` | upstream export |
+| `StartAuthenticationOpts` | input to `startAuthentication` | upstream export |
+| `AuthenticationResponseJSON` | return from `startAuthentication` | upstream export |
+
+Types NOT re-exported (consumers import from `@simplewebauthn/browser` directly if needed):
+- `PublicKeyCredentialCreationOptionsJSON`, `PublicKeyCredentialRequestOptionsJSON` (these are inputs to the upstream opts types — consumers building the optionsJSON can import them from `@simplewebauthn/browser` or from our server package)
+
+### The two-import-statement question
+
+A consumer using `verifyAuthenticationResponse` and needing to store/retrieve `WebAuthnCredential` shapes in their database will import `WebAuthnCredential` from `@fgv/ts-extras-webauthn`. They do NOT need to import `@simplewebauthn/server` for the common path. This is the correct ergonomic target.
+
+---
+
+## 6. Version-pin strategy
+
+### Pin style in package.json
+
+Use **caret (`^13.0.0`)** for `@simplewebauthn/server` and `@simplewebauthn/browser` in the new packages.
+
+**Rationale:** caret allows patch and minor updates within v13.x automatically. Given the library's track record (changelogs are comprehensive; the authors clearly mark breaking changes with `**Breaking**`), caret within a major version is safe. Pinning to exact or tilde would impose maintenance overhead on every patch release from upstream for no safety benefit.
+
+### Rush preferredVersions discipline
+
+Add both packages to `common/config/rush/common-versions.json` `preferredVersions`:
+```json
+"preferredVersions": {
+  "@simplewebauthn/server": "^13.0.0",
+  "@simplewebauthn/browser": "^13.0.0"
+}
+```
+This ensures any transitive consumers of these packages in the monorepo converge on the same version range and avoids duplicate installs.
+
+### Review cadence
+
+- **Security advisory:** immediately. If a CVE or security advisory affects `@simplewebauthn/*`, update and bump within days.
+- **Major version:** review within 30 days of upstream release. The migration pattern (see below) is well-understood; timeline is workable.
+- **Minor/patch:** allow caret to auto-absorb. No proactive review needed; rely on upstream's changelog discipline and our test suite for regression detection.
+- **Quarterly review (optional):** during normal maintenance, check whether upstream has shipped any v13.x changes that improve our wrapper. Not blocking.
+
+### Migration shape on upstream major version bump (e.g. v13 → v14)
+
+Pattern (matches fgv's general approach):
+1. Wait for v14 to be non-beta
+2. Review v14 changelog for changes to our six wrapped function signatures
+3. If signatures are backward-compatible: bump `^14.0.0` in both packages, update preferredVersions, run tests, ship
+4. If signatures break: update wrappers + type aliases in a single commit; re-export any renamed types; bump minor version on the fgv packages (since the downstream API surface may change for consumers); document in CHANGELOG
+
+**The `Parameters<typeof fn>[0]` alias idiom pays off here:** if upstream renames the options interface, our `VerifyRegistrationResponseOpts = Parameters<typeof _verifyRegistrationResponse>[0]` alias auto-updates with no code change. Only if we're re-exporting a named upstream type that changed would we need to touch our re-export list.
+
+**No deprecated-and-old shim pattern.** The active-development discipline (ACTIVE_DEVELOPMENT.md) applies — these new packages have no compat burden. Break and fix consumers when upstream breaks.
+
+---
+
+## 7. Documentation and consumer guidance
+
+The section to add to `LIBRARY_CAPABILITIES.md` after phase B:
+
+---
+
+### `@fgv/ts-extras-webauthn` + `@fgv/ts-web-extras-webauthn` — WebAuthn Result boundary
+
+[libraries/ts-extras-webauthn](https://github.com/ErikFortune/fgv/tree/release/libraries/ts-extras-webauthn)  
+[libraries/ts-web-extras-webauthn](https://github.com/ErikFortune/fgv/tree/release/libraries/ts-web-extras-webauthn)
+
+**These packages are a Result-integration boundary over `@simplewebauthn/server` and `@simplewebauthn/browser` — not an opinionated WebAuthn helper.** The upstream libraries are excellent; these packages add exactly one thing: converting `@simplewebauthn`'s throw-on-failure interface into `Promise<Result<T>>`.
+
+**Six primitive operations. Nothing else.**
+
+| Package | Function | Return |
+|---|---|---|
+| `@fgv/ts-extras-webauthn` | `generateRegistrationOptions(opts)` | `Promise<Result<PublicKeyCredentialCreationOptionsJSON>>` |
+| `@fgv/ts-extras-webauthn` | `verifyRegistrationResponse(opts)` | `Promise<Result<VerifiedRegistrationResponse>>` |
+| `@fgv/ts-extras-webauthn` | `generateAuthenticationOptions(opts)` | `Promise<Result<PublicKeyCredentialRequestOptionsJSON>>` |
+| `@fgv/ts-extras-webauthn` | `verifyAuthenticationResponse(opts)` | `Promise<Result<VerifiedAuthenticationResponse>>` |
+| `@fgv/ts-web-extras-webauthn` | `startRegistration(opts)` | `Promise<Result<RegistrationResponseJSON>>` |
+| `@fgv/ts-web-extras-webauthn` | `startAuthentication(opts)` | `Promise<Result<AuthenticationResponseJSON>>` |
+
+**Explicitly NOT in scope:**
+- Attestation policy selection
+- Challenge state management or challenge stores
+- PRF, LargeBlob, or any other extension helpers
+- Algorithm allowlist presets
+- Registration or authentication ceremony orchestration
+- Credential table or user database abstractions
+- Session token issuance
+
+For anything not in the table above, **use `@simplewebauthn/server` or `@simplewebauthn/browser` directly** (with try/catch or `captureAsyncResult`).
+
+**The recommended consumer pattern:**
+
+These packages are the foundation layer. Build a consumer-specific opinionated wrapper on top:
+
+```typescript
+// Your wrapper adds policy, state, and ceremony orchestration
+// Our package supplies the Result-integrated primitive
+async function completeAuthentication(
+  response: AuthenticationResponseJSON,
+  challenge: string,
+  credential: WebAuthnCredential
+): Promise<Result<AuthSessionInfo>> {
+  return verifyAuthenticationResponse({
+    response,
+    expectedChallenge: challenge,
+    expectedOrigin: env.ORIGIN,
+    expectedRPID: env.RP_ID,
+    credential,
+  })
+    .withErrorFormat((msg) => `webauthn authentication: ${msg}`)
+    .onSuccess((result) => succeed(buildSessionInfo(result)));
+}
+```
+
+**Shared types:** `RegistrationResponseJSON` and `AuthenticationResponseJSON` are exported from both packages. If using both packages, import these types consistently from one — the types are structurally identical (same WebAuthn JSON format). For server-side type needs, prefer importing from `@fgv/ts-extras-webauthn`; for browser-side, from `@fgv/ts-web-extras-webauthn`.
+
+**Use `rush add` to add these packages:**
+```bash
+rush add -p @fgv/ts-extras-webauthn      # server-side consumers
+rush add -p @fgv/ts-web-extras-webauthn  # browser-side consumers
+```
+
+---
+
+## 8. PRF extension — flag if anything special needed
+
+**Confirmed: no special handling needed in the boundary wrapper.**
+
+The WebAuthn PRF (Pseudo-Random Function) extension flows entirely through standard `AuthenticationExtensionsClientInputs` — the DOM-standard `extensions` field that is already present in `generateRegistrationOptions` and `generateAuthenticationOptions` as an optional parameter. PRF evaluation results come back in `authenticatorExtensionResults` in the verify function return types.
+
+**How PRF flows through our six primitives:**
+
+1. **Registration — server side (`generateRegistrationOptions`):** caller includes PRF eval request in `options.extensions.prf` (e.g., `{ eval: { first: saltBytes } }`). This goes through as-is via our passthrough wrapper.
+
+2. **Registration — browser side (`startRegistration`):** caller passes the options JSON received from the server (which includes the prf extension) as `options.optionsJSON`. The browser's `navigator.credentials.create()` processes the extension. `startRegistration` returns a `RegistrationResponseJSON` whose `clientExtensionResults.prf` field contains the PRF availability indicator.
+
+3. **Authentication — server side (`generateAuthenticationOptions`):** same extension field approach for authentication challenges.
+
+4. **Authentication — browser side (`startAuthentication`):** caller passes options including prf extension inputs; `startAuthentication` invokes `navigator.credentials.get()` and returns `AuthenticationResponseJSON` whose `clientExtensionResults.prf` field contains the PRF output (`{ results: { first: Uint8Array } }`).
+
+5. **Verification — server side (`verifyRegistrationResponse`, `verifyAuthenticationResponse`):** the `authenticatorExtensionResults` field in the return type contains the server-parsed extension results. The PRF output for the consumer's key-derivation step is available there.
+
+**Import path:** PRF types (`AuthenticationExtensionsClientInputs`, `AuthenticationExtensionsAuthenticatorOutputs`) come from the standard DOM types. `@simplewebauthn/server` and `@simplewebauthn/browser` use these types as-is. No separate `@simplewebauthn/server/prf` import path exists.
+
+**SimpleWebAuthn's stated position on PRF:** the upstream maintainers have explicitly stated they do not plan to make PRF simpler through helpers, due to the security implications of tying encryption material to a passkey. This is aligned with our D3 discipline — we also do not add PRF helpers. PRF is the caller's problem; it flows through our boundary transparently.
+
+**Source:** https://github.com/MasterKale/SimpleWebAuthn/discussions/583; https://developers.yubico.com/WebAuthn/Concepts/PRF_Extension/
+
+---
+
+## 9. Implementation plan
+
+### Phase B scope
+
+Two new packages, six functions, tests for all six, LIBRARY_CAPABILITIES.md update.
+
+#### Step 1: Rush registration and scaffolding
+
+1. Register both packages in `rush.json` (entries specified in §2)
+2. Create `libraries/ts-extras-webauthn/` directory tree:
+   - `package.json` with `@simplewebauthn/server ^13.0.0` as runtime dependency
+   - `tsconfig.json` extending `@rushstack/heft-node-rig/profiles/default/tsconfig-base.json`
+   - `config/rig.json` pointing to `@fgv/heft-dual-rig`
+   - `config/jest.config.json` with 100% coverage threshold
+   - `config/api-extractor.json` (copy from ts-utils-jest pattern)
+   - `CHANGELOG.json` (empty initial)
+3. Create `libraries/ts-web-extras-webauthn/` directory tree:
+   - Same structure; `package.json` depends on `@simplewebauthn/browser ^13.0.0`
+   - `config/jest.config.json` with `testEnvironment: "jsdom"` and 100% coverage threshold
+4. Run `rush install` to wire up the new packages
+
+#### Step 2: Server package implementation
+
+Single file: `src/index.ts`
+
+Content: exact code from §3 (server section). Four functions, type re-exports, `Parameters<>` aliases.
+
+No packlets needed — the package is a single-purpose boundary wrapper with four functions. Flat structure is appropriate.
+
+#### Step 3: Browser package implementation
+
+Single file: `src/index.ts`
+
+Content: exact code from §3 (browser section). Two functions, type re-exports.
+
+#### Step 4: Test coverage strategy
+
+**Mock strategy:** jest.mock the upstream library. Do NOT use the real `@simplewebauthn` in tests — that would require a real WebAuthn ceremony with an authenticator. The thing being tested is captureAsyncResult integration, not WebAuthn ceremony correctness.
+
+**Per-primitive test pattern:**
+
+```typescript
+import { jest } from '@jest/globals';
+jest.mock('@simplewebauthn/server');
+
+import { generateRegistrationOptions } from '../index';
+import * as upstream from '@simplewebauthn/server';
+
+describe('generateRegistrationOptions', () => {
+  const mockOpts = { rpName: 'Test', rpID: 'test.example.com', userName: 'user@test.com' };
+  const mockResult = { challenge: 'abc123', /* ... */ } as PublicKeyCredentialCreationOptionsJSON;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns Success wrapping upstream result on success', async () => {
+    jest.mocked(upstream.generateRegistrationOptions).mockResolvedValueOnce(mockResult);
+    await expect(generateRegistrationOptions(mockOpts)).resolves.toSucceedWith(mockResult);
+  });
+
+  test('returns Failure capturing upstream error message on throw', async () => {
+    jest.mocked(upstream.generateRegistrationOptions).mockRejectedValueOnce(
+      new Error('Challenge is not in the correct format')
+    );
+    await expect(generateRegistrationOptions(mockOpts)).resolves.toFailWith(
+      /challenge is not in the correct format/i
+    );
+  });
+});
+```
+
+Minimum 2 tests per primitive (success + failure) = 12 tests minimum across both packages.
+
+Coverage note: captureAsyncResult's failure branch will be exercised by the rejection test. The success branch by the resolution test. 100% coverage is achievable with this pattern.
+
+#### Step 5: LIBRARY_CAPABILITIES.md addition
+
+Add the section from §7 to `.ai/instructions/LIBRARY_CAPABILITIES.md` under a new "WebAuthn" subsection in the "Specialized utilities" section (or its own top-level section alongside ts-extras and ts-web-extras). Exact placement: after the `@fgv/ts-web-extras` section.
+
+#### Step 6: PR
+
+Single PR targeting `claude/crypto-batch-2-features` containing both new packages + LIBRARY_CAPABILITIES.md update.
+
+---
+
+### What the orchestrator needs for the phase B brief
+
+- Two new packages created from scratch (no existing package to clone exactly, but ts-utils-jest and ts-web-extras provide structural precedent)
+- Test environment: jsdom for browser package, node for server package
+- The six signatures in §3 are the canonical implementation spec; implementer should not deviate
+- Version pin: `^13.0.0` for both upstream packages
+- Mock strategy: jest.mock in all tests; no real WebAuthn ceremony in tests
+
+---
+
+## 10. Migration impact
+
+**Zero impact on existing consumers.** Both packages are net-new additions.
+
+Existing packages (`@fgv/ts-extras`, `@fgv/ts-web-extras`, `@fgv/ts-utils`, etc.) are not modified. No exports are removed or renamed. No types change. The new packages appear at new import paths; nothing points at them except new consumers who opt in.
+
+The `rush.json` addition and `common-versions.json` `preferredVersions` additions are additive and do not affect any existing package's behavior.
+
+Confirmed zero migration impact.
+
+---
+
+## 11. Open questions for signoff
+
+**OQ-1: Directory location — `libraries/` vs. a new `integrations/` top level**
+
+The WORKSTREAMS.md ledger note (§ `crypto-batch-2-webauthn`) flags this: "The 'Result-integration boundary over a well-maintained upstream library' pattern is worth codifying as a fgv convention after this stream lands. Plus the question of whether such packages belong in `libraries/` or a top-level `integrations/` directory."
+
+This design places both packages in `libraries/` — same as the Argon2 stream — for consistency with the existing pattern. If the orchestrator/user wants to pilot an `integrations/` top-level directory with this stream, the change is a mechanical rename of the project folder. The design is otherwise unaffected.
+
+**Recommendation:** use `libraries/` now; the convention question can be addressed in the lessons-codification step after the cluster lands.
+
+---
+
+**OQ-2: Whether to include `@simplewebauthn/types` as a transitive dependency**
+
+In v13+, types are exported directly from `@simplewebauthn/server` and `@simplewebauthn/browser` — the separate `@simplewebauthn/types` package is no longer required. This design assumes v13+ and does NOT include `@simplewebauthn/types` as a dependency.
+
+If the orchestrator decides to support v12 consumers as well, `@simplewebauthn/types` would need to be re-examined. **Recommendation:** target v13+ only (current stable major). No question blocking.
+
+---
+
+**OQ-3: `VerifyRegistrationResponseOpts` naming**
+
+This design defines `VerifyRegistrationResponseOpts` as our own `Parameters<>` alias because upstream does not export a named type for the verifyRegistrationResponse options object. Same for `VerifyAuthenticationResponseOpts`.
+
+This means these types live in our package's namespace, not upstream's. There is a risk that if upstream ships `VerifyRegistrationResponseOpts` in v14, consumers would have two import paths for the same type (ours and upstream's). Not blocking — but worth flagging.
+
+**Recommendation:** accept this risk; the `Parameters<>` alias guarantees structural identity.
+
+---
+
+**OQ-4: Temptations to add abstraction that this design explicitly rejected (record for D3 compliance)**
+
+The following abstractions were tempting during research and explicitly rejected:
+
+1. **Challenge generator helper** — upstream's `generateRegistrationOptions` and `generateAuthenticationOptions` can generate challenges automatically; nothing to add here. ✗ rejected per D3.
+
+2. **PRF salt helper** — converting a string or Buffer to the `Uint8Array` format needed for the PRF extension `eval.first` field. Out of scope: PRF is caller's concern. ✗ rejected per D3.
+
+3. **`browserAutofillInput` validator** — `startAuthentication`'s `verifyBrowserAutofillInput` option does input element validation. A helper to add the correct `autocomplete` attribute to input elements was tempting. ✗ rejected per D3.
+
+4. **`WebAuthnCredential` builder** — a helper to construct the `WebAuthnCredential` object from registration verification output for storage. Structurally appealing (DRY across consumers). ✗ rejected per D3: credential storage is the caller's responsibility.
+
+All four are caller-side concerns. None of them belong in a Result-integration boundary.
+
+---
+
+## References
+
+- SimpleWebAuthn GitHub: https://github.com/MasterKale/SimpleWebAuthn
+- SimpleWebAuthn CHANGELOG: https://github.com/MasterKale/SimpleWebAuthn/blob/master/CHANGELOG.md
+- `@simplewebauthn/server` source — generateRegistrationOptions: https://github.com/MasterKale/SimpleWebAuthn/blob/master/packages/server/src/registration/generateRegistrationOptions.ts
+- `@simplewebauthn/server` source — verifyRegistrationResponse: https://github.com/MasterKale/SimpleWebAuthn/blob/master/packages/server/src/registration/verifyRegistrationResponse.ts
+- `@simplewebauthn/server` source — generateAuthenticationOptions: https://github.com/MasterKale/SimpleWebAuthn/blob/master/packages/server/src/authentication/generateAuthenticationOptions.ts
+- `@simplewebauthn/server` source — verifyAuthenticationResponse: https://github.com/MasterKale/SimpleWebAuthn/blob/master/packages/server/src/authentication/verifyAuthenticationResponse.ts
+- `@simplewebauthn/browser` source — startRegistration: https://github.com/MasterKale/SimpleWebAuthn/blob/master/packages/browser/src/methods/startRegistration.ts
+- `@simplewebauthn/browser` source — startAuthentication: https://github.com/MasterKale/SimpleWebAuthn/blob/master/packages/browser/src/methods/startAuthentication.ts
+- PRF extension discussion: https://github.com/MasterKale/SimpleWebAuthn/discussions/583
+- YubiKey PRF developer guide: https://developers.yubico.com/WebAuthn/Concepts/PRF_Extension/Developers_Guide_to_PRF.html
+- fgv `ts-utils-jest` reference precedent: `libraries/ts-utils-jest/`
+- fgv `captureAsyncResult` implementation: `libraries/ts-utils/src/packlets/base/result.ts`

--- a/.ai/tasks/active/crypto-batch-2-webauthn/state.md
+++ b/.ai/tasks/active/crypto-batch-2-webauthn/state.md
@@ -1,7 +1,7 @@
 # Stream State: crypto-batch-2-webauthn
 
-**Status:** 🔵 phase A complete — awaiting orchestrator signoff for phase B
-**Last updated:** 2026-05-12 (implementing agent — phase A complete)
+**Status:** 🟢 phase A signed off; phase B ready to start
+**Last updated:** 2026-05-12 (orchestrator — phase B brief authored)
 
 ---
 
@@ -9,8 +9,23 @@
 
 | Phase | Status | Notes |
 |-------|--------|-------|
-| A — research and design | ✅ done | design.md committed; PR open on `claude/crypto-batch-2-features` |
-| B — implementation | ⏸ blocked on phase A signoff | Brief written by orchestrator post-signoff |
+| A — research and design | ✅ done | design.md merged into `claude/crypto-batch-2-features` (via consolidated phase-B prep) |
+| B — implementation | 🟢 ready | `brief-phase-b.md` is the binding contract; assignable to implementing agent |
+
+---
+
+## Phase A signoff summary (orchestrator)
+
+Design approved **as designed** — the Result-integration-boundary discipline (six primitives, nothing else) is exactly the right shape. Open question resolutions:
+
+- **OQ-1 (libraries/ vs integrations/):** stay in `libraries/`. The `integrations/` convention question is a separate lessons-codification chore.
+- **OQ-2 (v12 support):** v13+ only. Do not include `@simplewebauthn/types`.
+- **OQ-3 (`VerifyRegistrationResponseOpts` namespace duplication risk):** accept; `Parameters<>` alias guarantees structural identity.
+- **OQ-4 (rejected abstractions):** the four temptations stay rejected. The phase B brief encodes them as a "don't" list — abstraction creep is the failure mode for this stream.
+
+PR #342 (the phase A draft) is being superseded by the consolidated cluster work. Orchestrator will close it when the prep PR merges; implementing agent does not need to touch it.
+
+Phase B contract is baked into `.ai/tasks/active/crypto-batch-2-webauthn/brief-phase-b.md`. Where the brief conflicts with the design, the brief wins.
 
 ---
 

--- a/.ai/tasks/active/crypto-batch-2-webauthn/state.md
+++ b/.ai/tasks/active/crypto-batch-2-webauthn/state.md
@@ -89,4 +89,4 @@ All four documented in design.md §11 OQ-4.
 
 ## PR
 
-*(link to be added once PR is open)*
+[#342](https://github.com/ErikFortune/fgv/pull/342) — `claude/webauthn-batch-design-LqIDQ` → `claude/crypto-batch-2-features`

--- a/.ai/tasks/active/crypto-batch-2-webauthn/state.md
+++ b/.ai/tasks/active/crypto-batch-2-webauthn/state.md
@@ -1,7 +1,7 @@
 # Stream State: crypto-batch-2-webauthn
 
-**Status:** 🟢 phase A ready to start
-**Last updated:** 2026-05-11 (orchestrator — substrate prep)
+**Status:** 🔵 phase A complete — awaiting orchestrator signoff for phase B
+**Last updated:** 2026-05-12 (implementing agent — phase A complete)
 
 ---
 
@@ -9,23 +9,84 @@
 
 | Phase | Status | Notes |
 |-------|--------|-------|
-| A — research and design | 🟢 ready | Brief committed; awaiting agent kickoff |
+| A — research and design | ✅ done | design.md committed; PR open on `claude/crypto-batch-2-features` |
 | B — implementation | ⏸ blocked on phase A signoff | Brief written by orchestrator post-signoff |
+
+---
+
+## Work branch
+
+`claude/webauthn-batch-design-LqIDQ` (harness-assigned)
+
+PR target: `claude/crypto-batch-2-features`
 
 ---
 
 ## Decisions log
 
-*(empty — populated by implementing agent. Pre-baked decisions from orchestrator/user signoff are in brief.md § "Decisions already made". Note D3's strict no-abstraction-creep discipline.)*
+| Decision | Choice | Rationale |
+|---|---|---|
+| Upstream version | `^13.0.0` for both packages | v13.3.0 is current stable; caret allows patch/minor auto-update; v13 removed the separate `@simplewebauthn/types` dependency |
+| Error context format | `captureAsyncResult` bare, no prefix | Upstream errors are self-describing; consumer-level wrapping adds context via `.withErrorFormat()`; D1 principle |
+| Options type aliases for verify functions | `Parameters<typeof fn>[0]` | Upstream does not export named aliases for `verifyRegistrationResponse` / `verifyAuthenticationResponse` opts; `Parameters<>` guarantees structural sync |
+| Type re-export scope | Selective — types in signatures only | Avoids pulling the entire upstream API surface into our namespace; one-import ergonomic for common path |
+| PRF extension handling | None — flows through standard `extensions` field | Confirmed no special handling needed; PRF is caller's responsibility |
+| Directory location | `libraries/` (both packages) | Consistent with Argon2 stream; `integrations/` question deferred to post-cluster lessons |
+| Test strategy | jest.mock upstream; success + failure per primitive | Cannot run real WebAuthn ceremony in tests; captureAsyncResult integration is what we're testing |
 
 ---
 
-## Open questions / blockers
+## Recommendation summary
 
-*(empty — phase A agent populates as research surfaces them. If the agent surfaces any temptation to add abstraction beyond the six primitives, surface it here as an open question for orchestrator confirmation rather than acting on it.)*
+Design is straightforward: two new packages (`@fgv/ts-extras-webauthn` for Node, `@fgv/ts-web-extras-webauthn` for browser), each containing thin `captureAsyncResult` wrappers around `@simplewebauthn/server` and `@simplewebauthn/browser` respectively. Exactly six functions total. No opinion, no ceremony orchestration, no helpers above the primitive level. The D3 no-abstraction-creep discipline held throughout research — four specific abstraction temptations were identified and rejected (documented in §11 OQ-4 of design.md). The PRF extension flows through unchanged via the standard `AuthenticationExtensionsClientInputs` field; no special handling is needed at the boundary. Phase B is a mechanical implementation against the signatures in §3 of design.md, estimated at medium complexity (two new package scaffoldings + six trivial function bodies + tests).
+
+---
+
+## Research findings
+
+**@simplewebauthn stability:**
+- v13.3.0 is current (released 2026-03-10); active maintenance; releases in lockstep server+browser
+- Signature-level stability since v11 (v12 added JSR support, v13 added registration hints and trust anchor improvements)
+- v13 eliminates the separate `@simplewebauthn/types` dependency — all types now exported from the main packages
+- MIT license confirmed
+
+**Version-pin pattern:**
+- `^13.0.0` in package.json (caret allows patch/minor)
+- Rush `preferredVersions` for monorepo consistency
+- Security advisory → immediate; major bump → 30-day review window; patch/minor → auto-absorb
+
+**Bundle size (`@simplewebauthn/browser`):**
+- Approximately 9.1 KB gzipped — well within acceptable range for a WebAuthn integration library
+
+**PRF extension:**
+- Flows through `AuthenticationExtensionsClientInputs.prf` (standard DOM type)
+- No separate import path or helper in `@simplewebauthn/*`
+- PRF output in `authenticatorExtensionResults.prf.results.first` (Uint8Array)
+- Upstream explicitly will NOT simplify PRF — aligns with our D3 no-helpers discipline
+
+---
+
+## Abstraction temptations rejected (D3 compliance record)
+
+1. Challenge generator helper — out of scope
+2. PRF salt (string/Buffer → Uint8Array) helper — out of scope
+3. Browser autofill input validator — out of scope
+4. `WebAuthnCredential` builder from registration output — out of scope
+
+All four documented in design.md §11 OQ-4.
+
+---
+
+## Open questions for orchestrator
+
+| ID | Question | Recommendation |
+|---|---|---|
+| OQ-1 | `libraries/` vs. `integrations/` directory | Use `libraries/` now; defer convention question to post-cluster lessons |
+| OQ-2 | v12 support (requires `@simplewebauthn/types`) | Target v13+ only — no question blocking |
+| OQ-3 | `VerifyRegistrationResponseOpts` naming risk (upstream may ship in v14) | Accept risk; `Parameters<>` guarantees structural identity |
 
 ---
 
 ## PR
 
-*(none yet)*
+*(link to be added once PR is open)*

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -130,50 +130,53 @@ substrate. Don't queue streams against them here.
 
 ### `crypto-batch-2-hpke` 🟢
 
-**Status:** 🟢 phase A (research + design) ready to start
+**Status:** 🟢 phase A signed off; phase B ready to start
 **Cluster:** crypto-batch-2 (integration branch `claude/crypto-batch-2-features`)
-**Phase B sequencing:** decided post-design-signoff
 **Branch base:** `claude/crypto-batch-2-features` (integration branch off `release`)
 **Package surface:** `@fgv/ts-extras/crypto-utils`, `@fgv/ts-web-extras/crypto-utils`, `.ai/instructions/LIBRARY_CAPABILITIES.md`
 **Out-of-scope:** `wrapBytes`/`unwrapBytes` (ECIES; separate primitive), Argon2id, WebAuthn, sudoku packages
 
-**Mission.** Implement HPKE base mode (RFC 9180) with X25519/HKDF-SHA256/AES-256-GCM in `@fgv/ts-extras` and `@fgv/ts-web-extras` crypto-utils packlets. Required for a cross-repo consumer's Phase 2 (per-session material delivery, master-key wrap at unlock, recovery-proof envelopes). Phase A produces a design doc; phase B implements per design + signoff modifications. Includes HKDF as exposed primitive (placement decided in design).
+**Mission.** Implement HPKE base mode (RFC 9180) with X25519/HKDF-SHA256/AES-256-GCM as a class-based `HpkeProvider` in `@fgv/ts-extras/crypto-utils`, re-exported from `@fgv/ts-web-extras/crypto-utils`. Required for a cross-repo consumer's Phase 2 (per-session material delivery, master-key wrap at unlock, recovery-proof envelopes). HKDF exposed as a method on the same class (not on `ICryptoProvider`).
+
+**Signoff modification:** design's "subtle as first parameter" function-based API replaced with a class-based `HpkeProvider` pattern (private constructor + static `create(subtle): Result<HpkeProvider>`). Rest of design stands.
 
 **Origin.** Cross-repo consumer batch-2 handoff (archived at `.ai/notes/cross-repo-handoffs/fgv-batch-2-handoff-2026-05.md`).
 
-**Phase A artifacts:** `.ai/tasks/active/crypto-batch-2-hpke/{brief.md, state.md}` → produces `design.md`.
+**Artifacts:** `.ai/tasks/active/crypto-batch-2-hpke/{brief.md, design.md, state.md, brief-phase-b.md}`. `brief-phase-b.md` is the binding phase B contract.
 
 ### `crypto-batch-2-argon2id` 🟢
 
-**Status:** 🟢 phase A (research + design) ready to start
+**Status:** 🟢 phase A signed off; phase B ready to start
 **Cluster:** crypto-batch-2 (integration branch `claude/crypto-batch-2-features`)
-**Phase B sequencing:** decided post-design-signoff
 **Branch base:** `claude/crypto-batch-2-features` (integration branch off `release`)
-**Package surface:** NEW packages `@fgv/ts-extras-argon2` and `@fgv/ts-web-extras-argon2`; modifications to `@fgv/ts-extras/crypto-utils` `ICryptoProvider` interface for composition shape; possibly `KeyStore` integration; `.ai/instructions/LIBRARY_CAPABILITIES.md`
+**Package surface:** NEW packages `@fgv/ts-extras-argon2` (Node, wraps `argon2`) and `@fgv/ts-web-extras-argon2` (browser, wraps `hash-wasm`); model additions in `@fgv/ts-extras/crypto-utils` (`IArgon2idProvider`, `IArgon2idParams`, `IKeyDerivationParams` discriminated union); `KeyStore` integration (`addSecretFromPasswordArgon2id` / `verifySecretFromPasswordArgon2id`); `.ai/instructions/LIBRARY_CAPABILITIES.md`
 **Out-of-scope:** PBKDF2 (already shipped via `KeyStore.addSecretFromPassword`), HPKE, WebAuthn, other KDFs, sudoku packages
 
-**Mission.** Implement Argon2id (RFC 9106) as fgv-owned but in separate packages to keep WASM bundling out of consumers who don't need it. Required for a cross-repo consumer's Phase 2 (recovery rows, hybrid auth passphrases). Cross-runtime output equivalence is the load-bearing correctness property.
+**Mission.** Implement Argon2id (RFC 9106) as fgv-owned but in separate packages to keep WASM bundling out of consumers who don't need it. Required for a cross-repo consumer's Phase 2 (recovery rows, hybrid auth passphrases). Cross-runtime output equivalence is the load-bearing correctness property; testable as plain Jest in Node because `hash-wasm` is pure WASM.
+
+**Signoff:** as designed. Open questions resolved (readable parameter naming; JSDoc warning on `parallelism > 1` for WASM; discriminated union for `IKeyDerivationParams`; cross-runtime test placement in `ts-extras-argon2/`). Orchestrator precondition (B.0): live `hash-wasm` activity check.
 
 **Origin.** Cross-repo consumer batch-2 handoff (archived at `.ai/notes/cross-repo-handoffs/fgv-batch-2-handoff-2026-05.md`). Maintainer-policy decision Q2 resolved (a)+separate-packages on 2026-05-11.
 
-**Phase A artifacts:** `.ai/tasks/active/crypto-batch-2-argon2id/{brief.md, state.md}` → produces `design.md`.
+**Artifacts:** `.ai/tasks/active/crypto-batch-2-argon2id/{brief.md, design.md, state.md, brief-phase-b.md}`. `brief-phase-b.md` is the binding phase B contract.
 
 ### `crypto-batch-2-webauthn` 🟢
 
-**Status:** 🟢 phase A (research + design) ready to start
+**Status:** 🟢 phase A signed off; phase B ready to start
 **Cluster:** crypto-batch-2 (integration branch `claude/crypto-batch-2-features`)
-**Phase B sequencing:** decided post-design-signoff
 **Branch base:** `claude/crypto-batch-2-features` (integration branch off `release`)
-**Package surface:** NEW packages `@fgv/ts-extras-webauthn` and `@fgv/ts-web-extras-webauthn`; `.ai/instructions/LIBRARY_CAPABILITIES.md`
-**Out-of-scope:** Attestation policy, challenge state management, extension helpers, algorithm allowlist, ceremony orchestration, anything that's not one of six primitive operations (strictly enforced per D3 in brief)
+**Package surface:** NEW packages `@fgv/ts-extras-webauthn` (wraps `@simplewebauthn/server`) and `@fgv/ts-web-extras-webauthn` (wraps `@simplewebauthn/browser`); `common/config/rush/common-versions.json` preferredVersions; `.ai/instructions/LIBRARY_CAPABILITIES.md`
+**Out-of-scope:** Attestation policy, challenge state management, extension helpers, algorithm allowlist, ceremony orchestration, anything that's not one of six primitive operations (strictly enforced in phase B brief D2)
 
-**Mission.** Implement a Result-integration boundary over `@simplewebauthn/server` and `@simplewebauthn/browser`. Six primitive operations total (4 server + 2 browser). No opinion baked in; consumers build their own opinionated wrappers on top. Pattern mirrors `@fgv/ts-utils-jest`'s relationship to Jest.
+**Mission.** Implement a Result-integration boundary over `@simplewebauthn/server` and `@simplewebauthn/browser`. Six primitive operations total (4 server + 2 browser), each a one-line `captureAsyncResult` wrapper. No opinion baked in; consumers build their own opinionated wrappers on top. Pattern mirrors `@fgv/ts-utils-jest`'s relationship to Jest.
+
+**Signoff:** as designed. Open questions resolved (`libraries/` placement; v13+ only; `Parameters<>` aliases accepted; the four rejected abstractions stay rejected). The phase A draft PR #342 is being superseded by the consolidated cluster work; orchestrator will close it on prep PR merge.
 
 **Origin.** Cross-repo consumer batch-2 handoff. Maintainer-policy decision Q3 resolved (c)+separate-packages on 2026-05-11.
 
 **Lessons-codification candidate:** The "Result-integration boundary over a well-maintained upstream library" pattern is worth codifying as a fgv convention after this stream lands. Plus the question of whether such packages belong in `libraries/` or a top-level `integrations/` directory. Both parked for triage; not blocking.
 
-**Phase A artifacts:** `.ai/tasks/active/crypto-batch-2-webauthn/{brief.md, state.md}` → produces `design.md`.
+**Artifacts:** `.ai/tasks/active/crypto-batch-2-webauthn/{brief.md, design.md, state.md, brief-phase-b.md}`. `brief-phase-b.md` is the binding phase B contract.
 
 ### `crypto-batch-2-misc` 🟢
 


### PR DESCRIPTION
## Summary

Consolidated orchestrator signoff for all three crypto-batch-2 phase A designs. Adds binding `brief-phase-b.md` for each stream, updates `state.md` to reflect phase A signed off + phase B ready, and flips stream statuses in `docs/WORKSTREAMS.md`.

### Per-stream signoff outcome

- **HPKE** — signed off with **one architectural modification**: the design's "subtle as first parameter" function-based API is replaced with a class-based `HpkeProvider` pattern (private constructor + static `create(subtle): Result<HpkeProvider>`) matching the existing `NodeCryptoProvider` / `BrowserCryptoProvider` / `KeyStore` / `DirectEncryptionProvider` shape. The rest of the design (cipher suite, inclusive auth tag in ciphertext, HKDF on the provider class rather than `ICryptoProvider`, info as first-class `Uint8Array`, internal primitives stay internal, cross-runtime via re-export with shared test vectors) stands as designed. Plus B.0 precondition: live RFC 9180 verification — phase A research was rfc-editor.org-blocked.

- **Argon2id** — signed off **as designed**. Open question resolutions:
  - Readable parameter naming (`memoryKiB` / `iterations` / `parallelism` / `outputBytes`), not RFC's `m`/`t`/`p`.
  - JSDoc warning on `parallelism > 1` for WASM; no runtime logged warning.
  - Discriminated union for `IKeyDerivationParams`.
  - Cross-runtime test placement in `libraries/ts-extras-argon2/` with a `devDependency` on `@fgv/ts-web-extras-argon2` (plain Jest in Node — `hash-wasm` is pure WASM).
  - B.0 precondition: live `hash-wasm` GitHub activity check.

- **WebAuthn** — signed off **as designed**. The Result-integration-boundary discipline (six primitives, nothing else) is reinforced in the brief's "Don't" list; OQ-4 rejected-abstractions (challenge generator, PRF salt helper, autofill validator, credential builder) encoded as binding. `libraries/` placement; v13+ only; `Parameters<>` aliases accepted.

### Supersedes

PR #342 (WebAuthn phase A draft) is being superseded by this consolidated work. Orchestrator will close it after this prep PR merges.

## Test plan

- [x] All three `brief-phase-b.md` files authored with consistent structure (decisions baked in, B.0 preconditions where applicable, acceptance criteria including the lint-gate discipline)
- [x] `state.md` updated for each stream to reflect phase A signed off + phase B ready
- [x] `docs/WORKSTREAMS.md` flipped to phase B ready for all three streams
- [ ] After merge: assign implementing agents to each `brief-phase-b.md` independently (parallel execution OK; minor `LIBRARY_CAPABILITIES.md` overlap handled by section-level discipline)
- [ ] After merge: close #342 as superseded

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_