### PR TITLE
chore(crypto-batch-2): cluster close — move streams to Completed, surface followups

### DIFF
--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -23,4 +23,14 @@ Description with the user's framing expanded with the design space.
 
 ---
 
-*(No entries yet.)*
+## `integrations/` top-level directory for Result-integration boundary packages
+
+The `crypto-batch-2-webauthn` stream shipped two packages (`@fgv/ts-extras-webauthn`, `@fgv/ts-web-extras-webauthn`) whose entire mission is to wrap a well-maintained upstream library (`@simplewebauthn/*`) and adapt its throw-based API into the fgv `Result<T>` model. The package boundary is the whole product; no fgv-specific abstraction sits on top. This is structurally distinct from the libraries under `libraries/` that publish original utility primitives.
+
+The question: does the pattern deserve its own top-level directory (e.g. `integrations/`), or is `libraries/` plus the naming convention `ts-extras-X` / `ts-web-extras-X` sufficient signal? Today the packages live in `libraries/` for consistency, but as the pattern recurs (likely candidates: future LLM provider wrappers, future credential-protocol wrappers) the structural distinction may earn its own home.
+
+**Why deferred**: only one batch of packages so far (`-webauthn`); not enough recurrence to justify a directory rename. Decide when the second or third such package lands and the pattern is clearly distinct from "library that publishes original utilities."
+
+**Dependencies**: at least one more Result-integration-boundary package landing; or a concrete consumer-side ergonomics complaint about discoverability of these packages.
+
+**Reference**: `.ai/tasks/completed/2026-05/crypto-batch-2-webauthn/` (OQ-1 + followups section); cluster-close PR.

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -35,6 +35,17 @@ opportunistically when the right surface area is touched.
 
 ## P2 — Fix before next major feature in affected area
 
+- **[P2] `@fgv/ts-web-extras` is missing `eslint.config.js`; `rushx lint` fails for the whole package.**
+  ESLint 10.x requires `eslint.config.(js|mjs|cjs)`; `libraries/ts-web-extras/` has neither it nor a legacy `.eslintrc*`. Running `rushx lint` exits 2 with `ESLint couldn't find an eslint.config...`. Every other monorepo package has the file. This means the per-stream pre-PR lint gate has been bypassed for any stream touching `ts-web-extras` (e.g. `crypto-batch-2-misc`, `crypto-batch-2-hpke`, `auth-primitives-batch1`). Per stream READMEs the failure was acknowledged as "pre-existing infrastructure gap" rather than fixed in-stream.
+
+  **Trigger**: before the next stream that touches `ts-web-extras`; ideally before the next `release → main` promotion so we don't ship more code through an un-linted gate.
+
+  **Scope sketch**: copy `eslint.config.js` from a sibling package (`ts-extras` is the closest analog — same browser-flavored content, same dev-deps). Verify `rushx lint` passes on the existing `ts-web-extras` source. Fix any newly-surfaced violations (these would have been there for some time; likely small). Optional: add a guard test or CI step that fails when any package's `rushx lint` exits non-zero, so the next time this happens it surfaces immediately.
+
+  **Not a P1**: existing code shipped and downstream consumers integrate it; no production breakage today. P2 because it's an active gate-bypass — any new code landing in `ts-web-extras` is un-linted, which is exactly the failure mode the lint-gate codification (PR #337) was meant to prevent.
+
+  **Reference**: surfaced in `crypto-batch-2-misc` stream README ("Pre-existing issues"); confirmed during `crypto-batch-2` cluster-close (PR #350).
+
 - **[P2] Replace try/catch + instanceof-Error boilerplate in `ai-assist/apiClient.ts` with `captureAsyncResult`.**
   Four identical `catch (err: unknown) { const detail = err instanceof Error ? err.message : String(err); return fail(...detail...); }` blocks at lines ~158, 217, 272, 316. Each carries a `/* c8 ignore next 1 - defensive: fetch errors are always Error instances in practice */` directive to suppress the untestable catch branch — a signal that `captureAsyncResult()` is the right replacement. `captureAsyncResult` handles the `Error`-vs-string normalisation internally and makes the `c8 ignore` directives unnecessary.
 
@@ -60,6 +71,17 @@ opportunistically when the right surface area is touched.
   **Reference**: bug reported via personaility web app integration; one-off test added in the fix PR (see `@fgv/ts-extras` browser entry).
 
 ## P3 — Opportunistic cleanup
+
+- **[P3] New pure-library packages must declare `"sideEffects": false` in `package.json`.**
+  Every `libraries/` package whose `src/index.ts` exports only functions and types (no module-level side effects) carries `"sideEffects": false` so bundlers can tree-shake it. This was caught in PR review on `crypto-batch-2-webauthn`: `@fgv/ts-extras-webauthn` was missing the field; `@fgv/ts-web-extras-webauthn` had it. Fixed in-stream, but the gap reveals a scaffolding-checklist hole — the standard "new package" template doesn't enforce it.
+
+  **Trigger**: next stream that creates a new pure-library package, or next time someone refactors the scaffolding template / `rush.json` registration guide.
+
+  **Scope sketch**: (a) audit existing `libraries/*/package.json` to confirm everyone has the field correctly set (one quick grep), and (b) add a line to the per-package scaffolding doc / convention note that flags `"sideEffects": false` as required alongside `"main"` and `"types"`. Optionally add a tiny test or pre-PR check that fails when a `libraries/` package is missing the field and has no module-level side effects.
+
+  **Not a P2**: failure mode is "consumer bundle size slightly larger than necessary," not a functional regression.
+
+  **Reference**: PR #347 review (crypto-batch-2-webauthn); lesson captured in `.ai/tasks/completed/2026-05/crypto-batch-2-webauthn/README.md` § L1.
 
 - **[P3] `resolveImageCapability` in `ai-assist/registry.ts` returns `| undefined` instead of `Result<IAiImageModelCapability>`.**
   `registry.ts:328–339`. The function returns `undefined` when no capability matches `modelId`, silently swallowing the "unknown model" case. Callers must null-check rather than chain. Returning `Result<IAiImageModelCapability>` with a contextual error message would let callers propagate the failure cleanly.

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -46,6 +46,19 @@ opportunistically when the right surface area is touched.
 
   **Reference**: PR #329 review — patterns pre-existed the PR, absolved from that review.
 
+- **[P2] Cross-runtime entry-point export parity is not systematically tested.**
+  Libraries with both Node (`src/index.ts`) and browser (`src/index.browser.ts`) entry points can drift in export names without CI catching it. api-extractor runs only on the Node entry point, so a typo or rename in the browser entry slips through. Pattern has bitten the team several times; most recent instance: `@fgv/ts-extras` exported `Crypto` instead of `CryptoUtils` from `index.browser.ts`, surfacing as `CryptoUtils.Keystore undefined` in the personaility web app. Fixed with a one-off test for that specific import; no general practice.
+
+  Comprehensive per-export coverage on every library is too expensive given the API surface. The right scope is opportunistic per-library micro-tests.
+
+  **Trigger**: anytime a library's `index.browser.ts` is touched substantively (new exports added, namespace renames, refactors). Also: anytime a cross-runtime export bug is reported, expand the affected library's micro-test rather than just patching the single export.
+
+  **Scope sketch**: a tiny test file per library — `src/test/unit/browserEntry.test.ts` (or similar) — that imports from `index.browser.ts` and asserts the top-level exported names match a minimal expected list (the major namespaces, not every symbol). Renaming a Node export then breaks the browser test if the browser entry wasn't updated in lockstep. Per-library cost: ~15 lines. No commitment to backfill across all libraries; just add when the library's browser entry is touched.
+
+  **Not a P3**: the pattern has recurred multiple times across the team; the consumer-impact cost (production-visible undefined exports) is real. P2 trigger ("next time the browser entry is touched") puts it on a natural cadence.
+
+  **Reference**: bug reported via personaility web app integration; one-off test added in the fix PR (see `@fgv/ts-extras` browser entry).
+
 ## P3 — Opportunistic cleanup
 
 - **[P3] `resolveImageCapability` in `ai-assist/registry.ts` returns `| undefined` instead of `Result<IAiImageModelCapability>`.**

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -128,64 +128,6 @@ substrate. Don't queue streams against them here.
 
 ## Active workstreams
 
-### `crypto-batch-2-hpke` ✅ COMPLETED 2026-05
-
-**Status:** ✅ Implemented and merged to `claude/crypto-batch-2-features`
-**Cluster:** crypto-batch-2 (integration branch `claude/crypto-batch-2-features`)
-**Package surface:** `@fgv/ts-extras/crypto-utils`, `@fgv/ts-web-extras/crypto-utils`, `.ai/instructions/LIBRARY_CAPABILITIES.md`
-
-**Mission.** Implemented HPKE base mode (RFC 9180) — DHKEM(X25519, HKDF-SHA256) + HKDF-SHA256 + AES-256-GCM — as `HpkeProvider` class in `@fgv/ts-extras`, re-exported from `@fgv/ts-web-extras`. 100% coverage; cross-runtime anchor vectors validated on both Node and jsdom.
-
-**Artifacts:** `.ai/tasks/completed/2026-05/crypto-batch-2-hpke/`
-
-### `crypto-batch-2-argon2id` 🟢
-
-**Status:** 🟢 phase A signed off; phase B ready to start
-**Cluster:** crypto-batch-2 (integration branch `claude/crypto-batch-2-features`)
-**Branch base:** `claude/crypto-batch-2-features` (integration branch off `release`)
-**Package surface:** NEW packages `@fgv/ts-extras-argon2` (Node, wraps `argon2`) and `@fgv/ts-web-extras-argon2` (browser, wraps `hash-wasm`); model additions in `@fgv/ts-extras/crypto-utils` (`IArgon2idProvider`, `IArgon2idParams`, `IKeyDerivationParams` discriminated union); `KeyStore` integration (`addSecretFromPasswordArgon2id` / `verifySecretFromPasswordArgon2id`); `.ai/instructions/LIBRARY_CAPABILITIES.md`
-**Out-of-scope:** PBKDF2 (already shipped via `KeyStore.addSecretFromPassword`), HPKE, WebAuthn, other KDFs, sudoku packages
-
-**Mission.** Implement Argon2id (RFC 9106) as fgv-owned but in separate packages to keep WASM bundling out of consumers who don't need it. Required for a cross-repo consumer's Phase 2 (recovery rows, hybrid auth passphrases). Cross-runtime output equivalence is the load-bearing correctness property; testable as plain Jest in Node because `hash-wasm` is pure WASM.
-
-**Signoff:** as designed. Open questions resolved (readable parameter naming; JSDoc warning on `parallelism > 1` for WASM; discriminated union for `IKeyDerivationParams`; cross-runtime test placement in `ts-extras-argon2/`). Orchestrator precondition (B.0): live `hash-wasm` activity check.
-
-**Origin.** Cross-repo consumer batch-2 handoff (archived at `.ai/notes/cross-repo-handoffs/fgv-batch-2-handoff-2026-05.md`). Maintainer-policy decision Q2 resolved (a)+separate-packages on 2026-05-11.
-
-**Artifacts:** `.ai/tasks/active/crypto-batch-2-argon2id/{brief.md, design.md, state.md, brief-phase-b.md}`. `brief-phase-b.md` is the binding phase B contract.
-
-### `crypto-batch-2-webauthn` 🟢
-
-**Status:** 🟢 phase A signed off; phase B ready to start
-**Cluster:** crypto-batch-2 (integration branch `claude/crypto-batch-2-features`)
-**Branch base:** `claude/crypto-batch-2-features` (integration branch off `release`)
-**Package surface:** NEW packages `@fgv/ts-extras-webauthn` (wraps `@simplewebauthn/server`) and `@fgv/ts-web-extras-webauthn` (wraps `@simplewebauthn/browser`); `common/config/rush/common-versions.json` preferredVersions; `.ai/instructions/LIBRARY_CAPABILITIES.md`
-**Out-of-scope:** Attestation policy, challenge state management, extension helpers, algorithm allowlist, ceremony orchestration, anything that's not one of six primitive operations (strictly enforced in phase B brief D2)
-
-**Mission.** Implement a Result-integration boundary over `@simplewebauthn/server` and `@simplewebauthn/browser`. Six primitive operations total (4 server + 2 browser), each a one-line `captureAsyncResult` wrapper. No opinion baked in; consumers build their own opinionated wrappers on top. Pattern mirrors `@fgv/ts-utils-jest`'s relationship to Jest.
-
-**Signoff:** as designed. Open questions resolved (`libraries/` placement; v13+ only; `Parameters<>` aliases accepted; the four rejected abstractions stay rejected). The phase A draft PR #342 is being superseded by the consolidated cluster work; orchestrator will close it on prep PR merge.
-
-**Origin.** Cross-repo consumer batch-2 handoff. Maintainer-policy decision Q3 resolved (c)+separate-packages on 2026-05-11.
-
-**Lessons-codification candidate:** The "Result-integration boundary over a well-maintained upstream library" pattern is worth codifying as a fgv convention after this stream lands. Plus the question of whether such packages belong in `libraries/` or a top-level `integrations/` directory. Both parked for triage; not blocking.
-
-**Artifacts:** `.ai/tasks/active/crypto-batch-2-webauthn/{brief.md, design.md, state.md, brief-phase-b.md}`. `brief-phase-b.md` is the binding phase B contract.
-
-### `crypto-batch-2-misc` 🟢
-
-**Status:** 🟢 implementation-only (no design phase); ready to start
-**Cluster:** crypto-batch-2 (integration branch `claude/crypto-batch-2-features`)
-**Branch base:** `claude/crypto-batch-2-features` (integration branch off `release`)
-**Package surface:** `@fgv/ts-extras/crypto-utils`, `@fgv/ts-web-extras/crypto-utils`, `.ai/instructions/LIBRARY_CAPABILITIES.md`
-**Out-of-scope:** HPKE, Argon2id, WebAuthn (parallel streams), KeyStore changes, sudoku packages
-
-**Mission.** Add `sign`, `verify`, and `timingSafeEqual` to `ICryptoProvider`. Sign/verify wrap `crypto.subtle.sign`/`crypto.subtle.verify`; timingSafeEqual uses Node's native on Node and a constant-time XOR walk on browser. Small, well-specified, no design phase needed.
-
-**Origin.** Cross-repo consumer batch-2 handoff items 5 and 6. Q7 resolved on 2026-05-11 to add the wrappers (concentration of cross-runtime adaptation in `ICryptoProvider` is the load-bearing argument).
-
-**Artifacts:** `.ai/tasks/active/crypto-batch-2-misc/{brief.md, state.md}` → produces implementation PR.
-
 ### `ai-assist-thinking-events` 🟡
 
 **Status:** 🟡 ready; sequencing after `ai-assist-thinking-config` phase B lands (now satisfied; ai-assist cluster shipped via #336)
@@ -206,13 +148,68 @@ Design-triage-implement shape is likely; new public API has real consequences.
 
 **Phase A artifacts:** TBD when stream is commissioned; will live at `.ai/tasks/active/ai-assist-thinking-events/`.
 
-### Integration branch convention (active for the crypto-batch-2 cluster)
-
-The four crypto-batch-2 streams share an integration branch `claude/crypto-batch-2-features` based off `release`. Each phase PRs into the integration branch, not `release`. The integration branch merges to `release` at the end of the cluster after all stream artifacts have migrated to `completed/`. Same pattern as the ai-assist cluster.
-
 ---
 
 ## Completed workstreams
+
+### `crypto-batch-2-hpke` ✅
+
+**Status:** ✅ shipped — merged in [#348](https://github.com/ErikFortune/fgv/pull/348) into `claude/crypto-batch-2-features` integration branch; phase A design in [#343](https://github.com/ErikFortune/fgv/pull/343); phase B brief in [#346](https://github.com/ErikFortune/fgv/pull/346); branch `claude/crypto-batch-2-hpke-impl-pR3QU`
+**Package surface:** `@fgv/ts-extras/crypto-utils`, `@fgv/ts-web-extras/crypto-utils`, `.ai/instructions/LIBRARY_CAPABILITIES.md`
+
+**What shipped.**
+- `HpkeProvider` class (private constructor + static `create(subtle)` factory) implementing HPKE base mode (RFC 9180) with cipher suite DHKEM(X25519, HKDF-SHA256) + HKDF-SHA256 + AES-256-GCM
+- Public surface: `sealBase`, `openBase`, `hkdf`, `encodeEnvelope`, `decodeEnvelope`. Internal Encap/Decap/KeySchedule stay private.
+- Single implementation in `ts-extras` re-exported from `ts-web-extras` for browser callers; `CryptoUtils.HpkeProvider` namespace path works for both `moduleResolution: node` and `bundler` consumers
+- B.0 RFC verification caught a design-vs-RFC discrepancy: design.md §1 used label `"dh"` in ExtractAndExpand; RFC 9180 §4.1 specifies `"eae_prk"`. Agent stopped, surfaced, corrected (confirmed via OpenSSL happykey + multiple independent implementations)
+- Cross-runtime anchor vectors: Node-sealed ciphertext opens correctly on jsdom Web Crypto. 24 Node tests + 18 browser tests, 100% coverage.
+
+**Artifacts:** `.ai/tasks/completed/2026-05/crypto-batch-2-hpke/`
+
+### `crypto-batch-2-argon2id` ✅
+
+**Status:** ✅ shipped — merged in [#349](https://github.com/ErikFortune/fgv/pull/349) into `claude/crypto-batch-2-features` integration branch; phase A design in [#344](https://github.com/ErikFortune/fgv/pull/344); phase B brief in [#346](https://github.com/ErikFortune/fgv/pull/346); branch `claude/crypto-batch-2-argon2id-impl-bOXwM`
+**Package surface:** NEW packages `@fgv/ts-extras-argon2` (Node, wraps `argon2`) and `@fgv/ts-web-extras-argon2` (browser, wraps `hash-wasm`); model additions in `@fgv/ts-extras/crypto-utils`; `KeyStore` integration; `.ai/instructions/LIBRARY_CAPABILITIES.md`
+
+**What shipped.**
+- `IArgon2idProvider`, `IArgon2idParams`, `ARGON2ID_OWASP_MIN`, `ARGON2ID_PASSPHRASE` in `@fgv/ts-extras/crypto-utils/model.ts`
+- `IKeyDerivationParams` converted to discriminated union (`'pbkdf2'` | `'argon2id'`)
+- `NodeArgon2Provider` in `@fgv/ts-extras-argon2` backed by `argon2` (kelektiv v0.44.0)
+- `BrowserArgon2Provider` in `@fgv/ts-web-extras-argon2` backed by `hash-wasm` v4.12.0 — pure WASM, runs identically in Node and browsers
+- `KeyStore.addSecretFromPasswordArgon2id` and `verifySecretFromPasswordArgon2id` (explicit `IArgon2idProvider` injection — KeyStore does not hold one by default)
+- Cross-runtime byte-identical output verified: RFC 9106 §B.3 vector produces `03aab965...6d0c2e` on both providers; plus 7-case parameter sweep. 100% coverage across all three packages.
+
+**Artifacts:** `.ai/tasks/completed/2026-05/crypto-batch-2-argon2id/`
+
+### `crypto-batch-2-webauthn` ✅
+
+**Status:** ✅ shipped — merged in [#347](https://github.com/ErikFortune/fgv/pull/347) into `claude/crypto-batch-2-features` integration branch; phase A design in [#342](https://github.com/ErikFortune/fgv/pull/342); phase B brief in [#346](https://github.com/ErikFortune/fgv/pull/346); branch `claude/crypto-batch-2-webauthn-impl-6XN80`
+**Package surface:** NEW packages `@fgv/ts-extras-webauthn` (wraps `@simplewebauthn/server`) and `@fgv/ts-web-extras-webauthn` (wraps `@simplewebauthn/browser`); `common/config/rush/common-versions.json`; `.ai/instructions/LIBRARY_CAPABILITIES.md`
+
+**What shipped.** Result-integration boundary — six primitive functions, nothing else:
+- Server: `generateRegistrationOptions`, `verifyRegistrationResponse`, `generateAuthenticationOptions`, `verifyAuthenticationResponse`
+- Browser: `startRegistration`, `startAuthentication`
+- Each a one-line `captureAsyncResult(() => upstream(options))` over `@simplewebauthn/*` v13
+- No challenge generators, no PRF helpers, no autofill validators, no credential builders, no ceremony orchestration (four temptations explicitly considered and rejected per OQ-4)
+- Type re-exports limited to direct-signature types; `jest.mock` upstream entirely (no real WebAuthn ceremony in tests). 100% coverage in both packages.
+
+**Followup**: `integrations/` vs `libraries/` directory convention (parked to FUTURE.md); see also TECH_DEBT P3 entry on `"sideEffects": false` field consistency for new pure-library packages.
+
+**Artifacts:** `.ai/tasks/completed/2026-05/crypto-batch-2-webauthn/`
+
+### `crypto-batch-2-misc` ✅
+
+**Status:** ✅ shipped — merged in [#345](https://github.com/ErikFortune/fgv/pull/345) into `claude/crypto-batch-2-features` integration branch; branch `claude/add-crypto-provider-methods-hHMYd`
+**Package surface:** `@fgv/ts-extras/crypto-utils`, `@fgv/ts-web-extras/crypto-utils`, `.ai/instructions/LIBRARY_CAPABILITIES.md`
+
+**What shipped.** Five new methods on `ICryptoProvider` (and both concrete implementations):
+- `sign(privateKey, data)` / `verify(publicKey, signature, data)` — Ed25519 and ECDSA-P256, algorithm inferred from key
+- `timingSafeEqual(a, b)` — constant-time byte comparison (Node `crypto.timingSafeEqual`; browser XOR-walk accumulator)
+- `hmacSha256(key, data)` / `verifyHmacSha256(key, signature, data)` — HMAC-SHA256 MAC with constant-time verification via `timingSafeEqual`
+
+`sign`/`verify`/`timingSafeEqual` were specified in the stream brief; `hmacSha256`/`verifyHmacSha256` added during implementation per orchestrator review request (cross-repo consumer surfaced the need).
+
+**Artifacts:** `.ai/tasks/completed/2026-05/crypto-batch-2-misc/`
 
 ### `ai-assist-thinking-config` ✅
 


### PR DESCRIPTION
## Summary

Cluster-close substrate prep for the crypto-batch-2 cluster. All four streams have landed on `claude/crypto-batch-2-features`:

| Stream | PR | Branch |
|---|---|---|
| crypto-batch-2-hpke | #348 | `claude/crypto-batch-2-hpke-impl-pR3QU` |
| crypto-batch-2-argon2id | #349 | `claude/crypto-batch-2-argon2id-impl-bOXwM` |
| crypto-batch-2-webauthn | #347 | `claude/crypto-batch-2-webauthn-impl-6XN80` |
| crypto-batch-2-misc | #345 | `claude/add-crypto-provider-methods-hHMYd` |

Artifacts are migrated to `.ai/tasks/completed/2026-05/crypto-batch-2-*/` with polished READMEs. This PR closes the substrate before opening the integration → release promotion PR.

### Changes

- **`docs/WORKSTREAMS.md`** — move all four crypto-batch-2 entries from Active to Completed with "what shipped" summaries linking to merged PRs; drop the cluster-specific "Integration branch convention" subsection (cluster done).
- **`docs/TECH_DEBT.md`** — two new entries:
  - **P2** — `@fgv/ts-web-extras` is missing `eslint.config.js`. `rushx lint` exits 2 on that package; the lint gate has been silently bypassed for any stream touching ts-web-extras (e.g. misc, HPKE, auth-primitives-batch1). Surfaced in the crypto-batch-2-misc README as "pre-existing infrastructure gap"; confirmed locally during cluster close. Trigger: before the next stream that touches ts-web-extras.
  - **P3** — new pure-library packages need `"sideEffects": false`. Caught in #347 review on `@fgv/ts-extras-webauthn`; reveals a scaffolding-checklist hole.
- **`docs/FUTURE.md`** — parking-lot entry for the `integrations/` vs `libraries/` directory-convention question (per webauthn OQ-1 + L1 lesson; needs more recurrence before it earns a dedicated home).

Also includes the `release → claude/crypto-batch-2-features` merge that absorbs TECH_DEBT #341 (cross-runtime entry-point export parity P2 entry).

## Test plan

- [x] All four streams' artifacts under `.ai/tasks/completed/2026-05/` with polished READMEs
- [x] `.ai/tasks/active/` no longer contains any crypto-batch-2 stream directories
- [x] WORKSTREAMS.md Active section no longer references shipped crypto-batch-2 streams
- [x] No code changes in this PR — substrate-only
- [ ] After merge: open integration → release promotion PR

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_