### PR TITLE
chore(crypto-batch-2): add rush change files for cluster promotion

### DIFF
--- a/common/changes/@fgv/ts-extras-argon2/crypto-batch-2_2026-05-12-22-30.json
+++ b/common/changes/@fgv/ts-extras-argon2/crypto-batch-2_2026-05-12-22-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras-argon2",
+      "comment": "New package. NodeArgon2Provider — Node implementation of IArgon2idProvider backed by argon2 (kelektiv). Pair with @fgv/ts-web-extras-argon2 for cross-runtime Argon2id key derivation.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-argon2",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-extras-webauthn/crypto-batch-2_2026-05-12-22-30.json
+++ b/common/changes/@fgv/ts-extras-webauthn/crypto-batch-2_2026-05-12-22-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras-webauthn",
+      "comment": "New package. Result-integration boundary over @simplewebauthn/server v13+. Exports four primitives (generateRegistrationOptions, verifyRegistrationResponse, generateAuthenticationOptions, verifyAuthenticationResponse) — each a one-line captureAsyncResult wrapper. No abstraction beyond the boundary; callers own ceremony orchestration.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-webauthn",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-extras/crypto-batch-2_2026-05-12-22-30.json
+++ b/common/changes/@fgv/ts-extras/crypto-batch-2_2026-05-12-22-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add HpkeProvider (HPKE base mode, RFC 9180: DHKEM(X25519, HKDF-SHA256) + HKDF-SHA256 + AES-256-GCM) with sealBase/openBase/hkdf/encodeEnvelope/decodeEnvelope. Add IArgon2idProvider interface, IArgon2idParams, ARGON2ID_OWASP_MIN/PASSPHRASE presets. Convert IKeyDerivationParams to discriminated union ('pbkdf2' | 'argon2id'). Extend KeyStore with addSecretFromPasswordArgon2id and verifySecretFromPasswordArgon2id. Extend ICryptoProvider with sign/verify (Ed25519, ECDSA-P256), hmacSha256/verifyHmacSha256, and timingSafeEqual.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-web-extras-argon2/crypto-batch-2_2026-05-12-22-30.json
+++ b/common/changes/@fgv/ts-web-extras-argon2/crypto-batch-2_2026-05-12-22-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-web-extras-argon2",
+      "comment": "New package. BrowserArgon2Provider — pure-WASM implementation of IArgon2idProvider backed by hash-wasm. Runs identically in browsers and Node.js; output is byte-identical to NodeArgon2Provider (@fgv/ts-extras-argon2) for the same inputs and parameters.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras-argon2",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-web-extras-webauthn/crypto-batch-2_2026-05-12-22-30.json
+++ b/common/changes/@fgv/ts-web-extras-webauthn/crypto-batch-2_2026-05-12-22-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-web-extras-webauthn",
+      "comment": "New package. Result-integration boundary over @simplewebauthn/browser v13+. Exports two primitives (startRegistration, startAuthentication) — each a one-line captureAsyncResult wrapper. No abstraction beyond the boundary.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras-webauthn",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-web-extras/crypto-batch-2_2026-05-12-22-30.json
+++ b/common/changes/@fgv/ts-web-extras/crypto-batch-2_2026-05-12-22-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-web-extras",
+      "comment": "Re-export HpkeProvider (HPKE base mode, RFC 9180) from CryptoUtils namespace for browser consumers. Add sign/verify, hmacSha256/verifyHmacSha256, and timingSafeEqual to BrowserCryptoProvider matching the ICryptoProvider extension in @fgv/ts-extras.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras",
+  "email": "noreply@anthropic.com"
+}


### PR DESCRIPTION
## Summary

Rush change files for the six packages touched by the `crypto-batch-2` cluster. The promotion PR (#351) was opened without these — Erik flagged the omission as legit for a cluster of this magnitude. This PR adds them so the changelog reflects what shipped when the lockstep `5.1.0 → 5.2.0` minor bump publishes.

### Change files added

| Package | Note |
|---|---|
| `@fgv/ts-extras` | HpkeProvider, IArgon2idProvider + types, IKeyDerivationParams discriminated union, KeyStore Argon2id methods, ICryptoProvider sign/verify/timingSafeEqual/hmacSha256/verifyHmacSha256 |
| `@fgv/ts-web-extras` | HpkeProvider re-export; BrowserCryptoProvider sign/verify/timingSafeEqual/hmacSha256/verifyHmacSha256 |
| `@fgv/ts-extras-argon2` | New package — NodeArgon2Provider |
| `@fgv/ts-web-extras-argon2` | New package — BrowserArgon2Provider (pure WASM) |
| `@fgv/ts-extras-webauthn` | New package — Result-integration boundary over @simplewebauthn/server |
| `@fgv/ts-web-extras-webauthn` | New package — Result-integration boundary over @simplewebauthn/browser |

All entries use `type: "none"` — the lockstep version policy (`base-utils`, `nextBump: minor`) drives the version bump at publish time; change files supply changelog text only, matching the established convention (`wrap-bytes_*`, `release_*`, etc.).

### Verification

`rush change --verify` passes locally with these files staged.

## Test plan

- [x] `rush change --verify` exits clean
- [x] All six packages with substantive deltas have a change file
- [x] Change files use `type: "none"` per repo convention
- [ ] After merge: #351 (integration → release promotion) automatically picks up the change files; promotion completes; alpha publish flows through `prerelease`

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_