### PR TITLE
chore(ts-prompt-assist): phase B rescope — validator-chain redesign + sub-phase decomposition + guardrails

### DIFF
--- a/.ai/tasks/active/ts-prompt-assist/brief-phase-b.md
+++ b/.ai/tasks/active/ts-prompt-assist/brief-phase-b.md
@@ -1,11 +1,34 @@
-# Stream Brief: ts-prompt-assist (phase B — implementation)
+# Stream Brief: ts-prompt-assist (phase B — implementation, restart)
 
 **Stream ID:** ts-prompt-assist
-**Phase:** B — implementation
+**Phase:** B — implementation (restart after PR #359 retire)
 **Cluster:** `ts-prompt-assist-features` (integration branch `claude/ts-prompt-assist-features`)
-**Workflow shape:** design-triage-implement-refine. Phase B implements the locked v0.1 design. "Refine" (consumer-port pressure-test) is a follow-on phase absorbed as 1–2 PRs on the same integration branch.
+**Workflow shape:** design-triage-implement-refine, **decomposed into 5–6 scoped sub-phase agent runs** with clean handoffs (no carried context across sub-phases). Mid-run context drift was the failure mode of the first attempt; eliminating carried context is the structural fix.
+
+> **Restart context.** PR #359 was retired without merge after ~35 reviewer-flagged issues (catalog in the PR's close comment and `design.md` §17). The corrections in `design.md` §17 (validator-chain redesign + NQ-5 resolution + guardrails) are binding for the restart. Phase B is decomposed into sub-phases B-0b through B-5; each sub-phase is a separate agent commission against a frozen state.
 
 ---
+
+## Guardrails for the restart (binding — non-negotiable)
+
+These are existing CODING_STANDARDS rules made **explicit and unmissable** because PR #359 demonstrated the failure modes are real when not enforced upfront. The implementing agent MUST adhere; if any of these come into tension with the task, **STOP and surface to the orchestrator** rather than improvising.
+
+1. **No unsafe casts (`as T`, `as unknown as T`) in product code.** Test data may use `as unknown as BrandedType` for branded-type construction; product code must not. If the type system rejects what you're doing, **STOP and ask** — the data shape is wrong, you're missing a Converter / Validator, or the type definition needs refinement. Cast-driven typing is the failure mode this restart explicitly protects against.
+2. **No `unknown` in product code without explicit rationale.** If reaching for `unknown` to bypass a type error, **STOP and ask**. `unknown` is legitimate at parse boundaries (JSON.parse result, untyped input from external sources) before a Converter narrows; it is not legitimate as a sustained internal type.
+3. **Do not shadow types from `@fgv/*` libraries.** Use ts-res / ts-extras / ts-utils / ts-json-base types by their original import paths. If a type isn't exported where you need it, surface to the orchestrator — additive promotion in the upstream library is in scope per `CODING_STANDARDS.md` §"Extending Core Libraries Over Working Around Them". Recreating types locally is not.
+4. **Do not ship unimplemented features as placeholders.** No `// not implemented in v0.1` returning empty strings, no `kind: 'resource'` silently returning the literal value, no stubbed methods that pretend success. If a sub-phase doesn't fit, **STOP and ask** — splitting into a separate PR on the integration branch is fine.
+5. **Lint warnings are never "expected" or "pre-existing".** Fix them (`rushx fixlint` first, then manual). No inline `eslint-disable` directives added to make lint pass. See L15/L16 lessons-pending — silent lint bypass is a documented anti-pattern in this repo.
+6. **Mandatory `code-reviewer` agent invocation** (Task tool, `subagent_type: code-reviewer`) before declaring any packlet complete. Apply the code-reviewer's findings before opening the PR; document any disagreement.
+7. **PR target is binding** — `claude/ts-prompt-assist-features` integration branch, NOT `release`. Do not target release. Verify the base branch before pushing.
+8. **Family-convention factory pattern** on every fallible class: `static create(...): Result<T>`. Even when the constructor doesn't currently throw — extension points matter and consumers expect the pattern.
+9. **Code in `index.ts` is barrel-exports only.** Move all logic to dedicated files. Multiple PR #359 review flags hit this.
+10. **Use Result chaining throughout.** `/result-pattern` skill load is mandatory; result-chained sequences read better than intermediate-variable cascades. Multiple PR #359 review flags pointed at "this would be more legible with result chaining" — that critique applies preemptively.
+
+Read these guardrails before reading any other section. If a guardrail conflicts with what the design appears to require, **STOP and surface to the orchestrator** rather than improvising.
+
+---
+
+## Context
 
 ## Context
 
@@ -28,40 +51,38 @@ Ship `@fgv/ts-prompt-assist` v0.1 per the locked `design.md`. Two libraries are 
 
 ---
 
-## Phase B sub-phases (advisory; per design §14)
+## Phase B sub-phase decomposition (binding — restart approach)
 
-Design §14 recommends a 7-step breakdown. The implementing agent may consolidate or split commits as long as the acceptance criteria in design §12 are met. Recommended order — particularly the **B.0 before B.1** dependency is binding:
+The restart decomposes phase B into **5–6 separate agent commissions**, each scoped to one sub-phase, with a clean handoff via `state.md`. Each agent starts cold against `design.md` + `state.md` + this brief — no carried context across sub-phases. PR #359 demonstrated that mid-run context drift across a single long agent run is a real failure mode; sub-phase decomposition is the structural fix.
 
-| Step | Scope | Notes |
-|---|---|---|
-| **B.0** | `ts-extras/mustache` extension + `ts-extras/ai-assist` `extractJsonText` promote | **Must land before B.1.** Tests cover `escape: 'html'` (existing), `escape: 'none'`, and custom-function escape. No mutation of `Mustache.escape`. |
-| **B.1** | Types + `PromptLibrary.resolve` happy path | Branded scalars, Converters for all string-unions, descriptor / bindings / candidate Converters, unified `PromptRegistry`, chain walker, binding merger (without resource bindings yet), Mustache render (consuming the B.0 `escape: 'none'`), full trace. Both composition behaviors via per-candidate `isPartial`. |
-| **B.2** | Resource bindings | Recursive resolver, cycle detection (using `Hash.Crc32Normalizer.computeHash` on the chain — never `JSON.stringify`-compare), depth cap (default 5), OQ-2 strict-replace, inner-trace surfacing. |
-| **B.3** | `FileTreePromptStore` + YAML loader | YAML via `@fgv/ts-extras` `yaml.yamlConverter<T>(inner)` (no new direct `js-yaml` dep at this level). Filename-id consistency check. Double-brace rejection in the descriptor Converter (via the body-token-scanner per design §6). `_qualifiers.yaml` root-level loading via ts-res's `qualifierDecl` Converter. |
-| **B.4** | Output validation pipeline | Fence strip (consume `extractJsonText` from B.0's promote), `JSON.parse`, registered Converter, `outputValidations[]` chain via `MessageAggregator`. Resource-binding-to-`'json'`-descriptor rejection. |
-| **B.5** | Input safeguards | Per-slot length cap, regex screen (source-aware skipping), anti-jailbreak preface seam, `safeguardFindings` trace entries (kinds `'max-length' \| 'suspicious-pattern' \| 'screening-skipped' \| 'enforced-override-ignored'`). |
-| **B.6** | Docs + API Extractor + change file | README quick-start (the "pressure-test handoff package" per design §12 criterion 15), TSDoc audit, api-extractor `.api.md` regenerated for both `ts-extras` and `ts-prompt-assist`, rush change files for all modified packages. |
+**Each sub-phase is its own PR** to `claude/ts-prompt-assist-features`. Orchestrator reviews each PR before commissioning the next agent. Out-of-scope work surfaces to the orchestrator rather than expanding the current sub-phase.
 
-Each step can be a commit on the integration branch or its own PR — implementer's choice. Single phase B PR for everything is also fine. Acceptance criteria (§12) are non-negotiable.
+| Sub-phase | Owner | Scope | Model | Notes |
+|---|---|---|---|---|
+| **B-0a — NQ-5 audit** | Orchestrator | Audit `ts-res/runtime` for incremental-add support; record outcome in state.md | n/a | **Done** (2026-05-16): ts-res's `ResourceManagerBuilder` natively supports `addLooseCandidate` / `addResource` / `addCondition` / `addConditionSet` post-construction and implements `IResourceManager` itself. Option C achievable with zero ts-res changes. See design.md §17.1. |
+| **B-0b — ts-extras additive extensions** | Agent | `MustacheTemplate.create` `escape?: 'html' \| 'none' \| (s) => string` option (per-instance `Mustache.Writer`, no `Mustache.escape` global mutation); promote `extractJsonText` to stable public export from `@fgv/ts-extras/ai-assist`; rush change file for ts-extras. | Opus (small probe of new brief shape) | Small, isolated, well-defined. **Validates the restart brief** before committing to larger sub-phases. If this run is bad, we know early. Tests cover `'html'` (existing behavior unchanged), `'none'`, custom-function escape, and the promoted `extractJsonText` export. |
+| **B-1 — Foundation** | Agent | Types + Converters for string-unions / branded scalars / discriminated unions + descriptor / bindings / qualifier-axis Converters + unified `IPromptRegistry<TResponse>` (per design §17.2) + chain walker + binding merger (cross-scope merge with `enforced` lock + `winningScope` trace) + Mustache render via B-0b `escape: 'none'` + InMemoryFileTree test fixture (`PromptStoreFixture.build(seed)`) + happy-path `PromptLibrary.resolve` returning full `IPromptResolveTrace`. **Stops short of** resource bindings, FileTreePromptStore disk path, output validation pipeline, input safeguards. | Opus (the make-or-break run; sets the foundation quality bar) | Largest sub-phase. The agent's foundation reads define what the follow-on sub-phases look like. Code-reviewer pass mandatory before PR. |
+| **B-2 — Resource bindings** | Agent | Recursive resolver; cycle detection via `Hash.Crc32Normalizer.computeHash` on `(scopeChainHash, promptId)` pairs (NEVER `JSON.stringify`-compare); depth cap (default 5); OQ-2 strict-replace substitutions semantics with `'replace' \| 'inherit'` trace; full `innerTrace: IPromptResolveTrace` recursive surfacing in `IResourceBindingTraceEntry`. Sub-phase ends with resource bindings working against the InMemoryFileTree fixture (no FileTree disk path yet). | Sonnet (against working foundation) | Code-reviewer pass mandatory. |
+| **B-3 — FileTreePromptStore + YAML loader** | Agent | `FileTreePromptStore.create` (read-only at v0.1: `get` / `list` / `getBindings` / `getQualifierConfig`; `watch?` undefined; `put` / `putBindings` / `delete` not implemented); YAML loading via `@fgv/ts-extras` `yaml.yamlConverter<T>(inner)` (no new `js-yaml` dep at ts-prompt-assist level); filename-id consistency check; double-brace rejection in descriptor Converter (body-token-scanner: rejects `tokenType === 'name'` **and** `tokenType === '&'` — both); `_qualifiers.yaml` root-level loading via ts-res's `qualifierDecl` Converter (do NOT shadow); smoke test against `FsTree`. | Sonnet | Code-reviewer pass mandatory. |
+| **B-4 — Output validation pipeline + Input safeguards** | Agent | **Output (per design §8 + §17.2):** fence strip via `extractJsonText`; `JSON.parse`; resolve Converter by `output.converterId` (returns typed `T extends TResponse`); chain through `outputValidations[]` (each validator typed against `TResponse`; `appliesTo` narrows; runtime-fail safety net per §17.2.4); loader-side reject when validator `appliesTo` doesn't match Converter's declared response kind (belt). **Safeguards (per design §9):** per-slot length cap, regex screen (with `pattern.lastIndex = 0` reset for stateful flags), source-aware skipping, anti-jailbreak preface seam, full `safeguardFindings[]` surfacing including the `'enforced-override-ignored'` kind. | Sonnet | Combined since both are small post-resolve stages. Code-reviewer pass mandatory. |
+| **B-5 — Docs + handoff package** | Agent | README in `libraries/ts-prompt-assist/` with quick-start (PromptLibrary + InMemoryFileTree fixture + tiny example) — the pressure-test handoff per design §12 criterion 15; TSDoc audit (every exported symbol); api-extractor `.api.md` regenerated for `ts-extras` and `ts-prompt-assist`; LIBRARY_CAPABILITIES.md updated with new entries (ts-prompt-assist library, `MustacheTemplate.create({escape})`, `extractJsonText` public export); rush change files for both modified packages. | Sonnet | Mechanical / documentation work. Last sub-phase. |
 
----
+### Commissioning protocol
 
-## NQ-5 — ts-res incremental-add verification (orchestrator-flagged)
+1. Each sub-phase agent's commission cites this brief + `design.md` + `state.md` and the **specific sub-phase row** that scopes the work.
+2. Out-of-scope work is explicit (e.g., "B-2 does NOT touch the FileTreePromptStore disk path; if your work requires it, STOP and ask the orchestrator").
+3. The agent's PR includes a state.md update marking the sub-phase done before merging.
+4. Orchestrator reviews each PR; only after merge does the next sub-phase commission.
+5. If a sub-phase agent surfaces a real cross-sub-phase dependency, the orchestrator may amend this brief OR resequence.
 
-Design §15.5 commits to **Option C** for the candidate→ts-res handoff: one long-lived `ResourceManager` inside `PromptLibrary`, with resources materialized on demand into a shared runtime. This requires ts-res to support **incremental resource add-after-build** — adding a new resource to an already-built `ResourceManager` without rebuilding.
+### Cross-sub-phase invariants (always binding)
 
-**Phase B step zero (B.0a, before or alongside B.0):**
-
-1. Audit `libraries/ts-res/src/packlets/runtime/` for incremental add-after-build support.
-2. If supported: lock Option C, no ts-res changes needed.
-3. If not supported: implementation latitude per design §15.5:
-   - **Preferred:** extend ts-res additively (new builder method or runtime API). This expands cluster scope to three libraries (ts-extras + ts-res + ts-prompt-assist) but stays strictly additive. The repo's "Extending Core Libraries Over Working Around Them" guidance in CODING_STANDARDS endorses this. Surface scope expansion to orchestrator before implementing.
-   - **Acceptable fallback (ii):** periodic rebuild strategy — rebuild on first miss after N misses, or amortize via builder batches. Document trade-offs in `TECH_DEBT.md`.
-   - **Acceptable last-resort (iii):** fall back to per-resolve transient `Resource` construction (Option A) with hash-keyed materialization cache. Document the gap in `TECH_DEBT.md` so v0.2 picks up Option C.
-
-Store interface stays identical under all three paths (§15.5 final paragraph); the choice is internal to `PromptLibrary`.
-
-**Record the NQ-5 verification outcome and chosen path in `state.md` before B.1 starts.** Phase B implementer doesn't re-litigate Option C as the target; only the implementation strategy varies.
+- All sub-phase PRs target `claude/ts-prompt-assist-features` (NOT release).
+- All sub-phase PRs pass `rushx build && rushx lint && rushx test` in all modified packages with 100% coverage on new code.
+- All sub-phase PRs invoke the `code-reviewer` agent on completed packlets before opening the PR.
+- All sub-phase PRs include rush change files for the packages they touch.
+- No sub-phase ships unimplemented features as placeholders.
+- See the 10 Guardrails above for the rest.
 
 ---
 
@@ -193,15 +214,26 @@ Per `CODING_STANDARDS.md` §Pre-PR Validation Checklist (and the lint-gate codif
 
 ## Don't
 
-- Don't re-litigate phase A decisions. OQ-1 through OQ-6 are locked in `design.md` §2. NQs are resolved per `design.md` §15.6 / §16. If you find yourself wanting to revise a binding decision, **STOP and surface to the orchestrator**.
-- Don't open the phase B PR until `rushx build && rushx lint && rushx test` all pass locally. Lint is a separate gate from build (see CODING_STANDARDS).
-- Don't mutate `Mustache.escape` globally in the ts-extras mustache extension. Use a per-instance `Mustache.Writer` (per design §11.4 + OQ-6 implementation note).
-- Don't add a separate `InMemoryPromptStore` class. Tests use `FileTreePromptStore` over an `InMemoryFileTree` via the `PromptStoreFixture.build(seed)` helper (per design §5.2).
+These are binding. Items marked **[PR #359]** call out specific failure modes from the retired attempt.
+
+- Don't re-litigate phase A decisions. OQ-1 through OQ-6 are locked in `design.md` §2. NQs are resolved per `design.md` §15.6 / §16 / §17. If you find yourself wanting to revise a binding decision, **STOP and surface to the orchestrator**.
+- Don't open any sub-phase PR until `rushx build && rushx lint && rushx test` all pass locally with 100% coverage on the sub-phase's surface. Lint is a separate gate from build (see CODING_STANDARDS).
+- Don't target `release`. **[PR #359]** Sub-phase PRs target `claude/ts-prompt-assist-features` integration branch. Verify the base branch before pushing.
+- Don't mutate `Mustache.escape` globally in the ts-extras mustache extension. Use a per-instance `Mustache.Writer` (per design §11.4 + OQ-6 implementation note + §17.4).
+- Don't add a separate `InMemoryPromptStore` class. **[PR #359]** Tests use `FileTreePromptStore` over an `InMemoryFileTree` via the `PromptStoreFixture.build(seed)` helper (per design §5.2).
 - Don't add a `qualifierEnums` sub-registry. Qualifier config flows through ts-res directly per OQ-4 revised.
 - Don't add a `compositionMode` field on `IPromptDescriptor`. Use ts-res's per-candidate `isPartial` (per design §10.2).
 - Don't reimplement YAML parsing. Use `@fgv/ts-extras`'s `yaml.yamlConverter<T>(inner)`. No new direct `js-yaml` dep at the ts-prompt-assist level.
 - Don't reinvent ts-res's `import` pipeline. `FileTreePromptStore` consumes lower-level primitives (`FileTree`, `yamlConverter`, ts-res `ResourceJson` converters) per design §15.
 - Don't cache rendered prompt bodies / substituted bodies / post-validation outputs. ts-res's intrinsic caches (condition / conditionSet / decision) are the right cache level (per design §15.5 step 3). The parsed `MustacheTemplate` cache (parse cache) is separate and bounded by prompt-corpus body count.
+- Don't shadow types from `@fgv/*` libraries. **[PR #359]** `ConditionSetDecl`, `ILooseConditionDecl`, etc. are imported from ts-res; do NOT re-declare them. If a needed type isn't exported, surface to the orchestrator (additive promote upstream is in scope per CODING_STANDARDS).
+- Don't ship unimplemented features as placeholders. **[PR #359]** No empty-string returns for resource bindings, no stubbed methods that "succeed" with nothing, no `// not implemented in v0.1` returning fake-success. If a sub-phase doesn't fit, STOP and ask.
+- Don't use unsafe casts in product code. **[PR #359]** `as T`, `as unknown as T`, etc. signal a missing Converter / Validator or a wrong data shape. STOP and ask. (Test data may use `as unknown as BrandedType` for branded-type construction; product code may not.)
+- Don't use `unknown` in product code without explicit rationale. **[PR #359]** Legitimate at parse boundaries (JSON.parse result) before a Converter narrows; not legitimate as a sustained internal type.
+- Don't declare a logger in `ts-prompt-assist`. **[PR #359]** Use `Logging` from `@fgv/ts-utils`.
+- Don't put logic in `index.ts`. **[PR #359]** Move to dedicated files; `index.ts` is barrel-export only.
+- Don't dismiss lint warnings as "expected" or "pre-existing". **[PR #359]** Fix them. No inline `eslint-disable` directives added to make lint pass. See L15/L16 lessons-pending.
+- Don't skip `code-reviewer` invocation before declaring a packlet complete. **[PR #359]** Mandatory per the 10 Guardrails above.
 - Don't pin a YAML parser version other than what `@fgv/ts-extras` already uses.
 - Don't omit api-extractor / rush change file / LIBRARY_CAPABILITIES update; these are pre-PR gate items.
 

--- a/.ai/tasks/active/ts-prompt-assist/design.md
+++ b/.ai/tasks/active/ts-prompt-assist/design.md
@@ -1850,3 +1850,355 @@ up as they arise. None gate the design lock.
   §15.5: prefer (i) extend ts-res additively; acceptable fallbacks
   (ii) periodic-rebuild or (iii) Option A (per-resolve transient)
   with `TECH_DEBT.md` entry.
+
+---
+
+## 17. Phase B prep — corrections after PR #359 retire (2026-05-16)
+
+PR #359 (initial phase B attempt) was retired without merge. The
+implementing agent produced ~35 reviewer-flagged issues spanning
+structural design-level violations, family-convention violations,
+correctness bugs, and process violations (see PR #359 close comment
+for the catalog). The corrections below amend earlier sections to
+remove identified failure modes BEFORE re-commissioning. They are
+binding for the restart.
+
+### 17.1 NQ-5 resolved — ts-res natively supports incremental add-after-build
+
+**Outcome of the orchestrator audit (B-0a):** ts-res's
+`ResourceManagerBuilder` already implements `IResourceManager` (has
+`builtResources`, `numResources`, `resourceIds`, `getBuiltResource`,
+`validateContext`, etc. — see
+`libraries/ts-res/src/packlets/runtime/iResourceManager.ts` and
+`libraries/ts-res/src/packlets/resources/resourceManagerBuilder.ts`).
+Public methods include:
+
+- `addLooseCandidate(...)`
+- `addResource(...)`
+- `addCondition(decl)`
+- `addConditionSet(conditions)`
+- `getBuiltResource(id)`
+- `getAllBuiltResources()`
+- `validateContext(context)`
+
+These are first-class, post-construction-callable. There is no
+build-then-freeze step required — a long-lived `ResourceManagerBuilder`
+instance held inside `PromptLibrary` IS the runtime resource manager
+for `ResourceResolver` purposes.
+
+**Conclusion:** §15.5 Option C is achievable with **zero ts-res
+changes**. Phase B holds a `ResourceManagerBuilder` for the lifetime
+of the `PromptLibrary` instance; calls `addLooseCandidate` (or
+`addResource` depending on which is the right granularity per
+`ResourceJson` decl shape) on cache miss; uses the builder directly
+as the `IResourceManager` for a `ResourceResolver`.
+
+The fallback options (ii) periodic-rebuild and (iii) per-resolve
+transient remain documented in §15.5 for record but are not the
+target. Phase B implements Option C against the builder.
+
+NQ-5 closes resolved.
+
+### 17.2 Validator-chain typing — redesigned to discriminated-union-typed registries
+
+**Problem identified in PR #359 review:** the original §4.3 shape
+required `IPromptOutputValidator.validate` to return `Result<unknown>`,
+and the chain machinery cast back to `T` at the call site. Even
+correcting to `IPromptOutputValidator<T = unknown>` (generic with
+default) doesn't fix the deeper issue — the registry stores
+heterogeneous validators as `IPromptOutputValidator<unknown>` (the
+registry can't statically know each validator's specific `T`), so
+either the chain reintroduces a cast OR the consumer is forced to
+handle `unknown` at the call site (kicking the problem upstream
+rather than eliminating it).
+
+**Decision (binding):** **Discriminated-union-typed registries.** The
+consumer extends a base union with their own response shapes; each
+shape self-discriminates via a `kind` field; the registry is
+parameterized by the extended union; the validator chain is
+end-to-end-typed with no cast at any boundary.
+
+#### 17.2.1 Shape
+
+```ts
+// Response shape contract (consumer-side):
+//   Every output-Converter's produced type T must satisfy
+//   { kind: string }. The `kind` field is the discriminator the
+//   validator chain narrows on.
+
+// Library-side: no built-in union members for v0.1 (consumer-defined
+// universe). The library is generic over the union. The empty
+// universe (no Converters / no validators) is the v0.1 default —
+// nothing is forced on consumers who don't use the JSON output
+// pipeline.
+
+// Registry parameterization (per OQ-4 + this amendment):
+export interface IPromptRegistry<TResponse extends { kind: string } = { kind: string }> {
+  readonly converters: IPromptConverterRegistry<TResponse>;
+  readonly slotKinds: IPromptSlotKindRegistry;
+  readonly outputValidations: IPromptOutputValidationRegistry<TResponse>;
+}
+
+export interface IPromptConverterRegistry<TResponse extends { kind: string }> {
+  register<T extends TResponse>(id: ConverterId, converter: Converter<T>): Result<ConverterId>;
+  get<T extends TResponse = TResponse>(id: ConverterId): Result<Converter<T>>;
+  has(id: ConverterId): boolean;
+}
+
+export interface IPromptOutputValidator<TResponse extends { kind: string }> {
+  /** Discriminator value(s) this validator applies to. Single string for
+   *  validators that target one response kind; readonly array for cross-
+   *  kind validators. */
+  readonly appliesTo: TResponse['kind'] | ReadonlyArray<TResponse['kind']>;
+  /** Validates the converted output. The chain runner only invokes this
+   *  when `value.kind` matches `appliesTo`. */
+  validate(value: TResponse, context: IOutputValidationContext): Result<true>;
+}
+
+export interface IPromptOutputValidationRegistry<TResponse extends { kind: string }> {
+  register(id: ValidatorId, validator: IPromptOutputValidator<TResponse>): Result<ValidatorId>;
+  get(id: ValidatorId): Result<IPromptOutputValidator<TResponse>>;
+  has(id: ValidatorId): boolean;
+}
+```
+
+#### 17.2.2 Consumer extension example
+
+```ts
+// Consumer-defined response shapes:
+interface ICitedResponse      { kind: 'cited-response'; answer: string; citedIds: ReadonlyArray<string> }
+interface IClassifierResponse { kind: 'classifier-response'; class: string; confidence: number }
+type ChatResponses = ICitedResponse | IClassifierResponse;
+
+// Consumer's typed registry:
+const registry: IPromptRegistry<ChatResponses> = PromptRegistry.create<ChatResponses>().orThrow();
+
+// Register a Converter for cited responses (T narrows to ICitedResponse):
+registry.converters.register(
+  'cited-response' as ConverterId,
+  citedResponseConverter // : Converter<ICitedResponse>
+);
+
+// Register a validator for cited responses (typed input, no cast):
+const citedIdsAreInInputs: IPromptOutputValidator<ChatResponses> = {
+  appliesTo: 'cited-response',
+  validate(value, ctx) {
+    if (value.kind !== 'cited-response') return succeed(true); // appliesTo guards this; defensive only
+    const inputs = ctx.substitutions;
+    const missing = value.citedIds.filter((id) => !inputs.has(id as SlotName));
+    if (missing.length > 0) {
+      return fail(`citedIds not present in input bag: ${missing.join(', ')}`);
+    }
+    return succeed(true);
+  }
+};
+registry.outputValidations.register('cited-ids-in-inputs' as ValidatorId, citedIdsAreInInputs);
+```
+
+#### 17.2.3 Chain runtime (typed end-to-end; no cast)
+
+```ts
+// Inside PromptLibrary.resolveAndValidateOutput<T extends TResponse>(req, rawOutput):
+return Output
+  .extractJsonText(rawOutput)
+  .onSuccess((cleaned) => captureResult(() => JSON.parse(cleaned)))
+  .onSuccess((parsed) =>
+    registry.converters.get<T>(descriptor.output.converterId).onSuccess((converter) =>
+      converter.convert(parsed)
+    )
+  )
+  .onSuccess((value: T) => {
+    // value.kind is T['kind'] — strongly typed.
+    const aggregator = new MessageAggregator();
+    for (const id of descriptor.outputValidations ?? []) {
+      const vr = registry.outputValidations.get(id);
+      if (vr.isFailure()) {
+        aggregator.addMessage(`validator '${id}' not registered`);
+        continue;
+      }
+      const validator = vr.value;
+      const targets = Array.isArray(validator.appliesTo) ? validator.appliesTo : [validator.appliesTo];
+      if (!targets.includes(value.kind)) {
+        // Runtime safety net (belt). Loader-side reject is the suspenders
+        // (see §17.2.4). If a validator id slipped through descriptor
+        // load, fail explicitly with both kinds cited.
+        aggregator.addMessage(
+          `prompt '${descriptor.id}': validator '${id}' (appliesTo: ${targets.join('|')}) doesn't match output kind '${value.kind}'`
+        );
+        continue;
+      }
+      // No cast: validator.validate accepts TResponse; value extends TResponse.
+      validator.validate(value, ctx).aggregateError(aggregator);
+    }
+    return aggregator.hasMessages ? fail(aggregator.toString('; ')) : succeed(value);
+  });
+```
+
+No `unknown` exposed to the consumer; no `as T` anywhere; type
+flows from the Converter through every validator to the final
+`Result<T>`. Validator authors are guaranteed `value.kind` matches
+their `appliesTo` at the entry of `validate` (chain runner guards
+it).
+
+#### 17.2.4 Loader-side validation + runtime-fail (belt and suspenders)
+
+**Belt — loader-side reject at descriptor load.** The descriptor
+Converter (the `DescriptorConverter` in
+`packlets/converters/descriptorConverter.ts`) verifies, for each
+`outputValidations[]` entry:
+
+1. The validator id is registered in `registry.outputValidations`.
+2. The validator's `appliesTo` includes the response kind produced by
+   `output.converterId`'s registered Converter (the registry exposes
+   the response kind for each registered ConverterId — see §17.2.5).
+
+Mismatches fail descriptor load with a clear error citing both the
+validator's `appliesTo` and the descriptor's `output.converterId`'s
+declared response kind. This catches drift at boot.
+
+**Suspenders — runtime-fail on actual `value.kind` mismatch.** Even
+with loader-side checks, the chain runner verifies
+`value.kind ∈ validator.appliesTo` at runtime (per §17.2.3 example).
+This guards against:
+- Registry mutation after descriptor load
+- Converter implementation bugs that return wrong-kind values
+- Future patterns we haven't anticipated
+
+Both checks live at well-defined boundaries; neither is "just in
+case" defensive coding.
+
+#### 17.2.5 Discoverability of response kind from ConverterId
+
+The loader-side check (§17.2.4) requires `registry.converters` to
+expose the response kind for each `ConverterId`. The library cannot
+inspect a `Converter<T>`'s `T` reflectively at runtime (TypeScript
+types are erased). The registry therefore tracks the registered kind
+alongside each Converter:
+
+```ts
+export interface IPromptConverterRegistry<TResponse extends { kind: string }> {
+  /** Register a Converter that produces a specific TResponse member.
+   *  The `kind` parameter is the discriminator value the Converter is
+   *  guaranteed to emit. The chain runtime asserts this at first
+   *  invocation per descriptor (catches register-time lies). */
+  register<T extends TResponse>(id: ConverterId, kind: T['kind'], converter: Converter<T>): Result<ConverterId>;
+  get<T extends TResponse = TResponse>(id: ConverterId): Result<Converter<T>>;
+  /** Returns the declared response kind for a registered Converter. */
+  getKind(id: ConverterId): Result<TResponse['kind']>;
+  has(id: ConverterId): boolean;
+}
+```
+
+`getKind(id)` is what the descriptor Converter (loader) calls when
+validating `outputValidations[]` entries against `output.converterId`.
+
+#### 17.2.6 `'free-text'` interaction
+
+`output: { kind: 'free-text' }` descriptors:
+
+- `resolveAndValidateOutput<T>` for free-text returns the raw output
+  verbatim (per §8). No Converter, no validators in v0.1.
+- The descriptor loader continues to reject `outputValidations` on
+  `'free-text'` descriptors (per §8) until v0.2 introduces post-render
+  free-text validators.
+- The `TResponse` type parameter on the registry is irrelevant for
+  free-text resolves — the chain doesn't run. Consumers who only use
+  free-text never need to parameterize the registry; the default
+  `TResponse = { kind: string }` is sufficient.
+
+#### 17.2.7 `kind` naming — keep universally
+
+The library and design now have multiple `kind` discriminators:
+- `IPromptDescriptor.output.kind: 'free-text' | 'json'`
+- `SlotBinding.kind: 'literal' | 'resource'`
+- `IPromptStoreEvent.kind: 'descriptor-changed' | ...`
+- `ISafeguardFinding.kind: 'max-length' | ...`
+- **NEW** — consumer response value `kind` (per §17.2)
+
+**Decision:** keep `kind` universally. Rationale:
+
+- `kind` is the de-facto TypeScript community convention for
+  discriminated-union discriminator fields.
+- The `@fgv/*` family already uses `kind` everywhere (ts-res resource
+  decls, ts-extras crypto types, etc.). Renaming any of them would
+  break the family convention.
+- The discriminators are in structurally separate code paths —
+  descriptor YAML, slot bindings, store events, trace findings, and
+  response values don't share a code site where ambiguity could bite.
+- JSDoc on the consumer response interfaces should clarify the
+  discriminator role at the point of definition.
+
+If a real conflict surfaces during implementation, rename the
+specific conflicting site then. Until then, follow convention.
+
+### 17.3 Amendments to earlier sections
+
+This subsection enumerates the sections changed by §17 so phase B
+implements against the corrected shape. Where §17 and the earlier
+section conflict, **§17 wins**.
+
+- **§3.4 (Output contract)** — unchanged. `PromptOutputContract`
+  shape is identical; the consumer-side response value typing is the
+  TResponse parameter on the registry, not on the descriptor's
+  output contract.
+- **§3.9 (Descriptor)** — unchanged. `outputValidations: ReadonlyArray<ValidatorId>`
+  is the same; the validators behind those ids are now typed against
+  `TResponse` via the registry.
+- **§4.1 (`PromptLibrary` create params)** — `PromptLibrary` is
+  generic over `TResponse extends { kind: string } = { kind: string }`.
+  `IPromptLibraryCreateParams<TResponse>` accepts `registry?:
+  IPromptRegistry<TResponse>`. Default parameter preserves consumers
+  who don't use the JSON output pipeline.
+- **§4.3 (Registry shapes)** — replaced by §17.2.1 + §17.2.5
+  (parameterized by `TResponse`; Converters declare their emitted
+  `kind`).
+- **§4.6 (`IPromptStore`)** — unchanged.
+- **§8 (Output validation pipeline)** — clarified per §17.2.3 +
+  §17.2.4 (loader-side reject + runtime-fail; no cast in the chain).
+- **§12 (Acceptance criteria)** — adds: loader rejects descriptors
+  whose `outputValidations` reference validators with non-matching
+  `appliesTo`; chain runtime rejects mismatch (test both belt and
+  suspenders).
+
+No changes to §1, §2 OQ resolutions, §5–§7, §9–§11, §13–§16.
+
+### 17.4 Implementation discipline (binding for phase B restart)
+
+Beyond the technical corrections in §17.1–§17.3, the phase B
+restart adopts the following guardrails (see `brief-phase-b.md`
+§"Guardrails for the restart" for the full list, recapped here for
+design-doc completeness):
+
+1. **No unsafe casts (`as T`, `as unknown as T`) in product code.**
+   If the type system rejects what you're doing, **STOP and ask the
+   orchestrator** — the data shape is wrong, you're missing a
+   Converter / Validator, or the type definition needs refinement.
+   Cast-driven typing is the failure mode this design now explicitly
+   protects against.
+2. **No `unknown` in product code without explicit rationale.** If
+   reaching for `unknown`, **STOP and ask**.
+3. **Do not shadow types from `@fgv/*` libraries.** Use ts-res /
+   ts-extras / ts-utils / ts-json-base types by their import paths.
+   If a type isn't exported where you need it, surface to the
+   orchestrator (additive promote is in scope per CODING_STANDARDS
+   §"Extending Core Libraries").
+4. **Do not ship unimplemented features as placeholders.** If a
+   sub-phase doesn't fit, surface and split.
+5. **Lint warnings are never "expected" or "pre-existing".** Fix
+   them (`rushx fixlint`, then manual).
+6. **Mandatory `code-reviewer` agent invocation** before declaring
+   any packlet complete.
+7. **PR target binding** — integration branch `claude/ts-prompt-assist-features`,
+   NOT `release`.
+8. **Family-convention factory pattern** on every fallible class
+   (`static create(...): Result<T>`).
+9. **Code in `index.ts` is barrel-exports only** — move logic to
+   dedicated files.
+10. **Use Result chaining throughout.** `/result-pattern` skill load
+    is mandatory; result-chained sequences read better than
+    intermediate-variable cascades.
+
+These guardrails are not new repo policy — they are existing
+CODING_STANDARDS rules made explicit because PR #359 demonstrated
+the failure modes are real and consequential when not enforced
+upfront.

--- a/.ai/tasks/active/ts-prompt-assist/state.md
+++ b/.ai/tasks/active/ts-prompt-assist/state.md
@@ -1,7 +1,7 @@
 # Stream State: ts-prompt-assist
 
-**Status:** 🟢 phase A signed off + merged; phase B ready to start
-**Last updated:** 2026-05-15 (orchestrator — phase B brief authored)
+**Status:** 🟡 phase A merged; phase B in restart — PR #359 retired; rescoped into sub-phase commissions
+**Last updated:** 2026-05-16 (orchestrator — rescope after PR #359 retire)
 
 ---
 
@@ -9,9 +9,20 @@
 
 | Phase | Status | Notes |
 |-------|--------|-------|
-| A — research and design | ✅ done | `design.md` merged into `claude/ts-prompt-assist-features` via [#357](https://github.com/ErikFortune/fgv/pull/357). All 6 OQs resolved with rationale; new §15 documents ts-res `import` packlet audit (deliberate divergence) and locks the Option C candidate→ts-res handoff strategy. |
-| B — implementation | 🟢 ready | `brief-phase-b.md` is the binding phase B contract; assignable to implementing agent. Recommended sub-phasing per design §14: B.0 ts-extras additive extensions → B.1 types + happy-path resolve → B.2 resource bindings → B.3 FileTreePromptStore + YAML → B.4 output validation → B.5 safeguards → B.6 docs + api-extractor + change files |
+| A — research and design | ✅ done | `design.md` merged into `claude/ts-prompt-assist-features` via [#357](https://github.com/ErikFortune/fgv/pull/357). All 6 OQs resolved; §15 documents ts-res `import` packlet audit; §17 (added 2026-05-16) documents the validator-chain redesign + NQ-5 resolution + restart guardrails. |
+| B — implementation | 🟡 restart in progress | First attempt (PR #359) retired without merge after ~35 reviewer-flagged issues. Rescoped into sub-phase commissions (B-0a through B-5) per `brief-phase-b.md`. B-0a (NQ-5 audit) done by orchestrator 2026-05-16. B-0b commissionable. |
 | Refine — consumer-port pressure-test | ⏸ blocked on phase B publish | First-consumer port (an agent chat application) surfaces gaps; 1–2 follow-up PRs on the integration branch absorb refinements before integration→release promotion |
+
+---
+
+## Phase B restart history
+
+| Date | Event |
+|---|---|
+| 2026-05-15 | Phase B first attempt commissioned against `brief-phase-b.md` via [#358](https://github.com/ErikFortune/fgv/pull/358) (single-agent run; Sonnet) |
+| 2026-05-15/16 | Implementation produced [PR #359](https://github.com/ErikFortune/fgv/pull/359) targeting `release` (incorrect base; brief said integration branch) |
+| 2026-05-16 | PR #359 reviewed; ~35 issues flagged across structural design-level violations, family-convention violations, correctness bugs, process violations. Erik closed PR #359 "retire and regroup" |
+| 2026-05-16 | Orchestrator rescope: brief amended with 10 explicit guardrails + sub-phase decomposition; design.md §17 added with validator-chain redesign + NQ-5 resolution + kind-naming decision. B-0b commissionable next. |
 
 ---
 
@@ -139,10 +150,27 @@ Phase B implementation order: ts-extras Mustache extension lands first (B.0), th
 
 ---
 
+## Phase B rescope decision log (orchestrator, 2026-05-16)
+
+| Decision | Rationale |
+|---|---|
+| **NQ-5 resolved: Option C achievable with zero ts-res changes** | Orchestrator audit confirmed ts-res's `ResourceManagerBuilder` natively supports `addLooseCandidate` / `addResource` / `addCondition` / `addConditionSet` post-construction and implements `IResourceManager` itself. Phase B holds a long-lived builder inside `PromptLibrary`; calls `addLooseCandidate` on cache miss; uses the builder directly as the `IResourceManager` for a `ResourceResolver`. Fallbacks (ii) and (iii) from design §15.5 are documented but not the target. See design §17.1. |
+| **Validator-chain redesigned: discriminated-union-typed registries** | First attempt (PR #359) produced `runResult.value as T` cast in the chain runner — the original `Result<unknown>` shape forced it. Redesign per design §17.2: registries parameterized by `TResponse extends { kind: string }`; consumers extend the union with their own response shapes; each validator declares `appliesTo: TResponse['kind']`; chain runtime narrows via `value.kind` lookup; no cast anywhere. Belt (loader-side reject) + suspenders (runtime fail on kind mismatch). |
+| **`kind` discriminator naming kept universally** | Multiple `kind` fields now exist across the design (`output.kind`, `SlotBinding.kind`, `IPromptStoreEvent.kind`, `ISafeguardFinding.kind`, NEW consumer response `kind`). Decision: keep `kind` everywhere per TypeScript community convention + `@fgv/*` family convention; rename specific sites only if a real conflict surfaces during implementation. JSDoc clarifies discriminator role at definition. See design §17.2.7. |
+| **Sub-phase decomposition replaces single-agent run** | PR #359 demonstrated mid-run context drift is a real failure mode in a single long agent run. Restart decomposes phase B into 5–6 separate agent commissions (B-0a orchestrator audit; B-0b ts-extras additive; B-1 foundation; B-2 resource bindings; B-3 FileTreePromptStore + YAML; B-4 output validation + safeguards; B-5 docs + handoff). Each agent starts cold against `design.md` + `state.md` + `brief-phase-b.md` — no carried context across sub-phases. Orchestrator reviews each PR before next sub-phase commissions. See `brief-phase-b.md` "Phase B sub-phase decomposition". |
+| **10 explicit guardrails added to brief-phase-b.md** | Made existing CODING_STANDARDS rules unmissable because PR #359 demonstrated the failure modes are real when not enforced upfront: no unsafe casts, no `unknown` without rationale, no type-shadowing, no silent unimplemented placeholders, no inline `eslint-disable`, mandatory `code-reviewer`, integration-branch PR target binding, factory pattern, index.ts barrel-only, Result chaining. Each guardrail tagged to a specific PR #359 failure where applicable. |
+| **Model selection: Opus for B-0b probe and B-1 foundation; Sonnet for B-2/B-3/B-4/B-5** | B-0b is a small isolated probe of the new brief shape; Opus for the disciplinary properties. B-1 is the foundation run; Opus where it matters most. After the foundation lands clean, Sonnet against a working foundation for follow-ons. |
+
+---
+
 ## PR
 
 Substrate-prep PR: merged (#356, 2026-05-13).
-Phase A PR: https://github.com/ErikFortune/fgv/pull/357 (`claude/ts-prompt-assist-phase-a-Y8JIM` → `claude/ts-prompt-assist-features`).
+Phase A PR: merged (#357, 2026-05-15).
+Phase B brief authoring PR: merged (#358, 2026-05-15).
+Phase B first attempt (retired): #359 (closed 2026-05-16, not merged).
+Phase B rescope prep PR: this PR.
+Phase B sub-phase PRs (incoming): B-0b → B-5.
 
 ---
 


### PR DESCRIPTION
## Summary

Rescopes phase B of the `ts-prompt-assist` cluster after the first attempt (PR #359) was retired without merge. Three coordinated changes:

1. **`design.md` §17 (new)** — validator-chain redesign, NQ-5 resolution, kind-naming decision, and explicit guardrails baked into the binding design.
2. **`brief-phase-b.md`** — new "Guardrails for the restart" section + sub-phase decomposition + expanded Don't list with [PR #359] tags.
3. **`state.md`** — phase status flipped to restart-in-progress; phase B restart history; rescope decision log with rationale per choice.

No production code in this PR. Phase B remains commissionable; commission protocol changes from single-agent to sub-phase agent runs with clean handoffs.

### NQ-5 resolved — Option C with zero ts-res changes (orchestrator audit, B-0a)

ts-res's `ResourceManagerBuilder` natively supports incremental add-after-build:
- `addLooseCandidate(...)`, `addResource(...)`, `addCondition(decl)`, `addConditionSet(conditions)` are all first-class public methods callable post-construction
- The builder itself implements `IResourceManager` (has `builtResources`, `numResources`, `resourceIds`, `getBuiltResource`, `validateContext`)

`PromptLibrary` holds a long-lived builder for the instance's lifetime; calls `addLooseCandidate` on cache miss; uses the builder directly as the `IResourceManager` for a `ResourceResolver`. No ts-res changes needed. Fallbacks (ii) periodic-rebuild and (iii) per-resolve transient remain documented in design §15.5 for record but are not the target.

### Validator-chain redesign — discriminated-union-typed registries

**Problem from PR #359 review:** original §4.3 had `IPromptOutputValidator.validate` returning `Result<unknown>` and the chain runner casting `runResult.value as T`. Generic-with-default (`IPromptOutputValidator<T = unknown>`) was raised as a fix but it just kicks `unknown` to the consumer at the call site without eliminating it.

**Redesign:** registries are parameterized by `TResponse extends { kind: string }`. Consumers extend a base union with their own response shapes; each shape self-discriminates via a `kind` field; validators declare `appliesTo: TResponse['kind']`. The chain runtime narrows on `value.kind` and never casts. Belt (loader-side reject when validator `appliesTo` doesn't match Converter's declared response kind) + suspenders (runtime fail with explicit error citing both kinds). No `unknown` leaks to consumers; no cast in product code.

`kind` discriminator kept universally — TS community convention; `@fgv/*` family convention.

### Sub-phase decomposition replaces single-agent run

Mid-run context drift in a single long agent run was the failure mode in PR #359. Restart approach:

| Sub-phase | Owner | Model |
|---|---|---|
| B-0a — NQ-5 audit | Orchestrator | n/a — **done** in this PR |
| B-0b — ts-extras additive (Mustache `escape?` + `extractJsonText` promote) | Agent | Opus (small probe of new brief shape) |
| B-1 — Foundation (types + registries + chain walker + binding merger + InMemory fixture + happy-path resolve) | Agent | Opus (make-or-break run) |
| B-2 — Resource bindings | Agent | Sonnet |
| B-3 — FileTreePromptStore + YAML loader | Agent | Sonnet |
| B-4 — Output validation pipeline + Input safeguards | Agent | Sonnet |
| B-5 — Docs + handoff package | Agent | Sonnet |

Each sub-phase agent commissions cold against `design.md` + `state.md` + `brief-phase-b.md`; no carried context across sub-phases. Each sub-phase is its own PR to the integration branch; orchestrator reviews each before next sub-phase commissions.

### 10 Guardrails (explicit + binding)

Made existing CODING_STANDARDS rules unmissable because PR #359 showed the failure modes are real when not enforced upfront:

1. No unsafe casts in product code
2. No `unknown` in product code without explicit rationale
3. Don't shadow types from `@fgv/*` libraries
4. Don't ship unimplemented features as placeholders
5. Lint warnings never "expected" or "pre-existing"
6. Mandatory `code-reviewer` invocation before declaring complete
7. PR target binding (integration branch, NOT release)
8. Factory pattern on every fallible class
9. Code in `index.ts` is barrel-exports only
10. Use Result chaining throughout

Each guardrail in `brief-phase-b.md` is tagged to the specific PR #359 failure where applicable.

## Test plan

- [x] No production code in this PR
- [x] Design amendment is internally consistent — §17 enumerates which earlier sections it amends; conflicts resolve to §17
- [x] Brief amendment encodes the sub-phase decomposition + 10 guardrails + expanded Don't list
- [x] state.md reflects restart-in-progress + rescope decision log
- [ ] After merge: orchestrator commissions B-0b (ts-extras additive extensions; Opus); first probe of the new brief shape

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_