### PR TITLE
feat(ts-extras): B-0b — additive `escape` strategy on MustacheTemplate

### DIFF
--- a/.ai/tasks/active/ts-prompt-assist/state.md
+++ b/.ai/tasks/active/ts-prompt-assist/state.md
@@ -10,7 +10,7 @@
 | Phase | Status | Notes |
 |-------|--------|-------|
 | A — research and design | ✅ done | `design.md` merged into `claude/ts-prompt-assist-features` via [#357](https://github.com/ErikFortune/fgv/pull/357). All 6 OQs resolved; §15 documents ts-res `import` packlet audit; §17 (added 2026-05-16) documents the validator-chain redesign + NQ-5 resolution + restart guardrails. |
-| B — implementation | 🟡 restart in progress | First attempt (PR #359) retired without merge after ~35 reviewer-flagged issues. Rescoped into sub-phase commissions (B-0a through B-5) per `brief-phase-b.md`. B-0a (NQ-5 audit) done by orchestrator 2026-05-16. B-0b commissionable. |
+| B — implementation | 🟡 restart in progress | First attempt (PR #359) retired without merge after ~35 reviewer-flagged issues. Rescoped into sub-phase commissions (B-0a through B-5) per `brief-phase-b.md`. B-0a (NQ-5 audit) done by orchestrator 2026-05-16. **B-0b complete 2026-05-16** (ts-extras additive: `MustacheTemplate.create({escape})` + `extractJsonText` public-export confirmation). B-1 commissionable. |
 | Refine — consumer-port pressure-test | ⏸ blocked on phase B publish | First-consumer port (an agent chat application) surfaces gaps; 1–2 follow-up PRs on the integration branch absorb refinements before integration→release promotion |
 
 ---
@@ -23,6 +23,7 @@
 | 2026-05-15/16 | Implementation produced [PR #359](https://github.com/ErikFortune/fgv/pull/359) targeting `release` (incorrect base; brief said integration branch) |
 | 2026-05-16 | PR #359 reviewed; ~35 issues flagged across structural design-level violations, family-convention violations, correctness bugs, process violations. Erik closed PR #359 "retire and regroup" |
 | 2026-05-16 | Orchestrator rescope: brief amended with 10 explicit guardrails + sub-phase decomposition; design.md §17 added with validator-chain redesign + NQ-5 resolution + kind-naming decision. B-0b commissionable next. |
+| 2026-05-16 | **B-0b completed.** ts-extras additive: `MustacheEscapeStrategy` type + `escape?` option on `IMustacheTemplateOptions`; per-instance `Mustache.Writer` with locally-implemented `HTML_ESCAPE` so the strategy is immune to `Mustache.escape` global mutation (notably from `experimental/formatter.ts`); 8 new tests cover all three strategies (`'html'` back-compat, `'none'` verbatim, custom function) + concurrent-template safety + `validateAndRender` integration + triple-brace always-unescaped. `extractJsonText` confirmed already `@public` and re-exported from the ai-assist packlet — no source change needed; api.md regenerated. Rush change file added. Build / lint / fixlint / test all green; 100% coverage on `mustache` packlet; code-reviewer approved (no Priority 1/2 findings). Work branch: `claude/implement-b-0b-agent-R8kzX`. |
 
 ---
 

--- a/common/changes/@fgv/ts-extras/ts-prompt-assist-b-0b_2026-05-16-00-00.json
+++ b/common/changes/@fgv/ts-extras/ts-prompt-assist-b-0b_2026-05-16-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add additive `escape?: 'html' | 'none' | ((value: string) => string)` option to `MustacheTemplate.create` for verbatim-passthrough and custom escape strategies (LLM-prompt rendering and other non-HTML targets). Implementation uses a per-instance `Mustache.Writer` with a resolved escape function; no mutation of the global `Mustache.escape`. Default `'html'` preserves existing behavior. `extractJsonText` confirmed as a stable public export from the `ai-assist` packlet.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -1375,6 +1375,7 @@ function importPublicKeyFromMultibaseSpki(encoded: string, algorithm: KeyPairAlg
 
 // @public
 interface IMustacheTemplateOptions {
+    readonly escape?: MustacheEscapeStrategy;
     readonly includeComments?: boolean;
     readonly includePartials?: boolean;
     readonly tags?: readonly [string, string];
@@ -1884,11 +1885,15 @@ declare namespace Mustache {
         IMissingVariableDetail,
         IMustacheTemplateOptions,
         IVariableRef,
+        MustacheEscapeStrategy,
         MustacheTokenType,
         MustacheTemplate
     }
 }
 export { Mustache }
+
+// @public
+type MustacheEscapeStrategy = 'html' | 'none' | ((value: string) => string);
 
 // @public
 class MustacheTemplate {

--- a/libraries/ts-extras/src/packlets/mustache/index.ts
+++ b/libraries/ts-extras/src/packlets/mustache/index.ts
@@ -25,6 +25,7 @@ export {
   IMissingVariableDetail,
   IMustacheTemplateOptions,
   IVariableRef,
+  MustacheEscapeStrategy,
   MustacheTokenType
 } from './interfaces';
 

--- a/libraries/ts-extras/src/packlets/mustache/interfaces.ts
+++ b/libraries/ts-extras/src/packlets/mustache/interfaces.ts
@@ -111,6 +111,23 @@ export interface IContextValidationResult {
 }
 
 /**
+ * Strategy applied to double-brace `{{name}}` tokens at render time.
+ *
+ * - `'html'`: the standard mustache.js HTML escape (back-compat default).
+ * - `'none'`: verbatim passthrough — values are interpolated as-is
+ *   (coerced to `String`). Suitable for LLM-prompt rendering and other
+ *   non-HTML targets where `& → &amp;` corrupts the output.
+ * - `(value) => string`: caller-supplied escape function.
+ *
+ * Note: triple-brace `{{{name}}}` (and `{{&name}}`) tokens are always
+ * rendered unescaped regardless of this strategy — that is the standard
+ * mustache.js semantics and is not affected by this option.
+ *
+ * @public
+ */
+export type MustacheEscapeStrategy = 'html' | 'none' | ((value: string) => string);
+
+/**
  * Options for template parsing and validation.
  * @public
  */
@@ -129,6 +146,24 @@ export interface IMustacheTemplateOptions {
    * Whether to include partial references in variable extraction (default: false)
    */
   readonly includePartials?: boolean;
+
+  /**
+   * Escape strategy applied to double-brace `{{name}}` tokens at render
+   * time. Default `'html'` preserves the existing mustache.js behavior
+   * (back-compat).
+   *
+   * Pass `'none'` for LLM-prompt or other non-HTML targets where the
+   * default `& → &amp;` escape would corrupt the output. Pass a custom
+   * function for any other escape policy.
+   *
+   * The strategy is applied per-template via a private `Mustache.Writer`
+   * instance; no global state on the `mustache` module is mutated, so
+   * concurrent templates with different strategies are safe.
+   *
+   * Note: triple-brace `{{{name}}}` tokens are always rendered unescaped
+   * regardless of strategy (standard mustache.js semantics).
+   */
+  readonly escape?: MustacheEscapeStrategy;
 }
 
 /**
@@ -139,6 +174,7 @@ export interface IRequiredMustacheTemplateOptions {
   readonly tags: [string, string];
   readonly includeComments: boolean;
   readonly includePartials: boolean;
+  readonly escape: MustacheEscapeStrategy;
 }
 
 /* c8 ignore stop */

--- a/libraries/ts-extras/src/packlets/mustache/mustacheTemplate.ts
+++ b/libraries/ts-extras/src/packlets/mustache/mustacheTemplate.ts
@@ -21,7 +21,7 @@
  */
 
 import { Result, captureResult, fail, succeed } from '@fgv/ts-utils';
-import Mustache, { TemplateSpans } from 'mustache';
+import Mustache, { EscapeFunction, TemplateSpans, Writer } from 'mustache';
 
 import {
   IContextValidationResult,
@@ -29,6 +29,7 @@ import {
   IMustacheTemplateOptions,
   IRequiredMustacheTemplateOptions,
   IVariableRef,
+  MustacheEscapeStrategy,
   MustacheTokenType
 } from './interfaces';
 
@@ -38,8 +39,48 @@ import {
 const DEFAULT_OPTIONS: IRequiredMustacheTemplateOptions = {
   tags: ['{{', '}}'],
   includeComments: false,
-  includePartials: false
+  includePartials: false,
+  escape: 'html'
 };
+
+/**
+ * HTML entity map matching mustache.js's internal `escapeHtml`. Held
+ * locally so the `'html'` escape strategy does not depend on the global
+ * `Mustache.escape` (which other packlets — notably `experimental` —
+ * mutate at module load and which mustache.js itself defines as
+ * mutable). Per-instance escape avoids that shared-state coupling.
+ */
+const HTML_ENTITY_MAP: Readonly<Record<string, string>> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+  '/': '&#x2F;',
+  '`': '&#x60;',
+  '=': '&#x3D;'
+};
+
+const HTML_ESCAPE: EscapeFunction = (value) =>
+  String(value).replace(/[&<>"'`=/]/g, (ch) => HTML_ENTITY_MAP[ch]);
+
+const PASSTHROUGH_ESCAPE: EscapeFunction = (value) => String(value);
+
+/**
+ * Resolves a {@link MustacheEscapeStrategy} into the per-render
+ * `escape` function understood by `Mustache.Writer.render`. The
+ * resolved function is always non-`undefined` so the writer never
+ * consults the (mutable, process-global) `Mustache.escape`.
+ */
+function _resolveEscapeFunction(strategy: MustacheEscapeStrategy): EscapeFunction {
+  if (strategy === 'html') {
+    return HTML_ESCAPE;
+  }
+  if (strategy === 'none') {
+    return PASSTHROUGH_ESCAPE;
+  }
+  return (value) => strategy(String(value));
+}
 
 /**
  * A helper class for working with Mustache templates that provides
@@ -58,12 +99,16 @@ export class MustacheTemplate {
   public readonly options: Readonly<IRequiredMustacheTemplateOptions>;
 
   private readonly _tokens: TemplateSpans;
+  private readonly _writer: Writer;
+  private readonly _escapeFn: EscapeFunction;
   private _variables?: readonly IVariableRef[];
 
   private constructor(template: string, tokens: TemplateSpans, options: IRequiredMustacheTemplateOptions) {
     this.template = template;
     this._tokens = tokens;
     this.options = options;
+    this._writer = new Mustache.Writer();
+    this._escapeFn = _resolveEscapeFunction(options.escape);
   }
 
   /**
@@ -177,7 +222,9 @@ export class MustacheTemplate {
    * @returns Success with the rendered string, or Failure if rendering fails
    */
   public render(context: unknown): Result<string> {
-    return captureResult(() => Mustache.render(this.template, context));
+    return captureResult(() =>
+      this._writer.render(this.template, context, undefined, { escape: this._escapeFn })
+    );
   }
 
   /**
@@ -203,7 +250,8 @@ export class MustacheTemplate {
     return {
       tags: options.tags ? [options.tags[0], options.tags[1]] : DEFAULT_OPTIONS.tags,
       includeComments: options.includeComments ?? DEFAULT_OPTIONS.includeComments,
-      includePartials: options.includePartials ?? DEFAULT_OPTIONS.includePartials
+      includePartials: options.includePartials ?? DEFAULT_OPTIONS.includePartials,
+      escape: options.escape ?? DEFAULT_OPTIONS.escape
     };
   }
 

--- a/libraries/ts-extras/src/test/unit/mustacheTemplate.test.ts
+++ b/libraries/ts-extras/src/test/unit/mustacheTemplate.test.ts
@@ -536,4 +536,66 @@ describe('MustacheTemplate', () => {
       });
     });
   });
+
+  describe('escape option', () => {
+    const dangerous = { value: '<a href="x&y">hi</a>' };
+
+    test('defaults to HTML escape (back-compat)', () => {
+      const template = MustacheTemplate.create('{{value}}').orThrow();
+      expect(template.options.escape).toBe('html');
+      expect(template.render(dangerous)).toSucceedWith(
+        '&lt;a href&#x3D;&quot;x&amp;y&quot;&gt;hi&lt;&#x2F;a&gt;'
+      );
+    });
+
+    test('explicit html strategy matches default', () => {
+      const template = MustacheTemplate.create('{{value}}', { escape: 'html' }).orThrow();
+      expect(template.render(dangerous)).toSucceedWith(
+        '&lt;a href&#x3D;&quot;x&amp;y&quot;&gt;hi&lt;&#x2F;a&gt;'
+      );
+    });
+
+    test('"none" strategy renders the value verbatim', () => {
+      const template = MustacheTemplate.create('{{value}}', { escape: 'none' }).orThrow();
+      expect(template.options.escape).toBe('none');
+      expect(template.render(dangerous)).toSucceedWith('<a href="x&y">hi</a>');
+    });
+
+    test('"none" coerces non-string values via String()', () => {
+      const template = MustacheTemplate.create('{{value}}', { escape: 'none' }).orThrow();
+      expect(template.render({ value: 42 })).toSucceedWith('42');
+      expect(template.render({ value: true })).toSucceedWith('true');
+    });
+
+    test('custom escape function is applied to double-brace tokens', () => {
+      const template = MustacheTemplate.create('{{value}}', {
+        escape: (raw) => `[${raw.toUpperCase()}]`
+      }).orThrow();
+      expect(template.render({ value: 'abc' })).toSucceedWith('[ABC]');
+    });
+
+    test('triple-brace tokens are always unescaped regardless of strategy', () => {
+      const html = MustacheTemplate.create('{{{value}}}', { escape: 'html' }).orThrow();
+      expect(html.render(dangerous)).toSucceedWith('<a href="x&y">hi</a>');
+
+      const custom = MustacheTemplate.create('{{{value}}}', {
+        escape: (raw) => `[${raw}]`
+      }).orThrow();
+      // Verbatim — the custom escape MUST be bypassed for triple-brace.
+      expect(custom.render(dangerous)).toSucceedWith('<a href="x&y">hi</a>');
+    });
+
+    test('concurrent templates with different strategies do not interfere', () => {
+      const escaped = MustacheTemplate.create('{{value}}', { escape: 'html' }).orThrow();
+      const passthrough = MustacheTemplate.create('{{value}}', { escape: 'none' }).orThrow();
+      expect(escaped.render({ value: '<x>' })).toSucceedWith('&lt;x&gt;');
+      expect(passthrough.render({ value: '<x>' })).toSucceedWith('<x>');
+      expect(escaped.render({ value: '<y>' })).toSucceedWith('&lt;y&gt;');
+    });
+
+    test('escape strategy participates in validateAndRender', () => {
+      const template = MustacheTemplate.create('{{value}}', { escape: 'none' }).orThrow();
+      expect(template.validateAndRender({ value: '<safe>' })).toSucceedWith('<safe>');
+    });
+  });
 });


### PR DESCRIPTION
Sub-phase **B-0b** of the `ts-prompt-assist` cluster. Strictly additive
changes to `@fgv/ts-extras` per design §11.4 + §17.4 + OQ-6.

**Base branch is the cluster integration branch
`claude/ts-prompt-assist-features`, not `release`** (per `brief-phase-b.md`
binding PR target).

## Summary

- Add `MustacheEscapeStrategy = 'html' | 'none' | ((value: string) => string)`
  and an `escape?` option on `IMustacheTemplateOptions`.
  Default `'html'` preserves existing behavior.
- Implement the strategy via a per-instance `Mustache.Writer` configured
  with a resolved escape function. The render path now **always** passes
  an explicit `escape` in the writer config and **never** consults the
  mutable, process-global `Mustache.escape` — so behavior is
  deterministic regardless of who else has touched the global
  (notably `experimental/formatter.ts` mutates it at module load).
  The `'html'` strategy uses a locally-implemented escape function that
  matches mustache.js's internal `escapeHtml` byte-for-byte (entity map
  + regex verified against `mustache@4.2.0`).
- `extractJsonText` is already `@public` and re-exported from the
  `ai-assist` packlet — no source change required. The promotion is
  confirmed via the regenerated api.md (resolves NQ-1).
- Rush change file added; api.md regenerated; `state.md` updated to
  mark B-0b complete.

## Test plan

- [x] `rushx build` passes in `ts-extras`
- [x] `rushx lint` passes in `ts-extras` (separate gate from build)
- [x] `rushx fixlint` run before final commit
- [x] `rushx test` passes; 100% coverage on the `mustache` packlet
      (66 tests in `mustacheTemplate.test.ts`, including 8 new tests
      under the `escape option` describe block covering each strategy,
      concurrent-template safety, `validateAndRender` integration, and
      triple-brace always-unescaped semantics)
- [x] api-extractor regenerated (`etc/ts-extras.api.md`)
- [x] `code-reviewer` agent invoked on the change set — approved (no
      Priority 1 / 2 findings; one Priority 3 test-strengthening
      suggestion applied)

## Guardrail compliance

- No `any`, no `console.*`, no `node:fs`, no `JSON.stringify`-compare,
  no `Result<void>`, no unsafe casts in product code, no `unknown`
  introduced without rationale, no `@fgv/*` type shadowing.
- No inline `eslint-disable` directives added.
- `MustacheTemplate.create(...)` factory pattern preserved.
- `index.ts` remains barrel-exports only.
- Strictly additive on the established `ts-extras/mustache` surface —
  no removed / renamed / behavior-changed exports.

## Out of scope (per the brief)

- `libraries/ts-prompt-assist/` (queued for B-1).
- `LIBRARY_CAPABILITIES.md` update (B-5's job).
- Any other ts-extras packlet.

After merge: orchestrator commissions B-1 (foundation) per the
brief's sub-phase decomposition.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fcyb1beSNafFrEXKULzRMS)_