### PR TITLE
feat(ts-utils): add Failure<T>.withType<U>() for Result early-return pattern (F13)

### DIFF
--- a/common/changes/@fgv/ts-utils/result-failure-withtype_2026-05-18-12-00.json
+++ b/common/changes/@fgv/ts-utils/result-failure-withtype_2026-05-18-12-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-utils",
+      "comment": "Add Failure<T>.withType<U>() helper for the canonical Result early-return pattern, allowing a narrowed Failure<T> to be propagated as Failure<U> without reallocation (addresses ts-prompt-assist pressure-test finding F13).",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-utils"
+}

--- a/libraries/ts-utils/etc/ts-utils.api.md
+++ b/libraries/ts-utils/etc/ts-utils.api.md
@@ -1073,6 +1073,7 @@ export class Failure<out T> implements IResult<T> {
     withErrorFormat(cb: ErrorFormatter): Result<T>;
     // Warning: (ae-incompatible-release-tags) The symbol "withFailureDetail" is marked as @public, but its signature references "DetailedResult" which is marked as @beta
     withFailureDetail<TD>(detail: TD): DetailedResult<T, TD>;
+    withType<U>(): Failure<U>;
 }
 
 // @public

--- a/libraries/ts-utils/src/packlets/base/result.ts
+++ b/libraries/ts-utils/src/packlets/base/result.ts
@@ -752,6 +752,46 @@ export class Failure<out T> implements IResult<T> {
   }
 
   /**
+   * Re-types this {@link Failure | Failure<T>} as {@link Failure | Failure<U>} for
+   * propagation under a different success type.
+   * @remarks
+   * Supports the canonical Result early-return-after-`isFailure()` pattern when the
+   * outer function's success type differs from the inner Result's success type:
+   *
+   * ```ts
+   * const storeResult = await PromptStoreFixture.build(seed);
+   * if (storeResult.isFailure()) {
+   *   return storeResult.withType<PromptLibrary>();
+   * }
+   * return PromptLibrary.create({ store: storeResult.value, ... });
+   * ```
+   *
+   * Without this helper, TypeScript rejects `return storeResult` because
+   * `Failure<IPromptStore>` is invariant in `T` and not assignable to
+   * `Result<PromptLibrary>`. The workaround `return fail<U>(r.message)` is
+   * semantically equivalent but allocates a new {@link Failure} instance;
+   * `withType` returns `this` and only retypes statically.
+   *
+   * This method is sound because a {@link Failure} variant carries no `T`-shaped
+   * data — only an error message — so re-typing it as `Failure<U>` cannot
+   * misrepresent any value. The same operation is NOT exposed on {@link Success}
+   * because `Success<T>` carries `T`-shaped data and re-typing would be a lie.
+   *
+   * For `DetailedResult` propagation that preserves a typed `detail`, consider
+   * propagating the {@link DetailedFailure} directly through `onSuccess` (which
+   * already re-types the success arm) rather than reaching for `withType`.
+   *
+   * @returns This same {@link Failure} instance, statically retyped as
+   * {@link Failure | Failure<U>}.
+   * @public
+   */
+  public withType<U>(): Failure<U> {
+    // Safe by construction: Failure carries no T-shaped data, only a message.
+    // Re-typing the static T parameter cannot misrepresent any value.
+    return this as unknown as Failure<U>;
+  }
+
+  /**
    * Get a 'friendly' string representation of this object.
    * @remarks
    * The string representation of a {@link Failure} value is the error message.

--- a/libraries/ts-utils/src/test/unit/result.test.ts
+++ b/libraries/ts-utils/src/test/unit/result.test.ts
@@ -859,6 +859,50 @@ describe('Result module', () => {
         expect(new Failure('oops').toString()).toBe('oops');
       });
     });
+
+    describe('withType method', () => {
+      test('returns a failure', () => {
+        const original = fail<string>('oops');
+        const recast = original.withType<number>();
+        expect(recast.isFailure()).toBe(true);
+      });
+
+      test('preserves the original error message', () => {
+        const original = fail<string>('something went wrong');
+        const recast = original.withType<number>();
+        expect(recast).toFailWith('something went wrong');
+      });
+
+      test('returns the same Failure instance (no allocation)', () => {
+        const original = fail<string>('oops');
+        const recast = original.withType<number>();
+        expect(recast).toBe(original as unknown as Failure<number>);
+      });
+
+      test('supports the canonical early-return pattern with heterogeneous success types', () => {
+        function loadNumber(input: string): Result<number> {
+          if (input === 'bad') {
+            return fail('not a number');
+          }
+          return succeed(Number(input));
+        }
+
+        function describeNumber(input: string): Result<string> {
+          const numberResult = loadNumber(input);
+          if (numberResult.isFailure()) {
+            // The point of the test: this line must compile without
+            // recourse to `fail<string>(numberResult.message)` even though
+            // the inner Result's success type (number) differs from the
+            // outer return type (string).
+            return numberResult.withType<string>();
+          }
+          return succeed(`got ${numberResult.value}`);
+        }
+
+        expect(describeNumber('42')).toSucceedWith('got 42');
+        expect(describeNumber('bad')).toFailWith('not a number');
+      });
+    });
   });
 
   describe('detailedSuccess class', () => {


### PR DESCRIPTION
## Scope

Adds `Failure<T>.withType<U>(): Failure<U>` to `@fgv/ts-utils` — a single new public method on the `Failure` class supporting the canonical Result early-return pattern across heterogeneous success types.

This is **PR A** of the three ergonomics PRs absorbing ts-prompt-assist round-1 pressure-test findings.

## Finding reference

`F13` in `.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-1.md`.

The canonical pattern below previously did not compile:

```ts
const storeResult = await PromptStoreFixture.build(seed);
if (storeResult.isFailure()) {
  return storeResult;  // TS error: Failure<IPromptStore> not assignable to Result<PromptLibrary>
}
return PromptLibrary.create({ store: storeResult.value, ... });
```

Callers worked around it with `return fail<U>(storeResult.message)`, which reallocates the failure. The new method enables:

```ts
if (storeResult.isFailure()) {
  return storeResult.withType<PromptLibrary>();
}
```

## Soundness (why this isn't an unsafe cast)

The implementation is a single `return this as unknown as Failure<U>` — but it is safe by construction, not by handwave. A `Failure` variant carries no `T`-shaped data; only a string error message. Re-typing it as `Failure<U>` cannot misrepresent any value because there is no value to misrepresent. The static `T` parameter on `Failure` only constrains how the failure composes with `Success<T>` in a discriminated `Result<T>` — not what runtime data it carries.

The same operation is **explicitly NOT** exposed on `Success<T>` for the same reason in reverse: a `Success<T>` carries `T`-shaped data, so re-typing as `Success<U>` *would* be a lie. The asymmetry is intentional.

## Pre-PR gates (all green locally)

- [x] `rush build --to @fgv/ts-utils` passes (api-extractor regenerated `etc/ts-utils.api.md`)
- [x] `cd libraries/ts-utils && rushx lint` passes
- [x] `cd libraries/ts-utils && rushx fixlint` run before final commit
- [x] `cd libraries/ts-utils && rushx test` passes with 100% coverage on `result.ts`
- [x] `rush change --verify --target-branch origin/claude/ts-prompt-assist-features` passes
- [x] No `any` types; single documented `as unknown as Failure<U>` cast inside `withType` with TSDoc soundness argument

## Test plan

Four new tests in `result.test.ts`, all under the existing `Failure class` describe:

- [x] `returns a failure` — `isFailure()` still true after `.withType()`
- [x] `preserves the original error message` — `toFailWith(msg)` matches
- [x] `returns the same Failure instance (no allocation)` — identity check
- [x] `supports the canonical early-return pattern with heterogeneous success types` — exercises the actual use case (loadNumber → describeNumber chain), demonstrating both compile-success and correct runtime propagation

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_