### PR TITLE
feat(ts-res): qualifier ergonomics PR B — F1 mixed-shape collector + F14 Partial-widened context

### DIFF
--- a/common/changes/@fgv/ts-res/claude-qualifier-ergonomics-pr-b_2026-05-18-12-00.json
+++ b/common/changes/@fgv/ts-res/claude-qualifier-ergonomics-pr-b_2026-05-18-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Qualifier ergonomics (F1 + F14): QualifierCollector.create accepts mixed `(string | IQualifierDecl)[]` with optional qualifierTypes when all entries are strings; SimpleContextQualifierProvider and ValidatingSimpleContextQualifierProvider widen `qualifierValues` to `Readonly<Partial<Record<string, ...>>>` to accept conditional `{ k: v } | {}` shapes.",
+      "type": "minor",
+      "packageName": "@fgv/ts-res"
+    }
+  ],
+  "packageName": "@fgv/ts-res",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-res/etc/ts-res.api.md
+++ b/libraries/ts-res/etc/ts-res.api.md
@@ -2456,7 +2456,6 @@ interface IPathImporterCreateParams {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
 interface IQualifierCollectorCreateParams {
@@ -3809,18 +3808,11 @@ const qualifier: Converter<Qualifier, IQualifierConvertContext>;
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-const QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP: number;
-
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-//
-// @public
 class QualifierCollector extends ValidatingConvertingCollector<Qualifier, IQualifierDecl> implements IReadOnlyQualifierCollector {
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     protected constructor(qualifierTypes: ReadOnlyQualifierTypeCollector, qualifiers?: ReadonlyArray<IQualifierDecl>);
-    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -3937,7 +3929,6 @@ declare namespace Qualifiers {
         IQualifierDecl,
         IValidatedQualifierDecl,
         IReadOnlyQualifierCollector,
-        QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP,
         IQualifierCollectorCreateParams,
         QualifierCollector,
         IQualifierDefaultValueDecl,
@@ -5386,10 +5377,11 @@ details: string) => void;
 // src/packlets/import/importers/collectionImporter.ts:135:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/packlets/import/importers/collectionImporter.ts:135:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/packlets/import/importers/collectionImporter.ts:135:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// src/packlets/qualifiers/qualifierCollector.ts:192:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// src/packlets/qualifiers/qualifierCollector.ts:192:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// src/packlets/qualifiers/qualifierCollector.ts:233:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// src/packlets/qualifiers/qualifierCollector.ts:291:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/qualifiers/qualifierCollector.ts:215:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/qualifiers/qualifierCollector.ts:215:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-res" does not have an export "Converters"
+// src/packlets/qualifiers/qualifierCollector.ts:215:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/qualifiers/qualifierCollector.ts:265:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/qualifiers/qualifierCollector.ts:333:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/packlets/resources/resource.ts:242:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/packlets/resources/resource.ts:242:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/packlets/resources/resource.ts:265:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver

--- a/libraries/ts-res/etc/ts-res.api.md
+++ b/libraries/ts-res/etc/ts-res.api.md
@@ -2452,15 +2452,21 @@ interface IPathImporterCreateParams {
 }
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
 interface IQualifierCollectorCreateParams {
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-    qualifiers?: IQualifierDecl[];
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    qualifiers?: ReadonlyArray<string | IQualifierDecl>;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-    qualifierTypes: ReadOnlyQualifierTypeCollector;
+    qualifierTypes?: ReadOnlyQualifierTypeCollector;
 }
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -2997,7 +3003,7 @@ interface IResourceTypeConfig<T extends JsonObject = JsonObject> {
 interface ISimpleContextQualifierProviderCreateParams {
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     qualifiers: IReadOnlyQualifierCollector;
-    qualifierValues?: Record<string, QualifierContextValue>;
+    qualifierValues?: Readonly<Partial<Record<string, QualifierContextValue>>>;
 }
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -3274,7 +3280,7 @@ type IValidatedQualifierDefaultValuesDecl = Record<QualifierName, QualifierConte
 interface IValidatingSimpleContextQualifierProviderCreateParams {
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     qualifiers: IReadOnlyQualifierCollector;
-    qualifierValues?: Record<string, string>;
+    qualifierValues?: Readonly<Partial<Record<string, string>>>;
 }
 
 // @public
@@ -3803,9 +3809,20 @@ const qualifier: Converter<Qualifier, IQualifierConvertContext>;
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
+const QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP: number;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
 class QualifierCollector extends ValidatingConvertingCollector<Qualifier, IQualifierDecl> implements IReadOnlyQualifierCollector {
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-    protected constructor(params: IQualifierCollectorCreateParams);
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    protected constructor(qualifierTypes: ReadOnlyQualifierTypeCollector, qualifiers?: ReadonlyArray<IQualifierDecl>);
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -3920,6 +3937,7 @@ declare namespace Qualifiers {
         IQualifierDecl,
         IValidatedQualifierDecl,
         IReadOnlyQualifierCollector,
+        QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP,
         IQualifierCollectorCreateParams,
         QualifierCollector,
         IQualifierDefaultValueDecl,
@@ -5368,6 +5386,10 @@ details: string) => void;
 // src/packlets/import/importers/collectionImporter.ts:135:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/packlets/import/importers/collectionImporter.ts:135:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/packlets/import/importers/collectionImporter.ts:135:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/qualifiers/qualifierCollector.ts:192:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/qualifiers/qualifierCollector.ts:192:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/qualifiers/qualifierCollector.ts:233:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/qualifiers/qualifierCollector.ts:291:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/packlets/resources/resource.ts:242:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/packlets/resources/resource.ts:242:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/packlets/resources/resource.ts:265:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver

--- a/libraries/ts-res/src/packlets/qualifiers/qualifierCollector.ts
+++ b/libraries/ts-res/src/packlets/qualifiers/qualifierCollector.ts
@@ -24,6 +24,8 @@ import * as Common from '../common';
 import {
   captureResult,
   Collections,
+  Converter,
+  Converters,
   failWithDetail,
   mapResults,
   Result,
@@ -33,7 +35,7 @@ import {
   ValidatingConvertingCollector
 } from '@fgv/ts-utils';
 import { IQualifierDecl, IValidatedQualifierDecl } from './qualifierDecl';
-import { QualifierName } from '../common';
+import { MaxConditionPriority, MinConditionPriority, QualifierName } from '../common';
 import { Qualifier } from './qualifier';
 import { IQualifierDeclConvertContext, qualifierDecl, validatedQualifierDecl } from './convert';
 import {
@@ -41,6 +43,18 @@ import {
   QualifierTypeCollector,
   ReadOnlyQualifierTypeCollector
 } from '../qualifier-types';
+
+/**
+ * Converter for a single entry in the mixed-shape
+ * {@link Qualifiers.IQualifierCollectorCreateParams.qualifiers | qualifiers}
+ * input — either a bare axis-name string or a full
+ * {@link Qualifiers.IQualifierDecl | declaration}. Validates the entry
+ * shape at the public-API boundary rather than deferring to the
+ * internal qualifier factory.
+ */
+const _qualifierEntriesConverter: Converter<ReadonlyArray<string | IQualifierDecl>> = Converters.arrayOf(
+  Converters.oneOf<string | IQualifierDecl>([Converters.string, qualifierDecl])
+);
 
 /**
  * Readonly version of {@link Qualifiers.QualifierCollector | QualifierCollector}.
@@ -68,13 +82,6 @@ export interface IReadOnlyQualifierCollector extends Collections.IReadOnlyValida
 }
 
 /**
- * Default priority step used when synthesizing {@link Qualifiers.IQualifierDecl | declarations}
- * from a bare axis-name string in the mixed-shape {@link Qualifiers.QualifierCollector.create | create} input.
- * @public
- */
-export const QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP: number = 100;
-
-/**
  * Parameters for creating a new {@link Qualifiers.QualifierCollector}.
  * @public
  *
@@ -84,9 +91,16 @@ export const QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP: number = 100;
  * sugar for "literal qualifier with this name"; the library synthesizes a
  * {@link QualifierTypes.LiteralQualifierType | LiteralQualifierType} and a
  * declaration `{ name, typeName: name, defaultPriority: <descending> }`.
- * Priorities for synthesized declarations follow `(arr.length - index) * step`
- * (step = {@link Qualifiers.QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP | QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP}), so earlier
- * elements get higher priority.
+ *
+ * Synthesized priorities are distributed across the
+ * `[MinConditionPriority..MaxConditionPriority]` range adaptively to the
+ * array length: `step = max(1, floor((Max - Min) / length))`,
+ * `priority = max(Min, Max - index * step)`. Earlier elements get higher
+ * priority. The formula never overflows the `ConditionPriority` range
+ * regardless of input length; for inputs whose length exceeds the range
+ * cardinality (\>1000 axes), trailing priorities collapse at
+ * `MinConditionPriority` — supply explicit priorities in that regime
+ * if uniqueness matters.
  *
  * `qualifierTypes` may be omitted only when every element of `qualifiers`
  * is a string. If any element is an {@link Qualifiers.IQualifierDecl},
@@ -165,10 +179,13 @@ export class QualifierCollector
    * for a literal qualifier: the library synthesizes a
    * {@link QualifierTypes.LiteralQualifierType | LiteralQualifierType} named
    * after the string and a declaration `{ name, typeName: name, defaultPriority }`.
-   * Synthesized priorities follow `(arr.length - index) * step` (step =
-   * {@link Qualifiers.QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP | QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP}), so earlier elements
-   * get higher priority - matching the "earlier qualifier wins when multiple
-   * match" mental model.
+   * Synthesized priorities are distributed across the
+   * `[MinConditionPriority..MaxConditionPriority]` range adaptively to the
+   * input length (`step = max(1, floor((Max - Min) / length))`,
+   * `priority = max(Min, Max - index * step)`). Earlier elements get higher
+   * priority — matching the "earlier qualifier wins when multiple match"
+   * mental model — and the formula never overflows the `ConditionPriority`
+   * range regardless of input length.
    *
    * `qualifierTypes` may be omitted only when every element of `qualifiers`
    * is a string. If any element is a declaration, `qualifierTypes` is
@@ -186,10 +203,12 @@ export class QualifierCollector
    * into the concrete `(qualifierTypes, qualifiers)` pair the constructor expects.
    *
    * @remarks
-   * Walks the mixed-shape `qualifiers` array, synthesizing
-   * {@link QualifierTypes.LiteralQualifierType | LiteralQualifierType} entries
-   * for bare-string elements. If the caller passes any declaration but omits
-   * `qualifierTypes`, fails with an error that names the offending typeName.
+   * Validates the mixed-shape `qualifiers` input through
+   * {@link Converters.oneOf} (string vs {@link Qualifiers.IQualifierDecl})
+   * at the public-API boundary, then partitions into bare-string and decl
+   * buckets to drive type synthesis. If any decl is present and
+   * `qualifierTypes` is omitted, fails with an error that names the
+   * offending typeNames.
    *
    * @internal
    */
@@ -197,34 +216,43 @@ export class QualifierCollector
     qualifierTypes: ReadOnlyQualifierTypeCollector;
     qualifiers?: ReadonlyArray<IQualifierDecl>;
   }> {
-    const qualifiers = params.qualifiers;
-    if (qualifiers === undefined || qualifiers.length === 0) {
+    const raw = params.qualifiers;
+    if (raw === undefined || raw.length === 0) {
       if (params.qualifierTypes === undefined) {
         return succeed({ qualifierTypes: QualifierCollector._emptyQualifierTypes(), qualifiers: undefined });
       }
       return succeed({ qualifierTypes: params.qualifierTypes, qualifiers: undefined });
     }
 
-    const stringNames = qualifiers.filter((q): q is string => typeof q === 'string');
-    const allStrings = stringNames.length === qualifiers.length;
-
-    if (!allStrings && params.qualifierTypes === undefined) {
-      const declTypeNames = qualifiers
-        .filter((q): q is IQualifierDecl => typeof q !== 'string')
-        .map((q) => q.typeName);
-      const unique = Array.from(new Set(declTypeNames));
-      return fail(
-        `qualifierTypes must be supplied when qualifiers include declarations; ` +
-          `missing types for: ${unique.map((n) => `'${n}'`).join(', ')}`
-      );
-    }
-
-    return QualifierCollector._resolveQualifierTypes(params.qualifierTypes, stringNames).onSuccess(
-      (qualifierTypes) => {
-        const decls = QualifierCollector._normalizeQualifierDecls(qualifiers);
-        return succeed({ qualifierTypes, qualifiers: decls });
+    return _qualifierEntriesConverter.convert(raw).onSuccess((entries) => {
+      const stringNames: string[] = [];
+      const declTypeNames: string[] = [];
+      for (const entry of entries) {
+        if (typeof entry === 'string') {
+          stringNames.push(entry);
+        } else {
+          declTypeNames.push(entry.typeName);
+        }
       }
-    );
+
+      if (declTypeNames.length > 0 && params.qualifierTypes === undefined) {
+        const unique = Array.from(new Set(declTypeNames));
+        return fail<{
+          qualifierTypes: ReadOnlyQualifierTypeCollector;
+          qualifiers?: ReadonlyArray<IQualifierDecl>;
+        }>(
+          `qualifierTypes must be supplied when qualifiers include declarations; ` +
+            `missing types for: ${unique.map((n) => `'${n}'`).join(', ')}`
+        );
+      }
+
+      return QualifierCollector._resolveQualifierTypes(params.qualifierTypes, stringNames).onSuccess(
+        (qualifierTypes) => {
+          const decls = QualifierCollector._normalizeQualifierDecls(entries);
+          return succeed({ qualifierTypes, qualifiers: decls });
+        }
+      );
+    });
   }
 
   /**
@@ -266,20 +294,29 @@ export class QualifierCollector
   /**
    * Normalizes a mixed `(string | IQualifierDecl)[]` into a fully-resolved
    * `IQualifierDecl[]`, assigning descending default priorities to synthesized
-   * decls.
+   * decls within the `[MinConditionPriority..MaxConditionPriority]` range.
+   *
+   * @remarks
+   * Step size is adaptive to input length:
+   * `step = max(1, floor((Max - Min) / length))`. Each synthesized priority
+   * is `max(Min, Max - index * step)` — clamped at the bottom so length
+   * extremes (\>1000 axes) degrade gracefully into a tail of equal-`Min`
+   * priorities rather than overflowing the `ConditionPriority` range.
    *
    * @internal
    */
   private static _normalizeQualifierDecls(
     qualifiers: ReadonlyArray<string | IQualifierDecl>
   ): ReadonlyArray<IQualifierDecl> {
-    const step = QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP;
+    const range = MaxConditionPriority - MinConditionPriority;
+    const step = Math.max(1, Math.floor(range / qualifiers.length));
     return qualifiers.map((q, index) => {
       if (typeof q === 'string') {
+        const raw = MaxConditionPriority - index * step;
         return {
           name: q,
           typeName: q,
-          defaultPriority: (qualifiers.length - index) * step
+          defaultPriority: Math.max(MinConditionPriority, raw)
         };
       }
       return q;

--- a/libraries/ts-res/src/packlets/qualifiers/qualifierCollector.ts
+++ b/libraries/ts-res/src/packlets/qualifiers/qualifierCollector.ts
@@ -25,6 +25,7 @@ import {
   captureResult,
   Collections,
   failWithDetail,
+  mapResults,
   Result,
   fail,
   succeed,
@@ -35,7 +36,11 @@ import { IQualifierDecl, IValidatedQualifierDecl } from './qualifierDecl';
 import { QualifierName } from '../common';
 import { Qualifier } from './qualifier';
 import { IQualifierDeclConvertContext, qualifierDecl, validatedQualifierDecl } from './convert';
-import { ReadOnlyQualifierTypeCollector } from '../qualifier-types';
+import {
+  LiteralQualifierType,
+  QualifierTypeCollector,
+  ReadOnlyQualifierTypeCollector
+} from '../qualifier-types';
 
 /**
  * Readonly version of {@link Qualifiers.QualifierCollector | QualifierCollector}.
@@ -63,21 +68,52 @@ export interface IReadOnlyQualifierCollector extends Collections.IReadOnlyValida
 }
 
 /**
+ * Default priority step used when synthesizing {@link Qualifiers.IQualifierDecl | declarations}
+ * from a bare axis-name string in the mixed-shape {@link Qualifiers.QualifierCollector.create | create} input.
+ * @public
+ */
+export const QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP: number = 100;
+
+/**
  * Parameters for creating a new {@link Qualifiers.QualifierCollector}.
  * @public
+ *
+ * @remarks
+ * `qualifiers` accepts a mixed array of bare axis-name strings and full
+ * {@link Qualifiers.IQualifierDecl | declarations}. A string element is
+ * sugar for "literal qualifier with this name"; the library synthesizes a
+ * {@link QualifierTypes.LiteralQualifierType | LiteralQualifierType} and a
+ * declaration `{ name, typeName: name, defaultPriority: <descending> }`.
+ * Priorities for synthesized declarations follow `(arr.length - index) * step`
+ * (step = {@link Qualifiers.QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP | QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP}), so earlier
+ * elements get higher priority.
+ *
+ * `qualifierTypes` may be omitted only when every element of `qualifiers`
+ * is a string. If any element is an {@link Qualifiers.IQualifierDecl},
+ * `qualifierTypes` must be supplied and must contain the referenced
+ * {@link Qualifiers.IQualifierDecl.typeName | typeNames}.
  */
 export interface IQualifierCollectorCreateParams {
   /**
    * The {@link QualifierTypes.QualifierTypeCollector | qualifier types} used to
    * create {@link Qualifiers.Qualifier | qualifiers} from {@link Qualifiers.IQualifierDecl | declarations}.
+   *
+   * Optional only when every entry in `qualifiers` is a bare axis-name string
+   * (in which case the library synthesizes a literal qualifier type per name).
    */
-  qualifierTypes: ReadOnlyQualifierTypeCollector;
+  qualifierTypes?: ReadOnlyQualifierTypeCollector;
 
   /**
-   * Optional list of {@link Qualifiers.IQualifierDecl | declarations} for the qualifiers to add to the collection
-   * upon creation.
+   * Optional list of {@link Qualifiers.IQualifierDecl | declarations} or bare
+   * axis-name strings for the qualifiers to add to the collection on creation.
+   *
+   * @remarks
+   * A string element `'foo'` is sugar for a literal qualifier:
+   * `{ name: 'foo', typeName: 'foo', defaultPriority: <descending> }` backed by
+   * a synthesized {@link QualifierTypes.LiteralQualifierType | LiteralQualifierType}
+   * named `'foo'`.
    */
-  qualifiers?: IQualifierDecl[];
+  qualifiers?: ReadonlyArray<string | IQualifierDecl>;
 }
 
 /**
@@ -97,10 +133,15 @@ export class QualifierCollector
 
   /**
    * Constructor for a {@link Qualifiers.QualifierCollector | QualifierCollector} object.
-   * @param params - Parameters for creating the collector.
+   * @param qualifierTypes - The {@link QualifierTypes.ReadOnlyQualifierTypeCollector | qualifier types}
+   * used to validate declarations.
+   * @param qualifiers - Optional list of fully-resolved {@link Qualifiers.IQualifierDecl | declarations}.
    * @public
    */
-  protected constructor(params: IQualifierCollectorCreateParams) {
+  protected constructor(
+    qualifierTypes: ReadOnlyQualifierTypeCollector,
+    qualifiers?: ReadonlyArray<IQualifierDecl>
+  ) {
     super({
       factory: (k, i, v) => this._qualifierFactory(k, i, v),
       converters: new Collections.KeyValueConverters({
@@ -108,18 +149,153 @@ export class QualifierCollector
         value: qualifierDecl
       })
     });
-    this.qualifierTypes = params.qualifierTypes;
+    this.qualifierTypes = qualifierTypes;
     /* c8 ignore next 1 - coverage misses the branch intermittently */
-    params.qualifiers?.forEach((q) => this.validating.add(q.name, q).orThrow());
+    qualifiers?.forEach((q) => this.validating.add(q.name, q).orThrow());
   }
 
   /**
    * Creates a new {@link Qualifiers.QualifierCollector | QualifierCollector} object.
    * @param params - {@link Qualifiers.IQualifierCollectorCreateParams | Parameters} for creating a new {@link Qualifiers.QualifierCollector | QualifierCollector}.
    * @returns `Success` with the new collector if successful, or `Failure` if not.
+   *
+   * @remarks
+   * Accepts a mixed array of bare axis-name strings and full
+   * {@link Qualifiers.IQualifierDecl | declarations}. String elements are sugar
+   * for a literal qualifier: the library synthesizes a
+   * {@link QualifierTypes.LiteralQualifierType | LiteralQualifierType} named
+   * after the string and a declaration `{ name, typeName: name, defaultPriority }`.
+   * Synthesized priorities follow `(arr.length - index) * step` (step =
+   * {@link Qualifiers.QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP | QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP}), so earlier elements
+   * get higher priority - matching the "earlier qualifier wins when multiple
+   * match" mental model.
+   *
+   * `qualifierTypes` may be omitted only when every element of `qualifiers`
+   * is a string. If any element is a declaration, `qualifierTypes` is
+   * required (and must include the referenced typeNames); the error message
+   * names the offending typeName when it is missing.
    */
   public static create(params: IQualifierCollectorCreateParams): Result<QualifierCollector> {
-    return captureResult(() => new QualifierCollector(params));
+    return QualifierCollector._resolveCreateParams(params).onSuccess(({ qualifierTypes, qualifiers }) => {
+      return captureResult(() => new QualifierCollector(qualifierTypes, qualifiers));
+    });
+  }
+
+  /**
+   * Resolves the public {@link Qualifiers.IQualifierCollectorCreateParams | create params}
+   * into the concrete `(qualifierTypes, qualifiers)` pair the constructor expects.
+   *
+   * @remarks
+   * Walks the mixed-shape `qualifiers` array, synthesizing
+   * {@link QualifierTypes.LiteralQualifierType | LiteralQualifierType} entries
+   * for bare-string elements. If the caller passes any declaration but omits
+   * `qualifierTypes`, fails with an error that names the offending typeName.
+   *
+   * @internal
+   */
+  private static _resolveCreateParams(params: IQualifierCollectorCreateParams): Result<{
+    qualifierTypes: ReadOnlyQualifierTypeCollector;
+    qualifiers?: ReadonlyArray<IQualifierDecl>;
+  }> {
+    const qualifiers = params.qualifiers;
+    if (qualifiers === undefined || qualifiers.length === 0) {
+      if (params.qualifierTypes === undefined) {
+        return succeed({ qualifierTypes: QualifierCollector._emptyQualifierTypes(), qualifiers: undefined });
+      }
+      return succeed({ qualifierTypes: params.qualifierTypes, qualifiers: undefined });
+    }
+
+    const stringNames = qualifiers.filter((q): q is string => typeof q === 'string');
+    const allStrings = stringNames.length === qualifiers.length;
+
+    if (!allStrings && params.qualifierTypes === undefined) {
+      const declTypeNames = qualifiers
+        .filter((q): q is IQualifierDecl => typeof q !== 'string')
+        .map((q) => q.typeName);
+      const unique = Array.from(new Set(declTypeNames));
+      return fail(
+        `qualifierTypes must be supplied when qualifiers include declarations; ` +
+          `missing types for: ${unique.map((n) => `'${n}'`).join(', ')}`
+      );
+    }
+
+    return QualifierCollector._resolveQualifierTypes(params.qualifierTypes, stringNames).onSuccess(
+      (qualifierTypes) => {
+        const decls = QualifierCollector._normalizeQualifierDecls(qualifiers);
+        return succeed({ qualifierTypes, qualifiers: decls });
+      }
+    );
+  }
+
+  /**
+   * Returns the provided {@link QualifierTypes.ReadOnlyQualifierTypeCollector | qualifier-type collector}
+   * (or synthesizes a new one) augmented with synthesized literal qualifier types for the supplied
+   * string names that are not already present.
+   *
+   * @internal
+   */
+  private static _resolveQualifierTypes(
+    provided: ReadOnlyQualifierTypeCollector | undefined,
+    stringNames: ReadonlyArray<string>
+  ): Result<ReadOnlyQualifierTypeCollector> {
+    if (stringNames.length === 0) {
+      // No bare names to synthesize. The all-decls case requires `provided` to be defined
+      // (else _resolveCreateParams would have failed before calling us); fall back to an
+      // empty type collector only as a defensive measure.
+      /* c8 ignore next 1 - defensive: unreachable when called from _resolveCreateParams */
+      return succeed(provided ?? QualifierCollector._emptyQualifierTypes());
+    }
+    return mapResults(stringNames.map((name) => LiteralQualifierType.create({ name }))).onSuccess(
+      (literalTypes) => {
+        return QualifierTypeCollector.create().onSuccess((collector) => {
+          const existingAdds: ReadonlyArray<Result<unknown>> =
+            provided !== undefined
+              ? Array.from(provided.values()).map((existing) => collector.add(existing))
+              : [];
+          const literalAdds: ReadonlyArray<Result<unknown>> = literalTypes
+            .filter((lit) => !collector.has(lit.name))
+            .map((lit) => collector.add(lit));
+          return mapResults([...existingAdds, ...literalAdds]).onSuccess(() =>
+            succeed(collector as ReadOnlyQualifierTypeCollector)
+          );
+        });
+      }
+    );
+  }
+
+  /**
+   * Normalizes a mixed `(string | IQualifierDecl)[]` into a fully-resolved
+   * `IQualifierDecl[]`, assigning descending default priorities to synthesized
+   * decls.
+   *
+   * @internal
+   */
+  private static _normalizeQualifierDecls(
+    qualifiers: ReadonlyArray<string | IQualifierDecl>
+  ): ReadonlyArray<IQualifierDecl> {
+    const step = QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP;
+    return qualifiers.map((q, index) => {
+      if (typeof q === 'string') {
+        return {
+          name: q,
+          typeName: q,
+          defaultPriority: (qualifiers.length - index) * step
+        };
+      }
+      return q;
+    });
+  }
+
+  /**
+   * Returns an empty {@link QualifierTypes.ReadOnlyQualifierTypeCollector | qualifier-type collector}
+   * used as a placeholder when no qualifiers are supplied and the caller omits
+   * `qualifierTypes`.
+   *
+   * @internal
+   */
+  private static _emptyQualifierTypes(): ReadOnlyQualifierTypeCollector {
+    /* c8 ignore next 1 - QualifierTypeCollector.create() is total for the empty case */
+    return QualifierTypeCollector.create().orThrow();
   }
 
   /**

--- a/libraries/ts-res/src/packlets/runtime/context/simpleContextQualifierProvider.ts
+++ b/libraries/ts-res/src/packlets/runtime/context/simpleContextQualifierProvider.ts
@@ -43,8 +43,15 @@ export interface ISimpleContextQualifierProviderCreateParams {
 
   /**
    * Optional record of initial qualifier name-value pairs to populate the provider.
+   *
+   * @remarks
+   * Typed as `Readonly<Partial<Record<string, QualifierContextValue>>>` so a
+   * caller can naturally express conditional context construction, e.g.
+   * `tone === 'formal' ? { tone: 'formal' } : {}`. Entries whose value is
+   * `undefined` are skipped on load - semantically equivalent to omitting
+   * the key, which is how the candidate selector treats a missing key.
    */
-  qualifierValues?: Record<string, QualifierContextValue>;
+  qualifierValues?: Readonly<Partial<Record<string, QualifierContextValue>>>;
 }
 
 /**
@@ -83,6 +90,9 @@ export class SimpleContextQualifierProvider
 
     if (params.qualifierValues) {
       for (const [name, value] of Object.entries(params.qualifierValues)) {
+        if (value === undefined) {
+          continue;
+        }
         const qualifierName = Validate.toQualifierName(name).orThrow();
         this._qualifierValues.set(qualifierName, value);
       }

--- a/libraries/ts-res/src/packlets/runtime/context/validatingSimpleContextQualifierProvider.ts
+++ b/libraries/ts-res/src/packlets/runtime/context/validatingSimpleContextQualifierProvider.ts
@@ -42,8 +42,15 @@ export interface IValidatingSimpleContextQualifierProviderCreateParams {
   /**
    * Optional record of initial qualifier name-value pairs to populate the provider.
    * Accepts string keys and values which will be converted to strongly-typed values.
+   *
+   * @remarks
+   * Typed as `Readonly<Partial<Record<string, string>>>` so callers can
+   * naturally express conditional context construction, e.g.
+   * `tone === 'formal' ? { tone: 'formal' } : {}`. Entries whose value is
+   * `undefined` are skipped on load - semantically equivalent to omitting
+   * the key.
    */
-  qualifierValues?: Record<string, string>;
+  qualifierValues?: Readonly<Partial<Record<string, string>>>;
 }
 
 /**
@@ -65,13 +72,11 @@ export class ValidatingSimpleContextQualifierProvider extends SimpleContextQuali
    * @param params - {@link Runtime.IValidatingSimpleContextQualifierProviderCreateParams | Parameters} used to create the provider.
    */
   protected constructor(params: IValidatingSimpleContextQualifierProviderCreateParams) {
-    // Convert string values to QualifierContextValue for the base class
-    /* c8 ignore next 5 - functional code path tested but coverage intermittently missed */
-    const convertedValues: Record<string, QualifierContextValue> | undefined = params.qualifierValues
-      ? Object.fromEntries(
-          Object.entries(params.qualifierValues).map(([key, value]) => [key, value as QualifierContextValue])
-        )
-      : undefined;
+    // The branded QualifierContextValue is structurally a string; widen via cast
+    // and let the base class skip undefined entries on load.
+    const convertedValues = params.qualifierValues as
+      | Readonly<Partial<Record<string, QualifierContextValue>>>
+      | undefined;
 
     super({
       qualifiers: params.qualifiers,

--- a/libraries/ts-res/src/test/unit/qualifiers/qualifierCollector.test.ts
+++ b/libraries/ts-res/src/test/unit/qualifiers/qualifierCollector.test.ts
@@ -187,25 +187,26 @@ describe('QualifierCollector class', () => {
     });
 
     test('synthesizes literal qualifier types from bare string entries with descending priorities', () => {
+      // 2 entries: step = floor(1000 / 2) = 500. Priorities = 1000 - index * 500.
       expect(
         TsRes.Qualifiers.QualifierCollector.create({
           qualifiers: ['language', 'tone']
         })
       ).toSucceedAndSatisfy((qc) => {
         expect(qc.size).toBe(2);
-        const step = TsRes.Qualifiers.QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP;
         expect(qc.validating.get('language')).toSucceedAndSatisfy((q) => {
           expect(q.type.name).toBe('language');
-          expect(q.defaultPriority).toBe(2 * step);
+          expect(q.defaultPriority).toBe(1000);
         });
         expect(qc.validating.get('tone')).toSucceedAndSatisfy((q) => {
           expect(q.type.name).toBe('tone');
-          expect(q.defaultPriority).toBe(1 * step);
+          expect(q.defaultPriority).toBe(500);
         });
       });
     });
 
     test('accepts a mixed array of strings and full decls when qualifierTypes covers the decls', () => {
+      // 2 entries: synthesized string gets priority 1000 at index 0; explicit decl uses its own value.
       expect(
         TsRes.Qualifiers.QualifierCollector.create({
           qualifierTypes,
@@ -213,16 +214,44 @@ describe('QualifierCollector class', () => {
         })
       ).toSucceedAndSatisfy((qc) => {
         expect(qc.size).toBe(2);
-        const step = TsRes.Qualifiers.QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP;
         expect(qc.validating.get('greeting')).toSucceedAndSatisfy((q) => {
           expect(q.type.name).toBe('greeting');
-          expect(q.defaultPriority).toBe(2 * step);
+          expect(q.defaultPriority).toBe(1000);
         });
         expect(qc.validating.get('language')).toSucceedAndSatisfy((q) => {
           expect(q.type.name).toBe('language');
           expect(q.defaultPriority).toBe(500);
         });
       });
+    });
+
+    test('priority synthesis stays within ConditionPriority range for length=11 (regression: fixed-step overflowed)', () => {
+      // 11 entries: step = floor(1000/11) = 90. Priorities = 1000, 910, 820, ..., 100.
+      // Under the prior fixed-step formula `(length - index) * 100`, the first
+      // element would have priority 1100 — overflowing MaxConditionPriority and
+      // failing validation deep inside the qualifier factory.
+      const names = Array.from({ length: 11 }, (__unused, i) => `axis${i}`);
+      expect(TsRes.Qualifiers.QualifierCollector.create({ qualifiers: names })).toSucceedAndSatisfy((qc) => {
+        expect(qc.size).toBe(11);
+        expect(qc.validating.get('axis0')).toSucceedAndSatisfy((q) => {
+          expect(q.defaultPriority).toBe(1000);
+        });
+        expect(qc.validating.get('axis10')).toSucceedAndSatisfy((q) => {
+          expect(q.defaultPriority).toBe(100);
+        });
+      });
+    });
+
+    test('rejects an entry that is neither a string nor a valid IQualifierDecl shape at the Converter boundary', () => {
+      // The Converters.oneOf entry-validation rejects malformed inputs at the
+      // public-API boundary, citing the input rather than failing deep inside
+      // the qualifier factory.
+      expect(
+        TsRes.Qualifiers.QualifierCollector.create({
+          qualifierTypes,
+          qualifiers: [{ name: 'broken' } as unknown as TsRes.Qualifiers.IQualifierDecl]
+        })
+      ).toFail();
     });
 
     test('skips synthesizing a literal type when one with the same name is already supplied', () => {

--- a/libraries/ts-res/src/test/unit/qualifiers/qualifierCollector.test.ts
+++ b/libraries/ts-res/src/test/unit/qualifiers/qualifierCollector.test.ts
@@ -162,6 +162,96 @@ describe('QualifierCollector class', () => {
         })
       ).toFailWith(/qualifier name.*not unique/i);
     });
+
+    test('creates an empty collector when qualifierTypes is omitted and qualifiers is undefined', () => {
+      expect(TsRes.Qualifiers.QualifierCollector.create({})).toSucceedAndSatisfy((qc) => {
+        expect(qc.size).toBe(0);
+        expect(qc.qualifierTypes.size).toBe(0);
+      });
+    });
+
+    test('creates an empty collector when qualifierTypes is omitted and qualifiers is an empty array', () => {
+      expect(TsRes.Qualifiers.QualifierCollector.create({ qualifiers: [] })).toSucceedAndSatisfy((qc) => {
+        expect(qc.size).toBe(0);
+        expect(qc.qualifierTypes.size).toBe(0);
+      });
+    });
+
+    test('creates an empty collector when qualifierTypes is provided and qualifiers is an empty array', () => {
+      expect(
+        TsRes.Qualifiers.QualifierCollector.create({ qualifierTypes, qualifiers: [] })
+      ).toSucceedAndSatisfy((qc) => {
+        expect(qc.size).toBe(0);
+        expect(qc.qualifierTypes).toBe(qualifierTypes);
+      });
+    });
+
+    test('synthesizes literal qualifier types from bare string entries with descending priorities', () => {
+      expect(
+        TsRes.Qualifiers.QualifierCollector.create({
+          qualifiers: ['language', 'tone']
+        })
+      ).toSucceedAndSatisfy((qc) => {
+        expect(qc.size).toBe(2);
+        const step = TsRes.Qualifiers.QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP;
+        expect(qc.validating.get('language')).toSucceedAndSatisfy((q) => {
+          expect(q.type.name).toBe('language');
+          expect(q.defaultPriority).toBe(2 * step);
+        });
+        expect(qc.validating.get('tone')).toSucceedAndSatisfy((q) => {
+          expect(q.type.name).toBe('tone');
+          expect(q.defaultPriority).toBe(1 * step);
+        });
+      });
+    });
+
+    test('accepts a mixed array of strings and full decls when qualifierTypes covers the decls', () => {
+      expect(
+        TsRes.Qualifiers.QualifierCollector.create({
+          qualifierTypes,
+          qualifiers: ['greeting', { name: 'language', typeName: 'language', defaultPriority: 500 }]
+        })
+      ).toSucceedAndSatisfy((qc) => {
+        expect(qc.size).toBe(2);
+        const step = TsRes.Qualifiers.QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP;
+        expect(qc.validating.get('greeting')).toSucceedAndSatisfy((q) => {
+          expect(q.type.name).toBe('greeting');
+          expect(q.defaultPriority).toBe(2 * step);
+        });
+        expect(qc.validating.get('language')).toSucceedAndSatisfy((q) => {
+          expect(q.type.name).toBe('language');
+          expect(q.defaultPriority).toBe(500);
+        });
+      });
+    });
+
+    test('skips synthesizing a literal type when one with the same name is already supplied', () => {
+      // 'literal' qualifier type already exists in the test `qualifierTypes` collector
+      expect(
+        TsRes.Qualifiers.QualifierCollector.create({
+          qualifierTypes,
+          qualifiers: ['literal']
+        })
+      ).toSucceedAndSatisfy((qc) => {
+        expect(qc.size).toBe(1);
+        expect(qc.qualifierTypes.size).toBe(qualifierTypes.size);
+        expect(qc.validating.get('literal')).toSucceedAndSatisfy((q) => {
+          expect(q.type.name).toBe('literal');
+        });
+      });
+    });
+
+    test('fails when qualifiers include declarations and qualifierTypes is omitted, naming missing typeNames', () => {
+      expect(
+        TsRes.Qualifiers.QualifierCollector.create({
+          qualifiers: [
+            { name: 'lang', typeName: 'language', defaultPriority: 600 },
+            { name: 'home', typeName: 'territory', defaultPriority: 700 },
+            { name: 'language', typeName: 'language', defaultPriority: 500 }
+          ]
+        })
+      ).toFailWith(/qualifierTypes must be supplied.*'language'.*'territory'/);
+    });
   });
 
   describe('validating getOrAdd method', () => {


### PR DESCRIPTION
## Summary

Addresses round-1 pressure-test findings **F1** and **F14** from
`.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-1.md`.
PR B of the three ergonomics PRs absorbing the ts-prompt-assist pressure-test pressure.

### F1 — `Qualifiers.QualifierCollector.create` accepts mixed-shape input

`qualifiers` now accepts `ReadonlyArray<string | IQualifierDecl>`.

- A string element `'foo'` is sugar for a literal qualifier: the library
  synthesizes a `LiteralQualifierType` named `'foo'` and a decl
  `{ name: 'foo', typeName: 'foo', defaultPriority: <descending> }`.
- **Synthesized priorities are distributed across the
  `[MinConditionPriority..MaxConditionPriority]` range adaptively to input length**
  (`step = max(1, floor((Max - Min) / length))`,
  `priority = max(Min, Max - index * step)`). Earlier-in-array gets higher
  priority. The formula never overflows the `ConditionPriority` range
  regardless of input length; trailing priorities collapse at
  `MinConditionPriority` for length > 1000.
- `qualifierTypes` is now optional, **but only when every element of
  `qualifiers` is a string** (the simpler fallback rule from the brief).
  If any element is a declaration and `qualifierTypes` is omitted, the
  error names the offending typeNames specifically (improvement over
  the previous generic "qualifierTypes must be supplied" message).

The constructor is reshaped from `(params)` to `(qualifierTypes, qualifiers?)`
— protected, no subclasses in the monorepo, no breakage. All decl
normalization runs in `create()` before the constructor is invoked.

### F14 — Widen `qualifierValues` to `Partial<...>`

`ISimpleContextQualifierProviderCreateParams.qualifierValues` and
`IValidatingSimpleContextQualifierProviderCreateParams.qualifierValues`
widen from `Record<...>` to `Readonly<Partial<Record<...>>>`.
This lets callers write `tone === 'formal' ? { tone: 'formal' } : {}`
without an explicit annotation. The loader skips `undefined` values
(semantically equivalent to omitting the key, which is how the candidate
selector treats a missing key).

**Note about F14's surface:** the finding names `IQualifierContext`
"from `@fgv/ts-res`", but that type is actually defined in
`@fgv/ts-prompt-assist` (`packlets/types/qualifiers.ts`). The
equivalent ts-res surface — and the one a real consumer flows through
into ts-res's `SimpleContextQualifierProvider` — is the
`qualifierValues` parameter on the two factories widened here. **PR C
will widen `@fgv/ts-prompt-assist`'s `IQualifierContext` type itself**;
this PR makes the ts-res side of the cascade ready.

### Review-feedback cleanup commit (`1ef0d277e`)

Two changes from orchestrator review:

1. **`_resolveCreateParams` refactored to use `Converters.oneOf`** instead
   of hand-rolled `typeof q === 'string'` filter-and-type-guard. The
   canonical fgv pattern for `string | IQualifierDecl` is
   `Converters.oneOf([Converters.string, qualifierDecl])` + `arrayOf`,
   which validates AND discriminates at the public-API boundary. The
   downstream partition is a single forward pass with natural TS
   narrowing (no unsafe cast). Side win: malformed `IQualifierDecl`
   shapes fail at entry with a clear oneOf error rather than deep inside
   `_qualifierFactory.orThrow()`.

2. **Length-adaptive priority formula** replaces the prior fixed-step
   `(length - index) * 100`. The prior formula overflowed
   `MaxConditionPriority = 1000` at length > 10 (first element would
   have priority 1100, failing validation deep inside the decl converter
   chain). The new formula is described above.

   The previously-introduced `QUALIFIER_COLLECTOR_DEFAULT_PRIORITY_STEP = 100`
   public constant is **removed** — the length-adaptive formula doesn't
   have a meaningful fixed step. The constant was only added in this
   same unmerged PR; removal is pre-publish and non-breaking.

### What's not in scope

- F1's richer constrained-values shape (`{ name, values: ['formal', 'casual'] }`)
  — explicitly deferred to v0.2 per Erik's commissioning note.
- `PromptLibrary.create.qualifiers` mixed-shape cascade on ts-prompt-assist — PR C.
- A standalone `Qualifiers.simpleLiterals(names)` helper — folded into
  the mixed-shape `create` extension.
- Any qualifier-runtime behavior change. This is a constructor /
  decl-shape change only.

### Pre-PR gates (all green)

- [x] `rush build --to @fgv/ts-prompt-assist` — green (ts-res + ts-prompt-assist build clean against the new surface)
- [x] `rushx lint` in `libraries/ts-res` — clean
- [x] `rushx fixlint` was run before the final commit (import block reformatted)
- [x] `rushx test` in `libraries/ts-res` — green, **100% coverage on every file**
- [x] `rushx test` in `libraries/ts-prompt-assist` — pre-existing consumer tests still green
- [x] api-extractor regenerated; `etc/ts-res.api.md` diff included in the commit
- [x] Rush change file under `common/changes/@fgv/ts-res/` — bump type **minor** (additive surface)
- [x] No `any`; all new fallible operations return `Result`; chains throughout

### api-extractor diff summary

- `IQualifierCollectorCreateParams.qualifierTypes`: `ReadOnlyQualifierTypeCollector` → optional
- `IQualifierCollectorCreateParams.qualifiers`: `IQualifierDecl[]` → `ReadonlyArray<string | IQualifierDecl>`
- `QualifierCollector` constructor signature change (protected, additive externally)
- `ISimpleContextQualifierProviderCreateParams.qualifierValues`: `Record<...>` → `Readonly<Partial<Record<...>>>`
- `IValidatingSimpleContextQualifierProviderCreateParams.qualifierValues`: `Record<...>` → `Readonly<Partial<Record<...>>>`

## Test plan

- [x] `Qualifiers.QualifierCollector.create({ qualifiers: ['language', 'tone'] })` synthesizes literal types with length-adaptive descending priorities (1000, 500 for length=2)
- [x] Mixed `['greeting', { name: 'language', typeName: 'language', defaultPriority: 500 }]` with `qualifierTypes` supplied works (greeting → priority 1000, language → explicit 500)
- [x] String element whose name matches an existing type in `qualifierTypes` does NOT duplicate-add
- [x] Decl present + `qualifierTypes` omitted fails with offending typeNames in the message
- [x] Empty inputs (no qualifiers / empty array) succeed with an empty collector
- [x] Existing decl-array consumers (ts-prompt-assist tests, ts-res tests) unaffected
- [x] `qualifierValues: { tone: undefined }` is accepted and the key is skipped on load
- [x] **Length=11 regression test** — verifies the length-adaptive formula stays in range (first priority 1000, last 100); under the prior fixed-step formula the first would have been 1100 and failed validation
- [x] **Malformed `IQualifierDecl` rejected at the Converter boundary** — exercises the new oneOf entry validation

## Reader-side breakage from F14

No reader-side breakage was observed in `@fgv/ts-res`'s own tests or in
`@fgv/ts-prompt-assist`'s tests. The `Object.entries(qualifierValues)`
loop in `SimpleContextQualifierProvider`'s constructor was the only
in-repo reader; it now skips `undefined` values.

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_