### PR TITLE
fix(ts-extras): add Yaml to browser entry; add L13 export-parity test

### DIFF
--- a/common/changes/@fgv/ts-extras/chore-ts-extras-browser-entry-parity_2026-05-18-02-08.json
+++ b/common/changes/@fgv/ts-extras/chore-ts-extras-browser-entry-parity_2026-05-18-02-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add Yaml to ts-extras browser entry (was Node-only); add L13 export-parity test catching any future drift",
+      "type": "none",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/src/index.browser.ts
+++ b/libraries/ts-extras/src/index.browser.ts
@@ -32,6 +32,7 @@ import * as Hash from './packlets/hash/index.browser';
 import * as Mustache from './packlets/mustache';
 // eslint-disable-next-line @rushstack/packlets/mechanics
 import * as RecordJar from './packlets/record-jar/index.browser';
+import * as Yaml from './packlets/yaml';
 import * as ZipFileTree from './packlets/zip-file-tree';
 
 import { Converters } from './packlets/conversion';
@@ -48,6 +49,7 @@ export {
   Hash,
   Mustache,
   RecordJar,
+  Yaml,
   ZipFileTree
 };
 /* c8 ignore stop */

--- a/libraries/ts-extras/src/test/unit/index.browser.test.ts
+++ b/libraries/ts-extras/src/test/unit/index.browser.test.ts
@@ -22,14 +22,29 @@
 
 import '@fgv/ts-utils-jest';
 
-import * as TsExtras from '../../index.browser';
+import * as TsExtrasBrowser from '../../index.browser';
+import * as TsExtrasNode from '../../index';
 
 describe('ts-extras browser root exports', () => {
   test('should expose CryptoUtils and preserve the Crypto alias', () => {
-    expect(TsExtras.CryptoUtils).toBeDefined();
-    expect(TsExtras.Crypto).toBeDefined();
-    expect(TsExtras.CryptoUtils.KeyStore).toBeDefined();
-    expect(TsExtras.Crypto.KeyStore).toBeDefined();
-    expect(TsExtras.CryptoUtils.KeyStore).toBe(TsExtras.Crypto.KeyStore);
+    expect(TsExtrasBrowser.CryptoUtils).toBeDefined();
+    expect(TsExtrasBrowser.Crypto).toBeDefined();
+    expect(TsExtrasBrowser.CryptoUtils.KeyStore).toBeDefined();
+    expect(TsExtrasBrowser.Crypto.KeyStore).toBeDefined();
+    expect(TsExtrasBrowser.CryptoUtils.KeyStore).toBe(TsExtrasBrowser.Crypto.KeyStore);
+  });
+
+  test('browser entry exports every top-level name the Node entry exports (L13 parity)', () => {
+    // Per TECH_DEBT.md L13 ("Cross-runtime entry-point export parity"):
+    // every top-level name exported from `index.ts` MUST also be exported
+    // from `index.browser.ts`. The browser entry MAY have additional names
+    // (e.g. the `Crypto` back-compat alias), but nothing the Node entry
+    // ships may go missing on browser — that has bitten the team multiple
+    // times (most recently: `Yaml` was missing from the browser entry,
+    // surfacing only when the sample app tried to launch).
+    const nodeKeys = Object.keys(TsExtrasNode).sort();
+    const browserKeys = Object.keys(TsExtrasBrowser).sort();
+    const missingFromBrowser = nodeKeys.filter((k) => !browserKeys.includes(k));
+    expect(missingFromBrowser).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes a cross-runtime entry-point export divergence in `@fgv/ts-extras`: the `Yaml` namespace was exported from `index.ts` but missing from `index.browser.ts`. Surfaced when the ts-prompt-assist consumer pressure-test sample app (`samples/ai-image-gen-sample`) failed to launch in the browser — `Yaml` is a transitive dep via `@fgv/ts-prompt-assist`'s YAML loader, and the browser bundler couldn't find it.

This is the **L13 pattern** firing again — the same class of bug catalogued in `lessons-pending.md` + the **P2 TECH_DEBT entry** ("Cross-runtime entry-point export parity is not systematically tested"). The TECH_DEBT entry's trigger condition was *"anytime a cross-runtime export bug is reported, expand the affected library's micro-test"* — which this PR does.

## Fix

1. **`libraries/ts-extras/src/index.browser.ts`** — add `import * as Yaml from './packlets/yaml'` and `Yaml` to the export list, matching `index.ts`. `Yaml` uses pure-JS `js-yaml` with no node-specific dependencies, so the omission was an oversight rather than a deliberate exclusion.
2. **`libraries/ts-extras/src/test/unit/index.browser.test.ts`** — add the L13-pattern parity assertion: every top-level name in `index.ts` MUST also be in `index.browser.ts`. The browser entry MAY have additional names (e.g. the existing `Crypto` back-compat alias), but nothing Node ships may go missing on browser. Catches the next missing export silently before it ships.

The existing `CryptoUtils + Crypto alias preservation` assertion is preserved unchanged.

## Pre-PR gate checklist

- [x] `rush build --to @fgv/ts-extras` green
- [x] `rushx lint` clean
- [x] `rushx test` green — 100% coverage held on every file
- [x] The new parity assertion catches the original bug — verified by temporarily removing `Yaml` from the exports list locally (assertion fails as expected); restored before commit
- [x] api-extractor regenerated (no diff — adding to the browser entry doesn't affect the Node-only api.md)
- [x] Rush change file added under `common/changes/@fgv/ts-extras/`
- [x] PR target is `claude/ts-prompt-assist-features` (NOT release)

## Lessons-pending tie-in

This is the third cross-runtime export-parity finding the team has hit (per L13's reference history). The micro-test pattern shipped here is the recommended structural prevention from the TECH_DEBT P2 entry. Once this PR lands, the same micro-test pattern should propagate to other libraries with a `*.browser.ts` entry — currently ts-bcp47, ts-res, ts-web-extras, ts-app-shell, ts-res-ui-components, ts-json, ts-json-base, ts-sudoku-lib, ts-sudoku-ui. Not in scope for this PR (per the TECH_DEBT entry's opportunistic trigger), but flagged for the orchestrator to track when those libraries get touched.

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_