### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ lib/
 dist/
 temp/
 .claude/scheduled_tasks.lock
+.claude/worktrees/


### PR DESCRIPTION
## Summary

One-line `.gitignore` addition: `.claude/worktrees/`.

Task subagents launched with `isolation: "worktree"` create their isolated working tree under that path. It showed up as untracked and tripped the orchestrator's stop-hook git-check.

Added alongside the existing `.claude/scheduled_tasks.lock` entry rather than blanket-ignoring `.claude/` since other contents (`agents/`, `project/`, `settings.local.json`) are intentionally tracked.

## Pre-PR gate

- [x] No code changes; no build/test impact
- [x] PR targets `claude/ts-prompt-assist-features` integration branch

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_