### PR TITLE
feat(ts-prompt-assist): F3+F9+F12+F14 ergonomics — TAxes inference, React-wiring doc, optional descriptor.id, Partial qualifier context

### DIFF
--- a/common/changes/@fgv/ts-prompt-assist/claude-ergonomics-f3f9f12f14_2026-05-18-05-15.json
+++ b/common/changes/@fgv/ts-prompt-assist/claude-ergonomics-f3f9f12f14_2026-05-18-05-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-prompt-assist",
+      "comment": "Round-1 pressure-test ergonomics absorption (PR C of three): F3 — `PromptLibrary<TResponse, TAxes>` now carries a `TAxes extends string = string` parameter, inferred from a literal `qualifiers: ['tone', 'language'] as const` array on `PromptLibrary.create` so the resolve request's `qualifiers` shape narrows to `Readonly<Partial<Record<TAxes, string>>>` (typos like `tonr` fail at compile time). Pre-built `IReadOnlyQualifierCollector` keeps `TAxes = string` since the collector type doesn't expose its axis-name union; consumers can specify `TAxes` explicitly there. F9 — README adds a 'Wiring into a React app' section showing the canonical `useEffect`-initialiser + cancellation-guard pattern; mirrored in `readmeSmoke.test.ts`. F12 — `IPromptStoreFixtureSeed.records[].descriptor.id` is now optional; the fixture defaults it from the outer `id`, and an explicit-but-mismatched id rejects loudly. The on-disk-YAML schema is unchanged (filename-stem check still applies there). F14 — `IQualifierContext` widened from `Readonly<Record<string, string>>` to `Readonly<Partial<Record<string, string>>>` so the canonical `tone === 'formal' ? { tone } : {}` shape type-checks without an explicit annotation. Mixed-shape `(string | IQualifierDecl)[]` qualifiers input (post-PR-B ts-res change) plumbed through `PromptLibrary.create`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-prompt-assist"
+}

--- a/libraries/ts-prompt-assist/README.md
+++ b/libraries/ts-prompt-assist/README.md
@@ -148,6 +148,7 @@ the UI on the library landing.
 import { useEffect, useState } from 'react';
 import {
   Convert,
+  IPromptResponseBase,
   IPromptStoreFixtureSeed,
   PromptLibrary,
   PromptStoreFixture
@@ -177,10 +178,10 @@ const seed: IPromptStoreFixtureSeed = {
 };
 
 export function ChatPanel(): JSX.Element {
-  // TAxes is inferred from the decl-array literal — `tone` is the only
-  // accepted qualifier key on the resolve request, surfacing typos at
-  // compile time (F3).
-  const [library, setLibrary] = useState<PromptLibrary<{ kind: string }, 'tone'> | null>(null);
+  // TQualifierNames is inferred from the decl-array literal — `tone` is
+  // the only accepted qualifier key on the resolve request, surfacing
+  // typos at compile time (F3).
+  const [library, setLibrary] = useState<PromptLibrary<IPromptResponseBase, 'tone'> | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -204,7 +205,7 @@ export function ChatPanel(): JSX.Element {
   return <ChatInner library={library} />;
 }
 
-function ChatInner(props: { library: PromptLibrary<{ kind: string }, 'tone'> }): JSX.Element {
+function ChatInner(props: { library: PromptLibrary<IPromptResponseBase, 'tone'> }): JSX.Element {
   // The narrow `qualifiers: { tone?: string }` shape comes from F3 +
   // F14 — the empty `{}` branch assigns thanks to the Partial widening
   // and a misspelled axis (`tonr`) fails at compile time.
@@ -222,7 +223,7 @@ Three things this pattern earns you:
    safe to instantiate at module top level. Only the
    `PromptLibrary.create` call is async.
 3. **Typed qualifier axes** — `qualifiers: ['tone'] as const` (the
-   decl-array path of `PromptLibrary.create`) infers `TAxes = 'tone'`,
+   decl-array path of `PromptLibrary.create`) infers `TQualifierNames = 'tone'`,
    tightening the resolve request's `qualifiers` shape. A pre-built
    `Qualifiers.QualifierCollector` doesn't expose its axes at the type
    level; pass `as const` decls when you want the typed benefit.

--- a/libraries/ts-prompt-assist/README.md
+++ b/libraries/ts-prompt-assist/README.md
@@ -134,6 +134,101 @@ console.log(formal.trace.mergedBindings.get(AUDIENCE)?.source);
 
 ---
 
+## Wiring into a React app
+
+`PromptLibrary.create` and `PromptStoreFixture.build` both return
+`Promise<Result<...>>` — there is no synchronous fixture path, by
+design (the same code constructs an `InMemoryFileTree`, an `FsTree`, a
+zip-backed tree, or the browser File-System-Access tree, and the
+async-only contract preserves that symmetry). The canonical wiring for
+a React/web consumer is a one-shot `useEffect` initialiser that gates
+the UI on the library landing.
+
+```typescript
+import { useEffect, useState } from 'react';
+import {
+  Convert,
+  IPromptStoreFixtureSeed,
+  PromptLibrary,
+  PromptStoreFixture
+} from '@fgv/ts-prompt-assist';
+
+// Author the seed at module scope — same shape as the in-memory
+// quick-start.
+const SCOPE = Convert.scopeKey.convert('global').orThrow();
+const GREETING = Convert.promptId.convert('greeting').orThrow();
+const seed: IPromptStoreFixtureSeed = {
+  records: [
+    {
+      scope: SCOPE,
+      id: GREETING,
+      // F12: descriptor.id is optional on the fixture seed — the outer
+      // record.id is the source of truth on the fixture path.
+      descriptor: {
+        title: 'Greeting',
+        schemaVersion: '1',
+        surface: 'chat',
+        slots: [],
+        output: { kind: 'free-text' }
+      },
+      candidates: [{ conditions: {}, body: 'Hello, {{tone}} caller!' }]
+    }
+  ]
+};
+
+export function ChatPanel(): JSX.Element {
+  // TAxes is inferred from the decl-array literal — `tone` is the only
+  // accepted qualifier key on the resolve request, surfacing typos at
+  // compile time (F3).
+  const [library, setLibrary] = useState<PromptLibrary<{ kind: string }, 'tone'> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const store = (await PromptStoreFixture.build(seed)).orThrow();
+      const lib = (
+        await PromptLibrary.create({ store, qualifiers: ['tone'] as const })
+      ).orThrow();
+      if (!cancelled) {
+        setLibrary(lib);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (library === null) {
+    return <div>Loading...</div>;
+  }
+  return <ChatInner library={library} />;
+}
+
+function ChatInner(props: { library: PromptLibrary<{ kind: string }, 'tone'> }): JSX.Element {
+  // The narrow `qualifiers: { tone?: string }` shape comes from F3 +
+  // F14 — the empty `{}` branch assigns thanks to the Partial widening
+  // and a misspelled axis (`tonr`) fails at compile time.
+  return <div>Library ready.</div>;
+}
+```
+
+Three things this pattern earns you:
+
+1. **`useEffect` + `cancelled` guard** — protects against the
+   in-flight build resolving after the component unmounts (the standard
+   "set state after unmount" warning); no library-side cooperation
+   needed.
+2. **Module-scope seed authoring** — the seed itself is pure data,
+   safe to instantiate at module top level. Only the
+   `PromptLibrary.create` call is async.
+3. **Typed qualifier axes** — `qualifiers: ['tone'] as const` (the
+   decl-array path of `PromptLibrary.create`) infers `TAxes = 'tone'`,
+   tightening the resolve request's `qualifiers` shape. A pre-built
+   `Qualifiers.QualifierCollector` doesn't expose its axes at the type
+   level; pass `as const` decls when you want the typed benefit.
+
+---
+
 ## Quick start — on-disk YAML store
 
 `FileTreePromptStore` accepts any `FileTree.IFileTreeDirectoryItem` —

--- a/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
+++ b/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
@@ -64,12 +64,8 @@ export const Convert: {
 export type ConverterId = Brand<string, 'ConverterId'>;
 
 // @public
-export class ConverterRegistry<TResponse extends {
-    kind: string;
-}> implements IPromptConverterRegistry<TResponse> {
-    static create<TResponse extends {
-        kind: string;
-    }>(): Result<ConverterRegistry<TResponse>>;
+export class ConverterRegistry<TResponse extends IPromptResponseBase> implements IPromptConverterRegistry<TResponse> {
+    static create<TResponse extends IPromptResponseBase>(): Result<ConverterRegistry<TResponse>>;
     get<K extends TResponse['kind']>(id: ConverterId, kind: K): Result<Converter<Extract<TResponse, {
         kind: K;
     }>>>;
@@ -191,12 +187,12 @@ export interface ILiteralSlotBinding {
 }
 
 // @public
-export type InferAxes<Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl>> = Q[number] extends infer E ? E extends string ? E : E extends {
+export type InferQualifiers<Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl>> = Q[number] extends infer E ? E extends string ? E : E extends {
     readonly name: infer N;
 } ? N extends string ? N : never : never : never;
 
 // @public
-export type InferAxesFromCreate<Q extends Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl>> = Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl> ? InferAxes<Q> : string;
+export type InferQualifiersFromCreate<Q extends Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl>> = Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl> ? InferQualifiers<Q> : string;
 
 // @public
 export interface IOutputValidationContext {
@@ -223,9 +219,7 @@ export interface IPromptCandidateRecord {
 }
 
 // @public
-export interface IPromptConverterRegistry<TResponse extends {
-    kind: string;
-}> {
+export interface IPromptConverterRegistry<TResponse extends IPromptResponseBase> {
     get<K extends TResponse['kind']>(id: ConverterId, kind: K): Result<Converter<Extract<TResponse, {
         kind: K;
     }>>>;
@@ -284,16 +278,10 @@ export interface IPromptJoinPolicy {
 }
 
 // @public
-export interface IPromptLibraryCreateParams<TResponse extends {
-    kind: string;
-} = {
-    kind: string;
-}, TAxes extends string = string> {
+export interface IPromptLibraryCreateParams<TResponse extends IPromptResponseBase = IPromptResponseBase, TQualifierNames extends string = string> {
     readonly cacheListener?: Runtime.IResourceResolverCacheListener;
     readonly logger?: Logging.ILogger;
-    readonly qualifiers: Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<TAxes | (Qualifiers.IQualifierDecl & {
-        readonly name: TAxes;
-    })>;
+    readonly qualifiers: IPromptLibraryQualifiersInput<TQualifierNames>;
     readonly qualifierTypes?: QualifierTypes.ReadOnlyQualifierTypeCollector;
     readonly registry?: IPromptRegistry<TResponse>;
     readonly resourceBindingDepthLimit?: number;
@@ -303,18 +291,19 @@ export interface IPromptLibraryCreateParams<TResponse extends {
 }
 
 // @public
-export interface IPromptOutputValidationRegistry<TResponse extends {
-    kind: string;
-}> {
+export type IPromptLibraryQualifiersInput<TQualifierNames extends string = string> = Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<TQualifierNames | (Qualifiers.IQualifierDecl & {
+    readonly name: TQualifierNames;
+})>;
+
+// @public
+export interface IPromptOutputValidationRegistry<TResponse extends IPromptResponseBase> {
     get(id: ValidatorId): Result<IPromptOutputValidator<TResponse>>;
     has(id: ValidatorId): boolean;
     register(id: ValidatorId, validator: IPromptOutputValidator<TResponse>): Result<ValidatorId>;
 }
 
 // @public
-export interface IPromptOutputValidator<TResponse extends {
-    kind: string;
-}> {
+export interface IPromptOutputValidator<TResponse extends IPromptResponseBase> {
     readonly appliesTo: TResponse['kind'] | ReadonlyArray<TResponse['kind']>;
     validate(value: TResponse, context: IOutputValidationContext): Result<true>;
 }
@@ -330,11 +319,7 @@ export interface IPromptQualifierMetadata {
 }
 
 // @public
-export interface IPromptRegistry<TResponse extends {
-    kind: string;
-} = {
-    kind: string;
-}> {
+export interface IPromptRegistry<TResponse extends IPromptResponseBase = IPromptResponseBase> {
     // (undocumented)
     readonly converters: IPromptConverterRegistry<TResponse>;
     // (undocumented)
@@ -344,10 +329,10 @@ export interface IPromptRegistry<TResponse extends {
 }
 
 // @public
-export interface IPromptResolveRequest<TAxes extends string = string> {
+export interface IPromptResolveRequest<TQualifierNames extends string = string> {
     readonly chain: ReadonlyArray<ScopeKey>;
     readonly id: PromptId;
-    readonly qualifiers: Readonly<Partial<Record<TAxes, string>>>;
+    readonly qualifiers: Readonly<Partial<Record<TQualifierNames, string>>>;
     readonly substitutions?: PromptSubstitutions;
 }
 
@@ -359,6 +344,11 @@ export interface IPromptResolveTrace {
     readonly safeguardFindings: ReadonlyArray<ISafeguardFinding>;
     readonly scopesConsulted: ReadonlyArray<ScopeKey>;
     readonly winningScope: ScopeKey;
+}
+
+// @public
+export interface IPromptResponseBase {
+    readonly kind: string;
 }
 
 // @public
@@ -565,12 +555,8 @@ export function normalizeSubstitutionEntry(entry: string | SlotBinding): SlotBin
 export type OutputContractKind = 'free-text' | 'json';
 
 // @public
-export class OutputValidationRegistry<TResponse extends {
-    kind: string;
-}> implements IPromptOutputValidationRegistry<TResponse> {
-    static create<TResponse extends {
-        kind: string;
-    }>(): Result<OutputValidationRegistry<TResponse>>;
+export class OutputValidationRegistry<TResponse extends IPromptResponseBase> implements IPromptOutputValidationRegistry<TResponse> {
+    static create<TResponse extends IPromptResponseBase>(): Result<OutputValidationRegistry<TResponse>>;
     get(id: ValidatorId): Result<IPromptOutputValidator<TResponse>>;
     has(id: ValidatorId): boolean;
     register(id: ValidatorId, validator: IPromptOutputValidator<TResponse>): Result<ValidatorId>;
@@ -583,25 +569,17 @@ export const promptFileConverter: Converter<IPromptFileContents>;
 export type PromptId = Brand<string, 'PromptId'>;
 
 // @public
-export class PromptLibrary<TResponse extends {
-    kind: string;
-} = {
-    kind: string;
-}, TAxes extends string = string> {
-    static create<TResponse extends {
-        kind: string;
-    } = {
-        kind: string;
-    }, const Q extends Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl> = Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl>>(params: IPromptLibraryCreateParams<TResponse, InferAxesFromCreate<Q>> & {
+export class PromptLibrary<TResponse extends IPromptResponseBase = IPromptResponseBase, TQualifierNames extends string = string> {
+    static create<TResponse extends IPromptResponseBase = IPromptResponseBase, const Q extends Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl> = Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl>>(params: IPromptLibraryCreateParams<TResponse, InferQualifiersFromCreate<Q>> & {
         readonly qualifiers: Q;
-    }): Promise<Result<PromptLibrary<TResponse, InferAxesFromCreate<Q>>>>;
+    }): Promise<Result<PromptLibrary<TResponse, InferQualifiersFromCreate<Q>>>>;
     describe(id: PromptId): Promise<Result<IPromptDescriptor>>;
     invalidateDescriptor(id: PromptId): void;
     readonly logger: Logging.ILogger;
     get materializedCount(): number;
-    resolve(req: IPromptResolveRequest<TAxes>): Promise<Result<IResolvedPrompt>>;
-    resolveFreeTextOutput(req: IPromptResolveRequest<TAxes>, rawOutput: string): Promise<Result<string>>;
-    resolveJsonOutput<K extends TResponse['kind']>(req: IPromptResolveRequest<TAxes>, rawOutput: string, expectedKind: K): Promise<Result<Extract<TResponse, {
+    resolve(req: IPromptResolveRequest<TQualifierNames>): Promise<Result<IResolvedPrompt>>;
+    resolveFreeTextOutput(req: IPromptResolveRequest<TQualifierNames>, rawOutput: string): Promise<Result<string>>;
+    resolveJsonOutput<K extends TResponse['kind']>(req: IPromptResolveRequest<TQualifierNames>, rawOutput: string, expectedKind: K): Promise<Result<Extract<TResponse, {
         kind: K;
     }>>>;
     readonly resourceBindingDepthLimit: number;
@@ -611,18 +589,10 @@ export class PromptLibrary<TResponse extends {
 export type PromptOutputContract = ITextOutputContract | IJsonOutputContract;
 
 // @public
-export class PromptRegistry<TResponse extends {
-    kind: string;
-} = {
-    kind: string;
-}> implements IPromptRegistry<TResponse> {
+export class PromptRegistry<TResponse extends IPromptResponseBase = IPromptResponseBase> implements IPromptRegistry<TResponse> {
     // (undocumented)
     readonly converters: IPromptConverterRegistry<TResponse>;
-    static create<TResponse extends {
-        kind: string;
-    } = {
-        kind: string;
-    }>(): Result<PromptRegistry<TResponse>>;
+    static create<TResponse extends IPromptResponseBase = IPromptResponseBase>(): Result<PromptRegistry<TResponse>>;
     // (undocumented)
     readonly outputValidations: IPromptOutputValidationRegistry<TResponse>;
     // (undocumented)

--- a/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
+++ b/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
@@ -304,7 +304,7 @@ export interface IPromptOutputValidationRegistry<TResponse extends IPromptRespon
 
 // @public
 export interface IPromptOutputValidator<TResponse extends IPromptResponseBase> {
-    readonly appliesTo: TResponse['kind'] | ReadonlyArray<TResponse['kind']>;
+    readonly appliesTo: PromptOutputValidatorAppliesTo<TResponse>;
     validate(value: TResponse, context: IOutputValidationContext): Result<true>;
 }
 
@@ -587,6 +587,9 @@ export class PromptLibrary<TResponse extends IPromptResponseBase = IPromptRespon
 
 // @public
 export type PromptOutputContract = ITextOutputContract | IJsonOutputContract;
+
+// @public
+export type PromptOutputValidatorAppliesTo<TResponse extends IPromptResponseBase> = TResponse['kind'] | ReadonlyArray<TResponse['kind']>;
 
 // @public
 export class PromptRegistry<TResponse extends IPromptResponseBase = IPromptResponseBase> implements IPromptRegistry<TResponse> {

--- a/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
+++ b/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
@@ -191,6 +191,14 @@ export interface ILiteralSlotBinding {
 }
 
 // @public
+export type InferAxes<Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl>> = Q[number] extends infer E ? E extends string ? E : E extends {
+    readonly name: infer N;
+} ? N extends string ? N : never : never : never;
+
+// @public
+export type InferAxesFromCreate<Q extends Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl>> = Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl> ? InferAxes<Q> : string;
+
+// @public
 export interface IOutputValidationContext {
     // (undocumented)
     readonly promptId: PromptId;
@@ -280,10 +288,12 @@ export interface IPromptLibraryCreateParams<TResponse extends {
     kind: string;
 } = {
     kind: string;
-}> {
+}, TAxes extends string = string> {
     readonly cacheListener?: Runtime.IResourceResolverCacheListener;
     readonly logger?: Logging.ILogger;
-    readonly qualifiers: Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<Qualifiers.IQualifierDecl>;
+    readonly qualifiers: Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<TAxes | (Qualifiers.IQualifierDecl & {
+        readonly name: TAxes;
+    })>;
     readonly qualifierTypes?: QualifierTypes.ReadOnlyQualifierTypeCollector;
     readonly registry?: IPromptRegistry<TResponse>;
     readonly resourceBindingDepthLimit?: number;
@@ -334,10 +344,10 @@ export interface IPromptRegistry<TResponse extends {
 }
 
 // @public
-export interface IPromptResolveRequest {
+export interface IPromptResolveRequest<TAxes extends string = string> {
     readonly chain: ReadonlyArray<ScopeKey>;
     readonly id: PromptId;
-    readonly qualifiers: IQualifierContext;
+    readonly qualifiers: Readonly<Partial<Record<TAxes, string>>>;
     readonly substitutions?: PromptSubstitutions;
 }
 
@@ -415,15 +425,32 @@ export interface IPromptStoreEvent {
 }
 
 // @public
+export type IPromptStoreFixtureDescriptor = Omit<IPromptDescriptor, 'id'> & {
+    readonly id?: PromptId;
+};
+
+// @public
 export interface IPromptStoreFixtureSeed {
     // (undocumented)
     readonly bindings?: ReadonlyArray<IScopeSlotBindingsRecord>;
     // (undocumented)
     readonly qualifiers?: ReadonlyArray<Qualifiers.IQualifierDecl>;
     // (undocumented)
-    readonly records?: ReadonlyArray<IStoredPromptRecord>;
+    readonly records?: ReadonlyArray<IPromptStoreFixtureSeedRecord>;
     readonly scopeDecoding?: (encoded: string) => Result<ScopeKey>;
     readonly scopeEncoding?: (scope: ScopeKey) => Result<string>;
+}
+
+// @public
+export interface IPromptStoreFixtureSeedRecord {
+    // (undocumented)
+    readonly candidates: ReadonlyArray<IPromptCandidateRecord>;
+    // (undocumented)
+    readonly descriptor: IPromptStoreFixtureDescriptor;
+    // (undocumented)
+    readonly id: PromptId;
+    // (undocumented)
+    readonly scope: ScopeKey;
 }
 
 // @public
@@ -433,7 +460,7 @@ export interface IPromptStoreListFilter {
 }
 
 // @public
-export type IQualifierContext = Readonly<Record<string, string>>;
+export type IQualifierContext = Readonly<Partial<Record<string, string>>>;
 
 // @public
 export interface IQualifiersFileContents {
@@ -560,19 +587,21 @@ export class PromptLibrary<TResponse extends {
     kind: string;
 } = {
     kind: string;
-}> {
+}, TAxes extends string = string> {
     static create<TResponse extends {
         kind: string;
     } = {
         kind: string;
-    }>(params: IPromptLibraryCreateParams<TResponse>): Promise<Result<PromptLibrary<TResponse>>>;
+    }, const Q extends Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl> = Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl>>(params: IPromptLibraryCreateParams<TResponse, InferAxesFromCreate<Q>> & {
+        readonly qualifiers: Q;
+    }): Promise<Result<PromptLibrary<TResponse, InferAxesFromCreate<Q>>>>;
     describe(id: PromptId): Promise<Result<IPromptDescriptor>>;
     invalidateDescriptor(id: PromptId): void;
     readonly logger: Logging.ILogger;
     get materializedCount(): number;
-    resolve(req: IPromptResolveRequest): Promise<Result<IResolvedPrompt>>;
-    resolveFreeTextOutput(req: IPromptResolveRequest, rawOutput: string): Promise<Result<string>>;
-    resolveJsonOutput<K extends TResponse['kind']>(req: IPromptResolveRequest, rawOutput: string, expectedKind: K): Promise<Result<Extract<TResponse, {
+    resolve(req: IPromptResolveRequest<TAxes>): Promise<Result<IResolvedPrompt>>;
+    resolveFreeTextOutput(req: IPromptResolveRequest<TAxes>, rawOutput: string): Promise<Result<string>>;
+    resolveJsonOutput<K extends TResponse['kind']>(req: IPromptResolveRequest<TAxes>, rawOutput: string, expectedKind: K): Promise<Result<Extract<TResponse, {
         kind: K;
     }>>>;
     readonly resourceBindingDepthLimit: number;

--- a/libraries/ts-prompt-assist/src/packlets/fixture/promptStoreFixture.ts
+++ b/libraries/ts-prompt-assist/src/packlets/fixture/promptStoreFixture.ts
@@ -7,19 +7,50 @@ import { Result, fail, mapResults, succeed } from '@fgv/ts-utils';
 import { FileTree } from '@fgv/ts-json-base';
 import { Yaml } from '@fgv/ts-extras';
 import { Qualifiers } from '@fgv/ts-res';
-import { ScopeKey, SlotName } from '../types';
+import { PromptId, ScopeKey, SlotName } from '../types';
 import { SlotBinding } from '../types';
-import { IScopeSlotBindingsRecord, IStoredPromptRecord } from '../types';
+import { IPromptCandidateRecord, IPromptDescriptor, IScopeSlotBindingsRecord } from '../types';
 import { defaultScopeEncoding } from '../store';
 import { FileTreePromptStore } from '../store';
 import { IPromptStore } from '../store';
+
+/**
+ * Fixture-seed-only descriptor shape: `id` is optional. Per F12, on
+ * the fixture path the outer `IPromptStoreFixtureSeedRecord.id` already
+ * carries the prompt id, so the nested `descriptor.id` is redundant —
+ * the fixture defaults it from the outer id when omitted. An explicit
+ * `descriptor.id` that mismatches the outer id is rejected loudly.
+ *
+ * The on-disk-YAML schema is unchanged: the filename stem matters
+ * there, so `IPromptDescriptor.id` remains required on the
+ * loader-facing descriptor type.
+ *
+ * @public
+ */
+export type IPromptStoreFixtureDescriptor = Omit<IPromptDescriptor, 'id'> & {
+  readonly id?: PromptId;
+};
+
+/**
+ * Fixture-seed-only record shape: descriptor.id is optional and
+ * defaults to the outer record id (per F12). Other fields mirror
+ * {@link IStoredPromptRecord}.
+ *
+ * @public
+ */
+export interface IPromptStoreFixtureSeedRecord {
+  readonly scope: ScopeKey;
+  readonly id: PromptId;
+  readonly descriptor: IPromptStoreFixtureDescriptor;
+  readonly candidates: ReadonlyArray<IPromptCandidateRecord>;
+}
 
 /**
  * Seed describing the in-memory FileTree state for a test fixture.
  * @public
  */
 export interface IPromptStoreFixtureSeed {
-  readonly records?: ReadonlyArray<IStoredPromptRecord>;
+  readonly records?: ReadonlyArray<IPromptStoreFixtureSeedRecord>;
   readonly bindings?: ReadonlyArray<IScopeSlotBindingsRecord>;
   readonly qualifiers?: ReadonlyArray<Qualifiers.IQualifierDecl>;
   /**
@@ -45,9 +76,30 @@ function serializeBindingsRecord(record: IScopeSlotBindingsRecord): Result<strin
   return Yaml.yamlStringify({ bindings });
 }
 
-function serializePromptRecord(record: IStoredPromptRecord): Result<string> {
-  const { descriptor, candidates } = record;
-  return Yaml.yamlStringify({ ...descriptor, candidates });
+function serializePromptRecord(record: IPromptStoreFixtureSeedRecord): Result<string> {
+  return defaultDescriptorIdFromOuter(record).onSuccess((descriptor) =>
+    Yaml.yamlStringify({ ...descriptor, candidates: record.candidates })
+  );
+}
+
+/**
+ * Per F12: descriptor.id is optional on the fixture seed. If omitted,
+ * default from the outer record.id. If explicitly supplied and it
+ * mismatches the outer id, reject loudly — the redundancy is gone but
+ * silent inconsistency must remain impossible.
+ */
+function defaultDescriptorIdFromOuter(record: IPromptStoreFixtureSeedRecord): Result<IPromptDescriptor> {
+  const descriptor = record.descriptor;
+  if (descriptor.id === undefined) {
+    return succeed({ ...descriptor, id: record.id });
+  }
+  if (descriptor.id !== record.id) {
+    return fail(
+      `fixture: record id '${record.id}' does not match descriptor.id '${descriptor.id}'; ` +
+        `descriptor.id is optional on the fixture seed but, if supplied, must match the outer id`
+    );
+  }
+  return succeed({ ...descriptor, id: descriptor.id });
 }
 
 function serializeQualifiers(qualifiers: ReadonlyArray<Qualifiers.IQualifierDecl>): Result<string> {
@@ -112,7 +164,7 @@ function buildSeededStore(seed: IPromptStoreFixtureSeed): Promise<Result<IPrompt
 }
 
 function encodeRecords(
-  records: ReadonlyArray<IStoredPromptRecord> | undefined,
+  records: ReadonlyArray<IPromptStoreFixtureSeedRecord> | undefined,
   encode: (scope: ScopeKey) => Result<string>
 ): Result<ReadonlyArray<FileTree.IInMemoryFile>> {
   return mapResults(

--- a/libraries/ts-prompt-assist/src/packlets/output/outputPipeline.ts
+++ b/libraries/ts-prompt-assist/src/packlets/output/outputPipeline.ts
@@ -9,6 +9,7 @@ import {
   IBindingTraceEntry,
   IJsonOutputContract,
   IPromptDescriptor,
+  IPromptResponseBase,
   PromptId,
   SlotName,
   ValidatorId
@@ -30,7 +31,7 @@ import { IPromptOutputValidator, IPromptRegistry } from '../registry';
  *
  * @internal
  */
-export function assertOutputValidationsCompatible<TResponse extends { kind: string }>(
+export function assertOutputValidationsCompatible<TResponse extends IPromptResponseBase>(
   descriptor: IPromptDescriptor,
   registry: IPromptRegistry<TResponse> | undefined
 ): Result<true> {
@@ -109,7 +110,7 @@ export function assertOutputValidationsCompatible<TResponse extends { kind: stri
  *
  * @internal
  */
-export function runOutputValidationPipeline<TResponse extends { kind: string }>(params: {
+export function runOutputValidationPipeline<TResponse extends IPromptResponseBase>(params: {
   readonly descriptor: IPromptDescriptor;
   readonly contract: IJsonOutputContract;
   readonly registry: IPromptRegistry<TResponse>;
@@ -138,7 +139,7 @@ export function runOutputValidationPipeline<TResponse extends { kind: string }>(
     .onSuccess((value) => runValidatorChain(descriptor, registry, value, substitutions));
 }
 
-function runValidatorChain<TResponse extends { kind: string }>(
+function runValidatorChain<TResponse extends IPromptResponseBase>(
   descriptor: IPromptDescriptor,
   registry: IPromptRegistry<TResponse>,
   value: TResponse,
@@ -157,7 +158,7 @@ function runValidatorChain<TResponse extends { kind: string }>(
     : succeed(value);
 }
 
-function runOneValidator<TResponse extends { kind: string }>(
+function runOneValidator<TResponse extends IPromptResponseBase>(
   promptId: PromptId,
   registry: IPromptRegistry<TResponse>,
   id: ValidatorId,
@@ -187,7 +188,7 @@ function runOneValidator<TResponse extends { kind: string }>(
   });
 }
 
-function appliesToList<TResponse extends { kind: string }>(
+function appliesToList<TResponse extends IPromptResponseBase>(
   validator: IPromptOutputValidator<TResponse>
 ): ReadonlyArray<TResponse['kind']> {
   const appliesTo: TResponse['kind'] | ReadonlyArray<TResponse['kind']> = validator.appliesTo;
@@ -197,7 +198,7 @@ function appliesToList<TResponse extends { kind: string }>(
   return [appliesTo];
 }
 
-function isReadonlyArrayOfKind<TResponse extends { kind: string }>(
+function isReadonlyArrayOfKind<TResponse extends IPromptResponseBase>(
   value: TResponse['kind'] | ReadonlyArray<TResponse['kind']>
 ): value is ReadonlyArray<TResponse['kind']> {
   return Array.isArray(value);

--- a/libraries/ts-prompt-assist/src/packlets/output/outputPipeline.ts
+++ b/libraries/ts-prompt-assist/src/packlets/output/outputPipeline.ts
@@ -11,6 +11,7 @@ import {
   IPromptDescriptor,
   IPromptResponseBase,
   PromptId,
+  PromptOutputValidatorAppliesTo,
   SlotName,
   ValidatorId
 } from '../types';
@@ -191,7 +192,7 @@ function runOneValidator<TResponse extends IPromptResponseBase>(
 function appliesToList<TResponse extends IPromptResponseBase>(
   validator: IPromptOutputValidator<TResponse>
 ): ReadonlyArray<TResponse['kind']> {
-  const appliesTo: TResponse['kind'] | ReadonlyArray<TResponse['kind']> = validator.appliesTo;
+  const appliesTo: PromptOutputValidatorAppliesTo<TResponse> = validator.appliesTo;
   if (isReadonlyArrayOfKind<TResponse>(appliesTo)) {
     return appliesTo;
   }
@@ -199,7 +200,7 @@ function appliesToList<TResponse extends IPromptResponseBase>(
 }
 
 function isReadonlyArrayOfKind<TResponse extends IPromptResponseBase>(
-  value: TResponse['kind'] | ReadonlyArray<TResponse['kind']>
+  value: PromptOutputValidatorAppliesTo<TResponse>
 ): value is ReadonlyArray<TResponse['kind']> {
   return Array.isArray(value);
 }

--- a/libraries/ts-prompt-assist/src/packlets/registry/converterRegistry.ts
+++ b/libraries/ts-prompt-assist/src/packlets/registry/converterRegistry.ts
@@ -4,7 +4,7 @@
  */
 
 import { Converter, Result, fail, succeed } from '@fgv/ts-utils';
-import { ConverterId } from '../types';
+import { ConverterId, IPromptResponseBase } from '../types';
 import { IPromptConverterRegistry } from './interfaces';
 
 /**
@@ -18,8 +18,8 @@ import { IPromptConverterRegistry } from './interfaces';
  * Storing entries under this type lets `get(id, kind)` narrow via the
  * discriminator without a `Converter<TResponse> -> Converter<T>` cast.
  */
-type IEntry<TResponse extends { kind: string }> = TResponse extends infer R
-  ? R extends { kind: string }
+type IEntry<TResponse extends IPromptResponseBase> = TResponse extends infer R
+  ? R extends IPromptResponseBase
     ? { readonly kind: R['kind']; readonly converter: Converter<R> }
     : never
   : never;
@@ -34,7 +34,7 @@ type IEntry<TResponse extends { kind: string }> = TResponse extends infer R
  *
  * @public
  */
-export class ConverterRegistry<TResponse extends { kind: string }>
+export class ConverterRegistry<TResponse extends IPromptResponseBase>
   implements IPromptConverterRegistry<TResponse>
 {
   private readonly _entries: Map<ConverterId, IEntry<TResponse>>;
@@ -44,7 +44,7 @@ export class ConverterRegistry<TResponse extends { kind: string }>
   }
 
   /** Family-convention factory. */
-  public static create<TResponse extends { kind: string }>(): Result<ConverterRegistry<TResponse>> {
+  public static create<TResponse extends IPromptResponseBase>(): Result<ConverterRegistry<TResponse>> {
     return succeed(new ConverterRegistry<TResponse>());
   }
 

--- a/libraries/ts-prompt-assist/src/packlets/registry/interfaces.ts
+++ b/libraries/ts-prompt-assist/src/packlets/registry/interfaces.ts
@@ -5,7 +5,7 @@
 
 import { Converter, Result } from '@fgv/ts-utils';
 import { ConverterId, SlotName, ValidatorId } from '../types';
-import { IBindingTraceEntry } from '../types';
+import { IBindingTraceEntry, IPromptResponseBase } from '../types';
 import { PromptId } from '../types';
 
 /**
@@ -32,7 +32,7 @@ export interface IOutputValidationContext {
  * `validate` when `value.kind` matches `appliesTo`.
  * @public
  */
-export interface IPromptOutputValidator<TResponse extends { kind: string }> {
+export interface IPromptOutputValidator<TResponse extends IPromptResponseBase> {
   /**
    * Discriminator value(s) this validator applies to. Single string for
    * single-kind validators; readonly array for cross-kind validators.
@@ -61,7 +61,7 @@ export interface IPromptOutputValidator<TResponse extends { kind: string }> {
  *
  * @public
  */
-export interface IPromptConverterRegistry<TResponse extends { kind: string }> {
+export interface IPromptConverterRegistry<TResponse extends IPromptResponseBase> {
   /**
    * Registers a Converter that produces the `TResponse` member discriminated
    * by `kind`. The Converter's `T` is `Extract<TResponse, \{ kind: K \}>` —
@@ -115,7 +115,7 @@ export interface IPromptSlotKindRegistry {
  * Output validation sub-registry.
  * @public
  */
-export interface IPromptOutputValidationRegistry<TResponse extends { kind: string }> {
+export interface IPromptOutputValidationRegistry<TResponse extends IPromptResponseBase> {
   /** Registers a validator under `id`. Fails if `id` is already registered. */
   register(id: ValidatorId, validator: IPromptOutputValidator<TResponse>): Result<ValidatorId>;
   /** Returns the validator registered under `id`. Fails if not registered. */
@@ -131,7 +131,7 @@ export interface IPromptOutputValidationRegistry<TResponse extends { kind: strin
  * only use free-text output.
  * @public
  */
-export interface IPromptRegistry<TResponse extends { kind: string } = { kind: string }> {
+export interface IPromptRegistry<TResponse extends IPromptResponseBase = IPromptResponseBase> {
   readonly converters: IPromptConverterRegistry<TResponse>;
   readonly slotKinds: IPromptSlotKindRegistry;
   readonly outputValidations: IPromptOutputValidationRegistry<TResponse>;

--- a/libraries/ts-prompt-assist/src/packlets/registry/interfaces.ts
+++ b/libraries/ts-prompt-assist/src/packlets/registry/interfaces.ts
@@ -4,7 +4,7 @@
  */
 
 import { Converter, Result } from '@fgv/ts-utils';
-import { ConverterId, SlotName, ValidatorId } from '../types';
+import { ConverterId, PromptOutputValidatorAppliesTo, SlotName, ValidatorId } from '../types';
 import { IBindingTraceEntry, IPromptResponseBase } from '../types';
 import { PromptId } from '../types';
 
@@ -37,7 +37,7 @@ export interface IPromptOutputValidator<TResponse extends IPromptResponseBase> {
    * Discriminator value(s) this validator applies to. Single string for
    * single-kind validators; readonly array for cross-kind validators.
    */
-  readonly appliesTo: TResponse['kind'] | ReadonlyArray<TResponse['kind']>;
+  readonly appliesTo: PromptOutputValidatorAppliesTo<TResponse>;
   /**
    * Validates the converted output. The chain runner only invokes this when
    * `value.kind` matches `appliesTo`; defensive code may re-check.

--- a/libraries/ts-prompt-assist/src/packlets/registry/outputValidationRegistry.ts
+++ b/libraries/ts-prompt-assist/src/packlets/registry/outputValidationRegistry.ts
@@ -4,14 +4,14 @@
  */
 
 import { Result, fail, succeed } from '@fgv/ts-utils';
-import { ValidatorId } from '../types';
+import { IPromptResponseBase, ValidatorId } from '../types';
 import { IPromptOutputValidationRegistry, IPromptOutputValidator } from './interfaces';
 
 /**
  * In-memory implementation of {@link IPromptOutputValidationRegistry}.
  * @public
  */
-export class OutputValidationRegistry<TResponse extends { kind: string }>
+export class OutputValidationRegistry<TResponse extends IPromptResponseBase>
   implements IPromptOutputValidationRegistry<TResponse>
 {
   private readonly _entries: Map<ValidatorId, IPromptOutputValidator<TResponse>>;
@@ -21,7 +21,7 @@ export class OutputValidationRegistry<TResponse extends { kind: string }>
   }
 
   /** Family-convention factory. */
-  public static create<TResponse extends { kind: string }>(): Result<OutputValidationRegistry<TResponse>> {
+  public static create<TResponse extends IPromptResponseBase>(): Result<OutputValidationRegistry<TResponse>> {
     return succeed(new OutputValidationRegistry<TResponse>());
   }
 

--- a/libraries/ts-prompt-assist/src/packlets/registry/promptRegistry.ts
+++ b/libraries/ts-prompt-assist/src/packlets/registry/promptRegistry.ts
@@ -4,6 +4,7 @@
  */
 
 import { Result, succeed } from '@fgv/ts-utils';
+import { IPromptResponseBase } from '../types';
 import {
   IPromptConverterRegistry,
   IPromptOutputValidationRegistry,
@@ -23,7 +24,7 @@ import { SlotKindRegistry } from './slotKindRegistry';
  *
  * @public
  */
-export class PromptRegistry<TResponse extends { kind: string } = { kind: string }>
+export class PromptRegistry<TResponse extends IPromptResponseBase = IPromptResponseBase>
   implements IPromptRegistry<TResponse>
 {
   public readonly converters: IPromptConverterRegistry<TResponse>;
@@ -45,7 +46,7 @@ export class PromptRegistry<TResponse extends { kind: string } = { kind: string 
    * populated by `.converters.register(...)` / `.slotKinds.register(...)` /
    * `.outputValidations.register(...)`.
    */
-  public static create<TResponse extends { kind: string } = { kind: string }>(): Result<
+  public static create<TResponse extends IPromptResponseBase = IPromptResponseBase>(): Result<
     PromptRegistry<TResponse>
   > {
     return ConverterRegistry.create<TResponse>().onSuccess((converters) =>

--- a/libraries/ts-prompt-assist/src/packlets/resolve/promptLibrary.ts
+++ b/libraries/ts-prompt-assist/src/packlets/resolve/promptLibrary.ts
@@ -43,6 +43,39 @@ import {
 } from './resourceBindingResolver';
 
 /**
+ * Type-level helper: derive the `TAxes` string union from a mixed
+ * `(string | IQualifierDecl)[]` literal-typed array. Bare-string
+ * elements contribute their own string-literal type; decl elements
+ * contribute their `.name` literal. Falls back to `string` when the
+ * array element type is unconstrained.
+ *
+ * @public
+ */
+export type InferAxes<Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl>> = Q[number] extends infer E
+  ? E extends string
+    ? E
+    : E extends { readonly name: infer N }
+    ? N extends string
+      ? N
+      : never
+    : never
+  : never;
+
+/**
+ * Type-level helper used by `PromptLibrary.create`'s decl-array
+ * inference branch. When `Q` is a `ReadonlyArray<string | IQualifierDecl>`,
+ * derives the `TAxes` union via {@link InferAxes}; when `Q` is a
+ * pre-built `IReadOnlyQualifierCollector`, the collector type does not
+ * expose its axis-name union at the type level, so `TAxes` defaults to
+ * `string`.
+ *
+ * @public
+ */
+export type InferAxesFromCreate<
+  Q extends Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl>
+> = Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl> ? InferAxes<Q> : string;
+
+/**
  * ts-res resource type name the library synthesizes for prompt records.
  * Prompts are stored as JSON resources with shape `\{ body: string \}`;
  * the ts-res `JsonResourceType` (from `@fgv/ts-res`'s `ResourceTypes`
@@ -68,22 +101,41 @@ const DEFAULT_RESOURCE_BINDING_DEPTH_LIMIT: number = 5;
  *
  * @public
  */
-export interface IPromptLibraryCreateParams<TResponse extends { kind: string } = { kind: string }> {
+export interface IPromptLibraryCreateParams<
+  TResponse extends { kind: string } = { kind: string },
+  TAxes extends string = string
+> {
   /** Backing store. v0.1 ships `FileTreePromptStore`; consumers can implement custom adapters. */
   readonly store: IPromptStore;
   /**
    * ts-res qualifier configuration. Accepts either a pre-built
    * `IReadOnlyQualifierCollector` (when the consumer already maintains a
-   * ts-res qualifier set) or a declarative `IQualifierDecl[]` (the
-   * library builds the collector internally via ts-res's Converters).
-   * REQUIRED per design §4.1.
+   * ts-res qualifier set) or a mixed array of bare axis-name strings
+   * and / or `IQualifierDecl`s (the library builds the collector
+   * internally via ts-res's `Qualifiers.QualifierCollector.create`,
+   * which synthesizes `LiteralQualifierType`s for bare strings). REQUIRED
+   * per design §4.1.
+   *
+   * @remarks
+   * On the decl-array path, the `TAxes` type parameter is inferred
+   * from the array element types via the static `PromptLibrary.create`
+   * factory — e.g. `\{ qualifiers: ['language', 'tone'] \}` infers
+   * `TAxes = 'language' | 'tone'` and tightens
+   * `IPromptResolveRequest.qualifiers` accordingly. On the
+   * pre-built-collector path, `TAxes` falls back to `string`; consumers
+   * can specify it explicitly if they want the typed benefit on that
+   * path.
    */
-  readonly qualifiers: Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<Qualifiers.IQualifierDecl>;
+  readonly qualifiers:
+    | Qualifiers.IReadOnlyQualifierCollector
+    | ReadonlyArray<TAxes | (Qualifiers.IQualifierDecl & { readonly name: TAxes })>;
   /**
    * Optional ts-res qualifier-type collector. When `qualifiers` is
    * supplied as a pre-built `IReadOnlyQualifierCollector`, this is
-   * inferred from it. When `qualifiers` is supplied as decls, this
-   * must supply at least the qualifier types referenced by those decls.
+   * inferred from it. When `qualifiers` is supplied as decls and any
+   * element is an `IQualifierDecl`, `qualifierTypes` must supply the
+   * qualifier types referenced by those decls. Bare-string elements
+   * synthesize a `LiteralQualifierType` automatically.
    */
   readonly qualifierTypes?: QualifierTypes.ReadOnlyQualifierTypeCollector;
   /** Unified registry. Optional; defaults to an empty registry. */
@@ -123,13 +175,23 @@ export interface IPromptLibraryCreateParams<TResponse extends { kind: string } =
  * {@link PromptLibrary.resolveFreeTextOutput}.
  * @public
  */
-export interface IPromptResolveRequest {
+export interface IPromptResolveRequest<TAxes extends string = string> {
   /** Prompt id to resolve. */
   readonly id: PromptId;
   /** Scope chain — most-specific to most-general. The walker uses the first scope with a record. */
   readonly chain: ReadonlyArray<ScopeKey>;
-  /** Caller-supplied qualifier context, fed to ts-res's candidate selector. */
-  readonly qualifiers: IQualifierContext;
+  /**
+   * Caller-supplied qualifier context, fed to ts-res's candidate selector.
+   *
+   * @remarks
+   * Defaults to the loose shape `Readonly<Partial<Record<string, string>>>`
+   * (identical to {@link IQualifierContext}) so legacy callers compile
+   * unchanged. When `TAxes` is narrowed (typically via inference on
+   * `PromptLibrary.create` with a string-literal decl array), this
+   * narrows to `Readonly<Partial<Record<TAxes, string>>>`, surfacing
+   * misspelled qualifier-axis names at compile time.
+   */
+  readonly qualifiers: Readonly<Partial<Record<TAxes, string>>>;
   /** Optional caller substitutions, applied to slots not locked by an `enforced` scope binding. */
   readonly substitutions?: PromptSubstitutions;
 }
@@ -167,7 +229,10 @@ interface IMaterializedPrompt {
  *
  * @public
  */
-export class PromptLibrary<TResponse extends { kind: string } = { kind: string }> {
+export class PromptLibrary<
+  TResponse extends { kind: string } = { kind: string },
+  TAxes extends string = string
+> {
   private readonly _store: IPromptStore;
   private readonly _registry?: IPromptRegistry<TResponse>;
   private readonly _mustacheCache: MustacheTemplateCache;
@@ -261,10 +326,42 @@ export class PromptLibrary<TResponse extends { kind: string } = { kind: string }
     this._validatedRegistryKeys = new Set();
   }
 
-  /** Family-convention factory. */
+  /**
+   * Family-convention factory.
+   *
+   * @remarks
+   * Two overloads:
+   *
+   * 1. **Decl-array inference**: when `qualifiers` is supplied as a
+   *    `ReadonlyArray<string | IQualifierDecl>`, `TAxes` is inferred
+   *    from the array element types. Bare-string elements contribute
+   *    their string-literal type directly; `IQualifierDecl` elements
+   *    contribute their `name` literal. A call like
+   *    `PromptLibrary.create(\{ qualifiers: ['language', 'tone'] \})`
+   *    infers `TAxes = 'language' | 'tone'` so the request side rejects
+   *    `\{ tonr: 'formal' \}` at compile time.
+   *
+   * 2. **Pre-built collector**: when `qualifiers` is a
+   *    `IReadOnlyQualifierCollector`, the collector type does not
+   *    expose its axis-name union at the type level, so `TAxes`
+   *    defaults to `string`. Consumers wanting the typed benefit on
+   *    this path can specify `TAxes` explicitly.
+   */
+  public static async create<
+    TResponse extends { kind: string } = { kind: string },
+    const Q extends
+      | Qualifiers.IReadOnlyQualifierCollector
+      | ReadonlyArray<string | Qualifiers.IQualifierDecl> =
+      | Qualifiers.IReadOnlyQualifierCollector
+      | ReadonlyArray<string | Qualifiers.IQualifierDecl>
+  >(
+    params: IPromptLibraryCreateParams<TResponse, InferAxesFromCreate<Q>> & {
+      readonly qualifiers: Q;
+    }
+  ): Promise<Result<PromptLibrary<TResponse, InferAxesFromCreate<Q>>>>;
   public static async create<TResponse extends { kind: string } = { kind: string }>(
-    params: IPromptLibraryCreateParams<TResponse>
-  ): Promise<Result<PromptLibrary<TResponse>>> {
+    params: IPromptLibraryCreateParams<TResponse, string>
+  ): Promise<Result<PromptLibrary<TResponse, string>>> {
     return Promise.resolve(
       validateResourceBindingDepthLimit(params.resourceBindingDepthLimit).onSuccess((depthLimit) =>
         buildQualifierCollector(params.qualifiers, params.qualifierTypes).onSuccess((qualifierInfo) =>
@@ -277,7 +374,7 @@ export class PromptLibrary<TResponse extends { kind: string } = { kind: string }
               .onSuccess((builder) =>
                 MustacheTemplateCache.create(params.templateCacheSize).onSuccess((mustacheCache) =>
                   succeed(
-                    new PromptLibrary<TResponse>({
+                    new PromptLibrary<TResponse, string>({
                       store: params.store,
                       registry: params.registry,
                       mustacheCache,
@@ -352,12 +449,12 @@ export class PromptLibrary<TResponse extends { kind: string } = { kind: string }
    * long-lived ts-res `ResourceManagerBuilder` so materialization caches
    * hit across the recursion.
    */
-  public async resolve(req: IPromptResolveRequest): Promise<Result<IResolvedPrompt>> {
+  public async resolve(req: IPromptResolveRequest<TAxes>): Promise<Result<IResolvedPrompt>> {
     return this._resolveInternal(req, 0, []);
   }
 
   private async _resolveInternal(
-    req: IPromptResolveRequest,
+    req: IPromptResolveRequest<TAxes>,
     depth: number,
     stack: IResourceBindingStackFrame[]
   ): Promise<Result<IResolvedPrompt>> {
@@ -387,7 +484,7 @@ export class PromptLibrary<TResponse extends { kind: string } = { kind: string }
   }
 
   private async _resolveOnce(
-    req: IPromptResolveRequest,
+    req: IPromptResolveRequest<TAxes>,
     depth: number,
     stack: IResourceBindingStackFrame[]
   ): Promise<Result<IResolvedPrompt>> {
@@ -415,7 +512,7 @@ export class PromptLibrary<TResponse extends { kind: string } = { kind: string }
   }
 
   private async _resolveResourceBindings(
-    req: IPromptResolveRequest,
+    req: IPromptResolveRequest<TAxes>,
     mergeResult: IBindingMergeResult,
     depth: number,
     stack: IResourceBindingStackFrame[]
@@ -432,11 +529,19 @@ export class PromptLibrary<TResponse extends { kind: string } = { kind: string }
       depth,
       stack,
       innerResolve: (innerReq, innerDepth, innerStack) =>
+        // The inner resolve's qualifier shape is the wider
+        // `Readonly<Partial<Record<string, string>>>` carried by the
+        // resource-binding resolver (which doesn't know `TAxes`). At
+        // the boundary back into the typed `_resolveInternal`, narrow
+        // to `Partial<Record<TAxes, string>>` — this is a structural
+        // re-typing only; ts-res's runtime resolver consumes the
+        // values as `Record<string, string>` regardless of the public
+        // `TAxes` parameter.
         this._resolveInternal(
           {
             id: innerReq.id,
             chain: innerReq.chain,
-            qualifiers: innerReq.qualifiers,
+            qualifiers: innerReq.qualifiers as Readonly<Partial<Record<TAxes, string>>>,
             substitutions: innerReq.substitutions
           },
           innerDepth,
@@ -480,7 +585,7 @@ export class PromptLibrary<TResponse extends { kind: string } = { kind: string }
    * @public
    */
   public async resolveJsonOutput<K extends TResponse['kind']>(
-    req: IPromptResolveRequest,
+    req: IPromptResolveRequest<TAxes>,
     rawOutput: string,
     expectedKind: K
   ): Promise<Result<Extract<TResponse, { kind: K }>>> {
@@ -550,7 +655,10 @@ export class PromptLibrary<TResponse extends { kind: string } = { kind: string }
    *
    * @public
    */
-  public async resolveFreeTextOutput(req: IPromptResolveRequest, rawOutput: string): Promise<Result<string>> {
+  public async resolveFreeTextOutput(
+    req: IPromptResolveRequest<TAxes>,
+    rawOutput: string
+  ): Promise<Result<string>> {
     return (await this.resolve(req)).onSuccess((resolved) => {
       const output = resolved.descriptor.output;
       if (output.kind !== 'free-text') {
@@ -807,7 +915,7 @@ export class PromptLibrary<TResponse extends { kind: string } = { kind: string }
   }
 
   private _renderResolved(
-    req: IPromptResolveRequest,
+    req: IPromptResolveRequest<TAxes>,
     walked: {
       readonly record: IStoredPromptRecord;
       readonly winningScope: ScopeKey;
@@ -929,28 +1037,28 @@ function buildResourceTypes(): Result<ResourceTypes.ResourceTypeCollector> {
 }
 
 function buildQualifierCollector(
-  qualifiers: Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<Qualifiers.IQualifierDecl>,
+  qualifiers: Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl>,
   qualifierTypes?: QualifierTypes.ReadOnlyQualifierTypeCollector
 ): Result<{
   readonly qualifiers: Qualifiers.IReadOnlyQualifierCollector;
   readonly qualifierTypes: QualifierTypes.ReadOnlyQualifierTypeCollector;
 }> {
-  if (isQualifierDeclArray(qualifiers)) {
-    if (qualifierTypes === undefined) {
-      return fail(
-        'prompt library: qualifierTypes must be supplied when qualifiers are provided as declarations'
-      );
-    }
+  if (isMixedQualifierArray(qualifiers)) {
+    // Delegate the mixed-shape handling (including
+    // LiteralQualifierType synthesis for bare-string entries and the
+    // "qualifierTypes required when any decl is present" check) to
+    // ts-res's `QualifierCollector.create`, which is the canonical
+    // implementation post-PR-B.
     return Qualifiers.QualifierCollector.create({ qualifierTypes, qualifiers: [...qualifiers] })
       .withErrorFormat((msg) => `prompt library: invalid qualifier declarations: ${msg}`)
-      .onSuccess((collector) => succeed({ qualifiers: collector, qualifierTypes }));
+      .onSuccess((collector) => succeed({ qualifiers: collector, qualifierTypes: collector.qualifierTypes }));
   }
   return succeed({ qualifiers, qualifierTypes: qualifierTypes ?? qualifiers.qualifierTypes });
 }
 
-function isQualifierDeclArray(
-  value: Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<Qualifiers.IQualifierDecl>
-): value is ReadonlyArray<Qualifiers.IQualifierDecl> {
+function isMixedQualifierArray(
+  value: Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl>
+): value is ReadonlyArray<string | Qualifiers.IQualifierDecl> {
   return Array.isArray(value);
 }
 

--- a/libraries/ts-prompt-assist/src/packlets/resolve/promptLibrary.ts
+++ b/libraries/ts-prompt-assist/src/packlets/resolve/promptLibrary.ts
@@ -18,7 +18,12 @@ import {
 import { PromptId, ScopeKey, SlotName } from '../types';
 import { IPromptCandidateRecord, IPromptDescriptor, IStoredPromptRecord } from '../types';
 import { PromptSubstitutions } from '../types';
-import { IPromptSafetyPolicy, IQualifierContext } from '../types';
+import {
+  IPromptLibraryQualifiersInput,
+  IPromptResponseBase,
+  IPromptSafetyPolicy,
+  IQualifierContext
+} from '../types';
 import {
   IBindingTraceEntry,
   ICandidateMatchTraceEntry,
@@ -43,7 +48,7 @@ import {
 } from './resourceBindingResolver';
 
 /**
- * Type-level helper: derive the `TAxes` string union from a mixed
+ * Type-level helper: derive the `TQualifierNames` string union from a mixed
  * `(string | IQualifierDecl)[]` literal-typed array. Bare-string
  * elements contribute their own string-literal type; decl elements
  * contribute their `.name` literal. Falls back to `string` when the
@@ -51,29 +56,30 @@ import {
  *
  * @public
  */
-export type InferAxes<Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl>> = Q[number] extends infer E
-  ? E extends string
-    ? E
-    : E extends { readonly name: infer N }
-    ? N extends string
-      ? N
+export type InferQualifiers<Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl>> =
+  Q[number] extends infer E
+    ? E extends string
+      ? E
+      : E extends { readonly name: infer N }
+      ? N extends string
+        ? N
+        : never
       : never
-    : never
-  : never;
+    : never;
 
 /**
  * Type-level helper used by `PromptLibrary.create`'s decl-array
  * inference branch. When `Q` is a `ReadonlyArray<string | IQualifierDecl>`,
- * derives the `TAxes` union via {@link InferAxes}; when `Q` is a
+ * derives the `TQualifierNames` union via {@link InferQualifiers}; when `Q` is a
  * pre-built `IReadOnlyQualifierCollector`, the collector type does not
- * expose its axis-name union at the type level, so `TAxes` defaults to
+ * expose its axis-name union at the type level, so `TQualifierNames` defaults to
  * `string`.
  *
  * @public
  */
-export type InferAxesFromCreate<
+export type InferQualifiersFromCreate<
   Q extends Qualifiers.IReadOnlyQualifierCollector | ReadonlyArray<string | Qualifiers.IQualifierDecl>
-> = Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl> ? InferAxes<Q> : string;
+> = Q extends ReadonlyArray<string | Qualifiers.IQualifierDecl> ? InferQualifiers<Q> : string;
 
 /**
  * ts-res resource type name the library synthesizes for prompt records.
@@ -102,8 +108,8 @@ const DEFAULT_RESOURCE_BINDING_DEPTH_LIMIT: number = 5;
  * @public
  */
 export interface IPromptLibraryCreateParams<
-  TResponse extends { kind: string } = { kind: string },
-  TAxes extends string = string
+  TResponse extends IPromptResponseBase = IPromptResponseBase,
+  TQualifierNames extends string = string
 > {
   /** Backing store. v0.1 ships `FileTreePromptStore`; consumers can implement custom adapters. */
   readonly store: IPromptStore;
@@ -117,18 +123,16 @@ export interface IPromptLibraryCreateParams<
    * per design §4.1.
    *
    * @remarks
-   * On the decl-array path, the `TAxes` type parameter is inferred
+   * On the decl-array path, the `TQualifierNames` type parameter is inferred
    * from the array element types via the static `PromptLibrary.create`
    * factory — e.g. `\{ qualifiers: ['language', 'tone'] \}` infers
-   * `TAxes = 'language' | 'tone'` and tightens
+   * `TQualifierNames = 'language' | 'tone'` and tightens
    * `IPromptResolveRequest.qualifiers` accordingly. On the
-   * pre-built-collector path, `TAxes` falls back to `string`; consumers
+   * pre-built-collector path, `TQualifierNames` falls back to `string`; consumers
    * can specify it explicitly if they want the typed benefit on that
    * path.
    */
-  readonly qualifiers:
-    | Qualifiers.IReadOnlyQualifierCollector
-    | ReadonlyArray<TAxes | (Qualifiers.IQualifierDecl & { readonly name: TAxes })>;
+  readonly qualifiers: IPromptLibraryQualifiersInput<TQualifierNames>;
   /**
    * Optional ts-res qualifier-type collector. When `qualifiers` is
    * supplied as a pre-built `IReadOnlyQualifierCollector`, this is
@@ -175,7 +179,7 @@ export interface IPromptLibraryCreateParams<
  * {@link PromptLibrary.resolveFreeTextOutput}.
  * @public
  */
-export interface IPromptResolveRequest<TAxes extends string = string> {
+export interface IPromptResolveRequest<TQualifierNames extends string = string> {
   /** Prompt id to resolve. */
   readonly id: PromptId;
   /** Scope chain — most-specific to most-general. The walker uses the first scope with a record. */
@@ -186,12 +190,12 @@ export interface IPromptResolveRequest<TAxes extends string = string> {
    * @remarks
    * Defaults to the loose shape `Readonly<Partial<Record<string, string>>>`
    * (identical to {@link IQualifierContext}) so legacy callers compile
-   * unchanged. When `TAxes` is narrowed (typically via inference on
+   * unchanged. When `TQualifierNames` is narrowed (typically via inference on
    * `PromptLibrary.create` with a string-literal decl array), this
-   * narrows to `Readonly<Partial<Record<TAxes, string>>>`, surfacing
+   * narrows to `Readonly<Partial<Record<TQualifierNames, string>>>`, surfacing
    * misspelled qualifier-axis names at compile time.
    */
-  readonly qualifiers: Readonly<Partial<Record<TAxes, string>>>;
+  readonly qualifiers: Readonly<Partial<Record<TQualifierNames, string>>>;
   /** Optional caller substitutions, applied to slots not locked by an `enforced` scope binding. */
   readonly substitutions?: PromptSubstitutions;
 }
@@ -230,8 +234,8 @@ interface IMaterializedPrompt {
  * @public
  */
 export class PromptLibrary<
-  TResponse extends { kind: string } = { kind: string },
-  TAxes extends string = string
+  TResponse extends IPromptResponseBase = IPromptResponseBase,
+  TQualifierNames extends string = string
 > {
   private readonly _store: IPromptStore;
   private readonly _registry?: IPromptRegistry<TResponse>;
@@ -333,33 +337,33 @@ export class PromptLibrary<
    * Two overloads:
    *
    * 1. **Decl-array inference**: when `qualifiers` is supplied as a
-   *    `ReadonlyArray<string | IQualifierDecl>`, `TAxes` is inferred
+   *    `ReadonlyArray<string | IQualifierDecl>`, `TQualifierNames` is inferred
    *    from the array element types. Bare-string elements contribute
    *    their string-literal type directly; `IQualifierDecl` elements
    *    contribute their `name` literal. A call like
    *    `PromptLibrary.create(\{ qualifiers: ['language', 'tone'] \})`
-   *    infers `TAxes = 'language' | 'tone'` so the request side rejects
+   *    infers `TQualifierNames = 'language' | 'tone'` so the request side rejects
    *    `\{ tonr: 'formal' \}` at compile time.
    *
    * 2. **Pre-built collector**: when `qualifiers` is a
    *    `IReadOnlyQualifierCollector`, the collector type does not
-   *    expose its axis-name union at the type level, so `TAxes`
+   *    expose its axis-name union at the type level, so `TQualifierNames`
    *    defaults to `string`. Consumers wanting the typed benefit on
-   *    this path can specify `TAxes` explicitly.
+   *    this path can specify `TQualifierNames` explicitly.
    */
   public static async create<
-    TResponse extends { kind: string } = { kind: string },
+    TResponse extends IPromptResponseBase = IPromptResponseBase,
     const Q extends
       | Qualifiers.IReadOnlyQualifierCollector
       | ReadonlyArray<string | Qualifiers.IQualifierDecl> =
       | Qualifiers.IReadOnlyQualifierCollector
       | ReadonlyArray<string | Qualifiers.IQualifierDecl>
   >(
-    params: IPromptLibraryCreateParams<TResponse, InferAxesFromCreate<Q>> & {
+    params: IPromptLibraryCreateParams<TResponse, InferQualifiersFromCreate<Q>> & {
       readonly qualifiers: Q;
     }
-  ): Promise<Result<PromptLibrary<TResponse, InferAxesFromCreate<Q>>>>;
-  public static async create<TResponse extends { kind: string } = { kind: string }>(
+  ): Promise<Result<PromptLibrary<TResponse, InferQualifiersFromCreate<Q>>>>;
+  public static async create<TResponse extends IPromptResponseBase = IPromptResponseBase>(
     params: IPromptLibraryCreateParams<TResponse, string>
   ): Promise<Result<PromptLibrary<TResponse, string>>> {
     return Promise.resolve(
@@ -449,12 +453,28 @@ export class PromptLibrary<
    * long-lived ts-res `ResourceManagerBuilder` so materialization caches
    * hit across the recursion.
    */
-  public async resolve(req: IPromptResolveRequest<TAxes>): Promise<Result<IResolvedPrompt>> {
+  public async resolve(req: IPromptResolveRequest<TQualifierNames>): Promise<Result<IResolvedPrompt>> {
     return this._resolveInternal(req, 0, []);
   }
 
+  /**
+   * Wide-shape internal resolve. The public {@link PromptLibrary.resolve}
+   * entry accepts `IPromptResolveRequest<TQualifierNames>` — the typed
+   * `TQualifierNames` belongs at the public API where the caller commits
+   * to a context shape. Private internals (here and downstream:
+   * `_resolveOnce`, `_resolveResourceBindings`, `_renderResolved`) take
+   * the wide `IPromptResolveRequest<string>` because ts-res's resolver
+   * consumes qualifier values as a plain string-keyed map regardless of
+   * the public `TQualifierNames` parameter — and because the resource-
+   * binding inner-resolve path re-enters this method with the wider
+   * shape from `resourceBindingResolver` (which has no `TQualifierNames`).
+   * The public typed shape assigns cleanly to this wider shape
+   * (`Partial<Record<TQualifierNames, string>>` is a subtype of
+   * `Partial<Record<string, string>>`), so no cast is needed at the
+   * public-API boundary OR at the resource-binding re-entry boundary.
+   */
   private async _resolveInternal(
-    req: IPromptResolveRequest<TAxes>,
+    req: IPromptResolveRequest<string>,
     depth: number,
     stack: IResourceBindingStackFrame[]
   ): Promise<Result<IResolvedPrompt>> {
@@ -484,7 +504,7 @@ export class PromptLibrary<
   }
 
   private async _resolveOnce(
-    req: IPromptResolveRequest<TAxes>,
+    req: IPromptResolveRequest<string>,
     depth: number,
     stack: IResourceBindingStackFrame[]
   ): Promise<Result<IResolvedPrompt>> {
@@ -512,7 +532,7 @@ export class PromptLibrary<
   }
 
   private async _resolveResourceBindings(
-    req: IPromptResolveRequest<TAxes>,
+    req: IPromptResolveRequest<string>,
     mergeResult: IBindingMergeResult,
     depth: number,
     stack: IResourceBindingStackFrame[]
@@ -528,25 +548,11 @@ export class PromptLibrary<
       outerId: req.id,
       depth,
       stack,
+      // `innerReq.qualifiers` already has the wide shape
+      // `Readonly<Partial<Record<string, string>>>`, which matches the
+      // widened `_resolveInternal` signature directly — no cast needed.
       innerResolve: (innerReq, innerDepth, innerStack) =>
-        // The inner resolve's qualifier shape is the wider
-        // `Readonly<Partial<Record<string, string>>>` carried by the
-        // resource-binding resolver (which doesn't know `TAxes`). At
-        // the boundary back into the typed `_resolveInternal`, narrow
-        // to `Partial<Record<TAxes, string>>` — this is a structural
-        // re-typing only; ts-res's runtime resolver consumes the
-        // values as `Record<string, string>` regardless of the public
-        // `TAxes` parameter.
-        this._resolveInternal(
-          {
-            id: innerReq.id,
-            chain: innerReq.chain,
-            qualifiers: innerReq.qualifiers as Readonly<Partial<Record<TAxes, string>>>,
-            substitutions: innerReq.substitutions
-          },
-          innerDepth,
-          innerStack
-        )
+        this._resolveInternal(innerReq, innerDepth, innerStack)
     });
   }
 
@@ -585,7 +591,7 @@ export class PromptLibrary<
    * @public
    */
   public async resolveJsonOutput<K extends TResponse['kind']>(
-    req: IPromptResolveRequest<TAxes>,
+    req: IPromptResolveRequest<TQualifierNames>,
     rawOutput: string,
     expectedKind: K
   ): Promise<Result<Extract<TResponse, { kind: K }>>> {
@@ -656,7 +662,7 @@ export class PromptLibrary<
    * @public
    */
   public async resolveFreeTextOutput(
-    req: IPromptResolveRequest<TAxes>,
+    req: IPromptResolveRequest<TQualifierNames>,
     rawOutput: string
   ): Promise<Result<string>> {
     return (await this.resolve(req)).onSuccess((resolved) => {
@@ -915,7 +921,7 @@ export class PromptLibrary<
   }
 
   private _renderResolved(
-    req: IPromptResolveRequest<TAxes>,
+    req: IPromptResolveRequest<string>,
     walked: {
       readonly record: IStoredPromptRecord;
       readonly winningScope: ScopeKey;

--- a/libraries/ts-prompt-assist/src/packlets/resolve/resourceBindingResolver.ts
+++ b/libraries/ts-prompt-assist/src/packlets/resolve/resourceBindingResolver.ts
@@ -32,7 +32,7 @@ export interface IResourceBindingStackFrame {
 export interface IInnerResolveRequest {
   readonly id: PromptId;
   readonly chain: ReadonlyArray<ScopeKey>;
-  readonly qualifiers: Readonly<Record<string, string>>;
+  readonly qualifiers: Readonly<Partial<Record<string, string>>>;
   readonly substitutions: PromptSubstitutions | undefined;
 }
 
@@ -107,7 +107,7 @@ export interface IResourceBindingResolveResult {
 export async function resolvePendingResourceBindings(params: {
   readonly pending: ReadonlyArray<IPendingResourceBinding>;
   readonly outerChain: ReadonlyArray<ScopeKey>;
-  readonly outerQualifiers: Readonly<Record<string, string>>;
+  readonly outerQualifiers: Readonly<Partial<Record<string, string>>>;
   readonly outerSubstitutions: PromptSubstitutions | undefined;
   readonly outerId: PromptId;
   readonly depth: number;
@@ -159,11 +159,11 @@ export async function resolvePendingResourceBindings(params: {
 function buildInnerRequest(
   binding: IResourceSlotBinding,
   outerChain: ReadonlyArray<ScopeKey>,
-  outerQualifiers: Readonly<Record<string, string>>
+  outerQualifiers: Readonly<Partial<Record<string, string>>>
 ): Result<{
   readonly id: PromptId;
   readonly chain: ReadonlyArray<ScopeKey>;
-  readonly qualifiers: Readonly<Record<string, string>>;
+  readonly qualifiers: Readonly<Partial<Record<string, string>>>;
 }> {
   // `resourceId` is a `ResourceId` brand at the binding layer; the inner
   // resolve consumes a `PromptId` so re-validate. A resource binding that

--- a/libraries/ts-prompt-assist/src/packlets/types/output.ts
+++ b/libraries/ts-prompt-assist/src/packlets/types/output.ts
@@ -55,3 +55,26 @@ export interface IPromptResponseBase {
   /** String-literal discriminator that the JSON pipeline dispatches on. */
   readonly kind: string;
 }
+
+/**
+ * Shape of the `appliesTo` field on an {@link IPromptOutputValidator} — the
+ * discriminator value(s) the validator narrows by at runtime.
+ *
+ * @remarks
+ * Single-kind validators set `appliesTo` to one of the consumer's
+ * `TResponse['kind']` literals (e.g. `'cited'`); cross-kind validators set
+ * it to a `ReadonlyArray` of literals (e.g. `['cited', 'classifier']`). The
+ * output pipeline normalizes either form to an array at runtime and skips
+ * validators whose set doesn't include `value.kind`.
+ *
+ * Extracted as a named type so the "one value or array of values" union has
+ * a single TSDoc-attach point and consumers authoring validators can
+ * reference the field shape directly. Parameterized by
+ * `TResponse extends IPromptResponseBase` so the named alias preserves the
+ * same narrowing the inline union provided.
+ *
+ * @public
+ */
+export type PromptOutputValidatorAppliesTo<TResponse extends IPromptResponseBase> =
+  | TResponse['kind']
+  | ReadonlyArray<TResponse['kind']>;

--- a/libraries/ts-prompt-assist/src/packlets/types/output.ts
+++ b/libraries/ts-prompt-assist/src/packlets/types/output.ts
@@ -31,3 +31,27 @@ export interface IJsonOutputContract {
  * @public
  */
 export type PromptOutputContract = ITextOutputContract | IJsonOutputContract;
+
+/**
+ * Discriminator base for the consumer's response union type parameter
+ * (`TResponse`). Every member of the consumer's `TResponse` union must
+ * carry a string-literal `kind` field; the JSON output pipeline uses
+ * that discriminator to dispatch the registered Converter and to narrow
+ * each validator's `appliesTo`.
+ *
+ * @remarks
+ * Declared as a named interface (rather than the inline `\{ kind: string \}`
+ * lower bound that previously appeared at every parameterized signature)
+ * so the discriminator role has a single TSDoc-attach point and so
+ * `TResponse extends IPromptResponseBase` reads as a domain constraint
+ * rather than an ad-hoc shape.
+ *
+ * Consumers extend it as a discriminated union, e.g.
+ * `type MyResponses = \{ kind: 'classify'; label: string \} | \{ kind: 'extract'; data: Record<string, string> \}`.
+ *
+ * @public
+ */
+export interface IPromptResponseBase {
+  /** String-literal discriminator that the JSON pipeline dispatches on. */
+  readonly kind: string;
+}

--- a/libraries/ts-prompt-assist/src/packlets/types/qualifiers.ts
+++ b/libraries/ts-prompt-assist/src/packlets/types/qualifiers.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+import { Qualifiers } from '@fgv/ts-res';
 import { AxisName } from './ids';
 
 /**
@@ -49,3 +50,33 @@ export interface IPromptQualifierMetadata {
  * @public
  */
 export type IQualifierContext = Readonly<Partial<Record<string, string>>>;
+
+/**
+ * Shape of the `qualifiers` field on {@link IPromptLibraryCreateParams}.
+ * Accepts either a pre-built ts-res `IReadOnlyQualifierCollector` (when
+ * the consumer already maintains a ts-res qualifier set) or a mixed
+ * array of bare axis-name strings and / or `IQualifierDecl`s (the
+ * library builds the collector internally via ts-res's
+ * `Qualifiers.QualifierCollector.create`, which synthesizes
+ * `LiteralQualifierType`s for bare strings).
+ *
+ * @remarks
+ * Parameterized by `TQualifierNames extends string`, the qualifier-axis
+ * string-literal union the consumer wants to enforce. On the decl-array
+ * path, `TQualifierNames` is inferred from the array element types by
+ * the static `PromptLibrary.create` factory's first overload — bare-
+ * string elements contribute their string-literal type directly;
+ * `IQualifierDecl` elements contribute their `name` literal. On the
+ * pre-built-collector path the collector type does not expose its axis-
+ * name union at the type level, so `TQualifierNames` falls back to
+ * `string` unless the consumer specifies it explicitly.
+ *
+ * Extracted as a named type so the union has a single TSDoc-attach
+ * point and consumers writing typed `IPromptLibraryCreateParams`
+ * literals can reference the qualifiers shape directly.
+ *
+ * @public
+ */
+export type IPromptLibraryQualifiersInput<TQualifierNames extends string = string> =
+  | Qualifiers.IReadOnlyQualifierCollector
+  | ReadonlyArray<TQualifierNames | (Qualifiers.IQualifierDecl & { readonly name: TQualifierNames })>;

--- a/libraries/ts-prompt-assist/src/packlets/types/qualifiers.ts
+++ b/libraries/ts-prompt-assist/src/packlets/types/qualifiers.ts
@@ -30,15 +30,22 @@ export interface IPromptQualifierMetadata {
  * Maps qualifier axis name to value.
  *
  * @remarks
- * The context is intentionally a flat `Record<string, string>` even
- * though `IPromptCandidateRecord.conditions` accepts the richer ts-res
- * `ConditionSetDecl` (record-with-details with `priority` /
+ * The context is intentionally a flat `Partial<Record<string, string>>`
+ * even though `IPromptCandidateRecord.conditions` accepts the richer
+ * ts-res `ConditionSetDecl` (record-with-details with `priority` /
  * `scoreAsDefault`, plus array form). The asymmetry is by design: ts-
  * res's `SimpleContextQualifierProvider` itself takes a flat
- * `Record<string, string>`, so caller context is intentionally simple;
- * descriptor-side condition complexity flows through ts-res's resolver
- * unchanged. See design §10 + §15.5 (Option C) for the rationale.
+ * `Partial<Record<string, string>>`, so caller context is intentionally
+ * simple; descriptor-side condition complexity flows through ts-res's
+ * resolver unchanged. See design §10 + §15.5 (Option C) for the
+ * rationale.
+ *
+ * `Partial<...>` widening (post-F14): TS-friendly with the common
+ * `tone === 'formal' ? \{ tone: 'formal' \} : \{\}` shape — the empty-object
+ * branch assigns cleanly without requiring an explicit annotation. The
+ * underlying ts-res candidate selector treats missing keys and
+ * explicit-undefined identically (per PR B's note).
  *
  * @public
  */
-export type IQualifierContext = Readonly<Record<string, string>>;
+export type IQualifierContext = Readonly<Partial<Record<string, string>>>;

--- a/libraries/ts-prompt-assist/src/test/unit/foundation.test.ts
+++ b/libraries/ts-prompt-assist/src/test/unit/foundation.test.ts
@@ -1594,6 +1594,118 @@ describe('ts-prompt-assist foundation', () => {
       expect(result).toFailWith(/unknown qualifier 'not-a-real-qualifier'/);
     });
 
+    test('F12: fixture seed accepts a record whose descriptor omits its `id`, defaulting from the outer id', async () => {
+      // Per F12: descriptor.id is redundant on the fixture path (the
+      // outer record.id already names the prompt). The fixture defaults
+      // descriptor.id from the outer id; the loader's filename-id
+      // consistency check still holds because the encoder uses the
+      // outer id as the filename stem.
+      const base = buildDescriptor();
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentionally destructure-and-drop the descriptor.id field
+      const { id: _droppedId, ...descriptorWithoutId } = base.descriptor;
+      const seedRecord = {
+        scope: base.scope,
+        id: base.id,
+        descriptor: descriptorWithoutId,
+        candidates: base.candidates
+      };
+      const store = await buildStore({ records: [seedRecord] });
+      const lib = (await PromptLibrary.create({ store, qualifiers: TEST_QUALIFIER_COLLECTOR })).orThrow();
+      const resolved = await lib.resolve({
+        id: TEST_PROMPT,
+        chain: [TEST_SCOPE],
+        qualifiers: {},
+        substitutions: { audience: 'world' }
+      });
+      expect(resolved).toSucceedAndSatisfy((r: IResolvedPrompt) => {
+        expect(r.body).toBe('Hello, world!');
+        expect(r.descriptor.id).toBe(TEST_PROMPT);
+      });
+    });
+
+    test('F12: fixture seed rejects an explicit descriptor.id that mismatches the outer record id', async () => {
+      // Silent mismatch is impossible: if a caller supplies an explicit
+      // descriptor.id, it must match the outer id. Optionality removes
+      // the redundancy but preserves the consistency check.
+      const base = buildDescriptor();
+      const seedRecord = {
+        scope: base.scope,
+        id: base.id,
+        descriptor: { ...base.descriptor, id: 'mismatch' as unknown as PromptId },
+        candidates: base.candidates
+      };
+      const result = await PromptStoreFixture.build({ records: [seedRecord] });
+      expect(result).toFailWith(/does not match descriptor\.id/);
+    });
+
+    test('F3 + F14: PromptLibrary.create infers TAxes from a string-literal decl array', async () => {
+      // Per F3, the decl-array branch of PromptLibrary.create infers
+      // TAxes from the array element types. The narrowed library
+      // rejects an unknown axis name in the resolve request at compile
+      // time. The empty `qualifiers: {}` shape (post-F14 widening)
+      // assigns cleanly to the narrowed shape via Partial.
+      const store = await buildStore({ records: [buildDescriptor()] });
+      const lib = (
+        await PromptLibrary.create({ store, qualifiers: ['tone', 'language'] as const })
+      ).orThrow();
+
+      // Empty context — passes the Partial<Record<TAxes, string>>
+      // (post-F14) check.
+      const ok = await lib.resolve({
+        id: TEST_PROMPT,
+        chain: [TEST_SCOPE],
+        qualifiers: {},
+        substitutions: { audience: 'world' }
+      });
+      expect(ok).toSucceed();
+
+      // Known axis — also passes.
+      const okTone = await lib.resolve({
+        id: TEST_PROMPT,
+        chain: [TEST_SCOPE],
+        qualifiers: { tone: 'formal' },
+        substitutions: { audience: 'world' }
+      });
+      expect(okTone).toSucceed();
+
+      // Compile-time check: an unknown axis must be rejected by TS.
+      // `tonr` is a typo for `tone`; F3's whole point is that this
+      // fails at compile time, so the unknown-key form is annotated
+      // with @ts-expect-error.
+      const bad = await lib.resolve({
+        id: TEST_PROMPT,
+        chain: [TEST_SCOPE],
+        // @ts-expect-error - F3: 'tonr' is not a member of the inferred TAxes union 'tone' | 'language'
+        qualifiers: { tonr: 'formal' },
+        substitutions: { audience: 'world' }
+      });
+      // Runtime: ts-res's candidate selector treats the unknown key as
+      // "no value" and falls through to the base candidate; the test
+      // doesn't care about that, the load-bearing assertion is the
+      // compile-time directive above.
+      expect(bad).toSucceed();
+    });
+
+    test('F14: empty / mixed qualifier shapes assign to IPromptResolveRequest.qualifiers without an explicit annotation', async () => {
+      // The Readonly<Partial<Record<string, string>>> widening lets the
+      // canonical "context-or-not" ternary type-check without help —
+      // pre-F14 the empty branch failed the Record<string, string> index
+      // signature.
+      const store = await buildStore({ records: [buildDescriptor()] });
+      const lib = (await PromptLibrary.create({ store, qualifiers: TEST_QUALIFIER_COLLECTOR })).orThrow();
+      const tone: 'formal' | undefined = undefined;
+      // No explicit `IQualifierContext` annotation — the ternary
+      // assigns directly thanks to F14.
+      const ctx = tone === 'formal' ? { tone } : {};
+      const r = await lib.resolve({
+        id: TEST_PROMPT,
+        chain: [TEST_SCOPE],
+        qualifiers: ctx,
+        substitutions: { audience: 'world' }
+      });
+      expect(r).toSucceed();
+    });
+
     test('mustache render failure surfaces with prompt id', async () => {
       const recordWithMissingVar = buildDescriptor({
         candidates: [{ conditions: {}, body: 'hi {{{missing}}}' }],

--- a/libraries/ts-prompt-assist/src/test/unit/foundation.test.ts
+++ b/libraries/ts-prompt-assist/src/test/unit/foundation.test.ts
@@ -1638,9 +1638,9 @@ describe('ts-prompt-assist foundation', () => {
       expect(result).toFailWith(/does not match descriptor\.id/);
     });
 
-    test('F3 + F14: PromptLibrary.create infers TAxes from a string-literal decl array', async () => {
+    test('F3 + F14: PromptLibrary.create infers TQualifierNames from a string-literal decl array', async () => {
       // Per F3, the decl-array branch of PromptLibrary.create infers
-      // TAxes from the array element types. The narrowed library
+      // TQualifierNames from the array element types. The narrowed library
       // rejects an unknown axis name in the resolve request at compile
       // time. The empty `qualifiers: {}` shape (post-F14 widening)
       // assigns cleanly to the narrowed shape via Partial.
@@ -1649,7 +1649,7 @@ describe('ts-prompt-assist foundation', () => {
         await PromptLibrary.create({ store, qualifiers: ['tone', 'language'] as const })
       ).orThrow();
 
-      // Empty context — passes the Partial<Record<TAxes, string>>
+      // Empty context — passes the Partial<Record<TQualifierNames, string>>
       // (post-F14) check.
       const ok = await lib.resolve({
         id: TEST_PROMPT,
@@ -1675,7 +1675,7 @@ describe('ts-prompt-assist foundation', () => {
       const bad = await lib.resolve({
         id: TEST_PROMPT,
         chain: [TEST_SCOPE],
-        // @ts-expect-error - F3: 'tonr' is not a member of the inferred TAxes union 'tone' | 'language'
+        // @ts-expect-error - F3: 'tonr' is not a member of the inferred TQualifierNames union 'tone' | 'language'
         qualifiers: { tonr: 'formal' },
         substitutions: { audience: 'world' }
       });

--- a/libraries/ts-prompt-assist/src/test/unit/readmeSmoke.test.ts
+++ b/libraries/ts-prompt-assist/src/test/unit/readmeSmoke.test.ts
@@ -327,6 +327,47 @@ describe('README smoke tests', () => {
     expect(suspicious?.disposition).toBe('warn');
   });
 
+  test('wiring into a React app — F9 pattern (async init + typed axes)', async () => {
+    // Mirrors the README's "Wiring into a React app" snippet. We don't
+    // actually render React (the library has no React dep at runtime);
+    // the load-bearing assertions are (a) the seed compiles with
+    // descriptor.id omitted (F12), (b) PromptLibrary.create infers
+    // TAxes from `['tone'] as const` (F3), and (c) the empty-context
+    // resolve assigns cleanly to the narrowed shape (F14).
+    const SCOPE = Convert.scopeKey.convert('global').orThrow();
+    const GREETING = Convert.promptId.convert('greeting').orThrow();
+    const seed: IPromptStoreFixtureSeed = {
+      records: [
+        {
+          scope: SCOPE,
+          id: GREETING,
+          descriptor: {
+            // descriptor.id omitted — fixture defaults from outer id (F12).
+            title: 'Greeting',
+            schemaVersion: '1',
+            surface: 'chat',
+            slots: [],
+            output: { kind: 'free-text' }
+          },
+          candidates: [{ conditions: {}, body: 'Hello caller!' }]
+        }
+      ]
+    };
+    // Simulate the useEffect initialiser body.
+    const store = (await PromptStoreFixture.build(seed)).orThrow();
+    const library = (await PromptLibrary.create({ store, qualifiers: ['tone'] as const })).orThrow();
+    // The narrow qualifiers shape: `{ tone?: string }`. The empty
+    // branch assigns thanks to F14's Partial widening.
+    const resolved = (
+      await library.resolve({
+        id: GREETING,
+        chain: [SCOPE],
+        qualifiers: {}
+      })
+    ).orThrow();
+    expect(resolved.body).toBe('Hello caller!');
+  });
+
   test('quick start — on-disk FileTreePromptStore', async () => {
     // Mirrors the README's on-disk YAML quick-start against the on-disk
     // fixture under data/test/ts-prompt-assist/basic/ (which already

--- a/libraries/ts-prompt-assist/src/test/unit/readmeSmoke.test.ts
+++ b/libraries/ts-prompt-assist/src/test/unit/readmeSmoke.test.ts
@@ -332,7 +332,7 @@ describe('README smoke tests', () => {
     // actually render React (the library has no React dep at runtime);
     // the load-bearing assertions are (a) the seed compiles with
     // descriptor.id omitted (F12), (b) PromptLibrary.create infers
-    // TAxes from `['tone'] as const` (F3), and (c) the empty-context
+    // TQualifierNames from `['tone'] as const` (F3), and (c) the empty-context
     // resolve assigns cleanly to the narrowed shape (F14).
     const SCOPE = Convert.scopeKey.convert('global').orThrow();
     const GREETING = Convert.promptId.convert('greeting').orThrow();


### PR DESCRIPTION
## Summary

PR C of the three-PR round-1 ergonomics cycle (PRs A + B already merged on this branch). Lands the ts-prompt-assist-side absorption of F3, F9, F12, and F14 from `pressure-test-findings-round-1.md`.

- **F3** — `PromptLibrary<TResponse, TAxes extends string = string>`; `create`'s decl-array overload uses `const Q` inference to derive `TAxes` from a literal `qualifiers: ['tone', 'language'] as const`. Resolve request `qualifiers` narrows to `Readonly<Partial<Record<TAxes, string>>>` — misspelled axes fail at compile time. Pre-built-collector path keeps `TAxes = string` (collector type doesn't expose its axes); consumers can specify it explicitly. New `InferAxes` / `InferAxesFromCreate` exports.
- **F9** — README "Wiring into a React app" section with the canonical `useEffect` initialiser + cancellation guard. F6 (sync fixture) dropped on review; this doc IS the answer. Mirrored in `readmeSmoke.test.ts`.
- **F12** — `IPromptStoreFixtureSeedRecord.descriptor.id` now optional; the fixture defaults from outer `id`. Explicit mismatch rejects loudly. New `IPromptStoreFixtureSeedRecord` + `IPromptStoreFixtureDescriptor` types. On-disk-YAML schema unchanged.
- **F14** — `IQualifierContext` widened to `Readonly<Partial<Record<string, string>>>` so the canonical `tone === 'formal' ? { tone } : {}` ternary type-checks without an annotation. Cascaded through `IInnerResolveRequest` / `IResourceSlotBinding.qualifiers` / `resourceBindingResolver` reader types. ts-prompt-assist's internal readers (safeguards, mergeBindings, resolveJsonOutput, resolveFreeTextOutput) all consume the resolve-request shape verbatim — none relied on the no-undefined invariant.
- Mixed-shape `(string | IQualifierDecl)[]` qualifier input (post-PR-B ts-res) plumbed through `PromptLibrary.create`.

## Test plan

- [x] `rush build --to @fgv/ts-prompt-assist` — green
- [x] `rushx lint` — clean
- [x] `rushx test` — all tests pass (4 new in `foundation.test.ts` + 1 new in `readmeSmoke.test.ts`)
- [x] 100% coverage retained across the package
- [x] api-extractor regenerated (`etc/ts-prompt-assist.api.md`)
- [x] Rush change file (`common/changes/@fgv/ts-prompt-assist/`)
- [x] F3 inference verified at compile-time via `@ts-expect-error` directive on the misspelled-axis branch in `foundation.test.ts`

## Out of scope (per the brief)

- F1 (landed via PR B's cascade), F13 (landed via PR A), F2/F4/F7/F8/F10/F11 (deferred / retracted)
- Constrained-values `axes` shape (v0.2)
- Editor UX / samples app (`docs/FUTURE.md`)

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_