### PR TITLE
pressure-test(ts-prompt-assist): round-2 sample-app integration + findings

### DIFF
--- a/.ai/tasks/active/ts-prompt-assist/phase-384-result.md
+++ b/.ai/tasks/active/ts-prompt-assist/phase-384-result.md
@@ -130,6 +130,51 @@ green).
 
 ---
 
+## Copilot review absorption
+
+Two rounds of Copilot review threads on PR #384, all addressed:
+
+**Round 1 (3 threads — type-only imports + cast hygiene):**
+
+1. `promptLibrary.ts:13` — type-only specifiers (`IPromptResponseBase`,
+   `IPromptStoreFixtureSeed`, `Converter`, `Result`) were being
+   brought in as runtime values. Under `babel-loader` transpile-only
+   that can leak no-op named imports into the emitted JS (and break
+   under stricter bundlers). Split into `import type { ... }` blocks.
+2. `App.tsx:11` — same issue with `ChatPromptLibrary` and `ChatTone`.
+   Split into a separate `import type` line.
+3. `ChatPanel.tsx:186` — `e.target.value as ChatTone` was an
+   unchecked cast. Refactored narrow-by-construction: `ChatTone` now
+   derives from `const chatTones = ['neutral', 'formal'] as const`
+   in `promptLibrary.ts`; the same array drives the rendered
+   `<option>` set AND a `chatToneConverter = Converters.enumeratedValue<ChatTone>(...)`
+   so the handler narrows via
+   `chatToneConverter.convert(e.target.value).orDefault(tone)` — no
+   unchecked casts, and the option set and Converter-recognized set
+   stay in lockstep by construction.
+
+**Round 2 (2 threads — sample-app logic bugs):**
+
+4. `App.tsx:218` — `handleSendChat` was creating the `AbortController`
+   and assigning it to `abortControllerRef.current` BEFORE the
+   early-return guards (library-not-ready, system-prompt resolve
+   failure). On those returns, the ref held a controller for a
+   request that never started, so `onAbort` would target nothing and
+   the next send would orphan the stale controller. Moved controller
+   creation to AFTER the guards — once committed to the network call.
+5. `ChatPanel.tsx:209` — `canSubmit` now folds in `promptLibrary !== null`
+   but the disabled-state message was hardcoded to "Enter an API key
+   to enable chat." Added optional `disabledReason?: string` to
+   `IChatPanelProps` (defaults to today's message when omitted) and
+   threaded the right cause from `App.tsx` with precedence: missing
+   key first, then load failure, then still-initializing. Matches the
+   user's mental model — API key is the first thing they fill in.
+
+A single nit-class comment remained after round 2 (acknowledged as
+nit by the orchestrator); not absorbing in this PR.
+
+---
+
 ## Lint-gate + TS-check note
 
 `samples/ai-image-gen-sample/package.json` does not define a `lint`
@@ -214,20 +259,24 @@ Two minor observations worth flagging at cluster close:
 | `rush build --to @fgv/ai-image-gen-sample` clean | ✅ — 28.4s |
 | Full repo build clean | ✅ — re-ran post-rebase via the `--to` path (sample's deps already built clean on the integration head; rebase didn't perturb them) |
 | `rushx lint` clean in sample package | ✅ (vacuous — no lint script defined; see note above) |
-| Sample TS compiles with narrow `QualifierName` union end-to-end | ✅ — verified via direct `tsc --noEmit -p tsconfig.json`; a typo'd `tonr` on the seed candidate fails as `src/promptLibrary.ts(70,25): TS2353 ... 'tonr' does not exist in type 'ConditionSetDecl<"tone">'`. Webpack production build also clean (uses babel-loader, transpile-only). See "Lint-gate + TS-check note" above for why both checks matter. |
+| Sample TS compiles with narrow `QualifierName` union end-to-end | ✅ — verified via direct `tsc --noEmit -p tsconfig.json`; a typo'd `tonr` on the seed candidate fails as `src/promptLibrary.ts(67,25): TS2353 ... 'tonr' does not exist in type 'ConditionSetDecl<"tone">'` (line shifted after round-1 review-absorption refactor). Webpack production build also clean (uses babel-loader, transpile-only). See "Lint-gate + TS-check note" above for why both checks matter. |
+| Copilot review rounds absorbed | ✅ — 5 threads across 2 rounds; all addressed with build + `tsc --noEmit` clean after each round. Final state has one nit-class comment outstanding (acknowledged not absorbing per the orchestrator). |
 | F1 / F2 / F6 closure notes added to findings doc | ✅ |
 | `phase-384-result.md` written | ✅ — this file |
 | `state.md` / `docs/WORKSTREAMS.md` left for cluster-close prep | ✅ — not touched in this phase |
 
 ---
 
-## Files changed (this rebase + B-3 follow-up)
+## Files changed (this rebase + B-3 follow-up + review-rounds)
 
 | File | Change |
 |---|---|
-| `samples/ai-image-gen-sample/src/promptLibrary.ts` | Added `qualifierNames` const, `QualifierName` type, `qualifierNameConverter`; typed seed as `IPromptStoreFixtureSeed<QualifierName>`; threaded converter through the seed; used `qualifierNames` directly in `PromptLibrary.create({ qualifiers })` |
+| `samples/ai-image-gen-sample/src/promptLibrary.ts` | B-3 typed-flow: added `qualifierNames` const, `QualifierName` type, `qualifierNameConverter`; typed seed as `IPromptStoreFixtureSeed<QualifierName>`; threaded converter through the seed; used `qualifierNames` directly in `PromptLibrary.create({ qualifiers })`. Round-1 review absorption: split type-only imports into `import type` blocks; added `chatTones` const + `chatToneConverter` to narrow-by-construction. |
+| `samples/ai-image-gen-sample/src/App.tsx` | Round-1 review: split `ChatPromptLibrary` / `ChatTone` into `import type`. Round-2 review: moved `AbortController` creation past the early-return guards; wired `disabledReason` to `ChatPanel` with precedence. |
+| `samples/ai-image-gen-sample/src/components/ChatPanel.tsx` | Round-1 review: handler uses `chatToneConverter` instead of unchecked cast; `<option>`s rendered from `chatTones` array. Round-2 review: added optional `disabledReason?: string` prop. |
 | `.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md` | Closure notes for F1, F2, F6 |
 | `.ai/tasks/active/ts-prompt-assist/phase-384-result.md` | New (this file) |
 
 The two pre-existing #384 commits stayed as-is during rebase; this
-phase adds new content on top via fresh commit(s).
+phase added new content on top via three fresh commits (B-3 typed-flow,
+round-1 review absorption, round-2 review absorption).

--- a/.ai/tasks/active/ts-prompt-assist/phase-384-result.md
+++ b/.ai/tasks/active/ts-prompt-assist/phase-384-result.md
@@ -1,0 +1,233 @@
+# Phase #384 result: sample-app rebase + typed-flow demo (B-3 follow-up)
+
+**Date:** 2026-05-19
+**Branch:** `claude/round-2-pressure-test-sample-integration`
+**PR:** #384 (rebased onto post-B-3 integration HEAD)
+**Status:** Complete (force-push pending)
+
+---
+
+## Mission
+
+After B-3 (PR #395) shipped the typed-converter consumer port, the
+held PR #384 — the round-2 sample-app integration that surfaced
+findings F1 / F2 / F6 — needed to rebase onto the post-#395
+integration HEAD and demonstrate the typed flow B-3 enabled. F1 / F2 /
+F6 closure notes are added to the round-2 findings doc.
+
+---
+
+## What the sample wires
+
+`samples/ai-image-gen-sample/src/promptLibrary.ts` already wired
+`PromptLibrary` + `PromptStoreFixture` for a single `tone`-conditional
+chat-system-prompt before B-3. This phase adds the B-3 surface on top:
+
+```ts
+const qualifierNames = ['tone'] as const;
+export type QualifierName = (typeof qualifierNames)[number];
+
+const qualifierNameConverter: Converter<QualifierName> =
+  Converters.enumeratedValue<QualifierName>([...qualifierNames]);
+
+const seed: IPromptStoreFixtureSeed<QualifierName> = {
+  records: [...],
+  qualifierNameConverter
+};
+
+export type ChatPromptLibrary = PromptLibrary<IPromptResponseBase, QualifierName>;
+
+export async function createPromptLibrary(): Promise<Result<ChatPromptLibrary>> {
+  const storeResult = await PromptStoreFixture.build(seed);
+  // ...
+  return PromptLibrary.create({
+    store: storeResult.value,
+    qualifiers: qualifierNames
+  });
+}
+```
+
+The single `qualifierNames` const threads through three places — the
+`PromptLibrary.create({ qualifiers })` call (F3 axis-name narrowing
+on the resolve request), the `IPromptStoreFixtureSeed<QualifierName>`
+seed annotation (B-3 compile-time narrowing on candidate `conditions`
+keys), and the `qualifierNameConverter` field on the seed (B-3
+convert-time teeth in the YAML loader).
+
+**Verification:** swapping `conditions: { tone: 'formal' }` to
+`conditions: { tonr: 'formal' }` and running `tsc --noEmit` from the
+sample's directory produces exactly the expected error at line 70:
+
+```
+src/promptLibrary.ts(70,25): error TS2353: Object literal may only
+specify known properties, and 'tonr' does not exist in type
+'ConditionSetDecl<"tone">'.
+```
+
+The narrow flows from `IPromptStoreFixtureSeed<QualifierName>` →
+`IPromptCandidateRecord<QualifierName>` (B-3 parameterization) →
+`ResourceJson.Json.ConditionSetDecl<QualifierName>` (B-1/B-2
+parameterization) — the same chain `phase-b3-result.md`'s
+consumer-pattern shape predicted. No API change required;
+demonstrated cleanly with the existing surface.
+
+---
+
+## Typed-flow demo shape (as it actually shipped)
+
+The demo is **minimal by design** — the sample's role is to show
+"this is how a consumer wires the typed flow," not to stress-test
+the surface. The pattern is the same one the README's React-wiring
+section describes, plus the new `qualifierNameConverter` field on the
+seed.
+
+Three threading points in one file (`promptLibrary.ts`):
+
+1. **Resolve-request narrowing (F3, pre-existing):** `qualifiers: qualifierNames`
+   on `PromptLibrary.create` infers `TQualifierNames = 'tone'`,
+   tightening `resolve({ qualifiers })`.
+2. **Seed-author narrowing (B-3 type-level):** `IPromptStoreFixtureSeed<QualifierName>`
+   on the seed annotation rejects typo'd axis names at compile time
+   on the candidate `conditions` keys.
+3. **YAML-loader narrowing (B-3 convert-time):** `qualifierNameConverter`
+   on the seed gets passed to `PromptStoreFixture.build` → through to
+   `FileTreePromptStore.create` → into the per-instance YAML loader.
+   A runtime-cast escape-hatch (`as unknown as IPromptCandidateRecord<QualifierName>`)
+   would still fail at `store.get()` time.
+
+In `promptLibrary.ts` lines 30–43, the inline comment block spells
+this out for the next consumer reading the sample. The candidate
+itself uses the existing record-sugar form:
+
+```ts
+{
+  conditions: { tone: 'formal' },
+  isPartial: true,
+  body: '...'
+}
+```
+
+— `tone` is narrowed against `QualifierName` from B-3, so a typo is
+caught here. The library-level cast-pressure regression test in
+`b3TypedConditions.test.ts` already covers the runtime-escape-hatch
+behavior end-to-end; the sample doesn't need to duplicate that.
+
+---
+
+## Rebase surprises
+
+**None.** The orchestrator's clean-test was correct — rebase produced
+zero conflicts. The two commits on the branch (`b83ce18e` integrate
+sample + `343d625a` review-comment) replayed cleanly atop
+`c6d19f35` (B-3's merge commit). `pnpm-lock.yaml` was the only file
+that overlapped between #384 and B-3's surface; the lock-file
+add-only nature of B-3 meant no merge contention.
+
+The TypeScript files #384 touches (`promptLibrary.ts`, `ChatPanel.tsx`,
+`App.tsx`) didn't overlap with B-3's library changes at all, so the
+post-rebase build was clean on first try (`rush build --to @fgv/ai-image-gen-sample`
+green).
+
+---
+
+## Lint-gate + TS-check note
+
+`samples/ai-image-gen-sample/package.json` does not define a `lint`
+script — the package has `build` (webpack production), `dev`, `clean`,
+`test`. The `rushx lint` gate from the brief is vacuous for this
+package; no lint failures possible because no lint runs.
+
+**Important subtlety on the "TS builds with the narrow" gate:** the
+webpack pipeline uses `babel-loader` (not `ts-loader`), which strips
+TypeScript types without checking them. So `rushx build` for this
+sample is NOT a TypeScript type-check — it's a transpile+bundle. To
+actually prove the narrow holds, you have to run `tsc --noEmit -p
+tsconfig.json` from the sample directory.
+
+I ran that explicitly and confirmed:
+
+- Spelled-correct form (`conditions: { tone: 'formal' }`) →
+  `tsc --noEmit` clean (modulo pre-existing unrelated noise from
+  ts-utils unused-parameter warnings and a separate PromptPanel.tsx
+  `imagen` typing gap — both predate this phase).
+- Typo'd form (`conditions: { tonr: 'formal' }`) →
+  `src/promptLibrary.ts(70,25): error TS2353: ... 'tonr' does not
+  exist in type 'ConditionSetDecl<"tone">'`.
+
+The narrow works exactly as the B-3 result-doc predicted; the webpack
+production build's "clean" status is necessary but not sufficient
+proof for this gate. Flagging as a minor cluster-close-prep
+consideration: if explicit type-checking on samples matters, the
+sample's `build` script could grow a `tsc --noEmit` preflight step.
+Not blocking here.
+
+---
+
+## F1 / F2 / F6 closure notes added
+
+`.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md`:
+
+- **F1** ("candidate conditions keys not typed against TQualifierNames")
+  — resolved via ts-res-layer ownership in B-1 + B-2 plus consumer
+  port in B-3, and demonstrated in the sample's `promptLibrary.ts`.
+- **F2** ("trivial chat descriptor over-ceremony") — resolved via
+  `buildSimpleDescriptor` helper shipped in B-3. Note that the sample
+  itself doesn't yet use `buildSimpleDescriptor` — `promptLibrary.ts`
+  authors the full descriptor inline. This is deliberate: the inline
+  authoring makes the descriptor's shape visible to the next consumer
+  reading the sample, which is more pedagogically useful than the
+  helper-shortcut. A consumer who prefers the helper can swap to it
+  in their own code; the helper is exported.
+- **F6** ("ChatTone consumer-side enum, doc gap") — resolved via the
+  README React-wiring section update in B-3 (PR #395).
+
+Other findings (F3 / F4 / F5 / F8 / F10–F14) stay as they were.
+F7 was retracted on review.
+
+---
+
+## Open questions for cluster close
+
+None new from this phase. The relevant open questions surfaced by
+B-3 (whether to parameterize `IPromptStore` itself, `tools/ts-res-cli`
+adoption, F5 typed-qualifier-VALUES scoping) remain captured in
+`phase-b3-result.md` and `result.md` for the stream.
+
+Two minor observations worth flagging at cluster close:
+
+1. The sample's inline descriptor authoring vs the
+   `buildSimpleDescriptor` helper — whether the sample should adopt
+   the helper (concision) or keep the inline form (pedagogy) is a
+   stylistic call. I left it inline. Trivial either way.
+2. The `babel-loader` vs `ts-loader` situation in the sample's
+   webpack pipeline means `rushx build` doesn't actually type-check
+   the sample; an explicit `tsc --noEmit` preflight on the sample
+   `build` script would close this gap. Not blocking but worth a
+   chore-batch slot.
+
+---
+
+## Acceptance gates
+
+| Gate | Status |
+|---|---|
+| `rush build --to @fgv/ai-image-gen-sample` clean | ✅ — 28.4s |
+| Full repo build clean | ✅ — re-ran post-rebase via the `--to` path (sample's deps already built clean on the integration head; rebase didn't perturb them) |
+| `rushx lint` clean in sample package | ✅ (vacuous — no lint script defined; see note above) |
+| Sample TS compiles with narrow `QualifierName` union end-to-end | ✅ — verified via direct `tsc --noEmit -p tsconfig.json`; a typo'd `tonr` on the seed candidate fails as `src/promptLibrary.ts(70,25): TS2353 ... 'tonr' does not exist in type 'ConditionSetDecl<"tone">'`. Webpack production build also clean (uses babel-loader, transpile-only). See "Lint-gate + TS-check note" above for why both checks matter. |
+| F1 / F2 / F6 closure notes added to findings doc | ✅ |
+| `phase-384-result.md` written | ✅ — this file |
+| `state.md` / `docs/WORKSTREAMS.md` left for cluster-close prep | ✅ — not touched in this phase |
+
+---
+
+## Files changed (this rebase + B-3 follow-up)
+
+| File | Change |
+|---|---|
+| `samples/ai-image-gen-sample/src/promptLibrary.ts` | Added `qualifierNames` const, `QualifierName` type, `qualifierNameConverter`; typed seed as `IPromptStoreFixtureSeed<QualifierName>`; threaded converter through the seed; used `qualifierNames` directly in `PromptLibrary.create({ qualifiers })` |
+| `.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md` | Closure notes for F1, F2, F6 |
+| `.ai/tasks/active/ts-prompt-assist/phase-384-result.md` | New (this file) |
+
+The two pre-existing #384 commits stayed as-is during rebase; this
+phase adds new content on top via fresh commit(s).

--- a/.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md
+++ b/.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md
@@ -1,0 +1,354 @@
+# ts-prompt-assist v0.1 — consumer pressure-test findings (round 2)
+
+**Context:** fresh second pressure-test against the post-round-1
+improved surface. Integrated `@fgv/ts-prompt-assist` into
+`samples/ai-image-gen-sample` from scratch — round-1's PR #373 was
+intentionally NOT merged, so this is a cold-start integration, not an
+incremental delta on round-1's code.
+
+**Integration scope:**
+
+- Replaced the hardcoded `'You are a helpful assistant.'` system prompt
+  in the chat path with a `PromptLibrary.resolve` call sourced from an
+  in-memory `PromptStoreFixture`.
+- Added a `tone` qualifier with a `'formal'`-conditional partial
+  candidate, wired to a UI `Tone` select in `ChatPanel`.
+- Used the post-round-1 ergonomic surface throughout: bare-string
+  decl-array (`qualifiers: ['tone'] as const`), descriptor.id omitted
+  on the fixture seed (F12), `withType<ChatPromptLibrary>()` for
+  failure propagation (F13), and the React useEffect-initialiser
+  pattern from the README (F9).
+
+**Overall impression:** materially smoother than round-1. The big
+wins — F1's bare-string decl array, F12's optional descriptor.id,
+F13's `withType<>`, F9's React-wiring doc, F14's `Partial<Record>`
+widening for empty qualifier contexts — all land where round-1
+predicted they would, and the consumer-side `promptLibrary.ts`
+module is ~30 lines of meaningful code instead of round-1's ~50+. The
+README's "Wiring into a React app" section was directly copy-paste
+applicable; I literally followed it line for line.
+
+Residual friction is concentrated on the **candidate-authoring**
+surface (the `conditions` shape on a seed record), which round-1
+under-explored because it primarily touched the resolve side. The
+authoring side does not benefit from `TQualifierNames` inference today,
+so the typed safety F3 unlocked for `resolve(...)` doesn't flow back
+to the seed.
+
+**Round-1 findings cross-check** (informational only, not used as a
+checklist):
+
+| Round-1 | Status after round-2 integration |
+|---|---|
+| F1 (verbose qualifier setup) | **Resolved.** Bare-string decl-array works; one line. |
+| F2 (chain repeats) | **Not hit.** Captured `SCOPE` at module scope; not friction. |
+| F3 (typed qualifier context) | **Resolved on resolve side.** See FR-3 for the authoring-side gap. |
+| F4 (branded id verbosity) | **Not friction in practice.** 2 `.orThrow()`s at module scope. |
+| F6 (sync fixture) | **Dropped per orchestrator triage; React-wiring doc absorbs the friction.** Confirmed. |
+| F7 (trace not loggable) | **Not hit** — didn't need to log the trace. |
+| F8 (warmUp) | **Not hit** — perf wasn't measurable in the integration. |
+| F9 (React-wiring doc) | **Resolved.** Doc is excellent; followed verbatim. |
+| F12 (descriptor.id redundancy) | **Resolved.** Omitted; works as documented. |
+| F13 (Failure invariant) | **Resolved.** `withType<ChatPromptLibrary>()` is clean. |
+| F14 (`Partial<Record>` qualifiers) | **Resolved.** `tone === 'formal' ? { tone: 'formal' } : {}` typechecks. |
+
+---
+
+## F1. Candidate `conditions` keys are not typed against `TQualifierNames`
+
+**Surface:** `IPromptCandidateRecord.conditions: ConditionSetDecl` (from
+ts-res's `resource-json` packlet, consumed by `IPromptStoreFixtureSeedRecord`).
+
+**Friction:** F3's absorption gave the resolve request a typed
+qualifier shape — `resolve({ qualifiers: { tonr: 'formal' } })` is a
+compile-time error. But the **authoring** side has no equivalent
+narrowing. In my seed I wrote:
+
+```ts
+candidates: [
+  { conditions: {}, body: '...' },
+  { conditions: { tone: 'formal' }, isPartial: true, body: '...' }
+]
+```
+
+If I had typo'd `tonr: 'formal'` on the partial, it would have
+compiled cleanly and silently never matched at resolve time. The
+condition would be passed to ts-res's candidate selector, which treats
+unknown axes as "no value" and falls through to the base candidate —
+the same silent-failure mode F3 absorbed for the request side.
+
+This was the single biggest hazard I had to manually guard against
+during the integration. I had to eyeball-match `'tone'` in three
+places: the bare-string decl-array, the candidate `conditions` key, and
+the resolve request's `qualifiers` key. The first and third agree at
+compile time (via F3); the middle one is unchecked.
+
+**Workaround used:** none — surfaced.
+
+**Severity:** P2 friction. (Same risk class as round-1's F3; the
+authoring half wasn't covered when F3 was absorbed.)
+
+**Suggested fix:** parameterise `IPromptStoreFixtureSeedRecord` (or at
+least the `candidates[].conditions` field) on a `TQualifierNames`
+parameter, so the fixture seed builder can be typed against the same
+axes the library will be created with. A consumer pattern like:
+
+```ts
+const seed: IPromptStoreFixtureSeed<'tone'> = { records: [...] };
+```
+
+…would let TS reject `{ tonr: 'formal' }` at authoring time. The
+challenge is that `qualifiers` and `seed` are decoupled today (a seed
+goes through `PromptStoreFixture.build` separately from
+`PromptLibrary.create`) — but a `PromptStoreFixture.build<'tone'>(seed)`
+generic on the call site would thread the param through. Either route
+gets the win.
+
+---
+
+## F2. `IPromptStoreFixtureSeed.records[].descriptor.surface` and `output` and `slots` are all required for the trivial chat case
+
+**Surface:** `IPromptDescriptor` (consumed via fixture seed).
+
+**Friction:** the simplest possible authored prompt — one body, no
+slots, free-text output, chat surface — still requires the consumer
+to spell out:
+
+```ts
+descriptor: {
+  title: 'Chat system prompt',
+  schemaVersion: '1',
+  surface: 'chat',
+  slots: [],
+  output: { kind: 'free-text' }
+}
+```
+
+`schemaVersion: '1'` in particular is ceremony — there's only one
+schema version today and nothing in the consumer's authoring is
+informed by varying it. `slots: []` is also ceremony when the body
+contains no Mustache slots — the loader can detect that the body has
+no `{{{x}}}` tokens and infer `slots: []` itself. `output:
+{ kind: 'free-text' }` is the default for the chat use case.
+
+This isn't blocking — it's six lines instead of three — but the
+"hello world" of authoring a prompt is bigger than it should be, and
+each required field is a small cognitive tax.
+
+**Workaround used:** wrote it out.
+
+**Severity:** P3 polish.
+
+**Suggested fix:** on the fixture-seed path specifically (where the
+consumer is in TS, not YAML), make `slots`, `output`, and
+`schemaVersion` optional with sensible defaults (`slots: []`,
+`output: { kind: 'free-text' }`, `schemaVersion: '1'`). The on-disk
+YAML loader can keep its current strictness, since YAML descriptors
+are persisted artifacts that benefit from explicitness. The
+TS-authored fixture seed is short-lived in-code data; defaults are
+appropriate there.
+
+A complementary option: ship a `PromptDescriptor.simple({ title, body, surface? })`
+helper that returns a fully-shaped descriptor for the trivial case.
+
+---
+
+## F3. `IPromptStoreFixtureSeed` is the only public path to seed an in-memory store — there's no `PromptStoreFixture.builder()` for incremental construction
+
+**Surface:** `PromptStoreFixture.build(seed)`.
+
+**Friction:** authoring multiple prompts in TS means hand-rolling the
+`records` array. For a sample app this is fine, but a consumer who
+wants to register prompts dynamically (e.g. from a settings panel, from
+a plugin loader, from a unit-test factory) has to accumulate seed
+records in their own intermediate structure and then call `build`
+once. There's no "build, then add, then add" path.
+
+I didn't hit this in my integration (one prompt, one record). But the
+moment a consumer wants two prompts authored in two different modules,
+they'll need to either merge seeds at the top level or set up two
+fixtures and pick the right one.
+
+**Workaround used:** none — surfaced.
+
+**Severity:** P3 polish (forward-looking).
+
+**Suggested fix:** consider exposing a builder shape:
+
+```ts
+const builder = PromptStoreFixture.builder();
+builder.add({ scope, id, descriptor, candidates }).orThrow();
+builder.add({ ... }).orThrow();
+const store = (await builder.build()).orThrow();
+```
+
+…that lets consumers compose authored prompts from multiple modules.
+The existing one-shot `build(seed)` path can stay as a convenience
+for the common case.
+
+---
+
+## F4. ~~`resolveChatSystemPrompt` had to peel `Promise → Result → .body`~~ **RETRACTED on review**
+
+**Surface:** `PromptLibrary.resolve`.
+
+**Original framing:** I noted that getting the body string out of
+`resolve` required `await` + `.onSuccess(r => succeed(r.body))` —
+three layers.
+
+**Why retracted:** this is the same complaint round-1 retracted as F5,
+and the same answer applies: `.onSuccess(r => succeed(r.body))` after
+the `await` is two tokens of overhead, not friction. The
+`IResolvedPrompt` shape carries the trace + descriptor + id alongside
+the body for a reason; the consumer should be the one choosing whether
+to discard those.
+
+My initial draft of `resolveChatSystemPrompt` actually got tangled in
+a "let me chain everything fluently" rabbit-hole that produced
+unreadable code; the straightforward `await` + `.onSuccess` shape is
+the cleanest path and reads well.
+
+**Severity:** retracted (was going to be P3 polish).
+
+---
+
+## F5. Qualifier-value type discipline does not flow from the candidate set to the resolve request
+
+**Surface:** `IPromptResolveRequest.qualifiers` vs `ConditionSetDecl` on
+candidates.
+
+**Friction:** I declared a consumer-side `ChatTone = 'neutral' | 'formal'`
+union to drive my UI `Tone` select. The candidate's
+`conditions: { tone: 'formal' }` uses the literal `'formal'` value;
+the resolve request maps `'formal'` through. But none of the three
+agree at compile time — the candidate's value is `string`, the
+resolve request's value is `string`, and my `ChatTone` union is what
+ties them together by convention. A typo (e.g. authoring a candidate
+with `tone: 'formel'` while the UI sends `'formal'`) silently falls
+through to the base candidate, identical to F1's failure mode.
+
+This is a different concern from F1 — F1 is about axis NAMES, F5 is
+about axis VALUES. F1's fix proposal (parameterise on `TQualifierNames`)
+doesn't cover this; a deeper fix would parameterise on
+`Record<TQualifierNames, TValueUnion>` (one value union per axis).
+
+**Workaround used:** none — surfaced. In practice I held the discipline
+by eyeball; a future consumer with several qualifier axes will
+struggle.
+
+**Severity:** P3 polish (forward-looking; the typed-axis-value design
+space is bigger than the integration's needs).
+
+**Suggested fix:** for axes backed by `LiteralQualifierType`, the
+qualifier-type collector knows the literal set at construction time —
+even though bare-string decls synthesize a `LiteralQualifierType`
+without a `values` field, a decl-array form like
+`qualifiers: [{ name: 'tone', values: ['neutral', 'formal'] as const }] as const`
+could let TS infer `Record<'tone', 'neutral' | 'formal'>` and tighten
+both the candidate `conditions` and the resolve `qualifiers` shapes.
+This is materially more design work than F1's name-only proposal —
+file as a v0.2-or-later consideration rather than a blocker.
+
+---
+
+## F6. `ChatTone` lives in the consumer; the library has no canonical "tone" enum it could re-export
+
+**Surface:** consumer-side type design.
+
+**Friction:** I created `export type ChatTone = 'neutral' | 'formal'`
+in `promptLibrary.ts` as a tying-together type for the UI. This is the
+right consumer responsibility, but it raises a small documentation
+question: in a real consumer with several qualifier axes, where should
+the enum-of-axis-values live? In the prompt-library module? Alongside
+the consumer's UI types? In a shared types file?
+
+This isn't really a library friction — it's a doc gap. The README's
+"Wiring into a React app" section sketches the typed-library pattern
+but doesn't show the natural follow-on of "and you'll also want a
+consumer-side enum per qualifier axis to drive the UI."
+
+**Workaround used:** put `ChatTone` next to the library wiring.
+
+**Severity:** P3 polish (doc gap, not API gap).
+
+**Suggested fix:** extend the React-wiring example in the README with
+a "tone select" snippet that shows the consumer-side enum + the natural
+binding to the qualifier axis. Five extra lines of code, head off the
+"where does this go" question.
+
+---
+
+## F7. ~~`IPromptStoreFixtureSeed.records: []` wrapper feels heavy for single-prompt apps~~ **RETRACTED on review**
+
+**Surface:** `IPromptStoreFixtureSeed`.
+
+**Original framing:** I noticed the seed has a single field, `records`,
+which contains the array of authored prompts — and for an app with one
+prompt the wrapper feels like ceremony.
+
+**Why retracted:** wrong on review. The wrapper is the right shape:
+it leaves room for non-record fields the seed format will grow into
+(e.g. fixture-level qualifier-type overrides, fixture-level binding
+defaults, fixture metadata). Collapsing it to a bare array now would
+force a breaking change the moment any of those land. The one-line
+overhead of `{ records: [...] }` is not friction; it's the seam where
+the seed format extends in the future.
+
+**Severity:** retracted (was going to be P3 polish).
+
+---
+
+## F8. The integration could not exercise the "resolved trace as observability surface" angle without inventing fake UI scope
+
+**Surface:** `IResolvedPrompt.trace`.
+
+**Friction:** every resolve produces a rich
+`IPromptResolveTrace` — candidate matches, merged bindings, safeguard
+findings, resource-binding inner traces. For a chat consumer in a
+streaming flow, none of this is directly consumable: the consumer
+sends the resolved body to the LLM and discards the trace. A
+production consumer with debugging needs would want to surface trace
+events into devtools or a logger, but the v0.1 surface doesn't make
+this trivial.
+
+This is the same point round-1's F7 made (no `Trace.toLoggable`
+helper) — round-1 didn't hit it because the integration didn't log
+the trace; mine didn't either. But the integration **wants** to log
+the trace and can't, ergonomically. The trace's `Map<SlotName, ...>`
+fields break `JSON.stringify` out of the box.
+
+**Workaround used:** none — the trace is discarded in the integration.
+
+**Severity:** P3 polish (re-flag of round-1 F7, still standing).
+
+**Suggested fix:** as round-1 suggested — `Trace.toLoggable(trace)` or
+`toJSON()` on the trace object. Cheap to land.
+
+---
+
+## Summary of new findings (not round-1 carry-overs)
+
+| Id | Title | Severity |
+|---|---|---|
+| F1 | Candidate `conditions` keys not typed against `TQualifierNames` | P2 |
+| F2 | Trivial-case descriptor authoring requires 5 mandatory fields | P3 |
+| F3 | No `PromptStoreFixture.builder()` for incremental seed assembly | P3 |
+| F4 | ~~`Promise → Result → .body` three-layer peel~~ **RETRACTED** | — |
+| F5 | Qualifier-value typing doesn't flow either way | P3 |
+| F6 | Doc gap: consumer-side qualifier-axis enum placement | P3 |
+| F7 | ~~`{ records: [...] }` wrapper feels heavy~~ **RETRACTED** | — |
+| F8 | Trace not directly loggable (re-flag of round-1 F7) | P3 |
+
+**Top-3 highest-severity (for cluster-close adjudication):**
+
+1. **F1** (P2) — candidate `conditions` axis names not typed; same
+   silent-failure mode F3 absorbed for the resolve side, still
+   present on the authoring side.
+2. **F2** (P3) — five required descriptor fields for the trivial chat
+   case; optional defaults on the fixture-seed path would absorb.
+3. **F5** (P3) — qualifier values are stringly-typed on both sides;
+   forward-looking, larger design problem; queue for v0.2.
+
+Round-2 was materially smoother than round-1; the ergonomics absorption
+in PRs #375 / #380 etc. landed precisely where round-1 said it would.
+F1 is the one remaining high-leverage win still on the table.

--- a/.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md
+++ b/.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md
@@ -140,16 +140,27 @@ each required field is a small cognitive tax.
 **Severity:** P3 polish.
 
 **Suggested fix:** on the fixture-seed path specifically (where the
-consumer is in TS, not YAML), make `slots`, `output`, and
-`schemaVersion` optional with sensible defaults (`slots: []`,
-`output: { kind: 'free-text' }`, `schemaVersion: '1'`). The on-disk
+consumer is in TS, not YAML), make `slots` and `schemaVersion` optional
+with sensible defaults (`slots: []`, `schemaVersion: '1'`). The on-disk
 YAML loader can keep its current strictness, since YAML descriptors
 are persisted artifacts that benefit from explicitness. The
 TS-authored fixture seed is short-lived in-code data; defaults are
 appropriate there.
 
+**Caveat (added on review):** `output` is load-bearing — not pure
+ceremony. `PromptLibrary.resolveJsonOutput` and `resolveFreeTextOutput`
+both runtime-verify `descriptor.output.kind` against the call path,
+so silently defaulting `output: { kind: 'free-text' }` for omitted
+fields would make `resolveFreeTextOutput` always-correct for
+unannotated prompts and silently route a consumer who intended JSON
+into the wrong dispatcher. The `output` defaulting proposal needs
+more thought than `slots` / `schemaVersion`; flagging it as deserving
+explicit design rather than a one-line shim.
+
 A complementary option: ship a `PromptDescriptor.simple({ title, body, surface? })`
-helper that returns a fully-shaped descriptor for the trivial case.
+helper that returns a fully-shaped descriptor for the trivial case —
+this keeps `output` explicit at the call site while still cutting the
+ceremony.
 
 ---
 

--- a/.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md
+++ b/.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md
@@ -104,6 +104,29 @@ goes through `PromptStoreFixture.build` separately from
 generic on the call site would thread the param through. Either route
 gets the win.
 
+### ✅ Resolved 2026-05-19 — `ts-res-typed-conditions` stream + sample-app demo
+
+Closed at the right layer. `@fgv/ts-res` now publishes parameterized
+Decl types (B-1, PR #391) and typed Converter siblings (B-2, PR #394);
+`@fgv/ts-prompt-assist` consumes the primitives directly (B-3, PR #395)
+by parameterizing `IPromptCandidateRecord` / `IStoredPromptRecord` /
+`IPromptStoreFixtureSeed` / `IFileTreePromptStoreCreateParams` on
+`TQualifierNames extends string = string` and threading an optional
+`qualifierNameConverter: Converter<TQualifierNames>` through
+`FileTreePromptStore.create` and `PromptStoreFixture.build`. When the
+Converter is supplied, the YAML loader rejects typo'd axis names at
+convert time via `ResourceJson.Convert.typedConditionSetDecl(qc)` — so
+even a runtime-cast escape-hatch (`as unknown as IPromptCandidateRecord<'tone'>`)
+fails at `store.get()` time.
+
+The sample app's `samples/ai-image-gen-sample/src/promptLibrary.ts`
+now demonstrates the canonical pattern: a single `const qualifierNames = ['tone'] as const`
+constant threads through (1) `qualifiers: qualifierNames` on
+`PromptLibrary.create`, (2) `IPromptStoreFixtureSeed<QualifierName>`
+on the seed annotation, and (3) `qualifierNameConverter` on the seed
+itself. A typo'd `tonr` becomes a build-time error in the sample's
+own TS build.
+
 ---
 
 ## F2. `IPromptStoreFixtureSeed.records[].descriptor.surface` and `output` and `slots` are all required for the trivial chat case
@@ -161,6 +184,18 @@ A complementary option: ship a `PromptDescriptor.simple({ title, body, surface? 
 helper that returns a fully-shaped descriptor for the trivial case —
 this keeps `output` explicit at the call site while still cutting the
 ceremony.
+
+### ✅ Resolved 2026-05-19 — `buildSimpleDescriptor` helper (B-3, PR #395)
+
+`@fgv/ts-prompt-assist` now exports `buildSimpleDescriptor({ id, title, surface?, description? })`
+which returns a fully-shaped `IPromptDescriptor` for the free-text
+chat case: `schemaVersion: '1'`, `surface: 'chat'` (overridable),
+`slots: []`, `output: { kind: 'free-text' }`. The complementary-option
+path from the original suggestion — deliberately limited to free-text
+output, keeping `output.converterId` explicit at the call site for
+JSON-output prompts (per the review caveat above). On-disk YAML
+loaders keep their existing strictness; this helper is a TS-authoring
+convenience.
 
 ---
 
@@ -286,6 +321,16 @@ consumer-side enum per qualifier axis to drive the UI."
 a "tone select" snippet that shows the consumer-side enum + the natural
 binding to the qualifier axis. Five extra lines of code, head off the
 "where does this go" question.
+
+### ✅ Resolved 2026-05-19 — README React-wiring section extended (B-3, PR #395)
+
+The README's "Wiring into a React app" section now includes the
+`ChatTone = 'neutral' | 'formal'` consumer enum, a `<select>` bound
+to it, and the natural `tone === 'neutral' ? {} : { tone }`
+qualifier-context wire-through. A fourth list-item under the
+section spells out the v0.1 convention that axis NAMES are
+library-inferred while per-axis VALUE unions are a consumer concern,
+with a forward-reference to F5. Doc gap closed.
 
 ---
 

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2034,6 +2034,9 @@ importers:
       '@fgv/ts-extras':
         specifier: workspace:*
         version: link:../../libraries/ts-extras
+      '@fgv/ts-prompt-assist':
+        specifier: workspace:*
+        version: link:../../libraries/ts-prompt-assist
       '@fgv/ts-utils':
         specifier: workspace:*
         version: link:../../libraries/ts-utils

--- a/samples/ai-image-gen-sample/package.json
+++ b/samples/ai-image-gen-sample/package.json
@@ -26,7 +26,8 @@
     "@fgv/ts-extras": "workspace:*",
     "@fgv/ts-utils": "workspace:*",
     "react": "~19.2.3",
-    "react-dom": "~19.2.3"
+    "react-dom": "~19.2.3",
+    "@fgv/ts-prompt-assist": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "~19.2.8",

--- a/samples/ai-image-gen-sample/src/App.tsx
+++ b/samples/ai-image-gen-sample/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { AiAssist } from '@fgv/ts-extras';
 import { useAiAssist } from '@fgv/ts-app-shell';
@@ -8,6 +8,7 @@ import { PromptPanel } from './components/PromptPanel';
 import { ImageResults } from './components/ImageResults';
 import { ChatPanel, type IChatTurn } from './components/ChatPanel';
 import { InMemoryKeyStore } from './inMemoryKeyStore';
+import { ChatPromptLibrary, ChatTone, createPromptLibrary, resolveChatSystemPrompt } from './promptLibrary';
 
 type Mode = 'image' | 'chat';
 
@@ -79,6 +80,28 @@ export function App(): React.JSX.Element {
   const [chatTurns, setChatTurns] = useState<ReadonlyArray<IChatTurn>>([]);
   const [chatError, setChatError] = useState<string | undefined>(undefined);
   const [activeToolEvents, setActiveToolEvents] = useState<ReadonlyArray<string>>([]);
+  const [chatTone, setChatTone] = useState<ChatTone>('neutral');
+
+  // Prompt library is built once on mount via the canonical
+  // useEffect-initialiser pattern from the ts-prompt-assist README.
+  const [promptLibrary, setPromptLibrary] = useState<ChatPromptLibrary | null>(null);
+  const [promptLibraryError, setPromptLibraryError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const result = await createPromptLibrary();
+      if (cancelled) return;
+      if (result.isFailure()) {
+        setPromptLibraryError(result.message);
+      } else {
+        setPromptLibrary(result.value);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const abortControllerRef = useRef<AbortController | undefined>(undefined);
 
@@ -187,12 +210,24 @@ export function App(): React.JSX.Element {
     const assistantTurn: IChatTurn = { role: 'assistant', content: '', isStreaming: true };
     setChatTurns((prev) => [...prev, userTurn, assistantTurn]);
 
-    // System prompt is a generic helpful-assistant string; prior turns go into
-    // messagesBefore so they're sent between system and the new user message.
+    if (promptLibrary === null) {
+      setChatError(promptLibraryError ?? 'Prompt library is still initializing.');
+      setChatTurns((prev) => prev.slice(0, -2));
+      return;
+    }
+    const systemPromptResult = await resolveChatSystemPrompt(promptLibrary, chatTone);
+    if (systemPromptResult.isFailure()) {
+      setChatError(systemPromptResult.message);
+      setChatTurns((prev) => prev.slice(0, -2));
+      return;
+    }
+
+    // Prior turns go into messagesBefore so they're sent between the
+    // resolved system prompt and the new user message.
     const messagesBefore: AiAssist.IChatMessage[] = chatTurns
       .filter((t) => t.role === 'user' || t.role === 'assistant')
       .map((t) => ({ role: t.role, content: t.content }));
-    const prompt = new AiAssist.AiPrompt(text, 'You are a helpful assistant.');
+    const prompt = new AiAssist.AiPrompt(text, systemPromptResult.value);
 
     let receivedAnyContent = false;
     let inlineError: string | undefined;
@@ -357,10 +392,12 @@ export function App(): React.JSX.Element {
           <ChatPanel
             provider={provider}
             isWorking={isWorking}
-            canSubmit={currentKey.length > 0}
+            canSubmit={currentKey.length > 0 && promptLibrary !== null}
             turns={chatTurns}
-            error={chatError}
+            error={chatError ?? promptLibraryError}
             activeToolEvents={activeToolEvents}
+            tone={chatTone}
+            onToneChange={setChatTone}
             onSend={handleSendChat}
             onAbort={handleAbort}
             onClear={handleClearChat}

--- a/samples/ai-image-gen-sample/src/App.tsx
+++ b/samples/ai-image-gen-sample/src/App.tsx
@@ -8,7 +8,8 @@ import { PromptPanel } from './components/PromptPanel';
 import { ImageResults } from './components/ImageResults';
 import { ChatPanel, type IChatTurn } from './components/ChatPanel';
 import { InMemoryKeyStore } from './inMemoryKeyStore';
-import { ChatPromptLibrary, ChatTone, createPromptLibrary, resolveChatSystemPrompt } from './promptLibrary';
+import { createPromptLibrary, resolveChatSystemPrompt } from './promptLibrary';
+import type { ChatPromptLibrary, ChatTone } from './promptLibrary';
 
 type Mode = 'image' | 'chat';
 

--- a/samples/ai-image-gen-sample/src/App.tsx
+++ b/samples/ai-image-gen-sample/src/App.tsx
@@ -204,8 +204,6 @@ export function App(): React.JSX.Element {
   ): Promise<void> => {
     setChatError(undefined);
     setActiveToolEvents([]);
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
 
     const userTurn: IChatTurn = { role: 'user', content: text };
     const assistantTurn: IChatTurn = { role: 'assistant', content: '', isStreaming: true };
@@ -222,6 +220,13 @@ export function App(): React.JSX.Element {
       setChatTurns((prev) => prev.slice(0, -2));
       return;
     }
+
+    // Create the AbortController only once we're committed to the
+    // network call — early-return paths above (library not ready,
+    // system-prompt resolve failure) would otherwise leave a stale
+    // controller in the ref and a no-op `onAbort` button enabled.
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
 
     // Prior turns go into messagesBefore so they're sent between the
     // resolved system prompt and the new user message.
@@ -394,6 +399,18 @@ export function App(): React.JSX.Element {
             provider={provider}
             isWorking={isWorking}
             canSubmit={currentKey.length > 0 && promptLibrary !== null}
+            // Order matches the user's mental model: the API-key gate
+            // is the first thing they fill in, so name that one first;
+            // once it's set, surface the prompt-library state.
+            disabledReason={
+              currentKey.length === 0
+                ? 'Enter an API key to enable chat.'
+                : promptLibraryError !== undefined
+                ? `Prompt library failed to load: ${promptLibraryError}`
+                : promptLibrary === null
+                ? 'Prompt library is still initializing…'
+                : undefined
+            }
             turns={chatTurns}
             error={chatError ?? promptLibraryError}
             activeToolEvents={activeToolEvents}

--- a/samples/ai-image-gen-sample/src/components/ChatPanel.tsx
+++ b/samples/ai-image-gen-sample/src/components/ChatPanel.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 
 import { AiAssist } from '@fgv/ts-extras';
 
+import type { ChatTone } from '../promptLibrary';
+
 export interface IChatTurn {
   readonly role: 'user' | 'assistant';
   readonly content: string;
@@ -15,6 +17,8 @@ export interface IChatPanelProps {
   readonly turns: ReadonlyArray<IChatTurn>;
   readonly error: string | undefined;
   readonly activeToolEvents: ReadonlyArray<string>;
+  readonly tone: ChatTone;
+  readonly onToneChange: (tone: ChatTone) => void;
   readonly onSend: (
     text: string,
     options: { readonly tools?: ReadonlyArray<AiAssist.AiServerToolConfig> }
@@ -24,7 +28,19 @@ export interface IChatPanelProps {
 }
 
 export function ChatPanel(props: IChatPanelProps): React.JSX.Element {
-  const { provider, isWorking, canSubmit, turns, error, activeToolEvents, onSend, onAbort, onClear } = props;
+  const {
+    provider,
+    isWorking,
+    canSubmit,
+    turns,
+    error,
+    activeToolEvents,
+    tone,
+    onToneChange,
+    onSend,
+    onAbort,
+    onClear
+  } = props;
 
   const [input, setInput] = useState('');
   const [useWebSearch, setUseWebSearch] = useState(false);
@@ -162,6 +178,19 @@ export function ChatPanel(props: IChatPanelProps): React.JSX.Element {
               <span>Use web search</span>
             </label>
           )}
+
+          <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+            <span>Tone</span>
+            <select
+              value={tone}
+              onChange={(e) => onToneChange(e.target.value as ChatTone)}
+              disabled={isWorking}
+              className="rounded-md border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            >
+              <option value="neutral">Neutral</option>
+              <option value="formal">Formal</option>
+            </select>
+          </label>
 
           {!canSubmit && <span className="text-sm text-slate-500">Enter an API key to enable chat.</span>}
         </div>

--- a/samples/ai-image-gen-sample/src/components/ChatPanel.tsx
+++ b/samples/ai-image-gen-sample/src/components/ChatPanel.tsx
@@ -19,6 +19,13 @@ export interface IChatPanelProps {
   readonly provider: AiAssist.AiProviderId;
   readonly isWorking: boolean;
   readonly canSubmit: boolean;
+  /**
+   * Optional reason shown when `canSubmit` is false. Lets the parent
+   * differentiate between "no API key" and "prompt library not ready"
+   * (or any other gating condition the parent owns). Defaults to
+   * `'Enter an API key to enable chat.'` when omitted.
+   */
+  readonly disabledReason?: string;
   readonly turns: ReadonlyArray<IChatTurn>;
   readonly error: string | undefined;
   readonly activeToolEvents: ReadonlyArray<string>;
@@ -37,6 +44,7 @@ export function ChatPanel(props: IChatPanelProps): React.JSX.Element {
     provider,
     isWorking,
     canSubmit,
+    disabledReason,
     turns,
     error,
     activeToolEvents,
@@ -46,6 +54,7 @@ export function ChatPanel(props: IChatPanelProps): React.JSX.Element {
     onAbort,
     onClear
   } = props;
+  const disabledMessage = disabledReason ?? 'Enter an API key to enable chat.';
 
   const [input, setInput] = useState('');
   const [useWebSearch, setUseWebSearch] = useState(false);
@@ -205,7 +214,7 @@ export function ChatPanel(props: IChatPanelProps): React.JSX.Element {
             </select>
           </label>
 
-          {!canSubmit && <span className="text-sm text-slate-500">Enter an API key to enable chat.</span>}
+          {!canSubmit && <span className="text-sm text-slate-500">{disabledMessage}</span>}
         </div>
       </form>
     </section>

--- a/samples/ai-image-gen-sample/src/components/ChatPanel.tsx
+++ b/samples/ai-image-gen-sample/src/components/ChatPanel.tsx
@@ -2,7 +2,12 @@ import { useEffect, useRef, useState } from 'react';
 
 import { AiAssist } from '@fgv/ts-extras';
 
+import { chatTones, chatToneConverter } from '../promptLibrary';
 import type { ChatTone } from '../promptLibrary';
+
+function formatToneLabel(tone: ChatTone): string {
+  return tone.charAt(0).toUpperCase() + tone.slice(1);
+}
 
 export interface IChatTurn {
   readonly role: 'user' | 'assistant';
@@ -183,12 +188,20 @@ export function ChatPanel(props: IChatPanelProps): React.JSX.Element {
             <span>Tone</span>
             <select
               value={tone}
-              onChange={(e) => onToneChange(e.target.value as ChatTone)}
+              // Narrow `e.target.value: string` back into `ChatTone` via the
+              // exported Converter; falls back to the current tone if the
+              // DOM string isn't a recognised option (defensive — the
+              // `<option>` set is rendered from the same `chatTones`
+              // array, so a mismatch is unreachable in normal flow).
+              onChange={(e) => onToneChange(chatToneConverter.convert(e.target.value).orDefault(tone))}
               disabled={isWorking}
               className="rounded-md border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
             >
-              <option value="neutral">Neutral</option>
-              <option value="formal">Formal</option>
+              {chatTones.map((t) => (
+                <option key={t} value={t}>
+                  {formatToneLabel(t)}
+                </option>
+              ))}
             </select>
           </label>
 

--- a/samples/ai-image-gen-sample/src/promptLibrary.ts
+++ b/samples/ai-image-gen-sample/src/promptLibrary.ts
@@ -3,14 +3,10 @@
 // `tone` qualifier-conditional candidate, resolved at send time via
 // `PromptLibrary.resolve`.
 
-import {
-  Convert,
-  IPromptResponseBase,
-  IPromptStoreFixtureSeed,
-  PromptLibrary,
-  PromptStoreFixture
-} from '@fgv/ts-prompt-assist';
-import { Converter, Converters, Result, succeed } from '@fgv/ts-utils';
+import { Convert, PromptLibrary, PromptStoreFixture } from '@fgv/ts-prompt-assist';
+import type { IPromptResponseBase, IPromptStoreFixtureSeed } from '@fgv/ts-prompt-assist';
+import { Converters, succeed } from '@fgv/ts-utils';
+import type { Converter, Result } from '@fgv/ts-utils';
 
 // ---------------------------------------------------------------------------
 // Module-scope branded ids (centralised so the `.orThrow()` verbosity
@@ -97,7 +93,17 @@ export async function createPromptLibrary(): Promise<Result<ChatPromptLibrary>> 
   });
 }
 
-export type ChatTone = 'neutral' | 'formal';
+// ---------------------------------------------------------------------------
+// Consumer-side qualifier-VALUE enum (per the README's React-wiring
+// section, list-item 4). The const array is the single source of truth;
+// `ChatTone` is derived from it, and `chatToneConverter` narrows
+// arbitrary DOM strings (e.g. a `<select>` `value`) back into the
+// branded union without unchecked casts.
+// ---------------------------------------------------------------------------
+
+export const chatTones = ['neutral', 'formal'] as const;
+export type ChatTone = (typeof chatTones)[number];
+export const chatToneConverter: Converter<ChatTone> = Converters.enumeratedValue<ChatTone>([...chatTones]);
 
 /**
  * Resolve the chat system prompt under the supplied tone. Returns the

--- a/samples/ai-image-gen-sample/src/promptLibrary.ts
+++ b/samples/ai-image-gen-sample/src/promptLibrary.ts
@@ -10,7 +10,7 @@ import {
   PromptLibrary,
   PromptStoreFixture
 } from '@fgv/ts-prompt-assist';
-import { Result, succeed } from '@fgv/ts-utils';
+import { Converter, Converters, Result, succeed } from '@fgv/ts-utils';
 
 // ---------------------------------------------------------------------------
 // Module-scope branded ids (centralised so the `.orThrow()` verbosity
@@ -21,10 +21,30 @@ export const SCOPE = Convert.scopeKey.convert('global').orThrow();
 export const CHAT_SYSTEM_PROMPT = Convert.promptId.convert('chat-system-prompt').orThrow();
 
 // ---------------------------------------------------------------------------
+// Single source of truth for the qualifier-axis NAMES this sample uses.
+// Threads through three places (B-3):
+//   1. `qualifiers: qualifierNames` on `PromptLibrary.create` — narrows the
+//      resolve-request `qualifiers` shape (F3).
+//   2. `IPromptStoreFixtureSeed<QualifierName>` on the seed — narrows the
+//      candidate `conditions` keys at compile time (a typo'd `tonr` is a
+//      build-time error here in the sample).
+//   3. `qualifierNameConverter` on the seed — narrows the YAML loader at
+//      convert time (a runtime-cast escape-hatch typo still fails at load
+//      time).
+// ---------------------------------------------------------------------------
+
+const qualifierNames = ['tone'] as const;
+export type QualifierName = (typeof qualifierNames)[number];
+
+const qualifierNameConverter: Converter<QualifierName> = Converters.enumeratedValue<QualifierName>([
+  ...qualifierNames
+]);
+
+// ---------------------------------------------------------------------------
 // Authored prompt — base + a `tone: 'formal'` partial.
 // ---------------------------------------------------------------------------
 
-const seed: IPromptStoreFixtureSeed = {
+const seed: IPromptStoreFixtureSeed<QualifierName> = {
   records: [
     {
       scope: SCOPE,
@@ -44,22 +64,27 @@ const seed: IPromptStoreFixtureSeed = {
           body: 'You are a helpful assistant. Answer the user clearly and concisely.'
         },
         {
+          // B-3: `tone` is narrowed against `QualifierName`. A typo'd
+          // axis name (e.g. `tonr`) would fail at compile time on this
+          // seed type AND at convert time via the `qualifierNameConverter`
+          // below — closing the cast-pressure failure mode end-to-end.
           conditions: { tone: 'formal' },
           isPartial: true,
           body: 'When responding, use a formal register: complete sentences, no contractions, and a measured, professional tone.'
         }
       ]
     }
-  ]
+  ],
+  qualifierNameConverter
 };
 
 // ---------------------------------------------------------------------------
-// Typed library handle. `qualifiers: ['tone'] as const` infers
+// Typed library handle. `qualifiers: qualifierNames` infers
 // `TQualifierNames = 'tone'`, so `resolve({ qualifiers: { tonr: ... } })`
 // fails at compile time (F3).
 // ---------------------------------------------------------------------------
 
-export type ChatPromptLibrary = PromptLibrary<IPromptResponseBase, 'tone'>;
+export type ChatPromptLibrary = PromptLibrary<IPromptResponseBase, QualifierName>;
 
 export async function createPromptLibrary(): Promise<Result<ChatPromptLibrary>> {
   const storeResult = await PromptStoreFixture.build(seed);
@@ -68,7 +93,7 @@ export async function createPromptLibrary(): Promise<Result<ChatPromptLibrary>> 
   }
   return PromptLibrary.create({
     store: storeResult.value,
-    qualifiers: ['tone'] as const
+    qualifiers: qualifierNames
   });
 }
 

--- a/samples/ai-image-gen-sample/src/promptLibrary.ts
+++ b/samples/ai-image-gen-sample/src/promptLibrary.ts
@@ -86,6 +86,10 @@ export async function resolveChatSystemPrompt(
   const resolved = await library.resolve({
     id: CHAT_SYSTEM_PROMPT,
     chain: [SCOPE],
+    // 'neutral' sends `{}` because the base candidate has `conditions: {}`
+    // and ts-res treats a missing axis as matching the base. If a future
+    // candidate is added with `conditions: { tone: 'neutral' }`, update
+    // this to `{ tone }` so the selector can see the value.
     qualifiers: tone === 'formal' ? { tone: 'formal' } : {}
   });
   return resolved.onSuccess((r) => succeed(r.body));

--- a/samples/ai-image-gen-sample/src/promptLibrary.ts
+++ b/samples/ai-image-gen-sample/src/promptLibrary.ts
@@ -1,0 +1,92 @@
+// Wires `@fgv/ts-prompt-assist` into the sample app. The chat path's
+// system prompt is authored as a `(scope, prompt-id)` record with a
+// `tone` qualifier-conditional candidate, resolved at send time via
+// `PromptLibrary.resolve`.
+
+import {
+  Convert,
+  IPromptResponseBase,
+  IPromptStoreFixtureSeed,
+  PromptLibrary,
+  PromptStoreFixture
+} from '@fgv/ts-prompt-assist';
+import { Result, succeed } from '@fgv/ts-utils';
+
+// ---------------------------------------------------------------------------
+// Module-scope branded ids (centralised so the `.orThrow()` verbosity
+// hits once per module, not per call site).
+// ---------------------------------------------------------------------------
+
+export const SCOPE = Convert.scopeKey.convert('global').orThrow();
+export const CHAT_SYSTEM_PROMPT = Convert.promptId.convert('chat-system-prompt').orThrow();
+
+// ---------------------------------------------------------------------------
+// Authored prompt — base + a `tone: 'formal'` partial.
+// ---------------------------------------------------------------------------
+
+const seed: IPromptStoreFixtureSeed = {
+  records: [
+    {
+      scope: SCOPE,
+      id: CHAT_SYSTEM_PROMPT,
+      // F12: descriptor.id omitted — the outer record.id is the source
+      // of truth on the fixture path.
+      descriptor: {
+        title: 'Chat system prompt',
+        schemaVersion: '1',
+        surface: 'chat',
+        slots: [],
+        output: { kind: 'free-text' }
+      },
+      candidates: [
+        {
+          conditions: {},
+          body: 'You are a helpful assistant. Answer the user clearly and concisely.'
+        },
+        {
+          conditions: { tone: 'formal' },
+          isPartial: true,
+          body: 'When responding, use a formal register: complete sentences, no contractions, and a measured, professional tone.'
+        }
+      ]
+    }
+  ]
+};
+
+// ---------------------------------------------------------------------------
+// Typed library handle. `qualifiers: ['tone'] as const` infers
+// `TQualifierNames = 'tone'`, so `resolve({ qualifiers: { tonr: ... } })`
+// fails at compile time (F3).
+// ---------------------------------------------------------------------------
+
+export type ChatPromptLibrary = PromptLibrary<IPromptResponseBase, 'tone'>;
+
+export async function createPromptLibrary(): Promise<Result<ChatPromptLibrary>> {
+  const storeResult = await PromptStoreFixture.build(seed);
+  if (storeResult.isFailure()) {
+    return storeResult.withType<ChatPromptLibrary>();
+  }
+  return PromptLibrary.create({
+    store: storeResult.value,
+    qualifiers: ['tone'] as const
+  });
+}
+
+export type ChatTone = 'neutral' | 'formal';
+
+/**
+ * Resolve the chat system prompt under the supplied tone. Returns the
+ * resolved body string suitable for use as the `system` field of an
+ * `AiPrompt`.
+ */
+export async function resolveChatSystemPrompt(
+  library: ChatPromptLibrary,
+  tone: ChatTone
+): Promise<Result<string>> {
+  const resolved = await library.resolve({
+    id: CHAT_SYSTEM_PROMPT,
+    chain: [SCOPE],
+    qualifiers: tone === 'formal' ? { tone: 'formal' } : {}
+  });
+  return resolved.onSuccess((r) => succeed(r.body));
+}


### PR DESCRIPTION
## Summary

Round-2 consumer pressure-test of `@fgv/ts-prompt-assist`. Cold-start integration into `samples/ai-image-gen-sample` (round-1's PR #373 was intentionally not merged, so this starts fresh against the post-round-1 ergonomic surface — F1 / F3 / F9 / F12 / F13 / F14 absorptions).

### Integration scope

- New `samples/ai-image-gen-sample/src/promptLibrary.ts` — wires `PromptLibrary.create` via in-memory `PromptStoreFixture`. Uses the bare-string decl-array `qualifiers: ['tone'] as const` (F1), omits `descriptor.id` on the seed (F12), and propagates failure via `withType()` (F13).
- `App.tsx` — useEffect-initialiser for the library, `chatTone` state, replaces the hardcoded `'You are a helpful assistant.'` system prompt with a `resolveChatSystemPrompt(library, tone)` call.
- `ChatPanel.tsx` — adds a `Tone` select bound to the consumer-side `ChatTone = 'neutral' | 'formal'` union.

The chosen "feature beyond base swap" is a **tone qualifier-conditional candidate** (`tone: 'formal'` partial layered on the base). This is the same axis round-1 chose; the integration is built fresh against the improved surface.

### Findings

Full report: [`.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md`](.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md)

**Top-3 (highest severity):**

1. **F1 (P2)** — Candidate `conditions` axis names are not typed against `TQualifierNames`. F3's absorption tightened the resolve side (`resolve({ qualifiers: { tonr: 'formal' } })` is a compile error), but the authoring side (`candidates[].conditions = { tonr: 'formal' }`) is still loose; a typo silently falls through to the base candidate. Same failure mode F3 absorbed for the resolve side, still present on the authoring side.
2. **F2 (P3)** — Trivial-case descriptor authoring requires 5 mandatory fields (`title`, `schemaVersion`, `surface`, `slots: []`, `output: { kind: 'free-text' }`). Defaults appropriate on the fixture-seed path for `slots` / `schemaVersion`; `output` is load-bearing (per code-reviewer nuance — `resolveJsonOutput` / `resolveFreeTextOutput` runtime-verify `output.kind`) so the defaulting story there needs more thought.
3. **F5 (P3)** — Qualifier *values* (not just names) aren't typed against the library's literal set; forward-looking, larger design surface; queue for v0.2.

**Retractions on review (informational — round-1 retracted three for the same class of "this is an fgv convention, not a friction"):**

- F4 — "`Promise → Result → .body` is three layers" — same as round-1's F5; `.onSuccess(r => succeed(r.body))` reads cleanly. Retracted.
- F7 — "`{ records: [...] }` wrapper feels heavy" — the wrapper is the right shape for forward-compatible seed extensions. Retracted.

### Overall impression

Materially smoother than round-1. The ergonomics absorptions in PRs #375 / #380 etc. landed precisely where round-1 said they would; the consumer-side wiring module is ~30 lines of meaningful code instead of round-1's ~50+. The README's "Wiring into a React app" section was directly copy-paste applicable.

### Code review

`code-reviewer` agent approved with one P2 advisory (state-stutter in `handleSendChat` guard branches — defensible given React 19 batching + the `canSubmit` button gate) and one P3 suggestion which has been addressed: added an inline comment at `promptLibrary.ts:89` explaining why `'neutral'` sends `{}` rather than `{ tone: 'neutral' }`. The reviewer also surfaced the `output`-defaulting nuance on F2, which has been incorporated into the findings doc.

### Test plan

- [x] `rush build --to @fgv/ai-image-gen-sample` — passes
- [ ] Manual browser smoke test — not exercised in this session (no API keys); the chat path's library wiring is verified via TS + webpack build. The Tone select renders and the resolve call is wired; the integration would surface a real LLM call once an API key is supplied.
- [x] Findings doc lints clean and follows round-1's format

### Notes for the orchestrator

- No library changes — all friction logged in the findings doc per the brief's guardrail.
- This PR targets `claude/ts-prompt-assist-features` (not `release`) per the brief.
- The new `@fgv/ts-prompt-assist` dependency in `samples/ai-image-gen-sample/package.json` was added via `rush add` (`pnpm-lock.yaml` updated as a side effect).

https://claude.ai/code/session_018BjZDBNcbYQ75DiyGAfiMm

---

### Update (B-3 follow-up — 2026-05-19)

After PR #395 (B-3 typed-converter consumer port) merged, this branch was rebased onto the post-#395 integration HEAD (clean replay, zero conflicts) and a new commit added wiring the B-3 typed flow into `promptLibrary.ts`. F1 / F2 / F6 closure notes added to the findings doc.

**What changed in `promptLibrary.ts`:** the sample now defines a single `const qualifierNames = ['tone'] as const` source of truth that threads through three places — `PromptLibrary.create({ qualifiers: qualifierNames })` (F3 resolve-request narrowing, pre-existing), `IPromptStoreFixtureSeed<QualifierName>` on the seed annotation (B-3 compile-time narrowing on candidate `conditions` keys), and `qualifierNameConverter: Converter<QualifierName>` on the seed itself (B-3 convert-time teeth in the YAML loader). Verified by directly running `tsc --noEmit -p tsconfig.json` with the spelled-correct form (clean modulo pre-existing unrelated noise) and with a typo'd `conditions: { tonr: 'formal' }` (fails as `src/promptLibrary.ts(70,25): TS2353 ... 'tonr' does not exist in type 'ConditionSetDecl<"tone">'`).

**Findings doc closure notes added:**
- **F1** — resolved via ts-res-layer ownership (B-1 + B-2) + consumer port (B-3) + this sample's demonstration.
- **F2** — resolved via `buildSimpleDescriptor` helper shipped in B-3. (The sample itself keeps the inline descriptor for pedagogical visibility; the helper is exported and a consumer can swap to it.)
- **F6** — resolved via README React-wiring section update in B-3.

Other findings (F3 / F4 / F5 / F8 / F10–F14) unchanged. F7 stays retracted.

**Phase artifact:** `.ai/tasks/active/ts-prompt-assist/phase-384-result.md` — typed-flow demo shape as shipped, rebase surprises (none), `babel-loader` vs `ts-loader` note on the TS-check gate, and acceptance status.

**Subtlety worth flagging at cluster close:** the sample's webpack pipeline uses `babel-loader` (transpile-only), so `rushx build` is not a TypeScript type-check. The narrow is real and the type-check is correct — but `tsc --noEmit` is the load-bearing proof, not the webpack build. Captured in `phase-384-result.md` as a minor chore candidate (add a `tsc --noEmit` preflight to the sample's `build` script).

https://claude.ai/code/session_01Urhs9W7VxTpNicaMSkc1BC