### PR TITLE
feat(ts-prompt-assist): F1 + F2 + F6 round-2 ergonomics absorb

### DIFF
--- a/common/changes/@fgv/ts-prompt-assist/claude-round-2-absorb-f1f2f6_2026-05-18-08-00.json
+++ b/common/changes/@fgv/ts-prompt-assist/claude-round-2-absorb-f1f2f6_2026-05-18-08-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-prompt-assist",
+      "comment": "Round-2 pressure-test ergonomics absorption (F1 + F2 + F6): F1 — `IPromptStoreFixtureSeed` and `IPromptStoreFixtureSeedRecord` are now parameterized on `TQualifierNames extends string = string`; candidates' `conditions` keys are narrowed via the new `ITypedConditionSetDecl<TQualifierNames>` (preserves ts-res's value-side expressivity — string sugar, `IChildConditionDecl` record-with-details, and the array form — while typing the KEY side). `PromptStoreFixture.build<TQualifierNames>(seed)` infers the parameter from a typed seed annotation. Default `TQualifierNames = string` keeps existing seeds compiling unchanged. A typo'd axis name (`{ tonr: 'formal' }` against `'tone'`) is now a compile error instead of silently falling through to the base candidate at resolve time. F2 — new `buildSimpleDescriptor({ id, title, surface? })` helper builds a fully-shaped `IPromptDescriptor` for the trivial chat case (free-text output, no slots, schemaVersion '1', surface 'chat'). Deliberately limited to free-text output so the JSON-output path's `output.converterId` discriminator stays explicit at the call site. F6 — README 'Wiring into a React app' section extended with a `ChatTone = 'neutral' | 'formal'` consumer-side enum + select-bound resolve call, surfacing the v0.1 convention that axis NAMES are library-inferred while per-axis VALUE unions are a consumer concern.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-prompt-assist"
+}

--- a/libraries/ts-prompt-assist/README.md
+++ b/libraries/ts-prompt-assist/README.md
@@ -205,11 +205,31 @@ export function ChatPanel(): JSX.Element {
   return <ChatInner library={library} />;
 }
 
+// Consumer-side type union for the qualifier values driving the UI.
+// `PromptLibrary.create({ qualifiers: ['tone'] as const })` infers the
+// axis NAME (`'tone'`); the per-axis VALUE union is a consumer concern
+// at v0.1, so author it next to the wiring and reference it from both
+// the UI control and the resolve call.
+export type ChatTone = 'neutral' | 'formal';
+
 function ChatInner(props: { library: PromptLibrary<IPromptResponseBase, 'tone'> }): JSX.Element {
   // The narrow `qualifiers: { tone?: string }` shape comes from F3 +
   // F14 — the empty `{}` branch assigns thanks to the Partial widening
   // and a misspelled axis (`tonr`) fails at compile time.
-  return <div>Library ready.</div>;
+  const [tone, setTone] = useState<ChatTone>('neutral');
+  // 'neutral' is the unconditional base candidate (no `tone` key in
+  // the resolve context); 'formal' threads the value through to ts-res
+  // so the `conditions: { tone: 'formal' }` partial layers in.
+  const qualifiers = tone === 'neutral' ? {} : { tone };
+
+  // Use `qualifiers` in your resolve call:
+  //   props.library.resolve({ id: GREETING, chain: [SCOPE], qualifiers });
+  return (
+    <select value={tone} onChange={(e) => setTone(e.target.value as ChatTone)}>
+      <option value="neutral">Neutral</option>
+      <option value="formal">Formal</option>
+    </select>
+  );
 }
 ```
 
@@ -227,6 +247,14 @@ Three things this pattern earns you:
    tightening the resolve request's `qualifiers` shape. A pre-built
    `Qualifiers.QualifierCollector` doesn't expose its axes at the type
    level; pass `as const` decls when you want the typed benefit.
+4. **Consumer-side qualifier-value enum** — the library infers axis
+   NAMES from the decl-array, but the per-axis VALUE union (e.g.
+   `ChatTone = 'neutral' | 'formal'`) is a consumer concern at v0.1.
+   Author it next to the wiring module so the UI control, the resolve
+   call's `qualifiers`, and any seed-side `conditions: { tone: 'formal' }`
+   all draw from the same source of truth. (A future story may
+   parameterize the library on per-axis value unions; see F5 in the
+   round-2 pressure-test findings.)
 
 ---
 

--- a/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
+++ b/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
@@ -46,6 +46,9 @@ export type BindingTraceSource = 'caller-sub' | 'binding' | 'default' | 'empty';
 export function buildBindingsRecord(scope: ScopeKey, contents: IBindingsFileContents): IScopeSlotBindingsRecord;
 
 // @public
+export function buildSimpleDescriptor(params: IBuildSimpleDescriptorParams): IPromptDescriptor;
+
+// @public
 export function buildStoredPromptRecord(scope: ScopeKey, contents: IPromptFileContents): IStoredPromptRecord;
 
 // @public
@@ -126,6 +129,16 @@ export interface IBindingTraceEntry {
     readonly value: string;
     readonly wasEnforced: boolean;
     readonly winningScope?: ScopeKey;
+}
+
+// @public
+export interface IBuildSimpleDescriptorParams {
+    readonly description?: string;
+    // (undocumented)
+    readonly id: PromptId;
+    readonly surface?: string;
+    // (undocumented)
+    readonly title: string;
 }
 
 // @public
@@ -420,21 +433,21 @@ export type IPromptStoreFixtureDescriptor = Omit<IPromptDescriptor, 'id'> & {
 };
 
 // @public
-export interface IPromptStoreFixtureSeed {
+export interface IPromptStoreFixtureSeed<TQualifierNames extends string = string> {
     // (undocumented)
     readonly bindings?: ReadonlyArray<IScopeSlotBindingsRecord>;
     // (undocumented)
     readonly qualifiers?: ReadonlyArray<Qualifiers.IQualifierDecl>;
     // (undocumented)
-    readonly records?: ReadonlyArray<IPromptStoreFixtureSeedRecord>;
+    readonly records?: ReadonlyArray<IPromptStoreFixtureSeedRecord<TQualifierNames>>;
     readonly scopeDecoding?: (encoded: string) => Result<ScopeKey>;
     readonly scopeEncoding?: (scope: ScopeKey) => Result<string>;
 }
 
 // @public
-export interface IPromptStoreFixtureSeedRecord {
+export interface IPromptStoreFixtureSeedRecord<TQualifierNames extends string = string> {
     // (undocumented)
-    readonly candidates: ReadonlyArray<IPromptCandidateRecord>;
+    readonly candidates: ReadonlyArray<ITypedPromptCandidateRecord<TQualifierNames>>;
     // (undocumented)
     readonly descriptor: IPromptStoreFixtureDescriptor;
     // (undocumented)
@@ -534,6 +547,21 @@ export interface ITextOutputContract {
 }
 
 // @public
+export type ITypedConditionSetDecl<TQualifierNames extends string = string> = Readonly<Partial<Record<TQualifierNames, string | ResourceJson.Json.IChildConditionDecl>>> | ReadonlyArray<Omit<ResourceJson.Json.ILooseConditionDecl, 'qualifierName'> & {
+    readonly qualifierName: TQualifierNames;
+}>;
+
+// @public
+export interface ITypedPromptCandidateRecord<TQualifierNames extends string = string> {
+    // (undocumented)
+    readonly body: string;
+    // (undocumented)
+    readonly conditions: ITypedConditionSetDecl<TQualifierNames>;
+    // (undocumented)
+    readonly isPartial?: boolean;
+}
+
+// @public
 export function joinBodies(selected: ReadonlyArray<{
     readonly candidate: IPromptCandidateRecord;
 }>, policy: IPromptJoinPolicy | undefined): string;
@@ -607,7 +635,7 @@ export type PromptStoreEventKind = 'descriptor-changed' | 'descriptor-removed' |
 
 // @public
 export const PromptStoreFixture: {
-    build(seed: IPromptStoreFixtureSeed): Promise<Result<IPromptStore>>;
+    build<TQualifierNames extends string = string>(seed: IPromptStoreFixtureSeed<TQualifierNames>): Promise<Result<IPromptStore>>;
 };
 
 // @public

--- a/libraries/ts-prompt-assist/src/packlets/fixture/promptStoreFixture.ts
+++ b/libraries/ts-prompt-assist/src/packlets/fixture/promptStoreFixture.ts
@@ -9,7 +9,7 @@ import { Yaml } from '@fgv/ts-extras';
 import { Qualifiers } from '@fgv/ts-res';
 import { PromptId, ScopeKey, SlotName } from '../types';
 import { SlotBinding } from '../types';
-import { IPromptCandidateRecord, IPromptDescriptor, IScopeSlotBindingsRecord } from '../types';
+import { IPromptDescriptor, IScopeSlotBindingsRecord, ITypedPromptCandidateRecord } from '../types';
 import { defaultScopeEncoding } from '../store';
 import { FileTreePromptStore } from '../store';
 import { IPromptStore } from '../store';
@@ -33,24 +33,40 @@ export type IPromptStoreFixtureDescriptor = Omit<IPromptDescriptor, 'id'> & {
 
 /**
  * Fixture-seed-only record shape: descriptor.id is optional and
- * defaults to the outer record id (per F12). Other fields mirror
- * {@link IStoredPromptRecord}.
+ * defaults to the outer record id (per F12). Candidate `conditions`
+ * keys are narrowed by `TQualifierNames` (per F1) so typo'd axis
+ * names fail at compile time when the seed is threaded through a
+ * `TQualifierNames`-typed fixture build. Default
+ * `TQualifierNames = string` keeps unnarrowed seeds compiling
+ * unchanged.
+ *
+ * Other fields mirror {@link IStoredPromptRecord}.
  *
  * @public
  */
-export interface IPromptStoreFixtureSeedRecord {
+export interface IPromptStoreFixtureSeedRecord<TQualifierNames extends string = string> {
   readonly scope: ScopeKey;
   readonly id: PromptId;
   readonly descriptor: IPromptStoreFixtureDescriptor;
-  readonly candidates: ReadonlyArray<IPromptCandidateRecord>;
+  readonly candidates: ReadonlyArray<ITypedPromptCandidateRecord<TQualifierNames>>;
 }
 
 /**
  * Seed describing the in-memory FileTree state for a test fixture.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames extends string` (per F1). When
+ * `PromptStoreFixture.build` infers `TQualifierNames` from a typed
+ * call site (e.g. an `IPromptStoreFixtureSeed<'tone'>` annotation, or
+ * via the inferring `build<TQualifierNames>(seed)` signature), the
+ * candidates' `conditions` keys are narrowed to that union. Default
+ * `TQualifierNames = string` keeps existing call sites working
+ * unchanged.
+ *
  * @public
  */
-export interface IPromptStoreFixtureSeed {
-  readonly records?: ReadonlyArray<IPromptStoreFixtureSeedRecord>;
+export interface IPromptStoreFixtureSeed<TQualifierNames extends string = string> {
+  readonly records?: ReadonlyArray<IPromptStoreFixtureSeedRecord<TQualifierNames>>;
   readonly bindings?: ReadonlyArray<IScopeSlotBindingsRecord>;
   readonly qualifiers?: ReadonlyArray<Qualifiers.IQualifierDecl>;
   /**
@@ -76,7 +92,7 @@ function serializeBindingsRecord(record: IScopeSlotBindingsRecord): Result<strin
   return Yaml.yamlStringify({ bindings });
 }
 
-function serializePromptRecord(record: IPromptStoreFixtureSeedRecord): Result<string> {
+function serializePromptRecord(record: IPromptStoreFixtureSeedRecord<string>): Result<string> {
   return defaultDescriptorIdFromOuter(record).onSuccess((descriptor) =>
     Yaml.yamlStringify({ ...descriptor, candidates: record.candidates })
   );
@@ -88,7 +104,9 @@ function serializePromptRecord(record: IPromptStoreFixtureSeedRecord): Result<st
  * mismatches the outer id, reject loudly — the redundancy is gone but
  * silent inconsistency must remain impossible.
  */
-function defaultDescriptorIdFromOuter(record: IPromptStoreFixtureSeedRecord): Result<IPromptDescriptor> {
+function defaultDescriptorIdFromOuter(
+  record: IPromptStoreFixtureSeedRecord<string>
+): Result<IPromptDescriptor> {
   const descriptor = record.descriptor;
   if (descriptor.id === undefined) {
     return succeed({ ...descriptor, id: record.id });
@@ -113,21 +131,35 @@ function serializeQualifiers(qualifiers: ReadonlyArray<Qualifiers.IQualifierDecl
  * `InMemoryPromptStore`; tests round-trip through the same YAML schema
  * the FsTree adapter would.
  *
+ * @remarks
+ * Generic over `TQualifierNames extends string` (per F1). Inferred from
+ * the supplied seed when the seed's `IPromptStoreFixtureSeed<...>`
+ * type parameter is narrowed at the call site — e.g.
+ * `PromptStoreFixture.build<'tone'>(seed)` or via an annotated
+ * `const seed: IPromptStoreFixtureSeed<'tone'> = { ... }`. The
+ * resulting store has the same runtime shape regardless of
+ * `TQualifierNames`; the parameter exists purely to drive compile-
+ * time narrowing of candidate `conditions` keys.
+ *
  * @public
  */
 export const PromptStoreFixture: {
-  build(seed: IPromptStoreFixtureSeed): Promise<Result<IPromptStore>>;
+  build<TQualifierNames extends string = string>(
+    seed: IPromptStoreFixtureSeed<TQualifierNames>
+  ): Promise<Result<IPromptStore>>;
 } = {
   /**
    * Builds an in-memory FileTree from the seed, then wraps it in a
    * `FileTreePromptStore`. Returns the store ready for use.
    */
-  async build(seed: IPromptStoreFixtureSeed): Promise<Result<IPromptStore>> {
+  async build<TQualifierNames extends string = string>(
+    seed: IPromptStoreFixtureSeed<TQualifierNames>
+  ): Promise<Result<IPromptStore>> {
     return buildSeededStore(seed);
   }
 } as const;
 
-function buildSeededStore(seed: IPromptStoreFixtureSeed): Promise<Result<IPromptStore>> {
+function buildSeededStore(seed: IPromptStoreFixtureSeed<string>): Promise<Result<IPromptStore>> {
   const encode = seed.scopeEncoding ?? defaultScopeEncoding;
 
   // Single chained pipeline — each step runs only after the previous
@@ -164,7 +196,7 @@ function buildSeededStore(seed: IPromptStoreFixtureSeed): Promise<Result<IPrompt
 }
 
 function encodeRecords(
-  records: ReadonlyArray<IPromptStoreFixtureSeedRecord> | undefined,
+  records: ReadonlyArray<IPromptStoreFixtureSeedRecord<string>> | undefined,
   encode: (scope: ScopeKey) => Result<string>
 ): Result<ReadonlyArray<FileTree.IInMemoryFile>> {
   return mapResults(

--- a/libraries/ts-prompt-assist/src/packlets/types/descriptor.ts
+++ b/libraries/ts-prompt-assist/src/packlets/types/descriptor.ts
@@ -109,6 +109,15 @@ export interface IScopeSlotBindingsRecord {
 
 /**
  * A stored candidate within an {@link IStoredPromptRecord}.
+ *
+ * @remarks
+ * The runtime / store / loader-facing shape: `conditions` is the open
+ * ts-res `ConditionSetDecl` (record-sugar, record-with-details, or
+ * array form). The seed-authoring path uses
+ * {@link ITypedPromptCandidateRecord} instead, which parameterizes the
+ * `conditions` keys on a `TQualifierNames` literal-string union so a
+ * typo'd axis name fails at compile time.
+ *
  * @public
  */
 export interface IPromptCandidateRecord {
@@ -131,6 +140,50 @@ export interface IPromptCandidateRecord {
 }
 
 /**
+ * Typed `conditions` shape used by the fixture-seed authoring path
+ * (see {@link ITypedPromptCandidateRecord}). Preserves ts-res's
+ * expressivity on the VALUE side — string sugar, the record-with-
+ * details `IChildConditionDecl`, and the array form — while narrowing
+ * the KEY side to a consumer-supplied `TQualifierNames` literal-string
+ * union. A typo'd axis name on the record form fails at compile time
+ * when `TQualifierNames` is narrowed (typically via inference from a
+ * `qualifiers: ['tone'] as const` decl-array on
+ * `PromptLibrary.create`).
+ *
+ * Defaults to `string`, so callers who don't thread a literal-string
+ * union behave identically to the open
+ * `ResourceJson.Json.ConditionSetDecl` from `@fgv/ts-res`.
+ *
+ * @public
+ */
+export type ITypedConditionSetDecl<TQualifierNames extends string = string> =
+  | Readonly<Partial<Record<TQualifierNames, string | ResourceJson.Json.IChildConditionDecl>>>
+  | ReadonlyArray<
+      Omit<ResourceJson.Json.ILooseConditionDecl, 'qualifierName'> & {
+        readonly qualifierName: TQualifierNames;
+      }
+    >;
+
+/**
+ * Seed-authoring counterpart to {@link IPromptCandidateRecord}: the
+ * `conditions` shape is parameterized on a `TQualifierNames`
+ * literal-string union via {@link ITypedConditionSetDecl} so typos in
+ * axis names fail at compile time. Otherwise structurally identical
+ * to {@link IPromptCandidateRecord}.
+ *
+ * Default `TQualifierNames = string` keeps existing seeds untyped (the
+ * `ITypedConditionSetDecl<string>` shape is equivalent to
+ * `ResourceJson.Json.ConditionSetDecl` from `@fgv/ts-res`).
+ *
+ * @public
+ */
+export interface ITypedPromptCandidateRecord<TQualifierNames extends string = string> {
+  readonly conditions: ITypedConditionSetDecl<TQualifierNames>;
+  readonly isPartial?: boolean;
+  readonly body: string;
+}
+
+/**
  * Stored prompt record returned by the store.
  * @public
  */
@@ -139,4 +192,48 @@ export interface IStoredPromptRecord {
   readonly id: PromptId;
   readonly descriptor: IPromptDescriptor;
   readonly candidates: ReadonlyArray<IPromptCandidateRecord>;
+}
+
+/**
+ * Parameters for {@link buildSimpleDescriptor}.
+ *
+ * @public
+ */
+export interface IBuildSimpleDescriptorParams {
+  readonly id: PromptId;
+  readonly title: string;
+  /** Optional longer-form description. */
+  readonly description?: string;
+  /** Default `'chat'`. */
+  readonly surface?: string;
+}
+
+/**
+ * Builds a fully-shaped {@link IPromptDescriptor} for the trivial chat
+ * case: one body, no slots, free-text output. Cuts the boilerplate of
+ * spelling out `schemaVersion`, `slots: []`, and
+ * `output: \{ kind: 'free-text' \}` at every seed call site (per F2).
+ *
+ * @remarks
+ * Intentionally limited to the free-text-output shape. The descriptor's
+ * `output.kind` is load-bearing — `PromptLibrary.resolveJsonOutput` and
+ * `resolveFreeTextOutput` both runtime-verify it against the call
+ * path — so silently defaulting `output` for a JSON-output prompt
+ * would route the consumer into the wrong dispatcher. For JSON-output
+ * prompts, author the full {@link IPromptDescriptor} shape directly so
+ * the `output.converterId` discriminator is explicit at the call site.
+ *
+ * @public
+ */
+export function buildSimpleDescriptor(params: IBuildSimpleDescriptorParams): IPromptDescriptor {
+  const descriptor: IPromptDescriptor = {
+    id: params.id,
+    title: params.title,
+    schemaVersion: '1',
+    surface: params.surface ?? 'chat',
+    slots: [],
+    output: { kind: 'free-text' },
+    ...(params.description !== undefined ? { description: params.description } : {})
+  };
+  return descriptor;
 }

--- a/libraries/ts-prompt-assist/src/test/unit/foundation.test.ts
+++ b/libraries/ts-prompt-assist/src/test/unit/foundation.test.ts
@@ -18,8 +18,10 @@ import {
   IPromptCandidateRecord,
   IPromptFileContents,
   IPromptStore,
+  IPromptDescriptor,
   IPromptStoreFixtureSeed,
   IQualifiersFileContents,
+  buildSimpleDescriptor,
   IResolvedPrompt,
   IScopeSlotBindingsRecord,
   IStoredPromptRecord,
@@ -174,6 +176,127 @@ describe('ts-prompt-assist foundation', () => {
       expect(Convert.validatorId.convert(tooLong)).toFailWith(/exceeds maximum length/);
       expect(Convert.axisName.convert(tooLong)).toFailWith(/exceeds maximum length/);
       expect(Convert.scopeKey.convert(tooLong)).toFailWith(/exceeds maximum length/);
+    });
+  });
+
+  describe('buildSimpleDescriptor (F2)', () => {
+    test('builds a free-text chat descriptor from minimal input', () => {
+      const descriptor: IPromptDescriptor = buildSimpleDescriptor({
+        id: TEST_PROMPT,
+        title: 'Simple greeting'
+      });
+      expect(descriptor).toEqual({
+        id: TEST_PROMPT,
+        title: 'Simple greeting',
+        schemaVersion: '1',
+        surface: 'chat',
+        slots: [],
+        output: { kind: 'free-text' }
+      });
+    });
+
+    test('threads an explicit surface override through', () => {
+      const descriptor = buildSimpleDescriptor({
+        id: TEST_PROMPT,
+        title: 'Custom-surface prompt',
+        surface: 'completion'
+      });
+      expect(descriptor.surface).toBe('completion');
+      // Output remains free-text — the helper is deliberately limited to
+      // the free-text-output shape so a consumer who needs JSON output
+      // authors the full IPromptDescriptor and sets `output.converterId`
+      // explicitly.
+      expect(descriptor.output).toEqual({ kind: 'free-text' });
+    });
+
+    test('threads an optional description through', () => {
+      const descriptor = buildSimpleDescriptor({
+        id: TEST_PROMPT,
+        title: 'Documented prompt',
+        description: 'Longer-form description for editor surfaces'
+      });
+      expect(descriptor.description).toBe('Longer-form description for editor surfaces');
+    });
+  });
+
+  describe('ITypedPromptCandidateRecord (F1)', () => {
+    test('a TQualifierNames-narrowed seed compiles for the expected axis keys', () => {
+      // Smoke: the type machinery allows the expected key on the
+      // record-form conditions. The negative case ('tonr' typo) is
+      // verified by the @ts-expect-error block below.
+      const seed: IPromptStoreFixtureSeed<'tone'> = {
+        records: [
+          {
+            scope: TEST_SCOPE,
+            id: TEST_PROMPT,
+            descriptor: buildSimpleDescriptor({ id: TEST_PROMPT, title: 'typed-seed test' }),
+            candidates: [
+              { conditions: {}, body: 'base' },
+              { conditions: { tone: 'formal' }, isPartial: true, body: 'partial' }
+            ]
+          }
+        ]
+      };
+      expect(seed.records?.length).toBe(1);
+    });
+
+    test('a TQualifierNames-narrowed seed rejects a typo at compile time', () => {
+      // The @ts-expect-error directive captures F1's contract: the
+      // typo `tonr` (instead of `tone`) on the record-form conditions
+      // is a compile error when TQualifierNames is narrowed.
+      const seed: IPromptStoreFixtureSeed<'tone'> = {
+        records: [
+          {
+            scope: TEST_SCOPE,
+            id: TEST_PROMPT,
+            descriptor: buildSimpleDescriptor({ id: TEST_PROMPT, title: 'typo-rejection' }),
+            candidates: [
+              {
+                // @ts-expect-error — 'tonr' is not assignable to 'tone'
+                conditions: { tonr: 'formal' },
+                body: 'will not compile'
+              }
+            ]
+          }
+        ]
+      };
+      // Runtime shape is unchanged — the seed object still constructs;
+      // the contract is purely compile-time.
+      expect(seed.records?.length).toBe(1);
+    });
+
+    test('the default TQualifierNames = string compiles arbitrary axis keys', () => {
+      // Back-compat: unannotated seeds still accept any string key.
+      const seed: IPromptStoreFixtureSeed = {
+        records: [
+          {
+            scope: TEST_SCOPE,
+            id: TEST_PROMPT,
+            descriptor: buildSimpleDescriptor({ id: TEST_PROMPT, title: 'untyped seed' }),
+            candidates: [{ conditions: { arbitrary: 'value' }, body: 'ok' }]
+          }
+        ]
+      };
+      expect(seed.records?.length).toBe(1);
+    });
+
+    test('PromptStoreFixture.build infers TQualifierNames from a typed call', async () => {
+      // End-to-end: the typed seed builds successfully and the resulting
+      // store resolves through the runtime path unchanged.
+      const seed: IPromptStoreFixtureSeed<'tone'> = {
+        records: [
+          {
+            scope: TEST_SCOPE,
+            id: TEST_PROMPT,
+            descriptor: buildSimpleDescriptor({ id: TEST_PROMPT, title: 'inference test' }),
+            candidates: [{ conditions: {}, body: 'hi' }]
+          }
+        ],
+        qualifiers: [{ name: 'tone', typeName: 'tone', defaultPriority: 500 }]
+      };
+      const store = (await PromptStoreFixture.build<'tone'>(seed)).orThrow();
+      const got = (await store.get(TEST_SCOPE, TEST_PROMPT)).orThrow();
+      expect(got?.candidates[0].body).toBe('hi');
     });
   });
 


### PR DESCRIPTION
## Summary

Absorbs three findings from the ts-prompt-assist round-2 pressure test (`.ai/tasks/active/ts-prompt-assist/pressure-test-findings-round-2.md`) into the library surface, before sample-app PR #384 rebases + lands.

### F1 — Typed candidate `conditions` keys
- `IPromptStoreFixtureSeed<TQualifierNames>` + `IPromptStoreFixtureSeedRecord<TQualifierNames>` parameterized on `TQualifierNames extends string = string`.
- New `ITypedConditionSetDecl<T>` narrows the KEY side of the seed-side `conditions` field to `T` while preserving ts-res's value-side expressivity (string sugar, `IChildConditionDecl` record-with-details, and the array form). Candidates use the new sibling `ITypedPromptCandidateRecord<T>` whose `conditions` is `ITypedConditionSetDecl<T>`.
- Runtime / store `IPromptCandidateRecord` is unchanged (still string-keyed) — typing is purely compile-time authoring discipline at the seed.
- `PromptStoreFixture.build<TQualifierNames>(seed)` infers the parameter from a typed seed.
- Default `TQualifierNames = string` keeps every existing seed compiling unchanged.
- Verified by a `@ts-expect-error` test on the typo branch: `{ tonr: 'formal' }` against `IPromptStoreFixtureSeed<'tone'>` is now a compile error instead of silently falling through to the base candidate at resolve time.

### F2 — `buildSimpleDescriptor` helper
- New exported function `buildSimpleDescriptor({ id, title, surface?, description? })` returns a fully-shaped `IPromptDescriptor` for the trivial chat case (`schemaVersion: '1'`, `surface: 'chat'`, `slots: []`, `output: { kind: 'free-text' }`).
- Deliberately limited to free-text output — `descriptor.output.kind` is load-bearing (`resolveJsonOutput` / `resolveFreeTextOutput` runtime-verify it), so silently defaulting it for omitted-output prompts would route JSON consumers into the wrong dispatcher. JSON-output prompts continue to author the full `IPromptDescriptor` shape so the `output.converterId` discriminator stays explicit at the call site.

### F6 — README React-wiring section
- `ChatInner` snippet extended with `ChatTone = 'neutral' | 'formal'`, a `<select>` bound to it, and the natural `tone === 'neutral' ? {} : { tone }` qualifier-context wire-through.
- New 4th list-item documents the v0.1 convention that axis NAMES are library-inferred while per-axis VALUE unions are a consumer concern (forward-reference to F5 in the round-2 findings doc).

### Out of scope (deferred per brief)
- F3 (PromptStoreFixture builder) — v0.2.
- F5 (typed qualifier VALUES) — v0.2.
- F8 (trace not loggable) — already deferred in round-1 triage.
- Heavier TSDoc audit — TECH_DEBT P2 #382.

## Landing sequence
After this merges, PR #384 will rebase onto this PR's post-merge HEAD and update the sample-app integration to use the new shapes (`IPromptStoreFixtureSeed<'tone'>`, `buildSimpleDescriptor`, the documented `ChatTone` pattern). This is the last library change before cluster close.

## Gates
- [x] `rush build --to @fgv/ts-prompt-assist` clean (incl. api-extractor)
- [x] `rushx lint` clean
- [x] `rushx fixlint` run
- [x] `rushx test` passes with 100% coverage (statements / branches / functions / lines)
- [x] api-extractor regenerated — new exports: `buildSimpleDescriptor`, `IBuildSimpleDescriptorParams`, `ITypedConditionSetDecl`, `ITypedPromptCandidateRecord`; generic parameters added to `IPromptStoreFixtureSeed` / `IPromptStoreFixtureSeedRecord`.
- [x] Rush change file added under `common/changes/@fgv/ts-prompt-assist/`.

## Test plan
- [ ] CI green on the PR.
- [ ] Sample-app PR #384 rebase exercises the new shapes end-to-end before cluster close.

https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDi6fazcgVBqaPhbP8nphe)_