### PR TITLE
chore(ts-prompt-assist): substrate-prep for ts-res-typed-conditions stream

### DIFF
--- a/.ai/tasks/active/ts-prompt-assist/state.md
+++ b/.ai/tasks/active/ts-prompt-assist/state.md
@@ -199,3 +199,19 @@ Phase B sub-phase PRs (incoming): B-0b → B-5.
 ## Resume protocol
 
 Phase A agent: read `brief.md` (binding contract) + `design-brief.md` (binding input — conceptual model is locked, data shapes are proposals) + this `state.md` to resume.
+
+---
+
+## 2026-05-19 update: B+C ts-res stream commissioned
+
+PR #386 (leaf-only parameterization of `ConditionSetDecl`) closed as superseded. Design discussion (PRs #387, #388, #389) merged to integration as substrate for a new in-cluster ts-res stream `ts-res-typed-conditions` at `.ai/tasks/active/ts-res-typed-conditions/`.
+
+**Three sub-phases:**
+- B-1: Decl-tree cascade (`ts-res`, type-only, includes `getKeyFromLooseDecl` latent-bug fix carried forward from #386).
+- B-2: Converter parameterization (`ts-res`, runtime teeth; opt-in via collector-derived literal set).
+- B-3: ts-prompt-assist port (drop local `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord`; reference ts-res parameterized types directly).
+
+**Cluster reshape:** B+C absorbed in-cluster per Erik's "B+C cascades into deliverables for this cluster so deferring it just creates debt" framing. Cluster-close prep deferred until B-3 lands. Held cluster PRs:
+
+- #385 (round-2 absorb F1+F2+F6): holds for B-3 port; F1 ultimately resolved via ts-res ownership, not the local-types accommodation in #385.
+- #384 (sample app + round-2 findings): rebases onto post-B-3 HEAD; lands last.

--- a/.ai/tasks/active/ts-res-typed-conditions/brief.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/brief.md
@@ -1,0 +1,160 @@
+# Stream brief: `ts-res-typed-conditions`
+
+**Cluster:** `ts-prompt-assist-features` (in-cluster; B+C is a deliverable for the v0.1 ts-prompt-assist publish per Erik's "lowest appropriate level" framing)
+**Integration branch:** `claude/ts-prompt-assist-features` (existing; off `release`)
+**Status:** ready to commission
+
+---
+
+## Mission
+
+Make `@fgv/ts-res` honor qualifier-name semantics — the closed set of axis names a deployment declares — at both the **type level** (across the full Decl tree) and the **runtime level** (Converter pipeline). Replace the half-built leaf-only parameterization from closed PR #386 with the complete co-designed shape.
+
+The principle: ts-res is the layer that owns the qualifier-name concept (registered via `QualifierCollector`); it should own the discipline that enforces it. Consumer libraries (`@fgv/ts-prompt-assist` and future siblings) should be able to opt into typed-narrow authoring AND have on-disk JSON validated against the declared set — without the cast-pressure failure mode where the type narrows in code but evaporates at the Converter boundary.
+
+---
+
+## Why this stream exists — decision-track input
+
+Read these before drafting any code. They capture the option space, the evaluation, and the corrections that landed during the design discussion. All three live on integration at `.ai/tasks/active/ts-prompt-assist/`:
+
+- `ts-res-typed-conditions-design.md` — original four-option brief (A withdraw / B cascade / C runtime teeth / D land + TECH_DEBT). Establishes the option space.
+- `ts-res-typed-conditions-evaluation.md` — first evaluation (Option B recommendation) + **the load-bearing addendum** that corrected the framing: PR #386 was not actually Option B — it was leaf-only with no plumbing in the container types, so the parameterized `ConditionSetDecl<T>` had no flow path from any realistic authoring chain. **This correction is critical** — the implementing agent must thread `TQualifierNames` through the container types, not just the leaf.
+
+Plus: closed PR #386 itself (`chore/ts-res-typed-condition-set-decl` branch) carries the latent-bug fix in `ConditionSet.getKeyFromLooseDecl` (`conditions/conditionSet.ts:200-225`) — the `Partial` widening forces correct handling of explicit-`undefined` record entries. **Carry this fix forward into Phase B-1.**
+
+---
+
+## Sub-phase shape
+
+Per orchestrator + Erik discussion (2026-05-19), three sub-phases inside this single stream — each with its own sub-brief drafted at commission time, each landing as its own PR on integration:
+
+### Phase B-1 — Decl-tree cascade (`ts-res`, type-only)
+
+Thread `TQualifierNames extends string = string` through the full Decl chain in `libraries/ts-res/src/packlets/resource-json/json.ts`:
+
+- `ILooseConditionDecl<T>` (already parameterized by #386 — carry forward)
+- `ConditionSetDeclAsArray<T>` / `AsRecord<T>` / `ConditionSetDecl<T>` (already parameterized by #386 — carry forward)
+- **New (the cascade #386 missed):** `IChildResourceCandidateDecl<T>`, `ILooseResourceCandidateDecl<T>`, `IImporterResourceCandidateDecl<T>`, `IContainerContextDecl<T>`, `IChildResourceDecl<T>`, `ILooseResourceDecl<T>`, `IResourceCollectionDecl<T>`, `IImporterResourceCollectionDecl<T>`, `IResourceTreeRootDecl<T>`
+
+All with `extends string = string` default so existing untyped callers compile unchanged.
+
+Carry forward from #386:
+- The `ConditionSet.getKeyFromLooseDecl` adjustment (explicit-`undefined` handling) — this is a genuine correctness fix and lands with the cascade, not deferred.
+
+**Scope guardrails:** type-level only. Converters keep their default-string signatures in this sub-phase. No behavior change at runtime.
+
+**Acceptance:** `rush build`, `rushx lint`, `rushx test` all clean in `ts-res` and `ts-prompt-assist`; api-extractor regenerated; rush change file (minor bump, ts-res is on lockstep so this propagates).
+
+### Phase B-2 — Converter parameterization (`ts-res`, runtime teeth)
+
+Parameterize the Converter pipeline against a `QualifierCollector`-derived literal set so JSON loads validate qualifier names against the declared axes:
+
+- Surface design: how does the consumer thread their `QualifierCollector<TNames>` (or its name-set) into the Converter chain? Candidate shapes:
+  - Converter factory that accepts a collector / name-set and returns a parameterized Converter family.
+  - Per-call validation context carrying the name-set.
+  - Default behavior when no collector is supplied: today's loose-string behavior (back-compat).
+- The Converter signatures change. Defaults preserve existing callers — but the parameterized path is the one consumers should opt into when they want runtime teeth.
+- Affected files (at minimum, expand during design): `libraries/ts-res/src/packlets/conditions/convert/decls.ts` (where `validatedConditionDecl` already calls `context.qualifiers.validating.get(decl.qualifierName)`); cascade up through `ResourceJson` Converters.
+
+**Existing partial teeth, per the evaluation addendum:** `validatedConditionDecl` (`conditions/convert/decls.ts` ~line 68) ALREADY validates qualifier names against the registered collector at convert time. What's missing is enforcement of the consumer's **declared literal set** (their narrowed axes vs the broader registry). Phase B-2's scope is closing that narrower gap, not building runtime validation from scratch.
+
+**Scope guardrails:** the parameterization must be opt-in (default-string keeps existing consumers working). Breaking changes only via the Active Development surface designation for ts-res's resource-json packlet.
+
+**Acceptance:** same as B-1 plus a test demonstrating a JSON load with a typo'd qualifier name failing at convert time under the parameterized Converter path; existing consumers compile unchanged.
+
+### Phase B-3 — ts-prompt-assist port (`ts-prompt-assist`, consumer port)
+
+Drop ts-prompt-assist's local sibling types (`ITypedConditionSetDecl`, `ITypedPromptCandidateRecord`, currently introduced in PR #385); reference ts-res's parameterized types directly. Update `PromptStoreFixture` / `IPromptStoreFixtureSeed<T>` to thread the new ts-res shapes through. Verify that round-trip flows (seed → Converter → typed result) preserve narrows end-to-end without cast-pressure escape hatches.
+
+**Acceptance:** ts-prompt-assist's local sibling types are gone; the consumer-side authoring discipline uses ts-res's primitives directly; F1 from the round-2 findings is closed via ts-res ownership; `rush build`/`rushx lint`/`rushx test` clean in `ts-prompt-assist`.
+
+---
+
+## In-scope paths
+
+- `libraries/ts-res/src/packlets/resource-json/` — Decl interfaces (Phase B-1).
+- `libraries/ts-res/src/packlets/conditions/convert/` — Converter pipeline (Phase B-2).
+- `libraries/ts-res/src/packlets/conditions/conditionSet.ts` — `getKeyFromLooseDecl` carry-forward fix from #386 (Phase B-1).
+- `libraries/ts-res/etc/ts-res.api.md` — api-extractor regen (each phase).
+- `libraries/ts-res/src/test/unit/` — test coverage for parameterized surface (each phase).
+- `libraries/ts-prompt-assist/src/packlets/fixtures/` and the local sibling types — Phase B-3.
+- `libraries/ts-prompt-assist/src/test/unit/` — test updates (Phase B-3).
+- `common/changes/@fgv/ts-res/` and `common/changes/@fgv/ts-prompt-assist/` — rush change files (each phase).
+
+## Out-of-scope paths
+
+- `libraries/ts-res/src/packlets/qualifiers/` — `QualifierCollector` is the runtime authority for B-2's design, but its surface doesn't change here. If B-2's design surfaces a real `QualifierCollector` surface change, surface as an open question rather than proceeding.
+- `tools/ts-res-cli/` and `libraries/ts-res-ui-components/` — downstream consumers of ts-res's Decl surface. Default-string back-compat means these should compile unchanged; if they don't, surface as a blocker, don't fix in scope.
+- Any other ts-prompt-assist surface beyond the local-sibling-types replacement (Phase B-3).
+- The `ai-assist-thinking-events` follow-on stream — sequenced after this cluster, no overlap here.
+
+---
+
+## Skills to load (with trigger conditions)
+
+| Trigger | Skill |
+|---|---|
+| Writing or modifying Converter signatures, validate-time enforcement code | `/type-safe-validation` |
+| Writing or modifying Result-returning code in the Converter pipeline | `/result-pattern` |
+| Writing or modifying tests in any phase | `/result-tests` |
+| Any utility-shaped code that "feels general" — before reaching for a hand-rolled helper | `/published-primitives-reflex` |
+
+---
+
+## Missing-input rule
+
+If any of the following is missing or ambiguous when you start work, STOP and surface the question to the orchestrator — do NOT proceed by exploring the codebase to reconstruct intent:
+
+- The three decision-track docs on integration (named under "Why this stream exists" above).
+- The sub-phase sub-brief for the phase you've been commissioned to execute.
+- A clear answer to "is the Converter parameterization shape an opt-in factory call, a per-call validation context, or some other design?" if Phase B-2 sub-brief doesn't pin this — surface as design question before implementing.
+
+---
+
+## Acceptance criteria (stream exit)
+
+Per `.ai/instructions/CODING_STANDARDS.md` § Pre-PR Validation Checklist, every sub-phase PR must satisfy:
+
+- [ ] `rush build` passes in every modified package
+- [ ] `rushx lint` passes in every modified package *(NOT transitively run by build — separate gate)*
+- [ ] `rushx test` passes with 100% coverage in every modified package
+- [ ] `rushx fixlint` was run before the final commit
+- [ ] No `any` types; all fallible operations return `Result<T>`
+- [ ] api-extractor regenerated where public surface changed
+- [ ] Rush change file added under `common/changes/<package>/`
+
+Stream-level exit (after Phase B-3 lands):
+
+- [ ] All three sub-phases merged to integration.
+- [ ] ts-prompt-assist's local `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord` types are gone; references go directly to ts-res's parameterized types.
+- [ ] A test demonstrates the cast-pressure failure mode is closed: a JSON round-trip through the parameterized Converter preserves the narrow, and a typo'd qualifier name in a JSON load fails at convert time.
+- [ ] `result.md` written summarizing the three sub-phases' outcomes; state.md migrated to `.ai/tasks/completed/<YYYY-MM>/ts-res-typed-conditions/` with a polished `README.md` per the artifact-protocol convention.
+- [ ] Stream entry in `docs/WORKSTREAMS.md` flipped to ✅.
+
+---
+
+## Dependencies
+
+- **Hard:** none currently in flight that block this. PRs #385 and #384 are downstream of Phase B-3 (B-3 ports #385 to drop sibling types; #384 rebases after).
+- **Soft:** the substrate-prep PR (this brief + state.md) must merge before Phase B-1 commission.
+
+---
+
+## Resume protocol
+
+To pick up this stream from any cold-start orchestrator session:
+
+1. Read this brief.
+2. Read `state.md` (in the same directory) — phase status + decisions log.
+3. Read the three decision-track docs under `.ai/tasks/active/ts-prompt-assist/` (named under "Why this stream exists").
+4. Check the cluster's in-flight PRs (`mcp__github__list_pull_requests`, base = `claude/ts-prompt-assist-features`).
+5. If a sub-phase is in flight (state.md will say so), read its sub-brief at `.ai/tasks/active/ts-res-typed-conditions/phase-<B-1|B-2|B-3>-brief.md`.
+
+---
+
+## Branch + PR posture
+
+- Stream substrate (this brief + state.md): substrate-prep PR `chore/ts-res-typed-conditions-stream-prep` → `claude/ts-prompt-assist-features`.
+- Sub-phase work branches: `<phase-id>/ts-res-typed-conditions-<short-name>` (the cloud-agent harness will suffix; document the actual branch name in state.md per L2).
+- Sub-phase PRs target `claude/ts-prompt-assist-features` (integration), NOT `release`. Cluster close (later) is the single PR that goes integration → release.

--- a/.ai/tasks/active/ts-res-typed-conditions/state.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/state.md
@@ -1,0 +1,77 @@
+# Stream state: `ts-res-typed-conditions`
+
+**Status:** 🟢 ready to commission — substrate prep in flight
+**Cluster:** `ts-prompt-assist-features` (in-cluster)
+**Integration branch:** `claude/ts-prompt-assist-features`
+**Last updated:** 2026-05-19 (orchestrator — substrate prep)
+
+---
+
+## Phase status
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| B-1 — Decl-tree cascade (`ts-res`, type-only) | 🟢 ready | Sub-brief authored at commission time; expand container-type parameterization to all 9 Decl interfaces; carry forward `getKeyFromLooseDecl` latent-bug fix from closed #386 |
+| B-2 — Converter parameterization (`ts-res`, runtime teeth) | ⏸ blocked on B-1 | Surface-design questions to resolve in sub-brief; opt-in parameterization; default-string back-compat preserved |
+| B-3 — `ts-prompt-assist` port (consumer) | ⏸ blocked on B-2 | Drop local `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord`; reference ts-res parameterized types directly |
+
+---
+
+## Decisions log (orchestrator, substrate prep)
+
+| Decision | Rationale |
+|---|---|
+| In-cluster (not next-cluster) | Erik (2026-05-19): "B+C cascades into deliverables for this cluster so deferring it just creates debt." v0.1 of `@fgv/ts-prompt-assist` ships with B+C wired through; consumer-port deliverables avoid being built against a shape that gets re-done. |
+| Three sub-phases (B-1 type cascade, B-2 Converter teeth, B-3 ts-prompt-assist port), not one combined PR | Erik (2026-05-19): review attention has been a real problem in this cluster; smaller scoped PRs review more cleanly. Each sub-phase is independently mergeable (B-1 is type-only; B-2 adds opt-in runtime; B-3 is consumer port). |
+| Lockstep version policy applies | ts-res change → all packages bump. Each sub-phase's rush change file is `minor` (B-1 / B-2 are additive on ts-res's active-development surface; B-3 is also additive in ts-prompt-assist). |
+| Decision-track docs (PRs #387, #388, #389) merged to integration | Per `.ai/conventions/workflow/doc-graduation.md`: this stream is the named downstream consumer of the option-space + evaluation docs; they graduate to integration as substrate input. |
+| Closed PR #386 supersession | The leaf-only parameterization can't land as-is (no plumbing in containers); B-1 starts from the integration HEAD post-#389 merge and re-implements with full cascade. The `Partial` widening fix is carried forward into B-1 scope rather than landed separately — keeping it bundled with the cascade preserves review context. |
+
+---
+
+## Open questions
+
+### To resolve at sub-brief authoring time
+
+| ID | Question | Phase |
+|---|---|---|
+| OQ-1 | What's the Converter parameterization surface shape? Opt-in factory call returning a parameterized Converter family, per-call validation context carrying the name-set, or another shape? | B-2 sub-brief |
+| OQ-2 | Does B-2 require any `QualifierCollector` surface changes, or does the existing collector API support the consumer-side opt-in? | B-2 sub-brief (verify before commission) |
+| OQ-3 | Should the cast-pressure regression test live in `ts-res` (against a synthetic consumer) or in `ts-prompt-assist` (against the real consumer port)? | B-3 sub-brief |
+
+### Deferred (not this stream's concern)
+
+| ID | Question | Where it lives |
+|---|---|---|
+| F-1 | Should `ts-res-cli` adopt parameterized Converters once B+C lands? | Followup; opportunistic, not blocking |
+| F-2 | Future stream: typed qualifier VALUES (not just names) — round-2 finding F5 in `pressure-test-findings-round-2.md` | `docs/FUTURE.md` (queued as v0.2) |
+
+---
+
+## History
+
+| Date | Event | Notes |
+|---|---|---|
+| 2026-05-19 | Stream commissioned | Substrate-prep PR `chore/ts-res-typed-conditions-stream-prep` opened on `claude/ts-prompt-assist-features` |
+| 2026-05-19 | Decision-track docs landed on integration | PR #387 (options brief), #388 (first evaluation), #389 (addendum with leaf-only correction) all merged via squash |
+| 2026-05-19 | PR #386 closed | Superseded; latent-bug `Partial` widening fix carried forward into B-1 scope |
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep | (this PR) | open |
+| B-1 | TBD | not yet commissioned |
+| B-2 | TBD | not yet commissioned |
+| B-3 | TBD | not yet commissioned |
+
+---
+
+## Related cluster PRs (held by this stream)
+
+| PR | Why held |
+|---|---|
+| #385 (ts-prompt-assist round-2 absorb F1+F2+F6) | B-3 will drop its local `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord` to reference ts-res's parameterized types directly. #385 holds until B-3 lands. |
+| #384 (sample app + round-2 findings) | Rebases onto post-B-3 HEAD; lands last before cluster close. |

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -163,6 +163,21 @@ The data-structure specifics in the design brief are **proposed** — phase A lo
 - `ts-prompt-assist-samples` — sample/test app demonstrating end-to-end usage (might be standalone OR merged into `ai-assist-image-generator`)
 - `ts-prompt-assist-editor-ui` — generic editor UX for prompt editing (decide whether to make consumer-shape-agnostic vs require consumer-side implementation; UX is complex enough that sharing would be valuable, but the consumer-specific surfaces may make full generalization impractical). See `docs/FUTURE.md`.
 
+### `ts-res-typed-conditions` 🟢
+
+**Status:** 🟢 ready to commission (Phase B-1 next)
+**Cluster:** `ts-prompt-assist-features` (in-cluster; integration branch `claude/ts-prompt-assist-features`)
+**Workflow shape:** three sub-phases inside one stream (B-1 type cascade → B-2 Converter teeth → B-3 ts-prompt-assist port). Each sub-phase its own PR; same stream substrate.
+**Substrate:** `.ai/tasks/active/ts-res-typed-conditions/{brief.md, state.md}`
+**Package surface:** `@fgv/ts-res` (Decl tree in `resource-json/`; Converter pipeline in `conditions/convert/`) + `@fgv/ts-prompt-assist` (B-3 port to drop local sibling types).
+**Out-of-scope:** `tools/ts-res-cli`, `libraries/ts-res-ui-components`, `libraries/ts-res/src/packlets/qualifiers/` (existing `QualifierCollector` surface unchanged).
+
+**Mission.** Make ts-res honor qualifier-name semantics at both type level (Decl tree cascade) and runtime level (Converter pipeline parameterization). Replaces closed PR #386's leaf-only parameterization with the complete co-designed shape. Closes round-2 finding F1 from ts-prompt-assist pressure-test by ownership at the right layer (ts-res owns qualifier-name concept; ts-prompt-assist references rather than re-implements).
+
+**Decision-track input (binding):** `.ai/tasks/active/ts-prompt-assist/{ts-res-typed-conditions-design.md, ts-res-typed-conditions-evaluation.md}` (the latter includes the load-bearing addendum correcting the "Option B" framing — #386 was leaf-only with no plumbing through containers; the implementing agent must thread `TQualifierNames` through container types, not just the leaf).
+
+**Sequencing.** B-3 unblocks held PRs #385 (round-2 absorb — drops local sibling types) and #384 (sample app — rebases last). Stream exit precedes cluster-close prep.
+
 ### `ai-assist-thinking-events` 🟡
 
 **Status:** 🟡 ready; sequencing after `ai-assist-thinking-config` phase B lands (now satisfied; ai-assist cluster shipped via #336)


### PR DESCRIPTION
## Summary

Substrate-prep for new in-cluster ts-res stream `ts-res-typed-conditions`. Replaces closed PR #386 (leaf-only parameterization of `ConditionSetDecl` that had no plumbing through container types) with the proper B+C co-designed shape.

## Decision context

Per Erik's framing (2026-05-19): "B+C cascades into deliverables for this cluster so deferring it just creates debt." ts-res owns the qualifier-name concept (via `QualifierCollector`); it should own the discipline at both type and runtime layers. The cast-temptation critique (typed authoring without runtime teeth pressures consumers toward `as` casts on round-trip flows) is what makes B-without-C unviable — a primitive that trains the anti-pattern its own type-safe-validation skill exists to forbid is self-undermining.

Decision-track substrate already landed on integration: PRs #387 (option space), #388 (first evaluation), #389 (addendum with the load-bearing "#386 is leaf-only" correction).

## Sub-phase shape

Three sub-phases inside one stream, each its own PR:

1. **B-1 — Decl-tree cascade (ts-res, type-only).** Thread `TQualifierNames extends string = string` through all 9 container Decl interfaces in `resource-json/json.ts` (the cascade #386 missed). Carries forward the `ConditionSet.getKeyFromLooseDecl` latent-bug fix from #386.
2. **B-2 — Converter parameterization (ts-res, runtime teeth).** Opt-in Converter pipeline that validates qualifier names against a consumer-declared literal set (likely derived from `QualifierCollector`). Default-string back-compat preserved.
3. **B-3 — ts-prompt-assist port.** Drop local `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord`; reference ts-res's parameterized types directly. Closes round-2 finding F1.

Sub-phase decomposition motivated by review-attention pressure observed in prior cluster work — smaller scoped PRs review more cleanly than one combined B+C change.

## Held cluster PRs

- **#385** (round-2 absorb F1+F2+F6): holds for B-3 port (F1 ultimately resolved via ts-res ownership, not the local-types accommodation in #385).
- **#384** (sample app): rebases onto post-B-3 HEAD; lands last.

## Files

- `.ai/tasks/active/ts-res-typed-conditions/brief.md` — stream brief.
- `.ai/tasks/active/ts-res-typed-conditions/state.md` — phase status, decisions log, history.
- `.ai/tasks/active/ts-prompt-assist/state.md` — appended 2026-05-19 update section documenting the cluster reshape.
- `docs/WORKSTREAMS.md` — new active-stream entry above `ai-assist-thinking-events`.

No code changes; substrate only. Sub-phase sub-briefs will be drafted at each commission.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_