### PR TITLE
feat(ts-res): B-1 Decl-tree cascade — parameterize containers on TQualifierNames

### DIFF
--- a/.ai/tasks/active/ts-res-typed-conditions/phase-b1-result.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/phase-b1-result.md
@@ -1,0 +1,92 @@
+# Phase B-1 Result: Decl-tree cascade — parameterize containers on TQualifierNames
+
+**Date:** 2026-05-19
+**Branch:** `chore/ts-res-typed-conditions-b1-cascade`
+**Status:** Complete
+
+---
+
+## Types Parameterized
+
+All types now parameterized on `TQualifierNames extends string = string` (final list reflects the original commission plus the fix-up round absorbing Copilot review findings):
+
+**Leaf types (ported from PR #386):**
+1. `ILooseConditionDecl<TQualifierNames extends string = string>` — `qualifierName: TQualifierNames`
+2. `ConditionSetDeclAsArray<TQualifierNames extends string = string>` — `ReadonlyArray<ILooseConditionDecl<TQualifierNames>>`
+3. `ConditionSetDeclAsRecord<TQualifierNames extends string = string>` — `Readonly<Partial<Record<TQualifierNames, string | IChildConditionDecl>>>`
+4. `ConditionSetDecl<TQualifierNames extends string = string>` — union of the two above
+
+**Container types (full cascade, completing what #386 missed):**
+5. `IChildResourceCandidateDecl<TQualifierNames extends string = string>` — `conditions?: ConditionSetDecl<TQualifierNames>`
+6. `ILooseResourceCandidateDecl<TQualifierNames extends string = string>` — extends `IChildResourceCandidateDecl<TQualifierNames>`; redeclares `conditions` field explicitly
+7. `IImporterResourceCandidateDecl<TQualifierNames extends string = string>` — extends `IChildResourceCandidateDecl<TQualifierNames>`
+8. `IContainerContextDecl<TQualifierNames extends string = string>` — `conditions?: ConditionSetDecl<TQualifierNames>`
+9. `IChildResourceDecl<TQualifierNames extends string = string>` — `candidates?: ReadonlyArray<IChildResourceCandidateDecl<TQualifierNames>>`
+10. `ILooseResourceDecl<TQualifierNames extends string = string>` — extends `IChildResourceDecl<TQualifierNames>`; redeclares `candidates`
+11. `IResourceCollectionDecl<TQualifierNames extends string = string>` — `context`, `candidates`, `resources`, `collections` all threaded
+12. `IImporterResourceCollectionDecl<TQualifierNames extends string = string>` — same fields threaded
+13. `IResourceTreeChildNodeDecl<TQualifierNames extends string = string>` — `resources?` / `children?` threaded *(added in fix-up round; Copilot finding #1)*
+14. `IResourceTreeRootDecl<TQualifierNames extends string = string>` — extends `IResourceTreeChildNodeDecl<TQualifierNames>` *(restructured in fix-up round so root-level resources/children inherit threading via the parent; Copilot finding #1)*
+
+**Type aliases also parameterized:**
+15. `IImporterResourceDecl<TQualifierNames extends string = string>` — union of `ILooseResourceDecl<TQualifierNames> | IChildResourceDecl<TQualifierNames>`
+
+**Type guard functions also parameterized + soundness-fixed:**
+16. `isLooseResourceCandidateDecl<TQualifierNames>` — preserves narrowing through generic param; runtime check tightened from `'id' in decl` to `'id' in decl && typeof decl.id === 'string'` *(fix-up round; Copilot findings #7 + #9)*
+17. `isLooseResourceDecl<TQualifierNames>` — same parameterization + same soundness fix
+
+The brief named 9 container interfaces; the final count is 17 distinct items because the type guards, the union alias, and `IResourceTreeChildNodeDecl` (caught by Copilot review as a missing rung of the cascade) all needed updating to thread the parameter correctly. All remain backward-compatible at the type level; the type-guard soundness fix is a runtime change on previously-malformed inputs (decls with `id: undefined`), disclosed in the PR description.
+
+---
+
+## getKeyFromLooseDecl Fix (carried from #386)
+
+`ConditionSet.getKeyFromLooseDecl` at `conditionSet.ts:200-225` converted from `Array.map` to `for...of` loop with an explicit `undefined`-value guard. This handles the case where `Object.entries` on `Readonly<Partial<Record<...>>>` produces `[string, V | undefined]` entries — the `Partial` widening is now type-accurate, and the runtime guard correctly skips keys explicitly set to `undefined`. The `c8 ignore` directive on the guard is appropriate per the evaluation addendum (reaching a `[key, undefined]` entry requires deliberately setting a key to `undefined`, which is unusual enough to be defensive code).
+
+---
+
+## Subtleties Encountered
+
+**Inheritance pattern choices:** For interfaces that extend another parameterized interface (e.g. `ILooseResourceCandidateDecl extends IChildResourceCandidateDecl<TQualifierNames>`), the decision was to both declare the type parameter on the child AND re-declare the parameterized fields. This provides explicitness for readers and avoids interface members having different effective types depending on how the interface is used.
+
+**`ILooseResourceCandidateDecl.conditions` re-declaration:** This interface extends `IChildResourceCandidateDecl<TQualifierNames>` (which already declares `conditions?: ConditionSetDecl<TQualifierNames>`) but also re-declares `conditions` explicitly. This pre-existed in the HEAD code and was preserved.
+
+**API extractor `conditionDecl` discrepancy:** The pre-existing `ts-res.api.md` incorrectly showed `conditionDecl: ObjectConverter<ILooseConditionDecl, unknown>` but the actual source type was `IConditionDecl`. After parameterizing `ILooseConditionDecl`, api-extractor produced the correct `IConditionDecl` declaration. This is a pre-existing api.md inaccuracy being corrected, not a regression.
+
+**Unresolved-link warnings (resolved in fix-up round):** Three new api-extractor warnings initially appeared for `@link ConditionSetDeclAsArray`, `@link ConditionSetDeclAsRecord`, and `@link ILooseConditionDecl` in the new `@remarks` JSDoc. The fix-up round replaced these `@link` references with backtick-quoted type names; api-extractor now emits no B-1-introduced warnings. Two pre-existing warnings (`FileTree`, `Converters`) remain — unrelated to this PR; flagged for a future cleanup chore.
+
+---
+
+## Downstream Consumer Verification
+
+`rush build --from @fgv/ts-res` built all 11 downstream consumers successfully:
+- `@fgv/ts-prompt-assist` ✅
+- `@fgv/ts-res-cli` ✅
+- `@fgv/ts-res-tutorial` ✅
+- `@fgv/ts-res-ui-components` ✅
+- `@fgv/ts-res-browser` ✅
+- `@fgv/ts-res-browser-cli` ✅
+- `@fgv/ts-res-ui-playground` ✅
+- (plus upstream dependencies from cache)
+
+No downstream consumer needed any changes. The `extends string = string` defaults preserved all existing call sites.
+
+---
+
+## API Extractor Diff Summary
+
+Changes to `libraries/ts-res/etc/ts-res.api.md`:
+- **Added:** `<TQualifierNames extends string = string>` type parameter to 10 interface/type declarations (+ 2 type guard functions and 1 union type alias)
+- **Changed:** `ConditionSetDeclAsRecord` from `Record<string, ...>` to `Readonly<Partial<Record<TQualifierNames, ...>>>` (the `Partial` tightening from #386)
+- **Changed:** `conditionDecl: ObjectConverter<ILooseConditionDecl, unknown>` → `conditionDecl: ObjectConverter<IConditionDecl, unknown>` (pre-existing api.md inaccuracy corrected by the parameterization; source was always `IConditionDecl`)
+- **No removed exports**
+- **No renamed exports**
+- **No new unresolved-link warnings** after fix-up round (initial three replaced with backtick refs; two pre-existing warnings on `FileTree` / `Converters` remain, unrelated to this PR)
+
+---
+
+## Open Questions for B-2
+
+1. **Converter parameterization shape:** The evaluation addendum (Q2) sketches `qualifierNameConverter?: Converter<QualifierName>` as an optional field on `IConditionDeclConvertContext`. The sub-brief names this as OQ-1. The B-2 agent should read the evaluation addendum's Q2 sketch carefully — the default (`Converters.string` + branded cast) preserves existing behavior; the opt-in path requires consumer to supply `Converters.enumeratedValue([...] as const)`. No `QualifierCollector` surface changes appear to be required for B-2 per the evaluation (Q5 analysis).
+
+2. **The 4–6 internal file estimate from evaluation Q5:** The affected files are `conditions/convert/decls.ts` (`validatedConditionDecl` context interface), `conditions/convert/conditionSetDecls.ts`, and the cascade up through `ResourceJson` converters. The B-2 agent should verify this estimate before starting.

--- a/.ai/tasks/active/ts-res-typed-conditions/state.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/state.md
@@ -3,7 +3,7 @@
 **Status:** 🟢 ready to commission — substrate prep in flight
 **Cluster:** `ts-prompt-assist-features` (in-cluster)
 **Integration branch:** `claude/ts-prompt-assist-features`
-**Last updated:** 2026-05-19 (orchestrator — substrate prep)
+**Last updated:** 2026-05-19 (orchestrator — B-1 review-feedback absorbed; ready for merge)
 
 ---
 
@@ -11,8 +11,8 @@
 
 | Phase | Status | Notes |
 |-------|--------|-------|
-| B-1 — Decl-tree cascade (`ts-res`, type-only) | 🟢 ready | Sub-brief authored at commission time; expand container-type parameterization to all 9 Decl interfaces; carry forward `getKeyFromLooseDecl` latent-bug fix from closed #386 |
-| B-2 — Converter parameterization (`ts-res`, runtime teeth) | ⏸ blocked on B-1 | Surface-design questions to resolve in sub-brief; opt-in parameterization; default-string back-compat preserved |
+| B-1 — Decl-tree cascade (`ts-res`, type-only) | ✅ complete | PR #391 in review; all 9 container interfaces + leaf types parameterized; `getKeyFromLooseDecl` fix ported; 100% coverage; downstream consumers compile unchanged |
+| B-2 — Converter parameterization (`ts-res`, runtime teeth) | 🟢 ready | blocked on B-1 merge; surface-design questions to resolve in sub-brief (OQ-1); opt-in parameterization; default-string back-compat preserved |
 | B-3 — `ts-prompt-assist` port (consumer) | ⏸ blocked on B-2 | Drop local `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord`; reference ts-res parameterized types directly |
 
 ---
@@ -55,6 +55,8 @@
 | 2026-05-19 | Stream commissioned | Substrate-prep PR `chore/ts-res-typed-conditions-stream-prep` opened on `claude/ts-prompt-assist-features` |
 | 2026-05-19 | Decision-track docs landed on integration | PR #387 (options brief), #388 (first evaluation), #389 (addendum with leaf-only correction) all merged via squash |
 | 2026-05-19 | PR #386 closed | Superseded; latent-bug `Partial` widening fix carried forward into B-1 scope |
+| 2026-05-19 | B-1 commissioned + completed | Branch `chore/ts-res-typed-conditions-b1-cascade`; all 9 container interfaces + leaf types parameterized; `getKeyFromLooseDecl` fix ported; api-extractor regenerated; 100% coverage; downstream consumers compile unchanged; PR opened |
+| 2026-05-19 | B-1 review rounds absorbed | Round 1: cascade-incompleteness on `IResourceTreeRootDecl` (added `IResourceTreeChildNodeDecl` parameterization; root now extends child node); three api-extractor `@link` warnings replaced with backtick refs; missing `@fgv/ts-utils-jest` test import added; state.md artifact accuracy. Round 2: type-guard runtime soundness on `isLooseResourceCandidateDecl` / `isLooseResourceDecl` (`'id' in decl` → `'id' in decl && typeof decl.id === 'string'`). Round 3: PR description updated to explicitly disclose the two runtime fixes (no code change). All gates re-passed. |
 
 ---
 
@@ -62,8 +64,8 @@
 
 | Phase | PR | Status |
 |---|---|---|
-| Substrate prep | (this PR) | open |
-| B-1 | TBD | not yet commissioned |
+| Substrate prep | #390 | merged |
+| B-1 | #391 (branch: `chore/ts-res-typed-conditions-b1-cascade`) | in review |
 | B-2 | TBD | not yet commissioned |
 | B-3 | TBD | not yet commissioned |
 

--- a/common/changes/@fgv/ts-res/chore-ts-res-typed-conditions-b1-cascade_2026-05-19-00-00.json
+++ b/common/changes/@fgv/ts-res/chore-ts-res-typed-conditions-b1-cascade_2026-05-19-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "B-1 Decl-tree cascade: thread `TQualifierNames extends string = string` through all 9 container Decl interfaces (`IChildResourceCandidateDecl`, `ILooseResourceCandidateDecl`, `IImporterResourceCandidateDecl`, `IContainerContextDecl`, `IChildResourceDecl`, `ILooseResourceDecl`, `IResourceCollectionDecl`, `IImporterResourceCollectionDecl`, `IResourceTreeRootDecl`) plus the leaf types (`ILooseConditionDecl`, `ConditionSetDeclAsArray`, `ConditionSetDeclAsRecord`, `ConditionSetDecl`). Carry forward `ConditionSet.getKeyFromLooseDecl` correctness fix from closed PR #386 (handles explicit-undefined record entries forced by `Partial` widening on `ConditionSetDeclAsRecord`). All defaults preserve existing untyped callers unchanged.",
+      "type": "minor",
+      "packageName": "@fgv/ts-res"
+    }
+  ],
+  "packageName": "@fgv/ts-res",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-res/etc/ts-res.api.md
+++ b/libraries/ts-res/etc/ts-res.api.md
@@ -588,7 +588,7 @@ class ConditionCollector extends ValidatingCollector<Condition> {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-const conditionDecl: ObjectConverter<ILooseConditionDecl, unknown>;
+const conditionDecl: ObjectConverter<IConditionDecl, unknown>;
 
 // @public
 export type ConditionIndex = Brand<number, 'ConditionIndex'>;
@@ -707,7 +707,7 @@ class ConditionSetCollector extends ValidatingCollector<ConditionSet> {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-type ConditionSetDecl = ConditionSetDeclAsArray | ConditionSetDeclAsRecord;
+type ConditionSetDecl<TQualifierNames extends string = string> = ConditionSetDeclAsArray<TQualifierNames> | ConditionSetDeclAsRecord<TQualifierNames>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
@@ -727,12 +727,12 @@ const conditionSetDecl_2: ObjectConverter<IConditionSetDecl, unknown>;
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-type ConditionSetDeclAsArray = ReadonlyArray<ILooseConditionDecl>;
+type ConditionSetDeclAsArray<TQualifierNames extends string = string> = ReadonlyArray<ILooseConditionDecl<TQualifierNames>>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-type ConditionSetDeclAsRecord = Record<string, string | IChildConditionDecl>;
+type ConditionSetDeclAsRecord<TQualifierNames extends string = string> = Readonly<Partial<Record<TQualifierNames, string | IChildConditionDecl>>>;
 
 // @public
 export type ConditionSetHash = Brand<string, 'ConditionSetHash'>;
@@ -1596,8 +1596,8 @@ interface IChildConditionDecl {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-interface IChildResourceCandidateDecl {
-    readonly conditions?: ConditionSetDecl;
+interface IChildResourceCandidateDecl<TQualifierNames extends string = string> {
+    readonly conditions?: ConditionSetDecl<TQualifierNames>;
     readonly isPartial?: boolean;
     readonly json: JsonObject;
     readonly mergeMethod?: ResourceValueMergeMethod;
@@ -1616,8 +1616,8 @@ interface IChildResourceCandidateDecl_2 {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-interface IChildResourceDecl {
-    readonly candidates?: ReadonlyArray<IChildResourceCandidateDecl>;
+interface IChildResourceDecl<TQualifierNames extends string = string> {
+    readonly candidates?: ReadonlyArray<IChildResourceCandidateDecl<TQualifierNames>>;
     readonly resourceTypeName: string;
 }
 
@@ -1842,11 +1842,11 @@ interface IConfigInitFactory<TConfig, T> {
 }
 
 // @public
-interface IContainerContextDecl {
+interface IContainerContextDecl<TQualifierNames extends string = string> {
     // (undocumented)
     readonly baseId?: string;
     // (undocumented)
-    readonly conditions?: ConditionSetDecl;
+    readonly conditions?: ConditionSetDecl<TQualifierNames>;
     // (undocumented)
     readonly mergeMethod?: ResourceValueMergeMethod;
 }
@@ -2120,7 +2120,7 @@ interface IImporterCreateParams {
 }
 
 // @public
-interface IImporterResourceCandidateDecl extends IChildResourceCandidateDecl {
+interface IImporterResourceCandidateDecl<TQualifierNames extends string = string> extends IChildResourceCandidateDecl<TQualifierNames> {
     readonly id?: string;
     readonly resourceTypeName?: string;
 }
@@ -2132,17 +2132,17 @@ interface IImporterResourceCandidateDecl_2 extends IChildResourceCandidateDecl_2
 }
 
 // @public
-interface IImporterResourceCollectionDecl {
+interface IImporterResourceCollectionDecl<TQualifierNames extends string = string> {
     // (undocumented)
-    readonly candidates?: ReadonlyArray<IImporterResourceCandidateDecl>;
+    readonly candidates?: ReadonlyArray<IImporterResourceCandidateDecl<TQualifierNames>>;
     // (undocumented)
-    readonly collections?: ReadonlyArray<IImporterResourceCollectionDecl>;
+    readonly collections?: ReadonlyArray<IImporterResourceCollectionDecl<TQualifierNames>>;
     // (undocumented)
-    readonly context?: IContainerContextDecl;
+    readonly context?: IContainerContextDecl<TQualifierNames>;
     // (undocumented)
     readonly metadata?: JsonObject;
     // (undocumented)
-    readonly resources?: ReadonlyArray<IImporterResourceDecl>;
+    readonly resources?: ReadonlyArray<IImporterResourceDecl<TQualifierNames>>;
 }
 
 // @public
@@ -2160,7 +2160,7 @@ interface IImporterResourceCollectionDecl_2 {
 }
 
 // @public
-type IImporterResourceDecl = ILooseResourceDecl | IChildResourceDecl;
+type IImporterResourceDecl<TQualifierNames extends string = string> = ILooseResourceDecl<TQualifierNames> | IChildResourceDecl<TQualifierNames>;
 
 // @public
 type IImporterResourceDecl_2 = ILooseResourceDecl_2 | IChildResourceDecl_2;
@@ -2243,11 +2243,11 @@ interface ILiteralValueHierarchyCreateParams<T extends string = string> {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-interface ILooseConditionDecl {
+interface ILooseConditionDecl<TQualifierNames extends string = string> {
     operator?: ConditionOperator;
     priority?: number;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-    qualifierName: string;
+    qualifierName: TQualifierNames;
     scoreAsDefault?: number;
     value: string;
 }
@@ -2255,8 +2255,8 @@ interface ILooseConditionDecl {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-interface ILooseResourceCandidateDecl extends IChildResourceCandidateDecl {
-    readonly conditions?: ConditionSetDecl;
+interface ILooseResourceCandidateDecl<TQualifierNames extends string = string> extends IChildResourceCandidateDecl<TQualifierNames> {
+    readonly conditions?: ConditionSetDecl<TQualifierNames>;
     readonly id: string;
     readonly isPartial?: boolean;
     readonly json: JsonObject;
@@ -2279,8 +2279,8 @@ interface ILooseResourceCandidateDecl_2 extends IChildResourceCandidateDecl_2 {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-interface ILooseResourceDecl extends IChildResourceDecl {
-    readonly candidates?: ReadonlyArray<IChildResourceCandidateDecl>;
+interface ILooseResourceDecl<TQualifierNames extends string = string> extends IChildResourceDecl<TQualifierNames> {
+    readonly candidates?: ReadonlyArray<IChildResourceCandidateDecl<TQualifierNames>>;
     readonly id: string;
     readonly resourceTypeName: string;
 }
@@ -2761,17 +2761,17 @@ interface IResourceCandidateValidationProperties {
 }
 
 // @public
-interface IResourceCollectionDecl {
+interface IResourceCollectionDecl<TQualifierNames extends string = string> {
     // (undocumented)
-    readonly candidates?: ReadonlyArray<ILooseResourceCandidateDecl>;
+    readonly candidates?: ReadonlyArray<ILooseResourceCandidateDecl<TQualifierNames>>;
     // (undocumented)
-    readonly collections?: ReadonlyArray<IResourceCollectionDecl>;
+    readonly collections?: ReadonlyArray<IResourceCollectionDecl<TQualifierNames>>;
     // (undocumented)
-    readonly context?: IContainerContextDecl;
+    readonly context?: IContainerContextDecl<TQualifierNames>;
     // (undocumented)
     readonly metadata?: JsonObject;
     // (undocumented)
-    readonly resources?: ReadonlyArray<ILooseResourceDecl>;
+    readonly resources?: ReadonlyArray<ILooseResourceDecl<TQualifierNames>>;
 }
 
 // @public
@@ -2913,11 +2913,11 @@ interface IResourceTreeBranchInit<T> {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-interface IResourceTreeChildNodeDecl {
+interface IResourceTreeChildNodeDecl<TQualifierNames extends string = string> {
     // (undocumented)
-    readonly children?: Record<string, IResourceTreeChildNodeDecl>;
+    readonly children?: Record<string, IResourceTreeChildNodeDecl<TQualifierNames>>;
     // (undocumented)
-    readonly resources?: Record<string, IChildResourceDecl>;
+    readonly resources?: Record<string, IChildResourceDecl<TQualifierNames>>;
 }
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -2939,15 +2939,15 @@ interface IResourceTreeLeafInit<T> {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-interface IResourceTreeRootDecl extends IResourceTreeChildNodeDecl {
+interface IResourceTreeRootDecl<TQualifierNames extends string = string> extends IResourceTreeChildNodeDecl<TQualifierNames> {
     // (undocumented)
-    readonly children?: Record<string, IResourceTreeChildNodeDecl>;
+    readonly children?: Record<string, IResourceTreeChildNodeDecl<TQualifierNames>>;
     // (undocumented)
-    readonly context?: IContainerContextDecl;
+    readonly context?: IContainerContextDecl<TQualifierNames>;
     // (undocumented)
     readonly metadata?: JsonObject;
     // (undocumented)
-    readonly resources?: Record<string, IChildResourceDecl>;
+    readonly resources?: Record<string, IChildResourceDecl<TQualifierNames>>;
 }
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -3013,10 +3013,10 @@ interface ISimpleContextQualifierProviderCreateParams {
 function isImportable(i: IImportable): i is Importable;
 
 // @public
-function isLooseResourceCandidateDecl(decl: IImporterResourceCandidateDecl): decl is ILooseResourceCandidateDecl;
+function isLooseResourceCandidateDecl<TQualifierNames extends string = string>(decl: IImporterResourceCandidateDecl<TQualifierNames>): decl is ILooseResourceCandidateDecl<TQualifierNames>;
 
 // @public
-function isLooseResourceDecl(decl: IImporterResourceDecl): decl is ILooseResourceDecl;
+function isLooseResourceDecl<TQualifierNames extends string = string>(decl: IImporterResourceDecl<TQualifierNames>): decl is ILooseResourceDecl<TQualifierNames>;
 
 // @public
 function isResourceTreeLeafInit<T>(init: ResourceTreeNodeInit<T>): init is IResourceTreeLeafInit<T>;

--- a/libraries/ts-res/src/packlets/conditions/conditionSet.ts
+++ b/libraries/ts-res/src/packlets/conditions/conditionSet.ts
@@ -204,15 +204,24 @@ export class ConditionSet implements IValidatedConditionSetDecl {
       // ConditionSetDeclAsArray: array of ILooseConditionDecl
       conditionSetDecl = { conditions: conditionSet };
     } else {
-      // ConditionSetDeclAsRecord: Record<string, string | IChildConditionDecl>
-      const conditions = Object.entries(conditionSet).map(([qualifierName, value]) => {
+      // ConditionSetDeclAsRecord: Readonly<Partial<Record<string, string | IChildConditionDecl>>>.
+      // The record-form type is `Readonly<Partial<Record<..., V>>>`, so
+      // `Object.entries` produces `[string, V | undefined]` — runtime
+      // `undefined` values (a key explicitly set to undefined) skip;
+      // they're semantically equivalent to omitting the key.
+      const conditions: ResourceJson.Json.ILooseConditionDecl[] = [];
+      for (const [qualifierName, value] of Object.entries(conditionSet)) {
+        /* c8 ignore next 3 - defensive: explicit-undefined-value entries skipped */
+        if (value === undefined) {
+          continue;
+        }
         if (typeof value === 'string') {
-          return { qualifierName, value };
+          conditions.push({ qualifierName, value });
           /* c8 ignore next 3 - edge case */
         } else {
-          return { qualifierName, ...value };
+          conditions.push({ qualifierName, ...value });
         }
-      });
+      }
       conditionSetDecl = { conditions };
     }
 

--- a/libraries/ts-res/src/packlets/resource-json/json.ts
+++ b/libraries/ts-res/src/packlets/resource-json/json.ts
@@ -25,13 +25,21 @@ import { ConditionOperator, ResourceValueMergeMethod } from '../common';
 
 /**
  * Non-validated loose declaration of a {@link Conditions.Condition | condition}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames` so consumers authoring conditions
+ * in code can opt into compile-time axis-name discipline (e.g. via a
+ * literal-string union derived from a `qualifiers: ['tone'] as const`
+ * decl-array). Defaults to `string`, so existing untyped callers
+ * compile unchanged.
+ *
  * @public
  */
-export interface ILooseConditionDecl {
+export interface ILooseConditionDecl<TQualifierNames extends string = string> {
   /**
    * The name of the {@link Qualifiers.Qualifier | qualifier} to be compared.
    */
-  qualifierName: string;
+  qualifierName: TQualifierNames;
   /**
    * The value to be compared.
    */
@@ -80,28 +88,60 @@ export interface IChildConditionDecl {
 }
 
 /**
- * Non-validated declaration of a {@link Conditions.Condition | condition}.
+ * Non-validated array-form declaration of a {@link Conditions.ConditionSet | condition set}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames` via `ILooseConditionDecl`;
+ * defaults to `string` for back-compat with existing untyped callers.
+ *
  * @public
  */
-export type ConditionSetDeclAsArray = ReadonlyArray<ILooseConditionDecl>;
+export type ConditionSetDeclAsArray<TQualifierNames extends string = string> = ReadonlyArray<
+  ILooseConditionDecl<TQualifierNames>
+>;
 
 /**
- * Non-validated declaration of a {@link Conditions.Condition | condition}.
+ * Non-validated record-form declaration of a {@link Conditions.ConditionSet | condition set}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames`; defaults to `string` for back-compat with
+ * existing untyped callers. Uses `Readonly<Partial<Record<...>>>` to align with
+ * runtime reality (missing keys produce `undefined`; the `Partial` makes TypeScript
+ * aware of this, which is a strict type-system tightening).
+ *
  * @public
  */
-export type ConditionSetDeclAsRecord = Record<string, string | IChildConditionDecl>;
+export type ConditionSetDeclAsRecord<TQualifierNames extends string = string> = Readonly<
+  Partial<Record<TQualifierNames, string | IChildConditionDecl>>
+>;
 
 /**
- * Non-validated declaration of a {@link Conditions.Condition | condition}.
+ * Non-validated declaration of a {@link Conditions.ConditionSet | condition set}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames`; defaults to `string`. Both the
+ * array form (`ConditionSetDeclAsArray`) and the record form
+ * (`ConditionSetDeclAsRecord`) inherit the parameter, so a
+ * consumer threading a narrow `TQualifierNames` gets compile-time
+ * rejection of typo'd axis names in either form.
+ *
  * @public
  */
-export type ConditionSetDecl = ConditionSetDeclAsArray | ConditionSetDeclAsRecord;
+export type ConditionSetDecl<TQualifierNames extends string = string> =
+  | ConditionSetDeclAsArray<TQualifierNames>
+  | ConditionSetDeclAsRecord<TQualifierNames>;
 
 /**
  * Non-validated child declaration of a {@link Resources.ResourceCandidate | resource candidate}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames` so the `conditions` field can carry a
+ * narrowed axis-name set. Defaults to `string` so existing untyped callers
+ * compile unchanged.
+ *
  * @public
  */
-export interface IChildResourceCandidateDecl {
+export interface IChildResourceCandidateDecl<TQualifierNames extends string = string> {
   /**
    * The JSON value of the resource.
    */
@@ -110,7 +150,7 @@ export interface IChildResourceCandidateDecl {
   /**
    * The conditions that must be met for the resource to be selected.
    */
-  readonly conditions?: ConditionSetDecl;
+  readonly conditions?: ConditionSetDecl<TQualifierNames>;
 
   /**
    * If true, the resource is only a partial representation of the full resource.
@@ -127,9 +167,15 @@ export interface IChildResourceCandidateDecl {
 /**
  * Non-validated declaration of a resource candidate for import,
  * which can be either a loose or child resource candidate.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames`; inherits via `IChildResourceCandidateDecl`.
+ * Defaults to `string` for back-compat.
+ *
  * @public
  */
-export interface IImporterResourceCandidateDecl extends IChildResourceCandidateDecl {
+export interface IImporterResourceCandidateDecl<TQualifierNames extends string = string>
+  extends IChildResourceCandidateDecl<TQualifierNames> {
   /**
    * The {@link ResourceId | id} of the resource.
    */
@@ -143,9 +189,15 @@ export interface IImporterResourceCandidateDecl extends IChildResourceCandidateD
 
 /**
  * Non-validated loose declaration of a {@link Resources.ResourceCandidate | resource candidate}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames`; inherits via `IChildResourceCandidateDecl`.
+ * Defaults to `string` for back-compat.
+ *
  * @public
  */
-export interface ILooseResourceCandidateDecl extends IChildResourceCandidateDecl {
+export interface ILooseResourceCandidateDecl<TQualifierNames extends string = string>
+  extends IChildResourceCandidateDecl<TQualifierNames> {
   /**
    * The {@link ResourceId | id} of the resource.
    */
@@ -159,7 +211,7 @@ export interface ILooseResourceCandidateDecl extends IChildResourceCandidateDecl
   /**
    * The conditions that must be met for the resource to be selected.
    */
-  readonly conditions?: ConditionSetDecl;
+  readonly conditions?: ConditionSetDecl<TQualifierNames>;
 
   /**
    * If true, the resource is only a partial representation of the full resource.
@@ -180,9 +232,15 @@ export interface ILooseResourceCandidateDecl extends IChildResourceCandidateDecl
 
 /**
  * Non-validated child declaration of a {@link Resources.Resource | resource}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames` so the `candidates` field threads the
+ * narrowed axis-name set down to each candidate. Defaults to `string` for
+ * back-compat.
+ *
  * @public
  */
-export interface IChildResourceDecl {
+export interface IChildResourceDecl<TQualifierNames extends string = string> {
   /**
    * The name of the type of this resource.
    */
@@ -191,14 +249,20 @@ export interface IChildResourceDecl {
   /**
    * Possible candidates for this value.
    */
-  readonly candidates?: ReadonlyArray<IChildResourceCandidateDecl>;
+  readonly candidates?: ReadonlyArray<IChildResourceCandidateDecl<TQualifierNames>>;
 }
 
 /**
  * Non-validated loose declaration of a {@link Resources.Resource | resource}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames`; inherits via `IChildResourceDecl`.
+ * Defaults to `string` for back-compat.
+ *
  * @public
  */
-export interface ILooseResourceDecl extends IChildResourceDecl {
+export interface ILooseResourceDecl<TQualifierNames extends string = string>
+  extends IChildResourceDecl<TQualifierNames> {
   /**
    * The id of the resource.
    */
@@ -212,67 +276,104 @@ export interface ILooseResourceDecl extends IChildResourceDecl {
   /**
    * Possible candidates for this value.
    */
-  readonly candidates?: ReadonlyArray<IChildResourceCandidateDecl>;
+  readonly candidates?: ReadonlyArray<IChildResourceCandidateDecl<TQualifierNames>>;
 }
 
 /**
  * Normalized non-validated declaration of a {@link Resources.Resource | resource} tree node.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames` so the `resources` and `children` fields
+ * thread the narrowed axis-name set throughout the tree. Defaults to `string` for
+ * back-compat.
+ *
  * @public
  */
-export interface IResourceTreeChildNodeDecl {
-  readonly resources?: Record<string, IChildResourceDecl>;
-  readonly children?: Record<string, IResourceTreeChildNodeDecl>;
+export interface IResourceTreeChildNodeDecl<TQualifierNames extends string = string> {
+  readonly resources?: Record<string, IChildResourceDecl<TQualifierNames>>;
+  readonly children?: Record<string, IResourceTreeChildNodeDecl<TQualifierNames>>;
 }
 
 /**
  * Declared context for a resource container.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames` so the `conditions` field threads the
+ * narrowed axis-name set to the container context. Defaults to `string` for
+ * back-compat.
+ *
  * @public
  */
-export interface IContainerContextDecl {
+export interface IContainerContextDecl<TQualifierNames extends string = string> {
   readonly baseId?: string;
-  readonly conditions?: ConditionSetDecl;
+  readonly conditions?: ConditionSetDecl<TQualifierNames>;
   readonly mergeMethod?: ResourceValueMergeMethod;
 }
 
 /**
  * Normalized non-validated declaration of a {@link Resources.Resource | resource} tree root.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames` so the `context` field threads the
+ * narrowed axis-name set to the tree root context. Defaults to `string` for
+ * back-compat.
+ *
  * @public
  */
-export interface IResourceTreeRootDecl extends IResourceTreeChildNodeDecl {
-  readonly context?: IContainerContextDecl;
-  readonly resources?: Record<string, IChildResourceDecl>;
-  readonly children?: Record<string, IResourceTreeChildNodeDecl>;
+export interface IResourceTreeRootDecl<TQualifierNames extends string = string>
+  extends IResourceTreeChildNodeDecl<TQualifierNames> {
+  readonly context?: IContainerContextDecl<TQualifierNames>;
+  readonly resources?: Record<string, IChildResourceDecl<TQualifierNames>>;
+  readonly children?: Record<string, IResourceTreeChildNodeDecl<TQualifierNames>>;
   readonly metadata?: JsonObject;
 }
 
 /**
  * Non-validated declaration of a collection of resources.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames` so the `context`, `candidates`, and
+ * `resources` fields thread the narrowed axis-name set throughout the
+ * collection. Defaults to `string` for back-compat.
+ *
  * @public
  */
-export interface IResourceCollectionDecl {
-  readonly context?: IContainerContextDecl;
-  readonly candidates?: ReadonlyArray<ILooseResourceCandidateDecl>;
-  readonly resources?: ReadonlyArray<ILooseResourceDecl>;
-  readonly collections?: ReadonlyArray<IResourceCollectionDecl>;
+export interface IResourceCollectionDecl<TQualifierNames extends string = string> {
+  readonly context?: IContainerContextDecl<TQualifierNames>;
+  readonly candidates?: ReadonlyArray<ILooseResourceCandidateDecl<TQualifierNames>>;
+  readonly resources?: ReadonlyArray<ILooseResourceDecl<TQualifierNames>>;
+  readonly collections?: ReadonlyArray<IResourceCollectionDecl<TQualifierNames>>;
   readonly metadata?: JsonObject;
 }
 
 /**
  * Non-validated declaration of a resource for import,
  * which can be either a loose or child resource.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames`; defaults to `string` for back-compat.
+ *
  * @public
  */
-export type IImporterResourceDecl = ILooseResourceDecl | IChildResourceDecl;
+export type IImporterResourceDecl<TQualifierNames extends string = string> =
+  | ILooseResourceDecl<TQualifierNames>
+  | IChildResourceDecl<TQualifierNames>;
 
 /**
  * Non-validated declaration of a collection of resources for an importer.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames` so the `context`, `candidates`, and
+ * `resources` fields thread the narrowed axis-name set throughout the
+ * importer collection. Defaults to `string` for back-compat.
+ *
  * @public
  */
-export interface IImporterResourceCollectionDecl {
-  readonly context?: IContainerContextDecl;
-  readonly candidates?: ReadonlyArray<IImporterResourceCandidateDecl>;
-  readonly resources?: ReadonlyArray<IImporterResourceDecl>;
-  readonly collections?: ReadonlyArray<IImporterResourceCollectionDecl>;
+export interface IImporterResourceCollectionDecl<TQualifierNames extends string = string> {
+  readonly context?: IContainerContextDecl<TQualifierNames>;
+  readonly candidates?: ReadonlyArray<IImporterResourceCandidateDecl<TQualifierNames>>;
+  readonly resources?: ReadonlyArray<IImporterResourceDecl<TQualifierNames>>;
+  readonly collections?: ReadonlyArray<IImporterResourceCollectionDecl<TQualifierNames>>;
   readonly metadata?: JsonObject;
 }
 
@@ -280,16 +381,18 @@ export interface IImporterResourceCollectionDecl {
  * Type guard function to check if a resource candidate declaration is a loose resource candidate declaration.
  * @public
  */
-export function isLooseResourceCandidateDecl(
-  decl: IImporterResourceCandidateDecl
-): decl is ILooseResourceCandidateDecl {
-  return 'id' in decl;
+export function isLooseResourceCandidateDecl<TQualifierNames extends string = string>(
+  decl: IImporterResourceCandidateDecl<TQualifierNames>
+): decl is ILooseResourceCandidateDecl<TQualifierNames> {
+  return 'id' in decl && typeof decl.id === 'string';
 }
 
 /**
  * Type guard function to check if a resource declaration is a loose resource declaration.
  * @public
  */
-export function isLooseResourceDecl(decl: IImporterResourceDecl): decl is ILooseResourceDecl {
-  return 'id' in decl;
+export function isLooseResourceDecl<TQualifierNames extends string = string>(
+  decl: IImporterResourceDecl<TQualifierNames>
+): decl is ILooseResourceDecl<TQualifierNames> {
+  return 'id' in decl && typeof decl.id === 'string';
 }

--- a/libraries/ts-res/src/test/unit/resource-json/typedConditions.test.ts
+++ b/libraries/ts-res/src/test/unit/resource-json/typedConditions.test.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import '@fgv/ts-utils-jest';
+import * as TsRes from '../../../index';
+
+/**
+ * Compile-time tests for the B-1 Decl-tree cascade parameterization.
+ *
+ * These tests verify that `TQualifierNames extends string = string` has been
+ * threaded through the full container Decl chain so that consumers authoring
+ * seeds in code get compile-time typo rejection.
+ *
+ * The `@ts-expect-error` directives are the load-bearing assertions — they
+ * prove that TypeScript rejects the typo'd qualifier names at compile time.
+ * The runtime assertions are secondary; they confirm that the valid forms
+ * accepted by TS also work at runtime.
+ */
+
+describe('ResourceJson typed conditions (B-1 Decl-tree cascade)', () => {
+  describe('IResourceCollectionDecl<TQualifierNames>', () => {
+    test('accepts valid qualifier name in record-form ConditionSetDecl', () => {
+      // TS should accept 'tone' since it's in the declared union.
+      const valid: TsRes.ResourceJson.Json.IResourceCollectionDecl<'tone'> = {
+        candidates: [
+          {
+            id: 'candidate-1',
+            json: { value: 'hello' },
+            conditions: { tone: 'formal' }
+          }
+        ]
+      };
+      // Runtime check: the object is assignable and has the expected shape.
+      expect(valid.candidates).toHaveLength(1);
+      expect(valid.candidates?.[0]?.conditions).toEqual({ tone: 'formal' });
+    });
+
+    test('accepts valid qualifier name in array-form ConditionSetDecl', () => {
+      // TS should accept 'tone' in array form as well.
+      const valid: TsRes.ResourceJson.Json.IResourceCollectionDecl<'tone'> = {
+        candidates: [
+          {
+            id: 'candidate-1',
+            json: { value: 'hello' },
+            conditions: [{ qualifierName: 'tone', value: 'formal' }]
+          }
+        ]
+      };
+      expect(valid.candidates).toHaveLength(1);
+    });
+
+    test("rejects typo'd qualifier name at compile time", () => {
+      // Compile-time check: 'tonr' is a typo for 'tone'.
+      // The @ts-expect-error directive is the load-bearing assertion —
+      // it proves TS rejects the invalid qualifier name.
+      const _bad: TsRes.ResourceJson.Json.IResourceCollectionDecl<'tone'> = {
+        candidates: [
+          {
+            id: 'candidate-1',
+            json: { value: 'hello' },
+            conditions: {
+              // @ts-expect-error - 'tonr' is not assignable to 'tone'
+              tonr: 'formal'
+            }
+          }
+        ]
+      };
+      // The @ts-expect-error above is the point of this test.
+      // We still need a runtime assertion to keep jest happy.
+      expect(_bad).toBeDefined();
+    });
+  });
+
+  describe('IChildResourceCandidateDecl<TQualifierNames>', () => {
+    test('accepts valid qualifier name in conditions field', () => {
+      const valid: TsRes.ResourceJson.Json.IChildResourceCandidateDecl<'language' | 'tone'> = {
+        json: { value: 'hello' },
+        conditions: { language: 'en', tone: 'formal' }
+      };
+      expect(valid.conditions).toBeDefined();
+    });
+
+    test("rejects typo'd qualifier name at compile time", () => {
+      const _bad: TsRes.ResourceJson.Json.IChildResourceCandidateDecl<'language'> = {
+        json: { value: 'hello' },
+        conditions: {
+          // @ts-expect-error - 'langauge' is not assignable to 'language'
+          langauge: 'en'
+        }
+      };
+      expect(_bad).toBeDefined();
+    });
+  });
+
+  describe('IResourceTreeRootDecl<TQualifierNames>', () => {
+    test('accepts valid qualifier name in resources candidates', () => {
+      const valid: TsRes.ResourceJson.Json.IResourceTreeRootDecl<'tone'> = {
+        resources: {
+          'my-resource': {
+            resourceTypeName: 'string',
+            candidates: [
+              {
+                json: { value: 'hello' },
+                conditions: { tone: 'formal' }
+              }
+            ]
+          }
+        }
+      };
+      expect(valid.resources).toBeDefined();
+    });
+
+    test("rejects typo'd qualifier name in resources candidates at compile time", () => {
+      const _bad: TsRes.ResourceJson.Json.IResourceTreeRootDecl<'tone'> = {
+        resources: {
+          'my-resource': {
+            resourceTypeName: 'string',
+            candidates: [
+              {
+                json: { value: 'hello' },
+                conditions: {
+                  // @ts-expect-error - 'tonr' is not assignable to 'tone'
+                  tonr: 'formal'
+                }
+              }
+            ]
+          }
+        }
+      };
+      expect(_bad).toBeDefined();
+    });
+
+    test("rejects typo'd qualifier name in children resources at compile time", () => {
+      const _bad: TsRes.ResourceJson.Json.IResourceTreeRootDecl<'tone'> = {
+        children: {
+          'my-child': {
+            resources: {
+              'child-resource': {
+                resourceTypeName: 'string',
+                candidates: [
+                  {
+                    json: { value: 'hello' },
+                    conditions: {
+                      // @ts-expect-error - 'tonr' is not assignable to 'tone'
+                      tonr: 'formal'
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      };
+      expect(_bad).toBeDefined();
+    });
+  });
+
+  describe('unparameterized (default string) form compiles unchanged', () => {
+    test('unparameterized IResourceCollectionDecl accepts any string key', () => {
+      // Default form (TQualifierNames = string) — existing callers unchanged.
+      const untyped: TsRes.ResourceJson.Json.IResourceCollectionDecl = {
+        candidates: [
+          {
+            id: 'candidate-1',
+            json: { value: 'hello' },
+            conditions: { anyKey: 'anyValue', anotherKey: 'anotherValue' }
+          }
+        ]
+      };
+      expect(untyped.candidates).toHaveLength(1);
+    });
+
+    test('unparameterized ConditionSetDecl accepts any string qualifier name', () => {
+      // Default form — back-compat preserved.
+      const untyped: TsRes.ResourceJson.Json.ConditionSetDecl = [
+        { qualifierName: 'anyQualifier', value: 'anyValue' },
+        { qualifierName: 'anotherQualifier', value: 'anotherValue' }
+      ];
+      expect(untyped).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase B-1 of the `ts-res-typed-conditions` stream: thread `TQualifierNames extends string = string` through the full Decl-tree cascade in `@fgv/ts-res`'s `resource-json` packlet. Primarily type-level work, plus two bundled latent-bug runtime fixes (called out explicitly below). Completes what closed PR #386 started but did only at the leaf — #386 parameterized `ConditionSetDecl` but no container types, so the narrow had no flow path from a consumer's authoring chain into the leaf. This PR fixes that by parameterizing all container interfaces plus the type guards.

Stream brief: `.ai/tasks/active/ts-res-typed-conditions/brief.md`.
Phase result: `.ai/tasks/active/ts-res-typed-conditions/phase-b1-result.md`.

## What changed — type-level

**Leaf types (carried forward from #386):**
- `ILooseConditionDecl<TQualifierNames extends string = string>` — `qualifierName` field narrows to `TQualifierNames`.
- `ConditionSetDeclAsArray<T>` / `ConditionSetDeclAsRecord<T>` / `ConditionSetDecl<T>`.

**Container interfaces (the cascade #386 missed):**
- `IChildResourceCandidateDecl<T>`, `ILooseResourceCandidateDecl<T>`, `IImporterResourceCandidateDecl<T>`
- `IContainerContextDecl<T>`
- `IChildResourceDecl<T>`, `ILooseResourceDecl<T>`
- `IResourceCollectionDecl<T>`, `IImporterResourceCollectionDecl<T>`, `IResourceTreeRootDecl<T>`, `IResourceTreeChildNodeDecl<T>`

**Broader edit surface (surfaced during review):**
- The type guards `isLooseResourceCandidateDecl` and `isLooseResourceDecl` and the union alias `IImporterResourceDecl` also needed parameterization to thread correctly.
- `IResourceTreeRootDecl` was restructured to `extends IResourceTreeChildNodeDecl<TQualifierNames>` so the `resources` / `children` fields inherit threading correctly (Copilot caught the half-cascade in the original commit).

## What changed — runtime (bundled latent-bug fixes)

These were not introduced by B-1 but were uncovered while threading the type parameter. Per the cluster's ship-then-tidy mechanic, they land in-place rather than queued as separate PRs:

1. **`ConditionSet.getKeyFromLooseDecl`** (`conditions/conditionSet.ts:200-225`) — now skips explicit-`undefined` record entries. Previously, an `Object.entries` traversal would produce malformed `ILooseConditionDecl` objects via `{ qualifierName, ...undefined }` if a record-form `ConditionSetDecl` contained an explicit `undefined` value. The `Partial` widening on `ConditionSetDeclAsRecord<T>` made TS aware of what was already true at runtime; the guard now matches.

2. **Type guards `isLooseResourceCandidateDecl` / `isLooseResourceDecl`** — now check `'id' in decl && typeof decl.id === 'string'` instead of `'id' in decl` alone. Previously, a decl with `id: undefined` would falsely narrow to the "loose" sibling (where `id: string` is required). The runtime guard now matches the declared narrowing soundly.

## api-extractor

- `etc/ts-res.api.md` regenerated. Diff shows the new generic parameter additions plus the `ConditionSetDeclAsRecord` `Partial` tightening. No removed or renamed exports.
- One pre-existing api.md inaccuracy corrected (`conditionDecl` was shown as `ILooseConditionDecl` but was always `IConditionDecl` in source). Doc-vs-source drift bundled with the regen.
- B-1-introduced unresolved-`@link` warnings eliminated (replaced with backtick references). Two pre-existing warnings (`FileTree`, `Converters`) remain — not B-1's introduction; flagged for a future chore.

## Compatibility

Type-level: additive with `extends string = string` defaults; existing call sites compile unchanged.
Runtime: the two latent-bug fixes change behavior on inputs that were structurally malformed under the previous typing — explicit-`undefined` record entries, and decls with `id: undefined`. The previous behavior on those inputs was already incorrect (malformed object construction; unsound narrowing); no caller should be relying on it.

Verified downstream: `@fgv/ts-res-cli`, `@fgv/ts-res-ui-components`, `@fgv/ts-prompt-assist`, and all other consumers compile with no changes.

## Pre-PR gate

- [x] `rush build` passes (full repo; downstream consumers compile unchanged)
- [x] `rushx lint` passes in `@fgv/ts-res` (separate gate from build)
- [x] `rushx test` passes with 100% coverage across all 4 metrics (10/10 tests including new `IResourceTreeRootDecl<'tone'>.resources` / `.children` typo-rejection)
- [x] `rushx fixlint` was run before final commit
- [x] api-extractor regenerated; only B-1 surface changes in diff; no new unresolved-link warnings
- [x] Rush change file added under `common/changes/@fgv/ts-res/` (`type: minor`)
- [x] No `any` types; no manual casts beyond `@ts-expect-error` test assertions

## Phase status

| Phase | Status |
|---|---|
| B-1 — Decl-tree cascade | ✅ this PR |
| B-2 — Converter parameterization | 🟢 next |
| B-3 — ts-prompt-assist port | ⏸ blocked on B-2 |