### PR TITLE
feat(ts-res): B-2 Converter parameterization — typed sibling exports for qualifier-name narrows

### DIFF
--- a/.ai/tasks/active/ts-res-typed-conditions/phase-b2-result.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/phase-b2-result.md
@@ -1,0 +1,278 @@
+# Phase B-2 Result: Converter parameterization — typed sibling exports
+
+**Date:** 2026-05-19
+**Branch:** `chore/ts-res-typed-conditions-b2-converter-teeth`
+**Status:** Complete (PR pending; orchestrator to open against
+`claude/ts-prompt-assist-features`)
+
+---
+
+## Typed exports shipped
+
+All typed siblings take a single `qualifierNameConverter: Converter<TQualifierNames>`
+argument and return a converter whose result type is narrowed on
+`TQualifierNames`. Existing untyped exports are preserved at signature and
+behavior level (verified: `git diff libraries/ts-res/etc/ts-res.api.md` shows
+no removed/renamed exports).
+
+### `Conditions.Convert` (libraries/ts-res/src/packlets/conditions/convert/)
+
+| Existing | New typed sibling | Returns |
+|---|---|---|
+| `conditionDecl: ObjectConverter<IConditionDecl, unknown>` | `typedConditionDecl<T>(qc)` | `Converter<IConditionDecl<T>>` |
+| `validatedConditionDecl: GenericConverter<IValidatedConditionDecl, IConditionDeclConvertContext>` | `typedValidatedConditionDecl<T>(qc)` | `Converter<IValidatedConditionDecl, IConditionDeclConvertContext>` |
+| `conditionSetDecl: ObjectConverter<IConditionSetDecl, unknown>` | `typedConditionSetDecl<T>(qc)` | `Converter<IConditionSetDecl<T>>` |
+| `validatedConditionSetDecl: GenericConverter<IValidatedConditionSetDecl, IConditionSetDeclConvertContext>` | `typedValidatedConditionSetDecl<T>(qc)` | `Converter<IValidatedConditionSetDecl, IConditionSetDeclConvertContext>` |
+
+Also: `IConditionDecl` and `IConditionSetDecl` are now parameterized on
+`TQualifierNames extends string = string` (additive default — back-compat).
+
+### `ResourceJson.Convert` (libraries/ts-res/src/packlets/resource-json/convert.ts)
+
+12 typed siblings — covering every consumer entry-point converter plus all
+internal converters that an entry-point composes (so the narrow flows
+end-to-end without re-introducing default-`string` Converters mid-chain):
+
+- `typedLooseConditionDecl<T>(qc)` → `Converter<Json.ILooseConditionDecl<T>>`
+- `typedConditionSetDecl<T>(qc)` → `Converter<Json.ConditionSetDecl<T>>` (handles both array and record form via internal `oneOf`)
+- `typedLooseResourceCandidateDecl<T>(qc)` → `Converter<Json.ILooseResourceCandidateDecl<T>>`
+- `typedImporterResourceCandidateDecl<T>(qc)` → `Converter<Json.IImporterResourceCandidateDecl<T>>`
+- `typedChildResourceCandidateDecl<T>(qc)` → `Converter<Json.IChildResourceCandidateDecl<T>>`
+- `typedLooseResourceDecl<T>(qc)` → `Converter<Json.ILooseResourceDecl<T>>`
+- `typedChildResourceDecl<T>(qc)` → `Converter<Json.IChildResourceDecl<T>>`
+- `typedContainerContextDecl<T>(qc)` → `Converter<Json.IContainerContextDecl<T>>`
+- `typedResourceTreeChildNodeDecl<T>(qc)` → `Converter<Json.IResourceTreeChildNodeDecl<T>>`
+- `typedResourceTreeRootDecl<T>(qc)` → `Converter<Json.IResourceTreeRootDecl<T>>`
+- `typedResourceCollectionDecl<T>(qc)` → `Converter<Json.IResourceCollectionDecl<T>>`
+- `typedImporterResourceCollectionDecl<T>(qc)` → `Converter<Json.IImporterResourceCollectionDecl<T>>`
+
+### Boundary rationale (what stayed default-string)
+
+- `childConditionDecl` (`Converter<Json.IChildConditionDecl>`) — `IChildConditionDecl`
+  has **no** `qualifierName` field (the record form uses the object key as
+  the qualifier name and the value carries everything else). There is nothing
+  to narrow; a typed sibling would be a pure no-op rename.
+- The internal `conditionSetDeclFromArray` / `conditionSetDeclFromRecord`
+  module-private converters in `resource-json/convert.ts` — these are not
+  exported. The typed equivalents (`_typedConditionSetDeclFromArray` /
+  `_typedConditionSetDeclFromRecord`) are also module-private and composed
+  into the public `typedConditionSetDecl`.
+
+### Implementation pattern (factoring observation)
+
+I considered factoring a shared `_makeX<T>(qc)` core per converter and having
+both the default export and the typed sibling delegate to it. That works for
+the basic `strictObject` cases but produced an undesired side effect: the
+default export's return type widens from `ObjectConverter<X, unknown>` to
+`Converter<X, unknown>` (because a function's declared return type defaults
+to the broader interface). `ObjectConverter` carries additional methods
+(`.partial()`, etc.) that consumers may use, so the widening would be a real
+public-surface narrowing.
+
+Instead I kept each default export as the original literal
+`Converters.strictObject(...)` (preserving `ObjectConverter`) and have the
+typed sibling construct a fresh `strictObject(...)` with the typed
+`qualifierName` slot. The object literal is duplicated once per shape — a
+small repetition that buys exact signature preservation for the default
+exports. For the `Converters.generic(...)`-based converters
+(`validatedConditionDecl`, `validatedConditionSetDecl`, the tree-recursive
+ones, the collection ones), I did factor the body into a shared
+parameterized helper (`_validatedConditionDeclBody`,
+`_validatedConditionSetDeclBody`) because their return type is already
+`Converter`, so no surface-narrowing concern.
+
+---
+
+## OQ-2 empirical finding: no `QualifierCollector` surface change required
+
+Verified by reading `libraries/ts-res/src/packlets/qualifiers/qualifierCollector.ts:63`:
+
+```ts
+export interface IReadOnlyQualifierCollector extends Collections.IReadOnlyValidatingCollector<Qualifier> {
+  // ...
+}
+```
+
+The existing `IConditionDeclConvertContext.qualifiers.validating.get(name)`
+call in `_validatedConditionDeclBody` already performs collector-membership
+narrowing — it returns a `Failure` for unknown names. The typed sibling
+**layers** a Converter-level literal-set narrow on top of that collector
+check: the typed `qualifierNameConverter` rejects typo'd names at convert
+time (before the collector ever sees them), AND the same name then passes
+into `.validating.get(...)` for membership verification. Both checks
+compose cleanly; neither needs the other to change.
+
+Code evidence (`conditions/convert/decls.ts:84-122`): the
+`_validatedConditionDeclBody` helper accepts an `innerConditionDecl: Converter<IConditionDecl<TQualifierNames>>`
+parameter and otherwise threads through the unchanged collector lookup. No
+collector method was added, removed, or modified.
+
+**Conclusion:** the hypothesis from B-1's writeup ("no `QualifierCollector`
+surface change required for B-2") held empirically. The typed sibling
+contract is "convert-time narrow + same collector check"; no surface
+extension needed.
+
+---
+
+## Cast-pressure regression test design
+
+Two test files, both using the same synthetic-consumer pattern:
+
+- `libraries/ts-res/src/test/unit/conditions/typedConvert.test.ts` — exercises
+  the four `Conditions.Convert` typed siblings.
+- `libraries/ts-res/src/test/unit/resource-json/typedConvert.test.ts` —
+  exercises all 12 `ResourceJson.Convert` typed siblings.
+
+**Synthetic consumer:**
+
+```ts
+const validNames = ['tone', 'language'] as const;
+type ValidName = (typeof validNames)[number];
+const qualifierNameConverter = Converters.enumeratedValue<ValidName>(validNames);
+```
+
+**Three assertion shapes per converter:**
+
+1. **Convert-time rejection** — a JSON value carrying a typo'd qualifier name
+   (e.g. `'tonr'`) is passed to the typed converter; the test asserts
+   `toFailWith(/tonr/)`. This is the load-bearing assertion: it proves the
+   typed converter rejects the typo *at convert time*, not just at compile
+   time.
+2. **Convert-time acceptance of valid names** — a JSON value carrying a name
+   in the literal-string union (`'tone'` or `'language'`) is accepted, and
+   the narrowed return type carries that union through. Inside
+   `toSucceedAndSatisfy`, an assignment `const narrowed: ValidName = converted.qualifierName;`
+   exercises the type-level narrow (would fail compile if the result type
+   were still `string`).
+3. **Back-compat documentation** — the default untyped export (e.g.
+   `conditionDecl`, `looseConditionDecl`) accepts `'tonr'` without complaint
+   at the convert level. This documents the baseline: B-2 adds an opt-in,
+   does NOT change the default. (For `validatedConditionDecl` the
+   collector-membership check still rejects unknown names — but that's
+   pre-existing teeth, not B-2 teeth.)
+
+The resource-json file also covers the record-form (`{ tonr: 'formal' }`)
+path, the array-form (`[{ qualifierName: 'tonr', value: 'formal' }]`) path,
+nested candidate conditions, nested tree-node recursion, and the
+importer-collection mix of loose + child resources — i.e. every JSON shape a
+consumer might author.
+
+100% coverage on both new test files (verified by `rushx test` reporting
+`100 | 100 | 100 | 100` across all four metrics for every changed file).
+
+---
+
+## Surprises
+
+1. **Default-export return-type narrowing risk.** First implementation
+   factored a shared `_makeConditionDecl<T>(qc)` and made the default
+   `conditionDecl = _makeConditionDecl(Converters.string)`. The api-extractor
+   diff caught that the default's return type went from
+   `ObjectConverter<IConditionDecl, unknown>` to
+   `Converter<IConditionDecl<string>, unknown>` — a public-surface narrowing.
+   Restructured to keep each default export as the literal `strictObject`
+   call (preserving `ObjectConverter`) and have typed siblings build their
+   own `strictObject`. The duplication cost is acceptable; the surface
+   preservation is non-negotiable for the back-compat acceptance criterion.
+
+2. **`@link` JSDoc warnings on new exports.** Following B-1's lesson,
+   `@link` cross-package refs (`{@link @fgv/ts-utils#Converter | ...}`) and
+   even some namespaced refs (`{@link Conditions.Convert.typedConditionDecl | ...}`)
+   produce api-extractor unresolved-link warnings. Replaced all new
+   `@link` references in introduced JSDoc with backtick-quoted type names.
+   Pre-existing `@link` refs in unchanged JSDoc (e.g. on `conditionDecl`,
+   `validatedConditionDecl`) were left alone — those warnings are baseline,
+   not new. Final count: 849 warnings — matches the B-1-post-merge baseline
+   exactly. No new ones.
+
+3. **Threading depth shallower than estimated.** The B-1 result's "Open
+   Questions for B-2" estimated 4-6 internal files affected. Actual count:
+   3 source files (`conditions/convert/decls.ts`,
+   `conditions/convert/conditionSetDecls.ts`,
+   `resource-json/convert.ts`) plus the two type files
+   (`conditions/conditionDecls.ts`, `conditions/conditionSetDecls.ts`)
+   that grew an additional type parameter on `IConditionDecl` / `IConditionSetDecl`.
+   The cascade is shallower than expected because the typed siblings are
+   peer factories that compose lower-level typed siblings via parameter
+   passing — there is no internal mutable state that would force a wider
+   ripple.
+
+4. **`Normalized.*` vs `Json.*<T>` return types.** Existing
+   `resource-json/convert.ts` exports return `Converter<Normalized.X>` where
+   `Normalized.X` is structurally identical to `Json.X<string>` (the B-1
+   default-instantiation of the parameterized Json type). The typed siblings
+   return `Converter<Json.X<T>>` directly — slightly different type
+   identities, but a consumer who uses both gets compatible types because
+   `Normalized.X` and `Json.X<string>` are mutually assignable in either
+   direction. No `Normalized.*` types needed re-aliasing; the divergence is
+   purely cosmetic at the call site.
+
+5. **Two siblings collide on the same simple name across namespaces.**
+   `Conditions.Convert.typedConditionSetDecl` (returns
+   `Converter<IConditionSetDecl<T>>` — object form with `conditions` field)
+   and `ResourceJson.Convert.typedConditionSetDecl` (returns
+   `Converter<Json.ConditionSetDecl<T>>` — array | record form) are both
+   public. api-extractor disambiguates them as `typedConditionSetDecl` and
+   `typedConditionSetDecl_2` in the api.md report — same pattern as the
+   pre-existing `conditionSetDecl` / `conditionSetDecl_2` collision. No
+   action required (the public namespace paths
+   `Conditions.Convert.X` vs `ResourceJson.Convert.X` keep them distinct
+   for consumers).
+
+---
+
+## Open questions surfaced for Phase B-3 (ts-prompt-assist port)
+
+1. **Recommended ts-prompt-assist consumer pattern:** the consumer authors
+   a `qualifiersConverter` once (e.g.
+   `Converters.enumeratedValue(['tone', 'language', ...] as const)`),
+   threads it into `PromptStoreFixture.build` / `FileTreePromptStore` to
+   produce a typed `PromptLibrary<T>` whose seeded YAML and on-the-wire
+   stored prompts validate against the same literal-string union end-to-end.
+   The B-3 brief should specify which surfaces of the store layer take the
+   `qualifierNameConverter` — likely `FileTreePromptStore.create` and
+   `PromptStoreFixture.build`.
+
+2. **Drop-the-local-types checklist for B-3:** PR #385 (held) introduced
+   `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord` as
+   ts-prompt-assist-local shims. B-3 should:
+   - Remove those local types.
+   - Re-route consumers to `ResourceJson.Json.ConditionSetDecl<T>` and
+     `Json.ILooseResourceCandidateDecl<T>` directly.
+   - Re-route the JSON validation chain to use
+     `ResourceJson.Convert.typedLooseResourceCandidateDecl(qc)` or
+     `typedConditionSetDecl(qc)` as appropriate.
+
+3. **YAML loader signature:** the YAML loader path that builds a
+   `IResourceCollectionDecl` from authored YAML can now take an optional
+   `qualifierNameConverter` and produce a narrowed
+   `IResourceCollectionDecl<T>`. B-3 should expose this through the
+   `FileTreePromptStore.create` API and the `PromptStoreFixture.build`
+   factory. The default (no converter) keeps today's permissive string
+   behavior.
+
+4. **Whether `_bindings.yaml` / `_qualifiers.yaml` loaders should accept
+   the same `qualifierNameConverter`** for cross-file axis-name consistency
+   — out of scope here, surface in the B-3 brief.
+
+5. **Existing ts-res-cli adoption (F-1 in state.md):** not blocking B-3, but
+   a followup chore to opportunistically thread the typed converters
+   through the CLI's bundle/import path would catch typo'd axis names at
+   compile time in CLI consumer YAML — worth queuing as a tech-debt entry
+   once B-3 ships.
+
+---
+
+## Acceptance gates
+
+| Gate | Status |
+|---|---|
+| `rush build` (entire repo from `@fgv/ts-res`) | ✅ all 11 downstream consumers compile unchanged |
+| `rushx lint` (in `@fgv/ts-res`) | ✅ passes (exit 0) |
+| `rushx fixlint` run before final commit | ✅ ran during iteration |
+| `rushx test` (in `@fgv/ts-res`) | ✅ passes; 100% coverage on statements / branches / functions / lines |
+| Cast-pressure regression test exists | ✅ two files; 16 typed converters × 2-3 assertion shapes each |
+| `etc/ts-res.api.md` regenerated cleanly | ✅ only adds: new `typed*` exports + the `<T>` parameter on `IConditionDecl` / `IConditionSetDecl`; no removed/renamed exports; 849 unresolved-link warnings = pre-existing baseline |
+| Rush change file added | ✅ `common/changes/@fgv/ts-res/chore-ts-res-typed-conditions-b2-converter-teeth_2026-05-19-12-00.json` (type: minor) |
+| No `any` types; no manual casts | ✅ implementation contains zero `as any` / unsafe casts |
+| `phase-b2-result.md` written | ✅ this file |

--- a/.ai/tasks/active/ts-res-typed-conditions/phase-b2-result.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/phase-b2-result.md
@@ -276,3 +276,26 @@ consumer might author.
 | Rush change file added | ✅ `common/changes/@fgv/ts-res/chore-ts-res-typed-conditions-b2-converter-teeth_2026-05-19-12-00.json` (type: minor) |
 | No `any` types; no manual casts | ✅ implementation contains zero `as any` / unsafe casts |
 | `phase-b2-result.md` written | ✅ this file |
+
+---
+
+## Review rounds
+
+**Round 1 (Copilot, PR #394, 2026-05-19):** single comment flagged the
+typed/untyped pair drift hazard — if a field is added/removed/re-typed on
+an untyped converter, the typed sibling could silently diverge. The
+trade-off (preserving `ObjectConverter` return types on the defaults) is
+sound, but the maintenance contract was only documented in this result
+doc, not at the call site.
+
+**Resolution:** added a `// keep in sync with X` marker line directly above
+every typed sibling export in `resource-json/convert.ts`,
+`conditions/convert/decls.ts`, and `conditions/convert/conditionSetDecls.ts`
+(16 markers total — one per typed export). Also expanded the typed-block
+preamble in `resource-json/convert.ts` with an explicit `DRIFT HAZARD`
+paragraph. The `Converters.generic`-based pairs
+(`validatedConditionDecl` / `validatedConditionSetDecl` and their typed
+siblings) reference shared `_validatedConditionDeclBody` /
+`_validatedConditionSetDeclBody` helpers, so their bodies cannot drift; the
+marker on those typed siblings calls that out explicitly. Commit
+`253c6024`. Build + lint stay clean.

--- a/.ai/tasks/active/ts-res-typed-conditions/state.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/state.md
@@ -60,7 +60,8 @@
 | 2026-05-19 | B-1 merged | PR #391 squash-merged to integration as `c688292d3`. |
 | 2026-05-19 | B-2 sub-brief drafted | `phase-b2-brief.md` enumerates three candidate surface shapes for OQ-1 (A: context-field opt-in [lean]; B: generic Converter factory; C: generics on existing exports [reject — breaking]); OQ-2 hypothesis no-surface-change (verify); OQ-3 lean ts-res-internal cast-pressure regression test. Erik-driven phase. |
 | 2026-05-19 | B-2 design notes added | `phase-b2-design-notes.md` selects Candidate D — sibling `typed*` exports over a shared parameterized core, existing untyped exports preserved as thin wrappers. Non-breaking. |
-| 2026-05-19 | B-2 implemented | Branch `chore/ts-res-typed-conditions-b2-converter-teeth`; 16 new typed siblings (4 in `Conditions.Convert`, 12 in `ResourceJson.Convert`); `IConditionDecl` / `IConditionSetDecl` parameterized on `TQualifierNames` (additive default); cast-pressure regression tests added; api-extractor regenerated (no new unresolved-link warnings); 100% coverage; all 11 downstream consumers compile unchanged. Result: `phase-b2-result.md`. |
+| 2026-05-19 | B-2 implemented | Branch `chore/ts-res-typed-conditions-b2-converter-teeth`; 16 new typed siblings (4 in `Conditions.Convert`, 12 in `ResourceJson.Convert`); `IConditionDecl` / `IConditionSetDecl` parameterized on `TQualifierNames` (additive default); cast-pressure regression tests added; api-extractor regenerated (no new unresolved-link warnings); 100% coverage; all 11 downstream consumers compile unchanged. Result: `phase-b2-result.md`. PR #394 opened against integration. |
+| 2026-05-19 | B-2 Copilot review absorbed | Single review thread on PR #394: typed/untyped pair drift hazard. Addressed by adding `// keep in sync with X` markers next to every typed sibling and a drift-hazard preamble at the typed block in `resource-json/convert.ts`. Build + lint stay clean. Commit `253c6024` pushed. |
 
 ---
 
@@ -70,7 +71,7 @@
 |---|---|---|
 | Substrate prep | #390 | merged |
 | B-1 | #391 | merged (`c688292d3`) |
-| B-2 | TBD (pending push) | implementation complete on `chore/ts-res-typed-conditions-b2-converter-teeth`; result: `phase-b2-result.md` |
+| B-2 | #394 | open (review round 1 absorbed; awaiting merge) |
 | B-3 | TBD (task-subagent) | ready (was blocked on B-2) |
 
 ---

--- a/.ai/tasks/active/ts-res-typed-conditions/state.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/state.md
@@ -12,8 +12,8 @@
 | Phase | Status | Notes |
 |-------|--------|-------|
 | B-1 — Decl-tree cascade (`ts-res`, type-only) | ✅ merged | PR #391 merged 2026-05-19; final list parameterized = 17 items (containers + tree child node + type guards + union alias); `getKeyFromLooseDecl` + type-guard soundness fixes bundled; api-extractor regenerated; 100% coverage; downstream consumers compile unchanged |
-| B-2 — Converter parameterization (`ts-res`, runtime teeth) | 🟢 ready (Erik-driven) | Sub-brief: `phase-b2-brief.md`; OQ-1 candidate shapes A/B/C enumerated (lean A); OQ-2 hypothesis = no `QualifierCollector` surface change (verify before commit); OQ-3 lean = ts-res-internal regression test |
-| B-3 — `ts-prompt-assist` port (consumer) | ⏸ blocked on B-2 | Drop local `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord`; reference ts-res parameterized types directly |
+| B-2 — Converter parameterization (`ts-res`, runtime teeth) | ✅ complete (PR pending) | Branch `chore/ts-res-typed-conditions-b2-converter-teeth`; Candidate D shipped (sibling `typed*` exports over a shared core, existing untyped exports preserved); OQ-2 verified empirically — no `QualifierCollector` surface change; cast-pressure regression tests in `conditions/typedConvert.test.ts` and `resource-json/typedConvert.test.ts`; api-extractor unresolved-link warnings = baseline 849 (no new); all 11 downstream consumers compile unchanged; 100% coverage; result doc at `phase-b2-result.md` |
+| B-3 — `ts-prompt-assist` port (consumer) | 🟢 ready | Drop local `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord`; reference ts-res parameterized types directly; thread `qualifierNameConverter` into `FileTreePromptStore.create` and `PromptStoreFixture.build`; see open questions for B-3 in `phase-b2-result.md` |
 
 ---
 
@@ -59,6 +59,8 @@
 | 2026-05-19 | B-1 review rounds absorbed | Round 1: cascade-incompleteness on `IResourceTreeRootDecl` (added `IResourceTreeChildNodeDecl` parameterization; root now extends child node); three api-extractor `@link` warnings replaced with backtick refs; missing `@fgv/ts-utils-jest` test import added; state.md artifact accuracy. Round 2: type-guard runtime soundness on `isLooseResourceCandidateDecl` / `isLooseResourceDecl` (`'id' in decl` → `'id' in decl && typeof decl.id === 'string'`). Round 3: PR description updated to explicitly disclose the two runtime fixes (no code change). All gates re-passed. |
 | 2026-05-19 | B-1 merged | PR #391 squash-merged to integration as `c688292d3`. |
 | 2026-05-19 | B-2 sub-brief drafted | `phase-b2-brief.md` enumerates three candidate surface shapes for OQ-1 (A: context-field opt-in [lean]; B: generic Converter factory; C: generics on existing exports [reject — breaking]); OQ-2 hypothesis no-surface-change (verify); OQ-3 lean ts-res-internal cast-pressure regression test. Erik-driven phase. |
+| 2026-05-19 | B-2 design notes added | `phase-b2-design-notes.md` selects Candidate D — sibling `typed*` exports over a shared parameterized core, existing untyped exports preserved as thin wrappers. Non-breaking. |
+| 2026-05-19 | B-2 implemented | Branch `chore/ts-res-typed-conditions-b2-converter-teeth`; 16 new typed siblings (4 in `Conditions.Convert`, 12 in `ResourceJson.Convert`); `IConditionDecl` / `IConditionSetDecl` parameterized on `TQualifierNames` (additive default); cast-pressure regression tests added; api-extractor regenerated (no new unresolved-link warnings); 100% coverage; all 11 downstream consumers compile unchanged. Result: `phase-b2-result.md`. |
 
 ---
 
@@ -68,8 +70,8 @@
 |---|---|---|
 | Substrate prep | #390 | merged |
 | B-1 | #391 | merged (`c688292d3`) |
-| B-2 | TBD (Erik-driven) | sub-brief ready (`phase-b2-brief.md`) |
-| B-3 | TBD (task-subagent) | blocked on B-2 |
+| B-2 | TBD (pending push) | implementation complete on `chore/ts-res-typed-conditions-b2-converter-teeth`; result: `phase-b2-result.md` |
+| B-3 | TBD (task-subagent) | ready (was blocked on B-2) |
 
 ---
 

--- a/common/changes/@fgv/ts-res/chore-ts-res-typed-conditions-b2-converter-teeth_2026-05-19-12-00.json
+++ b/common/changes/@fgv/ts-res/chore-ts-res-typed-conditions-b2-converter-teeth_2026-05-19-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "B-2 Converter parameterization: add typed sibling exports (typedConditionDecl, typedValidatedConditionDecl, typedConditionSetDecl, typedValidatedConditionSetDecl in Conditions.Convert; typedLooseConditionDecl, typedConditionSetDecl, typedLooseResourceCandidateDecl, typedImporterResourceCandidateDecl, typedChildResourceCandidateDecl, typedLooseResourceDecl, typedChildResourceDecl, typedContainerContextDecl, typedResourceTreeChildNodeDecl, typedResourceTreeRootDecl, typedResourceCollectionDecl, typedImporterResourceCollectionDecl in ResourceJson.Convert) parameterized on TQualifierNames. Each typed sibling takes a `Converter<TQualifierNames>` argument so consumers can supply e.g. `Converters.enumeratedValue(['tone', 'language'] as const)` and get convert-time rejection of typo'd qualifier names plus a narrowed result type — without manual casts. Also parameterize IConditionDecl<T> and IConditionSetDecl<T> on TQualifierNames (defaulting to string). Existing untyped exports preserved at signature and behavior level; all 11 downstream consumers compile unchanged.",
+      "type": "minor",
+      "packageName": "@fgv/ts-res"
+    }
+  ],
+  "packageName": "@fgv/ts-res",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-res/etc/ts-res.api.md
+++ b/libraries/ts-res/etc/ts-res.api.md
@@ -722,7 +722,7 @@ type ConditionSetDecl_2 = ReadonlyArray<ILooseConditionDecl>;
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-const conditionSetDecl_2: ObjectConverter<IConditionSetDecl, unknown>;
+const conditionSetDecl_2: ObjectConverter<IConditionSetDecl<string>, unknown>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
@@ -1028,9 +1028,13 @@ declare namespace Convert_10 {
 
 declare namespace Convert_11 {
     export {
+        typedConditionDecl,
+        typedValidatedConditionDecl,
         conditionDecl,
         IConditionDeclConvertContext,
         validatedConditionDecl,
+        typedConditionSetDecl_2 as typedConditionSetDecl,
+        typedValidatedConditionSetDecl,
         conditionSetDecl_2 as conditionSetDecl,
         IConditionSetDeclConvertContext,
         validatedConditionSetDecl
@@ -1109,6 +1113,18 @@ declare namespace Convert_6 {
 
 declare namespace Convert_7 {
     export {
+        typedLooseConditionDecl,
+        typedConditionSetDecl,
+        typedLooseResourceCandidateDecl,
+        typedImporterResourceCandidateDecl,
+        typedChildResourceCandidateDecl,
+        typedLooseResourceDecl,
+        typedChildResourceDecl,
+        typedContainerContextDecl,
+        typedResourceTreeChildNodeDecl,
+        typedResourceTreeRootDecl,
+        typedResourceCollectionDecl,
+        typedImporterResourceCollectionDecl,
         looseConditionDecl,
         childConditionDecl,
         conditionSetDecl,
@@ -1769,7 +1785,7 @@ interface IConditionCollectorCreateParams {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-type IConditionDecl = ResourceJson.Json.ILooseConditionDecl;
+type IConditionDecl<TQualifierNames extends string = string> = ResourceJson.Json.ILooseConditionDecl<TQualifierNames>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
@@ -1804,9 +1820,9 @@ interface IConditionSetCollectorCreateParams {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-interface IConditionSetDecl {
+interface IConditionSetDecl<TQualifierNames extends string = string> {
     // (undocumented)
-    conditions: IConditionDecl[];
+    conditions: IConditionDecl<TQualifierNames>[];
 }
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -5139,6 +5155,54 @@ function toResourceTypeIndex(index: number): Result<ResourceTypeIndex>;
 
 // @public
 function toResourceTypeName(name: string): Result<ResourceTypeName>;
+
+// @public
+function typedChildResourceCandidateDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.IChildResourceCandidateDecl<TQualifierNames>>;
+
+// @public
+function typedChildResourceDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.IChildResourceDecl<TQualifierNames>>;
+
+// @public
+function typedConditionDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<IConditionDecl<TQualifierNames>>;
+
+// @public
+function typedConditionSetDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.ConditionSetDecl<TQualifierNames>>;
+
+// @public
+function typedConditionSetDecl_2<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<IConditionSetDecl<TQualifierNames>>;
+
+// @public
+function typedContainerContextDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.IContainerContextDecl<TQualifierNames>>;
+
+// @public
+function typedImporterResourceCandidateDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.IImporterResourceCandidateDecl<TQualifierNames>>;
+
+// @public
+function typedImporterResourceCollectionDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.IImporterResourceCollectionDecl<TQualifierNames>>;
+
+// @public
+function typedLooseConditionDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.ILooseConditionDecl<TQualifierNames>>;
+
+// @public
+function typedLooseResourceCandidateDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.ILooseResourceCandidateDecl<TQualifierNames>>;
+
+// @public
+function typedLooseResourceDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.ILooseResourceDecl<TQualifierNames>>;
+
+// @public
+function typedResourceCollectionDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.IResourceCollectionDecl<TQualifierNames>>;
+
+// @public
+function typedResourceTreeChildNodeDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.IResourceTreeChildNodeDecl<TQualifierNames>>;
+
+// @public
+function typedResourceTreeRootDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<Json.IResourceTreeRootDecl<TQualifierNames>>;
+
+// @public
+function typedValidatedConditionDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<IValidatedConditionDecl, IConditionDeclConvertContext>;
+
+// @public
+function typedValidatedConditionSetDecl<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<IValidatedConditionSetDecl, IConditionSetDeclConvertContext>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver

--- a/libraries/ts-res/src/packlets/conditions/conditionDecls.ts
+++ b/libraries/ts-res/src/packlets/conditions/conditionDecls.ts
@@ -32,9 +32,15 @@ import * as ResourceJson from '../resource-json';
 
 /**
  * Non-validated declaration of a {@link Conditions.Condition | condition}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames` (defaulting to `string`) so consumers
+ * authoring conditions in code can opt into compile-time axis-name discipline.
+ *
  * @public
  */
-export type IConditionDecl = ResourceJson.Json.ILooseConditionDecl;
+export type IConditionDecl<TQualifierNames extends string = string> =
+  ResourceJson.Json.ILooseConditionDecl<TQualifierNames>;
 
 /**
  * Validated declaration of a {@link Conditions.Condition | condition} with all defaults applied.

--- a/libraries/ts-res/src/packlets/conditions/conditionSetDecls.ts
+++ b/libraries/ts-res/src/packlets/conditions/conditionSetDecls.ts
@@ -25,10 +25,15 @@ import { IConditionDecl } from './conditionDecls';
 
 /**
  * Non-validated declaration of a {@link Conditions.ConditionSet | set of conditions}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames` (defaulting to `string`) so consumers can
+ * opt into compile-time axis-name discipline by supplying a literal-string union.
+ *
  * @public
  */
-export interface IConditionSetDecl {
-  conditions: IConditionDecl[];
+export interface IConditionSetDecl<TQualifierNames extends string = string> {
+  conditions: IConditionDecl<TQualifierNames>[];
 }
 
 /**

--- a/libraries/ts-res/src/packlets/conditions/convert/conditionSetDecls.ts
+++ b/libraries/ts-res/src/packlets/conditions/convert/conditionSetDecls.ts
@@ -20,20 +20,42 @@
  * SOFTWARE.
  */
 
-import { Converters, Result, fail, mapResults, succeed } from '@fgv/ts-utils';
+import { Converter, Converters, Result, fail, mapResults, succeed } from '@fgv/ts-utils';
 import { IConditionSetDecl, IValidatedConditionSetDecl } from '../conditionSetDecls';
-import { conditionDecl } from './decls';
+import { conditionDecl, typedConditionDecl } from './decls';
 import { ConditionCollector } from '../conditionCollector';
 
 /* eslint-disable @rushstack/typedef-var */
 
 /**
  * Converter which converts to a {@link Conditions.IConditionSetDecl | condition set declaration}.
+ *
+ * @remarks
+ * Accepts any string as the qualifier name of each contained condition. Use
+ * `typedConditionSetDecl` to narrow the accepted set of qualifier names to a literal-string union.
+ *
  * @public
  */
 export const conditionSetDecl = Converters.strictObject<IConditionSetDecl>({
   conditions: Converters.arrayOf(conditionDecl)
 });
+
+/**
+ * Returns a `Converter` for an `IConditionSetDecl<TQualifierNames>` narrowed on a supplied
+ * `qualifierName` converter.
+ *
+ * @remarks
+ * Each contained condition is converted via `typedConditionDecl(qualifierNameConverter)`.
+ *
+ * @public
+ */
+export function typedConditionSetDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<IConditionSetDecl<TQualifierNames>> {
+  return Converters.strictObject<IConditionSetDecl<TQualifierNames>>({
+    conditions: Converters.arrayOf(typedConditionDecl(qualifierNameConverter))
+  });
+}
 
 /**
  * Context for converting a {@link Conditions.IConditionSetDecl | condition set declaration}
@@ -45,22 +67,17 @@ export interface IConditionSetDeclConvertContext {
   conditionSetIndex?: number;
 }
 
-/**
- * Converter which constructs a {@link Conditions.IValidatedConditionSetDecl | validated condition set declaration}
- * from a {@link Conditions.IConditionSetDecl | condition set declaration}, instantiating qualifiers by name
- * from a supplied {@link Conditions.Convert.IConditionSetDeclConvertContext | conversion context}.
- * @public
- */
-export const validatedConditionSetDecl = Converters.generic<
-  IValidatedConditionSetDecl,
-  IConditionSetDeclConvertContext
->((from: unknown, __self, context?: IConditionSetDeclConvertContext): Result<IValidatedConditionSetDecl> => {
+function _validatedConditionSetDeclBody<TQualifierNames extends string>(
+  innerConditionSetDecl: Converter<IConditionSetDecl<TQualifierNames>>,
+  from: unknown,
+  context?: IConditionSetDeclConvertContext
+): Result<IValidatedConditionSetDecl> {
   /* c8 ignore next 3 - coverage is having a bad day */
   if (!context) {
     return fail('validatedConditionSetDecl converter requires a context');
   }
 
-  return conditionSetDecl.convert(from).onSuccess((decl) => {
+  return innerConditionSetDecl.convert(from).onSuccess((decl) => {
     return mapResults(
       decl.conditions.map((condition) => context.conditions.validating.getOrAdd(condition))
     ).onSuccess((conditions) => {
@@ -69,4 +86,43 @@ export const validatedConditionSetDecl = Converters.generic<
       return succeed({ conditions, index });
     });
   });
+}
+
+/**
+ * Converter which constructs a {@link Conditions.IValidatedConditionSetDecl | validated condition set declaration}
+ * from a {@link Conditions.IConditionSetDecl | condition set declaration}, instantiating qualifiers by name
+ * from a supplied {@link Conditions.Convert.IConditionSetDeclConvertContext | conversion context}.
+ *
+ * @remarks
+ * Accepts any string as the qualifier name. Use `typedValidatedConditionSetDecl` to layer
+ * literal-string narrowing on top of the collector-membership check.
+ *
+ * @public
+ */
+export const validatedConditionSetDecl = Converters.generic<
+  IValidatedConditionSetDecl,
+  IConditionSetDeclConvertContext
+>((from: unknown, __self, context?: IConditionSetDeclConvertContext): Result<IValidatedConditionSetDecl> => {
+  return _validatedConditionSetDeclBody(conditionSetDecl, from, context);
 });
+
+/**
+ * Returns a `Converter` for an `IValidatedConditionSetDecl` narrowed on a supplied
+ * `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedValidatedConditionSetDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<IValidatedConditionSetDecl, IConditionSetDeclConvertContext> {
+  const inner = typedConditionSetDecl(qualifierNameConverter);
+  return Converters.generic<IValidatedConditionSetDecl, IConditionSetDeclConvertContext>(
+    (
+      from: unknown,
+      __self,
+      context?: IConditionSetDeclConvertContext
+    ): Result<IValidatedConditionSetDecl> => {
+      return _validatedConditionSetDeclBody(inner, from, context);
+    }
+  );
+}

--- a/libraries/ts-res/src/packlets/conditions/convert/conditionSetDecls.ts
+++ b/libraries/ts-res/src/packlets/conditions/convert/conditionSetDecls.ts
@@ -49,6 +49,8 @@ export const conditionSetDecl = Converters.strictObject<IConditionSetDecl>({
  *
  * @public
  */
+// Keep the field list below in sync with `conditionSetDecl` above; the
+// duplication preserves the `ObjectConverter` return type on the default.
 export function typedConditionSetDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<IConditionSetDecl<TQualifierNames>> {
@@ -112,6 +114,9 @@ export const validatedConditionSetDecl = Converters.generic<
  *
  * @public
  */
+// Shares the `_validatedConditionSetDeclBody` helper with
+// `validatedConditionSetDecl` above, so the body cannot drift; only the inner
+// condition-set-decl converter differs.
 export function typedValidatedConditionSetDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<IValidatedConditionSetDecl, IConditionSetDeclConvertContext> {

--- a/libraries/ts-res/src/packlets/conditions/convert/decls.ts
+++ b/libraries/ts-res/src/packlets/conditions/convert/decls.ts
@@ -56,6 +56,8 @@ export const conditionDecl = Converters.strictObject<IConditionDecl>({
  *
  * @public
  */
+// Keep the field list below in sync with `conditionDecl` above; the
+// duplication preserves the `ObjectConverter` return type on the default.
 export function typedConditionDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<IConditionDecl<TQualifierNames>> {
@@ -147,6 +149,9 @@ export const validatedConditionDecl = Converters.generic<
  *
  * @public
  */
+// Shares the `_validatedConditionDeclBody` helper with `validatedConditionDecl`
+// above, so the populate-object body cannot drift; only the inner condition-decl
+// converter differs.
 export function typedValidatedConditionDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<IValidatedConditionDecl, IConditionDeclConvertContext> {

--- a/libraries/ts-res/src/packlets/conditions/convert/decls.ts
+++ b/libraries/ts-res/src/packlets/conditions/convert/decls.ts
@@ -21,7 +21,7 @@
  */
 
 import * as Common from '../../common';
-import { Converters, populateObject, Result, fail, succeed } from '@fgv/ts-utils';
+import { Converter, Converters, populateObject, Result, fail, succeed } from '@fgv/ts-utils';
 import { IConditionDecl, IValidatedConditionDecl } from '../conditionDecls';
 import { IReadOnlyQualifierCollector } from '../../qualifiers';
 
@@ -29,6 +29,11 @@ import { IReadOnlyQualifierCollector } from '../../qualifiers';
 
 /**
  * Converter for a {@link Conditions.IConditionDecl | condition declaration}.
+ *
+ * @remarks
+ * Accepts any string as the `qualifierName`. Use `typedConditionDecl` to narrow the
+ * accepted set of qualifier names to a literal-string union.
+ *
  * @public
  */
 export const conditionDecl = Converters.strictObject<IConditionDecl>({
@@ -40,6 +45,30 @@ export const conditionDecl = Converters.strictObject<IConditionDecl>({
 });
 
 /**
+ * Returns a `Converter` for an `IConditionDecl<TQualifierNames>` narrowed on a supplied
+ * `qualifierName` converter.
+ *
+ * @remarks
+ * Pass e.g. `Converters.enumeratedValue(['tone', 'language'] as const)` to reject
+ * typo'd qualifier names at convert time and to narrow the resulting
+ * `IConditionDecl<T>` type to the same literal-string union. The default
+ * `conditionDecl` is the `Converters.string` instantiation of this shape.
+ *
+ * @public
+ */
+export function typedConditionDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<IConditionDecl<TQualifierNames>> {
+  return Converters.strictObject<IConditionDecl<TQualifierNames>>({
+    qualifierName: qualifierNameConverter,
+    value: Converters.string,
+    operator: Common.Convert.conditionOperator.optional(),
+    priority: Converters.number.optional(),
+    scoreAsDefault: Converters.number.optional()
+  });
+}
+
+/**
  * Conversion context to uses when converting
  * a {@link Conditions.IValidatedConditionDecl | validated condition declaration}.
  * @public
@@ -49,21 +78,16 @@ export interface IConditionDeclConvertContext {
   conditionIndex?: number;
 }
 
-/**
- * Converter which constructs a {@link Conditions.IValidatedConditionDecl | validated condition declaration}
- * from a {@link Conditions.IConditionDecl | condition declaration}, instantiating qualifiers by name
- * from a supplied {@link Conditions.Convert.IConditionDeclConvertContext | conversion context}.
- * @public
- */
-export const validatedConditionDecl = Converters.generic<
-  IValidatedConditionDecl,
-  IConditionDeclConvertContext
->((from: unknown, __self, context?: IConditionDeclConvertContext): Result<IValidatedConditionDecl> => {
+function _validatedConditionDeclBody<TQualifierNames extends string>(
+  innerConditionDecl: Converter<IConditionDecl<TQualifierNames>>,
+  from: unknown,
+  context?: IConditionDeclConvertContext
+): Result<IValidatedConditionDecl> {
   /* c8 ignore next 3 - coverage is having a bad day */
   if (!context) {
     return fail('validatedConditionDecl converter requires a context');
   }
-  return conditionDecl.convert(from).onSuccess((decl) => {
+  return innerConditionDecl.convert(from).onSuccess((decl) => {
     const operator = decl.operator ?? 'matches';
     return context.qualifiers.validating.get(decl.qualifierName).onSuccess((qualifier) => {
       return populateObject<IValidatedConditionDecl>({
@@ -92,4 +116,44 @@ export const validatedConditionDecl = Converters.generic<
         .withDetail('success');
     });
   });
+}
+
+/**
+ * Converter which constructs a {@link Conditions.IValidatedConditionDecl | validated condition declaration}
+ * from a {@link Conditions.IConditionDecl | condition declaration}, instantiating qualifiers by name
+ * from a supplied {@link Conditions.Convert.IConditionDeclConvertContext | conversion context}.
+ *
+ * @remarks
+ * Accepts any string as the `qualifierName`; the collector membership check still rejects unknown
+ * names. Use `typedValidatedConditionDecl` to layer literal-string narrowing on top of the
+ * collector check.
+ *
+ * @public
+ */
+export const validatedConditionDecl = Converters.generic<
+  IValidatedConditionDecl,
+  IConditionDeclConvertContext
+>((from: unknown, __self, context?: IConditionDeclConvertContext): Result<IValidatedConditionDecl> => {
+  return _validatedConditionDeclBody(conditionDecl, from, context);
 });
+
+/**
+ * Returns a `Converter` for an `IValidatedConditionDecl` narrowed on a supplied
+ * `qualifierName` converter.
+ *
+ * @remarks
+ * The typed sibling layers literal-string narrowing on top of the existing
+ * collector-membership check performed by `validatedConditionDecl`.
+ *
+ * @public
+ */
+export function typedValidatedConditionDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<IValidatedConditionDecl, IConditionDeclConvertContext> {
+  const inner = typedConditionDecl(qualifierNameConverter);
+  return Converters.generic<IValidatedConditionDecl, IConditionDeclConvertContext>(
+    (from: unknown, __self, context?: IConditionDeclConvertContext): Result<IValidatedConditionDecl> => {
+      return _validatedConditionDeclBody(inner, from, context);
+    }
+  );
+}

--- a/libraries/ts-res/src/packlets/resource-json/convert.ts
+++ b/libraries/ts-res/src/packlets/resource-json/convert.ts
@@ -243,6 +243,13 @@ export const importerResourceCollectionDecl: Converter<Normalized.IImporterResou
 // opt in by calling a typed sibling. Internally each typed factory composes
 // lower-level typed factories so a single `qualifierNameConverter` flows
 // end-to-end through the converter tree.
+//
+// DRIFT HAZARD: each typed sibling duplicates the field list of its untyped
+// twin (the duplication exists to preserve `ObjectConverter` return types on
+// the defaults — see phase-b2-result.md). If a field is added, removed, or
+// re-typed on an untyped converter above, the typed sibling MUST be updated
+// in lockstep. The per-pair `keep in sync with X` markers below flag each
+// pair at the call site.
 
 /**
  * Returns a `Converter` for a `Json.ILooseConditionDecl<TQualifierNames>`
@@ -250,6 +257,7 @@ export const importerResourceCollectionDecl: Converter<Normalized.IImporterResou
  *
  * @public
  */
+// Keep in sync with `looseConditionDecl` above.
 export function typedLooseConditionDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.ILooseConditionDecl<TQualifierNames>> {
@@ -299,6 +307,8 @@ function _typedConditionSetDeclFromRecord<TQualifierNames extends string>(
  *
  * @public
  */
+// Keep in sync with `conditionSetDecl` (and its two private feeder converters
+// `conditionSetDeclFromArray` / `conditionSetDeclFromRecord`) above.
 export function typedConditionSetDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.ConditionSetDecl<TQualifierNames>> {
@@ -315,6 +325,7 @@ export function typedConditionSetDecl<TQualifierNames extends string>(
  *
  * @public
  */
+// Keep in sync with `looseResourceCandidateDecl` above.
 export function typedLooseResourceCandidateDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.ILooseResourceCandidateDecl<TQualifierNames>> {
@@ -334,6 +345,7 @@ export function typedLooseResourceCandidateDecl<TQualifierNames extends string>(
  *
  * @public
  */
+// Keep in sync with `importerResourceCandidateDecl` above.
 export function typedImporterResourceCandidateDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.IImporterResourceCandidateDecl<TQualifierNames>> {
@@ -353,6 +365,7 @@ export function typedImporterResourceCandidateDecl<TQualifierNames extends strin
  *
  * @public
  */
+// Keep in sync with `childResourceCandidateDecl` above.
 export function typedChildResourceCandidateDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.IChildResourceCandidateDecl<TQualifierNames>> {
@@ -370,6 +383,7 @@ export function typedChildResourceCandidateDecl<TQualifierNames extends string>(
  *
  * @public
  */
+// Keep in sync with `looseResourceDecl` above.
 export function typedLooseResourceDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.ILooseResourceDecl<TQualifierNames>> {
@@ -386,6 +400,7 @@ export function typedLooseResourceDecl<TQualifierNames extends string>(
  *
  * @public
  */
+// Keep in sync with `childResourceDecl` above.
 export function typedChildResourceDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.IChildResourceDecl<TQualifierNames>> {
@@ -401,6 +416,7 @@ export function typedChildResourceDecl<TQualifierNames extends string>(
  *
  * @public
  */
+// Keep in sync with `containerContextDecl` above.
 export function typedContainerContextDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.IContainerContextDecl<TQualifierNames>> {
@@ -417,6 +433,7 @@ export function typedContainerContextDecl<TQualifierNames extends string>(
  *
  * @public
  */
+// Keep in sync with `resourceTreeChildNodeDecl` above.
 export function typedResourceTreeChildNodeDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.IResourceTreeChildNodeDecl<TQualifierNames>> {
@@ -441,6 +458,7 @@ export function typedResourceTreeChildNodeDecl<TQualifierNames extends string>(
  *
  * @public
  */
+// Keep in sync with `resourceTreeRootDecl` above.
 export function typedResourceTreeRootDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.IResourceTreeRootDecl<TQualifierNames>> {
@@ -457,6 +475,7 @@ export function typedResourceTreeRootDecl<TQualifierNames extends string>(
  *
  * @public
  */
+// Keep in sync with `resourceCollectionDecl` above.
 export function typedResourceCollectionDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.IResourceCollectionDecl<TQualifierNames>> {
@@ -486,6 +505,7 @@ export function typedResourceCollectionDecl<TQualifierNames extends string>(
  *
  * @public
  */
+// Keep in sync with `importerResourceCollectionDecl` above.
 export function typedImporterResourceCollectionDecl<TQualifierNames extends string>(
   qualifierNameConverter: Converter<TQualifierNames>
 ): Converter<Json.IImporterResourceCollectionDecl<TQualifierNames>> {

--- a/libraries/ts-res/src/packlets/resource-json/convert.ts
+++ b/libraries/ts-res/src/packlets/resource-json/convert.ts
@@ -234,3 +234,278 @@ export const importerResourceCollectionDecl: Converter<Normalized.IImporterResou
       }).convert(from, context);
     }
   );
+
+// --- Typed sibling converters (Phase B-2) -----------------------------------
+//
+// Each `typed*<TQualifierNames>(qualifierNameConverter)` returns a converter
+// whose result type is narrowed on `TQualifierNames`. The existing untyped
+// exports above remain unchanged at the signature and behavior level; consumers
+// opt in by calling a typed sibling. Internally each typed factory composes
+// lower-level typed factories so a single `qualifierNameConverter` flows
+// end-to-end through the converter tree.
+
+/**
+ * Returns a `Converter` for a `Json.ILooseConditionDecl<TQualifierNames>`
+ * narrowed on a supplied `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedLooseConditionDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.ILooseConditionDecl<TQualifierNames>> {
+  return Converters.strictObject<Json.ILooseConditionDecl<TQualifierNames>>({
+    qualifierName: qualifierNameConverter,
+    value: Converters.string,
+    operator: CommonConvert.conditionOperator.optional(),
+    priority: CommonConvert.conditionPriority.optional(),
+    scoreAsDefault: Converters.number.optional()
+  });
+}
+
+function _typedConditionSetDeclFromArray<TQualifierNames extends string>(
+  innerLooseConditionDecl: Converter<Json.ILooseConditionDecl<TQualifierNames>>
+): Converter<Json.ConditionSetDeclAsArray<TQualifierNames>> {
+  return Converters.arrayOf(innerLooseConditionDecl);
+}
+
+function _typedConditionSetDeclFromRecord<TQualifierNames extends string>(
+  innerLooseConditionDecl: Converter<Json.ILooseConditionDecl<TQualifierNames>>
+): Converter<Json.ConditionSetDecl<TQualifierNames>> {
+  return Converters.generic<Json.ConditionSetDecl<TQualifierNames>, unknown>(
+    (
+      from: unknown,
+      __self: Converter<Json.ConditionSetDecl<TQualifierNames>, unknown>,
+      context?: unknown
+    ): Result<Json.ConditionSetDecl<TQualifierNames>> => {
+      /* c8 ignore next 3 - branch covered by underlying record check */
+      if (!_isConditionSetRecord(from)) {
+        return fail('Expected an object');
+      }
+      return mapResults(
+        Array.from(Object.entries(from)).map(([qualifierName, value]) => {
+          const toConvert: Json.ILooseConditionDecl =
+            typeof value === 'string' ? { qualifierName, value } : { qualifierName, ...value };
+          return innerLooseConditionDecl.convert(toConvert, context);
+        })
+      );
+    }
+  );
+}
+
+/**
+ * Returns a `Converter` for a `Json.ConditionSetDecl<TQualifierNames>`
+ * (either array form or record form) narrowed on a supplied `qualifierName`
+ * converter.
+ *
+ * @public
+ */
+export function typedConditionSetDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.ConditionSetDecl<TQualifierNames>> {
+  const inner = typedLooseConditionDecl(qualifierNameConverter);
+  return Converters.oneOf<Json.ConditionSetDecl<TQualifierNames>>([
+    _typedConditionSetDeclFromArray(inner),
+    _typedConditionSetDeclFromRecord(inner)
+  ]);
+}
+
+/**
+ * Returns a `Converter` for a `Json.ILooseResourceCandidateDecl<TQualifierNames>`
+ * narrowed on a supplied `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedLooseResourceCandidateDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.ILooseResourceCandidateDecl<TQualifierNames>> {
+  return Converters.strictObject<Json.ILooseResourceCandidateDecl<TQualifierNames>>({
+    id: CommonConvert.resourceId,
+    json: JsonConverters.jsonObject,
+    conditions: typedConditionSetDecl(qualifierNameConverter).optional(),
+    mergeMethod: CommonConvert.resourceValueMergeMethod.optional(),
+    isPartial: Converters.boolean.optional(),
+    resourceTypeName: CommonConvert.resourceTypeName.optional()
+  });
+}
+
+/**
+ * Returns a `Converter` for a `Json.IImporterResourceCandidateDecl<TQualifierNames>`
+ * narrowed on a supplied `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedImporterResourceCandidateDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.IImporterResourceCandidateDecl<TQualifierNames>> {
+  return Converters.strictObject<Json.IImporterResourceCandidateDecl<TQualifierNames>>({
+    id: CommonConvert.resourceId.optional(),
+    json: JsonConverters.jsonObject,
+    conditions: typedConditionSetDecl(qualifierNameConverter).optional(),
+    mergeMethod: CommonConvert.resourceValueMergeMethod.optional(),
+    isPartial: Converters.boolean.optional(),
+    resourceTypeName: CommonConvert.resourceTypeName.optional()
+  });
+}
+
+/**
+ * Returns a `Converter` for a `Json.IChildResourceCandidateDecl<TQualifierNames>`
+ * narrowed on a supplied `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedChildResourceCandidateDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.IChildResourceCandidateDecl<TQualifierNames>> {
+  return Converters.strictObject<Json.IChildResourceCandidateDecl<TQualifierNames>>({
+    json: JsonConverters.jsonObject,
+    conditions: typedConditionSetDecl(qualifierNameConverter).optional(),
+    isPartial: Converters.boolean.optional(),
+    mergeMethod: CommonConvert.resourceValueMergeMethod.optional()
+  });
+}
+
+/**
+ * Returns a `Converter` for a `Json.ILooseResourceDecl<TQualifierNames>`
+ * narrowed on a supplied `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedLooseResourceDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.ILooseResourceDecl<TQualifierNames>> {
+  return Converters.strictObject<Json.ILooseResourceDecl<TQualifierNames>>({
+    id: CommonConvert.resourceId,
+    resourceTypeName: CommonConvert.resourceTypeName,
+    candidates: Converters.arrayOf(typedChildResourceCandidateDecl(qualifierNameConverter)).optional()
+  });
+}
+
+/**
+ * Returns a `Converter` for a `Json.IChildResourceDecl<TQualifierNames>`
+ * narrowed on a supplied `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedChildResourceDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.IChildResourceDecl<TQualifierNames>> {
+  return Converters.strictObject<Json.IChildResourceDecl<TQualifierNames>>({
+    resourceTypeName: CommonConvert.resourceTypeName,
+    candidates: Converters.arrayOf(typedChildResourceCandidateDecl(qualifierNameConverter)).optional()
+  });
+}
+
+/**
+ * Returns a `Converter` for a `Json.IContainerContextDecl<TQualifierNames>`
+ * narrowed on a supplied `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedContainerContextDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.IContainerContextDecl<TQualifierNames>> {
+  return Converters.strictObject<Json.IContainerContextDecl<TQualifierNames>>({
+    baseId: Converters.oneOf([CommonConvert.resourceId, Converters.literal('')]).optional(),
+    conditions: typedConditionSetDecl(qualifierNameConverter).optional(),
+    mergeMethod: CommonConvert.resourceValueMergeMethod.optional()
+  });
+}
+
+/**
+ * Returns a `Converter` for a `Json.IResourceTreeChildNodeDecl<TQualifierNames>`
+ * narrowed on a supplied `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedResourceTreeChildNodeDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.IResourceTreeChildNodeDecl<TQualifierNames>> {
+  const childResource = typedChildResourceDecl(qualifierNameConverter);
+  return Converters.generic<Json.IResourceTreeChildNodeDecl<TQualifierNames>, unknown>(
+    (
+      from: unknown,
+      self: Converter<Json.IResourceTreeChildNodeDecl<TQualifierNames>, unknown>,
+      context?: unknown
+    ): Result<Json.IResourceTreeChildNodeDecl<TQualifierNames>> => {
+      return Converters.strictObject<Json.IResourceTreeChildNodeDecl<TQualifierNames>>({
+        resources: Converters.recordOf(childResource).optional(),
+        children: Converters.recordOf(self).optional()
+      }).convert(from, context);
+    }
+  );
+}
+
+/**
+ * Returns a `Converter` for a `Json.IResourceTreeRootDecl<TQualifierNames>`
+ * narrowed on a supplied `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedResourceTreeRootDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.IResourceTreeRootDecl<TQualifierNames>> {
+  return Converters.strictObject<Json.IResourceTreeRootDecl<TQualifierNames>>({
+    context: typedContainerContextDecl(qualifierNameConverter).optional(),
+    resources: Converters.recordOf(typedChildResourceDecl(qualifierNameConverter)).optional(),
+    children: Converters.recordOf(typedResourceTreeChildNodeDecl(qualifierNameConverter)).optional()
+  });
+}
+
+/**
+ * Returns a `Converter` for a `Json.IResourceCollectionDecl<TQualifierNames>`
+ * narrowed on a supplied `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedResourceCollectionDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.IResourceCollectionDecl<TQualifierNames>> {
+  const containerContext = typedContainerContextDecl(qualifierNameConverter);
+  const looseCandidate = typedLooseResourceCandidateDecl(qualifierNameConverter);
+  const looseResource = typedLooseResourceDecl(qualifierNameConverter);
+  return Converters.generic<Json.IResourceCollectionDecl<TQualifierNames>, unknown>(
+    (
+      from: unknown,
+      self: Converter<Json.IResourceCollectionDecl<TQualifierNames>, unknown>,
+      context?: unknown
+    ): Result<Json.IResourceCollectionDecl<TQualifierNames>> => {
+      return Converters.strictObject<Json.IResourceCollectionDecl<TQualifierNames>>({
+        context: containerContext.optional(),
+        candidates: Converters.arrayOf(looseCandidate).optional(),
+        resources: Converters.arrayOf(looseResource).optional(),
+        collections: Converters.arrayOf(self).optional(),
+        metadata: JsonConverters.jsonObject.optional()
+      }).convert(from, context);
+    }
+  );
+}
+
+/**
+ * Returns a `Converter` for a `Json.IImporterResourceCollectionDecl<TQualifierNames>`
+ * narrowed on a supplied `qualifierName` converter.
+ *
+ * @public
+ */
+export function typedImporterResourceCollectionDecl<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<Json.IImporterResourceCollectionDecl<TQualifierNames>> {
+  const containerContext = typedContainerContextDecl(qualifierNameConverter);
+  const importerCandidate = typedImporterResourceCandidateDecl(qualifierNameConverter);
+  const looseResource = typedLooseResourceDecl(qualifierNameConverter);
+  const childResource = typedChildResourceDecl(qualifierNameConverter);
+  return Converters.generic<Json.IImporterResourceCollectionDecl<TQualifierNames>, unknown>(
+    (
+      from: unknown,
+      self: Converter<Json.IImporterResourceCollectionDecl<TQualifierNames>, unknown>,
+      context?: unknown
+    ): Result<Json.IImporterResourceCollectionDecl<TQualifierNames>> => {
+      return Converters.strictObject<Json.IImporterResourceCollectionDecl<TQualifierNames>>({
+        context: containerContext.optional(),
+        candidates: Converters.arrayOf(importerCandidate).optional(),
+        resources: Converters.arrayOf(Converters.oneOf([looseResource, childResource])).optional(),
+        collections: Converters.arrayOf(self).optional(),
+        metadata: JsonConverters.jsonObject.optional()
+      }).convert(from, context);
+    }
+  );
+}

--- a/libraries/ts-res/src/test/unit/conditions/typedConvert.test.ts
+++ b/libraries/ts-res/src/test/unit/conditions/typedConvert.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converters } from '@fgv/ts-utils';
+import * as TsRes from '../../../index';
+import { TestQualifierType } from '../qualifier-types/testQualifierType';
+import { ConditionCollector } from '../../../packlets/conditions';
+
+// Phase B-2 cast-pressure regression tests for the typed Converter siblings.
+//
+// The point of these tests is that a consumer who supplies a literal-string
+// qualifierName converter gets convert-time rejection of typo'd qualifier
+// names AND a narrowed result type — without manual casts.
+//
+// The synthetic consumer is qualifierNameConverter, a Converter over the
+// 'tone' | 'language' union. The default (untyped) Converter exports continue
+// to accept any string for qualifierName, so the cast-pressure isolates to
+// the typed sibling.
+describe('Phase B-2 typed Converter siblings (cast-pressure regression)', () => {
+  const validNames = ['tone', 'language'] as const;
+  type ValidName = (typeof validNames)[number];
+  const qualifierNameConverter = Converters.enumeratedValue<ValidName>(validNames);
+
+  describe('typedConditionDecl', () => {
+    test('accepts a declaration whose qualifierName is in the literal-string union', () => {
+      const decl = { qualifierName: 'tone', value: 'formal' };
+      const typedConverter = TsRes.Conditions.Convert.typedConditionDecl(qualifierNameConverter);
+      expect(typedConverter.convert(decl)).toSucceedAndSatisfy((converted) => {
+        // The narrowed return type is `IConditionDecl<'tone' | 'language'>`;
+        // `qualifierName` is narrowed to `'tone' | 'language'`.
+        const narrowed: ValidName = converted.qualifierName;
+        expect(narrowed).toBe('tone');
+        expect(converted.value).toBe('formal');
+      });
+    });
+
+    test("rejects a typo'd qualifierName at convert time", () => {
+      const decl = { qualifierName: 'tonr', value: 'formal' };
+      const typedConverter = TsRes.Conditions.Convert.typedConditionDecl(qualifierNameConverter);
+      expect(typedConverter.convert(decl)).toFailWith(/tonr/);
+    });
+
+    test('the untyped default conditionDecl accepts any string qualifierName', () => {
+      // Documents the back-compat baseline: the default export still accepts
+      // unknown names at convert time. The collector membership check
+      // performed by `validatedConditionDecl` is the existing teeth at the
+      // collector level; B-2 adds literal-set narrowing as an opt-in.
+      const decl = { qualifierName: 'tonr', value: 'formal' };
+      expect(TsRes.Conditions.Convert.conditionDecl.convert(decl)).toSucceedAndSatisfy((c) => {
+        expect(c.qualifierName).toBe('tonr');
+      });
+    });
+  });
+
+  describe('typedValidatedConditionDecl', () => {
+    let qualifierTypes: TsRes.QualifierTypes.QualifierTypeCollector;
+    let qualifiers: TsRes.Qualifiers.QualifierCollector;
+
+    beforeAll(() => {
+      qualifierTypes = TsRes.QualifierTypes.QualifierTypeCollector.create({
+        qualifierTypes: [
+          TsRes.QualifierTypes.LanguageQualifierType.create().orThrow(),
+          TsRes.QualifierTypes.LiteralQualifierType.create().orThrow(),
+          new TestQualifierType()
+        ]
+      }).orThrow();
+      qualifiers = TsRes.Qualifiers.QualifierCollector.create({
+        qualifierTypes,
+        qualifiers: [
+          { name: 'tone', typeName: 'literal', defaultPriority: 500 },
+          { name: 'language', typeName: 'language', defaultPriority: 600 }
+        ]
+      }).orThrow();
+    });
+
+    test('layers literal-string narrowing on top of the collector check', () => {
+      const typedConverter = TsRes.Conditions.Convert.typedValidatedConditionDecl(qualifierNameConverter);
+
+      // Valid qualifier in both the literal set AND the collector — succeeds.
+      expect(typedConverter.convert({ qualifierName: 'tone', value: 'formal' }, { qualifiers })).toSucceed();
+
+      // Typo'd qualifier — rejected at the typed-Converter level, before the
+      // collector check ever runs.
+      expect(typedConverter.convert({ qualifierName: 'tonr', value: 'formal' }, { qualifiers })).toFailWith(
+        /tonr/
+      );
+    });
+  });
+
+  describe('typedConditionSetDecl (Conditions namespace, object form)', () => {
+    test("rejects a typo'd qualifierName inside the conditions array", () => {
+      const typedConverter = TsRes.Conditions.Convert.typedConditionSetDecl(qualifierNameConverter);
+      const bad = {
+        conditions: [{ qualifierName: 'tonr', value: 'formal' }]
+      };
+      expect(typedConverter.convert(bad)).toFailWith(/tonr/);
+    });
+
+    test('accepts a condition set whose qualifiers are all in the literal union', () => {
+      const typedConverter = TsRes.Conditions.Convert.typedConditionSetDecl(qualifierNameConverter);
+      const good = {
+        conditions: [
+          { qualifierName: 'tone', value: 'formal' },
+          { qualifierName: 'language', value: 'en' }
+        ]
+      };
+      expect(typedConverter.convert(good)).toSucceedAndSatisfy((cs) => {
+        // Narrowed: cs.conditions[i].qualifierName is `'tone' | 'language'`.
+        const names: ReadonlyArray<ValidName> = cs.conditions.map((c) => c.qualifierName);
+        expect(names).toEqual(['tone', 'language']);
+      });
+    });
+  });
+
+  describe('typedValidatedConditionSetDecl', () => {
+    let qualifierTypes: TsRes.QualifierTypes.QualifierTypeCollector;
+    let qualifiers: TsRes.Qualifiers.QualifierCollector;
+    let conditions: ConditionCollector;
+
+    beforeEach(() => {
+      qualifierTypes = TsRes.QualifierTypes.QualifierTypeCollector.create({
+        qualifierTypes: [
+          TsRes.QualifierTypes.LanguageQualifierType.create().orThrow(),
+          TsRes.QualifierTypes.LiteralQualifierType.create().orThrow()
+        ]
+      }).orThrow();
+      qualifiers = TsRes.Qualifiers.QualifierCollector.create({
+        qualifierTypes,
+        qualifiers: [
+          { name: 'tone', typeName: 'literal', defaultPriority: 500 },
+          { name: 'language', typeName: 'language', defaultPriority: 600 }
+        ]
+      }).orThrow();
+      conditions = TsRes.Conditions.ConditionCollector.create({ qualifiers }).orThrow();
+    });
+
+    test("rejects a typo'd qualifier in the set before the collector check", () => {
+      const typedConverter = TsRes.Conditions.Convert.typedValidatedConditionSetDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({ conditions: [{ qualifierName: 'tonr', value: 'formal' }] }, { conditions })
+      ).toFailWith(/tonr/);
+    });
+
+    test('succeeds when every qualifierName is in the literal union AND in the collector', () => {
+      const typedConverter = TsRes.Conditions.Convert.typedValidatedConditionSetDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({ conditions: [{ qualifierName: 'tone', value: 'formal' }] }, { conditions })
+      ).toSucceed();
+    });
+  });
+});

--- a/libraries/ts-res/src/test/unit/resource-json/typedConvert.test.ts
+++ b/libraries/ts-res/src/test/unit/resource-json/typedConvert.test.ts
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2025 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converters } from '@fgv/ts-utils';
+import * as TsRes from '../../../index';
+
+// Phase B-2 cast-pressure regression tests for the ResourceJson typed
+// Converter siblings. Mirrors conditions/typedConvert.test.ts but exercises
+// the resource-json entry-point converters that consumers (e.g.
+// ts-prompt-assist) wire into their importer / store layers.
+describe('Phase B-2 ResourceJson typed Converter siblings (cast-pressure regression)', () => {
+  const validNames = ['tone', 'language'] as const;
+  type ValidName = (typeof validNames)[number];
+  const qualifierNameConverter = Converters.enumeratedValue<ValidName>(validNames);
+
+  describe('typedLooseConditionDecl', () => {
+    test('accepts a declaration whose qualifierName is in the literal union', () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedLooseConditionDecl(qualifierNameConverter);
+      expect(typedConverter.convert({ qualifierName: 'tone', value: 'formal' })).toSucceedAndSatisfy((c) => {
+        const narrowed: ValidName = c.qualifierName;
+        expect(narrowed).toBe('tone');
+      });
+    });
+
+    test("rejects a typo'd qualifierName at convert time", () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedLooseConditionDecl(qualifierNameConverter);
+      expect(typedConverter.convert({ qualifierName: 'tonr', value: 'formal' })).toFailWith(/tonr/);
+    });
+
+    test('the untyped default looseConditionDecl accepts arbitrary qualifierNames', () => {
+      // Documents back-compat: default conversion still passes any string
+      // qualifierName because `CommonConvert.qualifierName` is permissive at
+      // the JSON shape level.
+      expect(
+        TsRes.ResourceJson.Convert.looseConditionDecl.convert({ qualifierName: 'tonr', value: 'formal' })
+      ).toSucceed();
+    });
+  });
+
+  describe('typedConditionSetDecl (array form)', () => {
+    test("rejects a typo'd qualifierName in array form", () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedConditionSetDecl(qualifierNameConverter);
+      expect(typedConverter.convert([{ qualifierName: 'tonr', value: 'formal' }])).toFailWith(/tonr/);
+    });
+
+    test('accepts a valid array-form condition set', () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedConditionSetDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert([
+          { qualifierName: 'tone', value: 'formal' },
+          { qualifierName: 'language', value: 'en' }
+        ])
+      ).toSucceed();
+    });
+  });
+
+  describe('typedConditionSetDecl (record form)', () => {
+    test("rejects a typo'd qualifierName in record form", () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedConditionSetDecl(qualifierNameConverter);
+      expect(typedConverter.convert({ tonr: 'formal' })).toFailWith(/tonr/);
+    });
+
+    test('accepts a valid record-form condition set', () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedConditionSetDecl(qualifierNameConverter);
+      expect(typedConverter.convert({ tone: 'formal', language: 'en' })).toSucceed();
+    });
+
+    test('rejects a non-object in record-form input via the underlying record guard', () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedConditionSetDecl(qualifierNameConverter);
+      // `oneOf` falls through to the record path when the array path fails;
+      // a primitive fails both branches.
+      expect(typedConverter.convert(42)).toFail();
+    });
+
+    test('accepts record-form values that supply IChildConditionDecl shape', () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedConditionSetDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          tone: { value: 'formal', priority: 700 }
+        })
+      ).toSucceed();
+    });
+  });
+
+  describe('typedLooseResourceCandidateDecl', () => {
+    test("rejects a typo'd qualifierName inside conditions", () => {
+      const typedConverter =
+        TsRes.ResourceJson.Convert.typedLooseResourceCandidateDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          id: 'foo',
+          json: { value: 'hello' },
+          conditions: { tonr: 'formal' }
+        })
+      ).toFailWith(/tonr/);
+    });
+
+    test('accepts a valid candidate', () => {
+      const typedConverter =
+        TsRes.ResourceJson.Convert.typedLooseResourceCandidateDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          id: 'foo',
+          json: { value: 'hello' },
+          conditions: { tone: 'formal' }
+        })
+      ).toSucceed();
+    });
+  });
+
+  describe('typedImporterResourceCandidateDecl', () => {
+    test("rejects a typo'd qualifierName inside conditions", () => {
+      const typedConverter =
+        TsRes.ResourceJson.Convert.typedImporterResourceCandidateDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          json: { value: 'hello' },
+          conditions: [{ qualifierName: 'tonr', value: 'formal' }]
+        })
+      ).toFailWith(/tonr/);
+    });
+
+    test('accepts a valid importer candidate', () => {
+      const typedConverter =
+        TsRes.ResourceJson.Convert.typedImporterResourceCandidateDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          json: { value: 'hello' },
+          conditions: [{ qualifierName: 'tone', value: 'formal' }]
+        })
+      ).toSucceed();
+    });
+  });
+
+  describe('typedChildResourceCandidateDecl', () => {
+    test("rejects a typo'd qualifierName inside conditions", () => {
+      const typedConverter =
+        TsRes.ResourceJson.Convert.typedChildResourceCandidateDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          json: { value: 'hello' },
+          conditions: { tonr: 'formal' }
+        })
+      ).toFailWith(/tonr/);
+    });
+
+    test('accepts a valid child candidate', () => {
+      const typedConverter =
+        TsRes.ResourceJson.Convert.typedChildResourceCandidateDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          json: { value: 'hello' },
+          conditions: { tone: 'formal' }
+        })
+      ).toSucceed();
+    });
+  });
+
+  describe('typedLooseResourceDecl', () => {
+    test("rejects a typo'd qualifierName inside nested candidate conditions", () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedLooseResourceDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          id: 'my-resource',
+          resourceTypeName: 'string',
+          candidates: [
+            {
+              json: { value: 'hello' },
+              conditions: { tonr: 'formal' }
+            }
+          ]
+        })
+      ).toFailWith(/tonr/);
+    });
+
+    test('accepts a valid loose resource', () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedLooseResourceDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          id: 'my-resource',
+          resourceTypeName: 'string',
+          candidates: [
+            {
+              json: { value: 'hello' },
+              conditions: { tone: 'formal' }
+            }
+          ]
+        })
+      ).toSucceed();
+    });
+  });
+
+  describe('typedChildResourceDecl', () => {
+    test("rejects a typo'd qualifierName inside nested candidate conditions", () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedChildResourceDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          resourceTypeName: 'string',
+          candidates: [
+            {
+              json: { value: 'hello' },
+              conditions: { tonr: 'formal' }
+            }
+          ]
+        })
+      ).toFailWith(/tonr/);
+    });
+
+    test('accepts a valid child resource', () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedChildResourceDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          resourceTypeName: 'string',
+          candidates: [{ json: { value: 'hello' } }]
+        })
+      ).toSucceed();
+    });
+  });
+
+  describe('typedContainerContextDecl', () => {
+    test("rejects a typo'd qualifierName inside container conditions", () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedContainerContextDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          baseId: '',
+          conditions: { tonr: 'formal' }
+        })
+      ).toFailWith(/tonr/);
+    });
+
+    test('accepts a valid container context', () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedContainerContextDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          baseId: '',
+          conditions: { tone: 'formal' }
+        })
+      ).toSucceed();
+    });
+  });
+
+  describe('typedResourceTreeChildNodeDecl', () => {
+    test("rejects a typo'd qualifierName deep in a tree node", () => {
+      const typedConverter =
+        TsRes.ResourceJson.Convert.typedResourceTreeChildNodeDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          resources: {
+            r1: {
+              resourceTypeName: 'string',
+              candidates: [{ json: { value: 'hi' }, conditions: { tonr: 'formal' } }]
+            }
+          }
+        })
+      ).toFailWith(/tonr/);
+    });
+
+    test('handles nested children recursion', () => {
+      const typedConverter =
+        TsRes.ResourceJson.Convert.typedResourceTreeChildNodeDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          children: {
+            sub: {
+              resources: {
+                r1: {
+                  resourceTypeName: 'string',
+                  candidates: [{ json: { value: 'hi' }, conditions: { tone: 'formal' } }]
+                }
+              }
+            }
+          }
+        })
+      ).toSucceed();
+    });
+  });
+
+  describe('typedResourceTreeRootDecl', () => {
+    test("rejects a typo'd qualifierName in tree root resources", () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedResourceTreeRootDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          resources: {
+            r1: {
+              resourceTypeName: 'string',
+              candidates: [{ json: { value: 'hi' }, conditions: { tonr: 'formal' } }]
+            }
+          }
+        })
+      ).toFailWith(/tonr/);
+    });
+
+    test('accepts a valid tree root with context and children', () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedResourceTreeRootDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          context: { baseId: '', conditions: { tone: 'formal' } },
+          resources: {
+            r1: { resourceTypeName: 'string' }
+          },
+          children: {
+            sub: { resources: { r2: { resourceTypeName: 'string' } } }
+          }
+        })
+      ).toSucceed();
+    });
+  });
+
+  describe('typedResourceCollectionDecl', () => {
+    test("rejects a typo'd qualifierName in collection context conditions", () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedResourceCollectionDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          context: { conditions: { tonr: 'formal' } }
+        })
+      ).toFailWith(/tonr/);
+    });
+
+    test('accepts a valid collection with candidates, resources, and nested collections', () => {
+      const typedConverter = TsRes.ResourceJson.Convert.typedResourceCollectionDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          context: { conditions: { tone: 'formal' } },
+          candidates: [{ id: 'cand', json: { value: 'hi' }, conditions: { language: 'en' } }],
+          resources: [{ id: 'res', resourceTypeName: 'string' }],
+          collections: [{}]
+        })
+      ).toSucceed();
+    });
+  });
+
+  describe('typedImporterResourceCollectionDecl', () => {
+    test("rejects a typo'd qualifierName in nested candidate", () => {
+      const typedConverter =
+        TsRes.ResourceJson.Convert.typedImporterResourceCollectionDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          candidates: [{ json: { value: 'hi' }, conditions: { tonr: 'formal' } }]
+        })
+      ).toFailWith(/tonr/);
+    });
+
+    test('accepts a valid importer collection with both loose and child resources', () => {
+      const typedConverter =
+        TsRes.ResourceJson.Convert.typedImporterResourceCollectionDecl(qualifierNameConverter);
+      expect(
+        typedConverter.convert({
+          context: { conditions: { tone: 'formal' } },
+          candidates: [{ json: { value: 'hi' }, conditions: { tone: 'formal' } }],
+          resources: [{ id: 'res1', resourceTypeName: 'string' }, { resourceTypeName: 'string' }],
+          collections: [{}]
+        })
+      ).toSucceed();
+    });
+  });
+});


### PR DESCRIPTION
Implements Phase B-2 of the `ts-res-typed-conditions` stream — Candidate D from `.ai/tasks/active/ts-res-typed-conditions/phase-b2-design-notes.md`. Adds typed sibling Converter exports that take a `Converter<TQualifierNames>` argument and return a Converter whose result type is narrowed on that literal-string union. Existing untyped exports are preserved at signature and behavior level.

## Typed exports shipped

**`Conditions.Convert`** (4): `typedConditionDecl`, `typedValidatedConditionDecl`, `typedConditionSetDecl`, `typedValidatedConditionSetDecl`.

**`ResourceJson.Convert`** (12): `typedLooseConditionDecl`, `typedConditionSetDecl`, `typedLooseResourceCandidateDecl`, `typedImporterResourceCandidateDecl`, `typedChildResourceCandidateDecl`, `typedLooseResourceDecl`, `typedChildResourceDecl`, `typedContainerContextDecl`, `typedResourceTreeChildNodeDecl`, `typedResourceTreeRootDecl`, `typedResourceCollectionDecl`, `typedImporterResourceCollectionDecl`.

Also: `IConditionDecl` and `IConditionSetDecl` parameterized on `TQualifierNames extends string = string` (additive default).

## OQ-2 empirical finding

No `QualifierCollector` surface change required. Verified by reading `IReadOnlyQualifierCollector` at `qualifiers/qualifierCollector.ts:63` and confirming the existing `validating.get(name)` call in the validated converter body already provides collector-membership teeth. The typed siblings layer literal-set narrowing **at convert time** on top of that existing collector check; the two compose without either needing to change.

## Cast-pressure regression tests

Two new test files (`conditions/typedConvert.test.ts`, `resource-json/typedConvert.test.ts`) using the synthetic consumer pattern:

```ts
const validNames = ['tone', 'language'] as const;
const qualifierNameConverter = Converters.enumeratedValue<(typeof validNames)[number]>(validNames);
```

Three assertion shapes per converter: (1) `'tonr'` is rejected at convert time with `toFailWith(/tonr/)`; (2) valid names are accepted and the narrowed return type lets the test write `const narrowed: ValidName = c.qualifierName;` (compile-time evidence of the narrow); (3) the default untyped export still accepts `'tonr'` (back-compat baseline).

## Compatibility

- Existing `conditionDecl`, `conditionSetDecl`, `validatedConditionDecl`, `validatedConditionSetDecl`, and every `ResourceJson.Convert` export keep their pre-existing `ObjectConverter` / `Converter` return type (verified by reading the regenerated `etc/ts-res.api.md` diff — no removed or renamed exports, no return-type narrowing on defaults).
- `IConditionDecl` / `IConditionSetDecl` gained a `TQualifierNames extends string = string` parameter — the default is back-compat, existing callers (`IConditionDecl[]`) work unchanged.
- `rush build --from @fgv/ts-res` builds all 11 downstream consumers cleanly (ts-prompt-assist, ts-res-cli, ts-res-ui-components, ts-res-browser, ts-res-browser-cli, ts-res-tutorial, ts-res-ui-playground, ts-web-extras, ts-extras, ts-utils-jest, typedoc-compact-theme).

## Pre-PR gates

- [x] `rush build` passes for `@fgv/ts-res` and all downstream consumers
- [x] `rushx lint` passes (separate gate from build; exit 0)
- [x] `rushx fixlint` run before final commit (prettier autoformatting applied during commit hook)
- [x] `rushx test` passes with 100% coverage on statements / branches / functions / lines
- [x] api-extractor `etc/ts-res.api.md` regenerated — only adds: 16 new `typed*` exports + 2 type-parameter additions; no removed/renamed exports
- [x] `ae-unresolved-link` warning count: 849 — matches B-1-post-merge baseline (no new unresolved-link warnings)
- [x] No `any` types; no unsafe casts in implementation
- [x] Rush change file added (`common/changes/@fgv/ts-res/...minor.json`)
- [x] `phase-b2-result.md` written with the actual exports list, the OQ-2 finding, the cast-pressure test design, surprises, and open questions for B-3

See `.ai/tasks/active/ts-res-typed-conditions/phase-b2-result.md` for full surprises + B-3 open questions (recommended ts-prompt-assist consumer pattern, drop-the-local-types checklist for #385, YAML loader signature).

https://claude.ai/code/session_01TDZLxxwt87vJNkqLYz6JGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDZLxxwt87vJNkqLYz6JGg)_