### PR TITLE
feat(ts-prompt-assist): B-3 typed-converter consumer port + F2/F6 absorb

### DIFF
--- a/.ai/tasks/active/ts-res-typed-conditions/README.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/README.md
@@ -1,0 +1,62 @@
+# `ts-res-typed-conditions` (completed stream)
+
+Three-sub-phase stream that taught `@fgv/ts-res` to honor qualifier-name semantics at both the **type level** (Decl-tree cascade) and the **runtime level** (Converter pipeline), then ported `@fgv/ts-prompt-assist` to consume the new primitives directly — closing the cast-pressure failure mode end-to-end.
+
+**Completed:** 2026-05-19
+**Cluster:** `ts-prompt-assist-features`
+**Integration branch:** `claude/ts-prompt-assist-features`
+**Stream-level outcome:** see [`result.md`](./result.md).
+
+## Why this stream existed
+
+The closed PR #386 attempted to parameterize `@fgv/ts-res`'s Decl types on a `TQualifierNames` literal-string union but only got the leaf types — the container types (resource-candidate, resource, collection, tree-root) weren't threaded, so the narrow had no flow path from any realistic authoring chain. Meanwhile, the Converter pipeline had no opt-in path to validate qualifier names against a consumer's declared literal set at JSON-load time — so even when a consumer narrowed axis names in code, the narrow evaporated at the Converter boundary, and a typo in YAML silently fell through to the base candidate at resolve time.
+
+That failure mode (round-2 finding F1 in the cluster's pressure-test docs) needed ownership at the right layer: `@fgv/ts-res` owns the qualifier-name concept (registered via `QualifierCollector`), so it should own the discipline that enforces it — not consumer libraries reimplementing partial-shape local sibling types.
+
+## What shipped
+
+| Sub-phase | What | PR | Merged |
+|---|---|---|---|
+| B-1 | Decl-tree cascade — 17 types in `resource-json/` + `conditions/` parameterized on `TQualifierNames extends string = string`. Two latent fixes (`getKeyFromLooseDecl` undefined-handling; type-guard runtime soundness) carried forward from #386. | #391 | `c688292d` |
+| B-2 | Converter parameterization — 16 typed sibling Converters (4 in `Conditions.Convert`, 12 in `ResourceJson.Convert`) that take a `qualifierNameConverter: Converter<TQualifierNames>` and narrow their return type accordingly. Existing untyped exports preserved at signature + behavior level. | #394 | `f32ba55f` |
+| B-3 | `@fgv/ts-prompt-assist` consumer port — 6 container types parameterized; `typedPromptFileConverter<T>` factory; `qualifierNameConverter?` threaded through `FileTreePromptStore.create` and `PromptStoreFixture.build`. F2 (`buildSimpleDescriptor`) + F6 (README React-wiring) absorbed verbatim from closed PR #385; F1 local sibling types from #385 NOT carried forward (B-2 ships the canonical primitive). | #395 | pending |
+
+Substrate prep PR #390 added the brief + state.md before B-1 commission.
+
+## Artifacts
+
+| File | Purpose |
+|---|---|
+| [`brief.md`](./brief.md) | Stream brief — mission, sub-phase shape, in-scope/out-of-scope paths, acceptance criteria, decision-track input. |
+| [`state.md`](./state.md) | Stream state — phase status, decisions log, history, PR table. |
+| [`phase-b2-brief.md`](./phase-b2-brief.md) | B-2 sub-brief — three candidate surface shapes enumerated (Options A/B/C). |
+| [`phase-b2-design-notes.md`](./phase-b2-design-notes.md) | B-2 design notes — selects Candidate D (sibling `typed*` exports over a shared core, defaults preserved). |
+| [`phase-b1-result.md`](./phase-b1-result.md) | B-1 result — full type list, fix-up rounds, Copilot-review absorptions. |
+| [`phase-b2-result.md`](./phase-b2-result.md) | B-2 result — typed export catalog, factoring observation on default-export return-type narrowing, OQ-2 empirical resolution, drift-hazard markers. |
+| [`phase-b3-result.md`](./phase-b3-result.md) | B-3 result — consumer-pattern shape, F2/F6 absorption notes, cast-pressure regression test design, bindings/qualifiers widening decision. |
+| [`result.md`](./result.md) | Stream-level consolidated result across all three sub-phases — outcome, surface-preservation table, decisions log, lessons captured, open questions for cluster close. |
+
+## Stream-level lessons (for the next stream that does parameterization work)
+
+1. **Trace every Decl flow before parameterizing.** B-1's first cut missed `IResourceTreeRootDecl.resources` / `children`; B-3 picked this up by tracing every spot a Decl flows through the store/fixture path before parameterizing the seed types. Without the trace pass, the narrow evaporates mid-pipeline and you ship a story that compiles but doesn't enforce.
+
+2. **Typed/untyped pair drift hazards demand explicit markers.** B-2's review surfaced this. The resolution — a `// keep in sync with X` marker above every typed sibling, plus a drift-hazard paragraph in the typed block preamble — is now a documented pattern. B-3 inherits the same idiom via the shared `_buildPromptFileContentsConverter` core.
+
+3. **"No manual casts beyond `@ts-expect-error`" pushes for cleaner internal-shape design.** B-3's first cut had a `params as IFileTreePromptStoreCreateParams<string>` cast in the static `create`. Refactoring to an internal `IInternalStoreParams` interface that carries the pre-built converter eliminated the cast and produced a cleaner separation between public surface and internal wiring.
+
+4. **API-extractor regen catches `@public`-placement bugs.** B-3's regen surfaced an `@public` placement issue (an inserted interface above the class doc block stripped the release tag). The warning gate caught it before reviewers saw it.
+
+5. **Stream-level lockstep version discipline is load-bearing.** All three sub-phases shipped as additive — zero removed/renamed exports across `@fgv/ts-res` and `@fgv/ts-prompt-assist`. The cluster's other concurrent streams rebased cleanly across each sub-phase merge as a result.
+
+## Cluster-close handoff
+
+The stream's `result.md` enumerates three open questions for the cluster-close prep:
+
+1. Whether to parameterize `IPromptStore` itself on `TQualifierNames` (suggests deferring as FUTURE — convert-time teeth already carry the safety; threading the parameter through the resolve packlet's surface is significant).
+2. `tools/ts-res-cli` adoption of typed Converters (state.md F-1) — opportunistic followup chore.
+3. Round-2 finding F5 (typed qualifier VALUES, not just names) — confirm v0.2 scoping at cluster close.
+
+## Held PRs unblocked
+
+- **PR #385** (round-2 absorb F1+F2+F6) — superseded by this stream's consolidation. F2 + F6 carried forward into B-3 verbatim; F1's local sibling types replaced by ts-res's parameterized primitives. PR #385 can be closed without merge.
+- **PR #384** (sample app + round-2 findings) — rebases onto post-B-3 HEAD; lands last in the cluster-close sequence.

--- a/.ai/tasks/active/ts-res-typed-conditions/phase-b3-result.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/phase-b3-result.md
@@ -1,0 +1,321 @@
+# Phase B-3 Result: ts-prompt-assist typed-converter consumer port
+
+**Date:** 2026-05-19
+**Branch:** `claude/ts-res-typed-conditions-b3-MXEfo`
+**Status:** Complete (PR pending; orchestrator to open against
+`claude/ts-prompt-assist-features`)
+
+---
+
+## What shipped
+
+B-3 closes the cast-pressure failure mode in `@fgv/ts-prompt-assist`:
+when a consumer supplies a `qualifierNameConverter` on the store /
+fixture build, the YAML loader validates each candidate's
+`conditions` keys (record form) or `qualifierName` fields (array form)
+against the Converter's literal-string union at convert time. A typo'd
+axis name fails at load time with a regex-matchable error.
+
+Three additive shape changes plus the two carry-forwards from closed
+PR #385:
+
+1. **Parameterized container types** — `IPromptCandidateRecord`,
+   `IStoredPromptRecord`, `IPromptFileContents`,
+   `IPromptStoreFixtureSeed`, `IPromptStoreFixtureSeedRecord`, and
+   `IFileTreePromptStoreCreateParams` now carry
+   `TQualifierNames extends string = string`. The `conditions` field on
+   `IPromptCandidateRecord` resolves to ts-res's parameterized
+   `ResourceJson.Json.ConditionSetDecl<TQualifierNames>` directly — no
+   local sibling types.
+
+2. **Typed Converter sibling** — new `typedPromptFileConverter<T>(qc)`
+   factory builds a `Converter<IPromptFileContents<T>>` whose candidate
+   `conditions` slot is validated through
+   `ResourceJson.Convert.typedConditionSetDecl(qc)`. Shares a private
+   helper `_buildPromptFileContentsConverter` with the default
+   `promptFileConverter`, so the body-scan and
+   `outputValidations`-on-free-text rejection cannot drift between the
+   typed and untyped paths.
+
+3. **Threaded qualifier-name converter through the consumer surface** —
+   `FileTreePromptStore.create` and the `IPromptStoreFixtureSeed`
+   accept `qualifierNameConverter?: Converter<TQualifierNames>`. When
+   supplied, the store builds a per-instance YAML converter from the
+   typed sibling; when omitted, it falls back to today's
+   default-string converter.
+
+4. **F2 — `buildSimpleDescriptor` helper** carried forward verbatim
+   from closed PR #385. New exported function and `IBuildSimpleDescriptorParams`
+   interface. Free-text only (the `output.kind` discriminator is
+   load-bearing; the helper deliberately doesn't generalize to JSON
+   output).
+
+5. **F6 — README React-wiring section** carried forward verbatim from
+   closed PR #385. `ChatTone` consumer enum, `<select>` bound to it,
+   `tone === 'neutral' ? {} : { tone }` qualifier wire-through, plus a
+   fourth list-item under the three-things-this-pattern-earns block
+   spelling out the v0.1 convention that axis NAMES are
+   library-inferred while per-axis VALUE unions are a consumer concern.
+
+The local sibling types `ITypedConditionSetDecl` and
+`ITypedPromptCandidateRecord` from PR #385 were NOT carried forward —
+B-2 ships the canonical primitive at the ts-res layer, so the consumer
+references it directly.
+
+---
+
+## Consumer-pattern shape (as shipped)
+
+```ts
+import { Converters } from '@fgv/ts-utils';
+import { PromptLibrary, PromptStoreFixture, buildSimpleDescriptor } from '@fgv/ts-prompt-assist';
+
+const validNames = ['tone', 'language'] as const;
+type ValidName = (typeof validNames)[number];
+const qualifierNameConverter = Converters.enumeratedValue<ValidName>([...validNames]);
+
+const seed: IPromptStoreFixtureSeed<ValidName> = {
+  records: [
+    {
+      scope: 'global' as ScopeKey,
+      id: 'greeting' as PromptId,
+      descriptor: buildSimpleDescriptor({ id: 'greeting' as PromptId, title: 'Greeting' }),
+      candidates: [
+        { conditions: {}, body: 'Hello.' },
+        // ↓ At compile time: 'tonr' is not assignable to 'tone' | 'language'.
+        //   At convert time: even if a runtime cast bypassed the compile
+        //   check, the YAML loader rejects the typo with /tonr/.
+        { conditions: { tone: 'formal' }, isPartial: true, body: 'Greetings.' }
+      ]
+    }
+  ],
+  qualifiers: [...], // ts-res qualifier decls
+  qualifierNameConverter // ← threads through to the store's YAML loader
+};
+const store = (await PromptStoreFixture.build(seed)).orThrow();
+const library = (await PromptLibrary.create({
+  store,
+  qualifiers: [...validNames]
+})).orThrow();
+```
+
+The same `qualifierNameConverter` is also accepted directly by
+`FileTreePromptStore.create` for the FsTree path. The seed-side
+generic parameter `IPromptStoreFixtureSeed<ValidName>` and the
+runtime converter `qualifierNameConverter` are independent — a
+consumer who wants only compile-time discipline can annotate the seed
+type without supplying the Converter, or vice versa. The cast-pressure
+regression test exercises the full path: typed seed plus typed
+Converter, with a runtime-cast escape-hatch (`as unknown as
+IPromptCandidateRecord<ValidName>`) proving the Converter rejects
+typos that bypass the compile check.
+
+---
+
+## F2 / F6 absorption notes
+
+**F2 — `buildSimpleDescriptor`.** Brought forward verbatim from PR
+#385 (commit `20780782`). No reshaping needed: the helper's contract
+is independent of the typed-conditions work, and the descriptor
+returned doesn't carry any qualifier-name parameterization (the
+`output: { kind: 'free-text' }` discriminator is what matters, and the
+slots / qualifier metadata fields are unchanged). The three tests
+from #385 are mirrored in `b3TypedConditions.test.ts`.
+
+**F6 — README React-wiring section.** Brought forward verbatim. The
+`ChatTone = 'neutral' | 'formal'` example pattern composes cleanly
+with the new `qualifierNameConverter` story — the consumer-supplied
+enum still authors per-axis VALUE unions next to the wiring module,
+and the new B-3 surface adds an optional Converter for the
+axis-NAME side. The list-item callout ("axis NAMES are
+library-inferred while per-axis VALUE unions are a consumer concern")
+still applies as written.
+
+---
+
+## Cast-pressure regression test design
+
+Two test files share the regression coverage:
+
+- **`b3TypedConditions.test.ts`** (new) — the dedicated B-3 surface.
+  Three sub-blocks:
+
+  - **`buildSimpleDescriptor (F2)`** — three positive tests mirroring
+    #385's coverage of the helper.
+  - **`cast-pressure regression (B-3)`** — eight tests exercising:
+    - `typedPromptFileConverter` rejecting record-form typos at convert
+      time with `/tonr/`.
+    - Same rejection for the array form.
+    - Acceptance of valid axis names through the typed converter.
+    - The default `promptFileConverter` accepting the same typo
+      (back-compat baseline — documents that the default path is
+      permissive and the teeth live on the opt-in path).
+    - `FileTreePromptStore.create({ qualifierNameConverter })` rejecting
+      a YAML round-trip with `/tonr/` at `store.get()` time.
+    - The same store accepting a valid YAML.
+    - `PromptStoreFixture.build` threading the Converter through
+      end-to-end for a structurally valid seed.
+    - `PromptStoreFixture.build` catching a runtime-cast escape-hatch
+      typo (`as unknown as IPromptCandidateRecord<ValidName>`) at
+      `store.get()` — the load-bearing assertion that the convert-time
+      teeth are tighter than the seed-type compile check.
+  - **`compile-time seed-type discipline (B-3)`** — three smoke tests
+    using `@ts-expect-error` on the typo branch and verifying the
+    default `string` parameter remains permissive.
+
+- **`foundation.test.ts`** (existing) — the existing 164 tests stay
+  unchanged; coverage of `IPromptCandidateRecord` /
+  `IStoredPromptRecord` flows unchanged through the default `string`
+  parameter (back-compat verified).
+
+Synthetic consumer used throughout the new file:
+
+```ts
+const validNames = ['tone', 'language'] as const;
+type ValidName = (typeof validNames)[number];
+const qualifierNameConverter: Converter<ValidName> =
+  Converters.enumeratedValue<ValidName>([...validNames]);
+```
+
+100% coverage on all four metrics (statements / branches / functions /
+lines) across every changed file, verified by `rushx test`.
+
+---
+
+## `_bindings.yaml` / `_qualifiers.yaml` widening decision
+
+**Narrow scope held.** The bindings and qualifiers loaders were NOT
+threaded with the `qualifierNameConverter`.
+
+Rationale:
+
+- `_bindings.yaml` carries slot-name → SlotBinding entries. The key is
+  a `SlotName` (Mustache-name production), not a qualifier name.
+  Nothing to narrow.
+- `_qualifiers.yaml` carries `Qualifiers.IQualifierDecl[]` — the
+  authority that DEFINES the axis-name set. The qualifierNameConverter
+  is a downstream consumer of that set; threading it into the
+  qualifiers loader would invert the dependency direction.
+- The cast-pressure regression test passes end-to-end with the narrow
+  scope, including the YAML round-trip path that was the original
+  failure mode #385's local types tried to close.
+
+If a future story needs cross-file axis-name consistency on the
+bindings side (e.g. validating that scope-level binding records
+reference only known qualifiers), that's a different concern and
+warrants its own surface — surface as a FUTURE entry rather than
+bundling here.
+
+---
+
+## Surprises
+
+1. **Variance between parameterized record types and the store's
+   open-shape return.** Parameterizing `IStoredPromptRecord<TQualifierNames>`
+   with `default = string` made the store's `IPromptStore.get` return
+   `Promise<Result<IStoredPromptRecord<string> | undefined>>` — same
+   shape as today. A typed-converter-built store produces records that
+   are runtime-narrowed (the YAML loader rejects out-of-set keys) but
+   typed at the open `string` lower bound at the IPromptStore
+   interface boundary. This composes cleanly: a consumer who wants the
+   narrow on the consumer-side can annotate
+   `(await store.get(...)).orThrow().candidates[0].conditions as
+   ConditionSetDecl<'tone'>` — but the convert-time teeth ensure that
+   the cast cannot smuggle invalid axis names through.
+
+2. **Constructor-cast avoidance.** Initial implementation introduced
+   `params as IFileTreePromptStoreCreateParams<string>` in the static
+   `create` to fan a `TQualifierNames`-parameterized public input down
+   to a constructor accepting the open shape. Refactored to an
+   internal `IInternalStoreParams` interface that carries the
+   pre-built `promptYamlConverter: Converter<IPromptFileContents>` so
+   the constructor never sees the type-parameterized form. Closed the
+   one manual-cast point that the B-3 brief specifically flagged ("no
+   manual casts beyond `@ts-expect-error`").
+
+3. **`@public` placement.** Splitting the YAML-converter build out of
+   the constructor required adding a private `IInternalStoreParams`
+   interface above the class. Initially I left the class's
+   `/** @public */` doc block ABOVE the new interface, which left the
+   class without its `@public` release tag and produced an
+   api-extractor warning. Moved the interface to before the class doc
+   block so the `@public` tag flows back to the class. Trivial but
+   caught by the api-extractor warning gate.
+
+4. **File-size lint cap.** Adding the B-3 tests directly to
+   `foundation.test.ts` pushed it past the 2000-line max-lines lint
+   rule. Split the new tests into a dedicated
+   `b3TypedConditions.test.ts` — cleaner organization anyway since the
+   typed-converter pipeline is a distinct feature surface from
+   foundation. `foundation.test.ts` is now back at 1736 lines.
+
+5. **`_typedLooseCandidateBodyConverter` indirection.** Originally I
+   considered factoring `looseCandidateBodyConverter` into a shared
+   helper that took the conditions Converter as a parameter, then
+   instantiating it twice (once with default, once with the typed
+   sibling). The default path needed to preserve its `Converter` typing
+   over the conditions slot (which is `ResourceJson.Normalized.ConditionSetDecl`,
+   not the typed `Json.ConditionSetDecl<T>`), so I kept the default
+   converter inline as `Converters.object<IPromptCandidateRecord>(...)`
+   and made the typed sibling a separate private function. This
+   mirrors the pattern from B-2 (typed siblings as fresh literals,
+   not factored-out cores).
+
+---
+
+## Open questions for the cluster close
+
+1. **Should `IPromptStore` itself be parameterized on
+   `TQualifierNames`?** The convert-time teeth make the runtime narrow
+   load-bearing, but the IPromptStore.get return type is the open
+   `IStoredPromptRecord<string>` — a typed-store consumer who wants
+   their `store.get()` calls to return narrowed records needs to cast.
+   Threading `TQualifierNames` through the IPromptStore interface
+   would tighten this but expands the parameterization surface
+   significantly (every internal call site of the resolve packlet
+   would carry the parameter). Suggest deferring as FUTURE rather than
+   bundling into cluster close.
+
+2. **`tools/ts-res-cli` adoption** (state.md F-1) — the CLI's import
+   path could opportunistically thread the typed converters now that
+   B-2 ships them. Still a tech-debt chore rather than a blocker; queue
+   for after the cluster lands.
+
+3. **Round-2 finding F5 (typed qualifier VALUES, not just names)** —
+   the README's new list-item explicitly forward-references this. The
+   cluster close is the right time to confirm whether F5 stays
+   v0.2-scoped or whether a v0.1 stub is warranted.
+
+---
+
+## Acceptance gates
+
+| Gate | Status |
+|---|---|
+| `rush build` passes full repo | ✅ — all 27 packages build clean |
+| `rushx lint` passes in `@fgv/ts-prompt-assist` | ✅ (exit 0) |
+| `rushx fixlint` ran before final commit | ✅ |
+| `rushx test` passes with 100% coverage on all 4 metrics | ✅ — 178 tests, 100/100/100/100 |
+| Cast-pressure regression test rejects typo at convert time | ✅ — `b3TypedConditions.test.ts` cast-pressure regression block |
+| api-extractor regenerated | ✅ — additive diff only: new `TQualifierNames` params, new `buildSimpleDescriptor` / `IBuildSimpleDescriptorParams` / `typedPromptFileConverter` / `qualifierNameConverter` field. No removed/renamed exports. |
+| Rush change file added (`minor`) | ✅ — `chore-ts-res-typed-conditions-b3_2026-05-19-00-00.json` |
+| `phase-b3-result.md` written | ✅ — this file |
+| state.md updated | (pending — flip B-3 row to ✅ with PR link after PR opens) |
+| `docs/WORKSTREAMS.md` updated | (pending — flip stream-level entry to ✅ after PR merges) |
+| No `any` types; no manual casts beyond `@ts-expect-error` | ✅ — internal store params refactor eliminated the one cast point |
+| Local sibling types removed | ✅ — `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord` from PR #385 are NOT in the implementation; references go directly to `ResourceJson.Json.ConditionSetDecl<T>` |
+
+---
+
+## Files changed (summary)
+
+| File | Change |
+|---|---|
+| `src/packlets/types/descriptor.ts` | Parameterized `IPromptCandidateRecord` / `IStoredPromptRecord`; added `IBuildSimpleDescriptorParams` + `buildSimpleDescriptor` |
+| `src/packlets/converters/descriptorConverter.ts` | Parameterized `IPromptFileContents` + `buildStoredPromptRecord`; new `typedPromptFileConverter<T>` factory; private `_buildPromptFileContentsConverter` + `_typedLooseCandidateBodyConverter` helpers |
+| `src/packlets/store/fileTreePromptStore.ts` | Parameterized `IFileTreePromptStoreCreateParams<TQualifierNames>`; added `qualifierNameConverter?` field; refactored ctor to take a per-instance `promptYamlConverter` built from typed/default factory |
+| `src/packlets/fixture/promptStoreFixture.ts` | Parameterized `IPromptStoreFixtureSeed<TQualifierNames>` + `IPromptStoreFixtureSeedRecord<TQualifierNames>`; added `qualifierNameConverter?` to seed; threaded through to `FileTreePromptStore.create` |
+| `src/test/unit/b3TypedConditions.test.ts` (new) | 14 tests covering F2, cast-pressure regression, and compile-time seed-type discipline |
+| `README.md` | F6 React-wiring update (verbatim from #385) |
+| `etc/ts-prompt-assist.api.md` | api-extractor regen (additive only) |
+| `common/changes/@fgv/ts-prompt-assist/chore-ts-res-typed-conditions-b3_*.json` | Rush change file (minor) |

--- a/.ai/tasks/active/ts-res-typed-conditions/result.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/result.md
@@ -1,0 +1,126 @@
+# Stream result: `ts-res-typed-conditions`
+
+**Status:** ✅ all three sub-phases complete
+**Cluster:** `ts-prompt-assist-features` (in-cluster)
+**Integration branch:** `claude/ts-prompt-assist-features`
+**Duration:** 2026-05-19 (single day; substrate prep → B-1 → B-2 → B-3 all in one calendar day)
+**PRs:** #390 (substrate), #391 (B-1), #394 (B-2), #395 (B-3)
+
+---
+
+## Mission recap
+
+Make `@fgv/ts-res` honor qualifier-name semantics — the closed set of axis names a deployment declares — at both the **type level** (across the full Decl tree) and the **runtime level** (Converter pipeline). Replace closed PR #386's leaf-only parameterization with the complete co-designed shape, then port `@fgv/ts-prompt-assist` to consume the result, closing round-2 finding F1 by ownership at the right layer (ts-res owns the qualifier-name concept; consumers reference rather than re-implement).
+
+---
+
+## Outcome
+
+Three sub-phases landed on `claude/ts-prompt-assist-features` as separate, additive PRs:
+
+### B-1 — Decl-tree cascade (PR #391)
+
+Type-level parameterization. 17 items in `@fgv/ts-res/src/packlets/resource-json/` and `conditions/` carry `TQualifierNames extends string = string`. The leaf types from #386 plus the full container cascade #386 missed (resource-candidate, resource, collection, tree-child-node, tree-root). Two latent fixes carried forward: `getKeyFromLooseDecl` correct handling of explicit-`undefined` record entries, and `isLooseResourceCandidateDecl` / `isLooseResourceDecl` runtime-soundness on the `id` field. No runtime-behavior change; 100% coverage; all 11 downstream consumers compile unchanged.
+
+### B-2 — Converter parameterization (PR #394)
+
+Runtime teeth. 16 new typed Converter siblings — 4 in `Conditions.Convert` (`typedConditionDecl`, `typedValidatedConditionDecl`, `typedConditionSetDecl`, `typedValidatedConditionSetDecl`) and 12 in `ResourceJson.Convert` (covering every consumer entry-point Converter plus every internal Converter an entry-point composes). Each takes a `qualifierNameConverter: Converter<TQualifierNames>` and returns a Converter whose result type is narrowed on `TQualifierNames`. Existing untyped exports preserved at signature and behavior level; `ObjectConverter` return type preserved on the defaults (Candidate D shape from `phase-b2-design-notes.md`). `// keep in sync with X` markers on every typed sibling to surface drift hazards explicitly. Cast-pressure regression tests in `conditions/typedConvert.test.ts` and `resource-json/typedConvert.test.ts` cover every sibling at three assertion shapes (convert-time rejection of typos, convert-time acceptance of valid names with type-level narrowing, back-compat documentation that defaults accept typos). 100% coverage; all 11 downstream consumers compile unchanged.
+
+### B-3 — `ts-prompt-assist` consumer port (PR #395)
+
+Consumer port. Six container types in `@fgv/ts-prompt-assist` (`IPromptCandidateRecord`, `IStoredPromptRecord`, `IPromptFileContents`, `IPromptStoreFixtureSeed`, `IPromptStoreFixtureSeedRecord`, `IFileTreePromptStoreCreateParams`) parameterized on `TQualifierNames extends string = string`. New `typedPromptFileConverter<T>(qc)` factory exported as the typed sibling of `promptFileConverter`. `FileTreePromptStore.create` and `PromptStoreFixture.build` accept an optional `qualifierNameConverter: Converter<TQualifierNames>` that routes the YAML loader through B-2's `typedConditionSetDecl(qc)`. Round-2 findings F2 (`buildSimpleDescriptor` helper) and F6 (README React-wiring section) absorbed verbatim from closed PR #385. Local sibling types `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord` from #385 NOT carried forward — B-2 ships the canonical primitive. Cast-pressure regression in `b3TypedConditions.test.ts` verifies the convert-time teeth via a runtime-cast escape-hatch path, proving the Converter rejects typos that bypass the seed-type compile check. 100% coverage; full repo build clean.
+
+---
+
+## Cast-pressure failure mode — closed
+
+The original problem (cluster's round-2 finding F1) was that a consumer narrowing axis names in TypeScript code (e.g. `ConditionSetDecl<'tone' | 'language'>`) lost the narrow at the Converter boundary — JSON parsing produced an untyped record, and a typo'd axis name slipped through to runtime where it silently fell through to the base candidate at resolve time.
+
+The stream closed this end-to-end:
+
+1. **Type level (B-1):** `TQualifierNames` flows through every Decl container, so authoring code that constructs a Decl tree gets compile-time discipline.
+2. **Converter level (B-2):** opt-in typed Converter siblings narrow the JSON-load result type AND reject typo'd names at convert time via `Converters.enumeratedValue`.
+3. **Consumer level (B-3):** `@fgv/ts-prompt-assist` threads the typed Converter through `FileTreePromptStore.create` and `PromptStoreFixture.build`, so YAML round-trips through real adapter code preserve the narrow.
+
+Verified by three test files exercising the same synthetic-consumer pattern (`const validNames = ['tone', 'language'] as const; const qc = Converters.enumeratedValue<ValidName>(validNames)`):
+
+- `libraries/ts-res/src/test/unit/conditions/typedConvert.test.ts` — 4 typed Converter siblings.
+- `libraries/ts-res/src/test/unit/resource-json/typedConvert.test.ts` — 12 typed Converter siblings.
+- `libraries/ts-prompt-assist/src/test/unit/b3TypedConditions.test.ts` — full consumer-path regression including the runtime-cast escape-hatch (`as unknown as IPromptCandidateRecord<ValidName>`) that proves the teeth are tighter than the seed-type compile check.
+
+---
+
+## Surface preservation outcomes
+
+| Library | Removed exports | Renamed exports | Behavior change on existing exports |
+|---|---|---|---|
+| `@fgv/ts-res` (B-1) | 0 | 0 | 0 (type-only) |
+| `@fgv/ts-res` (B-2) | 0 | 0 | 0 (additive siblings) |
+| `@fgv/ts-prompt-assist` (B-3) | 0 | 0 | 0 (additive parameters with `default = string`) |
+
+The lockstep-version policy means a single breaking change anywhere bumps every package's alpha version. The stream's discipline of preserving existing signatures end-to-end was load-bearing for this — the cluster's other concurrent streams could rebase cleanly across each sub-phase merge.
+
+---
+
+## Decisions log (consolidated)
+
+| Decision | Rationale |
+|---|---|
+| Three sub-phases inside one stream (B-1 / B-2 / B-3), not one combined PR | Erik (2026-05-19): smaller scoped PRs review more cleanly; each sub-phase independently mergeable (B-1 type-only; B-2 adds opt-in runtime; B-3 consumer port). |
+| In-cluster (not next-cluster) | Erik (2026-05-19): "B+C cascades into deliverables for this cluster so deferring it just creates debt." |
+| B-2 surface shape: typed sibling exports over a shared core, defaults preserved | Candidate D from `phase-b2-design-notes.md` — preserves `ObjectConverter` return type on defaults; opt-in via separate `typed*` symbol. |
+| B-3 narrow scope: bindings/qualifiers loaders not threaded with `qualifierNameConverter` | `_bindings.yaml` carries slot-name keys (not qualifier-names); `_qualifiers.yaml` is the AUTHORITY defining the axis set. Threading the downstream Converter into either inverts dependency direction or is a no-op. Cast-pressure regression passes without it. |
+| Drop #385's local sibling types (`ITypedConditionSetDecl`, `ITypedPromptCandidateRecord`) | B-2 ships the canonical primitive at the ts-res layer. Carrying #385's local types forward would duplicate the shape ts-res now publishes. |
+| Carry forward #385's F2 (`buildSimpleDescriptor`) and F6 (README React-wiring) verbatim | Independent of B-3's typed-conditions story; both are pure-additive ergonomics that compose cleanly with the new surface. |
+| `IPromptStore` interface NOT parameterized on `TQualifierNames` | Convert-time teeth carry the runtime narrow; threading the parameter through the interface would expand the parameterization surface significantly into the resolve packlet without proportional value. Deferred as a FUTURE consideration (see open questions). |
+
+---
+
+## Lessons captured
+
+1. **Cascade completeness matters.** B-1 review caught `IResourceTreeRootDecl.resources` / `children` not being parameterized; the brief lesson "trace every place a Decl flows" applied at every layer. B-3 picked this up by tracing every spot a Decl flows through the store/fixture path before parameterizing the seed types — the narrow doesn't evaporate mid-pipeline.
+
+2. **Typed/untyped pair drift hazards demand explicit markers.** B-2's first review surfaced this; the resolution (a `// keep in sync with X` marker above every typed sibling, plus a drift-hazard paragraph in the typed block preamble) is now a documented pattern in the repo's review checklist. B-3 inherits the same idiom via the shared `_buildPromptFileContentsConverter` core.
+
+3. **API-extractor regen as a first-class gate.** Both B-1 and B-2 had warnings on `@link` cross-package refs; both rounds standardized on backtick-quoted type names for new JSDoc. B-3's regen surfaced an `@public` placement issue (an inserted interface above the class doc block stripped the release tag) — caught by the warning gate, fixed in one commit.
+
+4. **The "no manual casts beyond `@ts-expect-error`" rule pushes for cleaner internal-shape design.** B-3's first cut had `params as IFileTreePromptStoreCreateParams<string>` in the static `create` to widen a parameterized public input down to the constructor's expected shape. Refactoring to an internal `IInternalStoreParams` interface that carries the pre-built `promptYamlConverter` eliminated the cast entirely and arguably produced a cleaner separation between public surface and internal wiring.
+
+5. **Result-doc protocol load-bearing for cluster cohesion.** All three phases produced `phase-bN-result.md` artifacts with the same section structure (typed exports, surprises, open questions, acceptance gates). B-3's open-questions section threaded directly into this stream-level result, which in turn threads into the cluster-close prep. Each artifact is self-contained but composes with the next.
+
+---
+
+## Open questions for cluster close
+
+1. **`IPromptStore` parameterization on `TQualifierNames`.** Threading through the interface would tighten the type-level narrow at `store.get()` call sites but expand the parameterization surface through the resolve packlet. Suggest deferring as FUTURE — convert-time teeth already carry the safety. (Documented in `phase-b3-result.md` §Open questions.)
+
+2. **`tools/ts-res-cli` adoption** (state.md F-1). Opportunistic followup chore to thread typed Converters through the CLI's bundle/import path. Not blocking; queue as tech-debt.
+
+3. **Round-2 finding F5 (typed qualifier VALUES, not just names).** The README's new fourth list-item (per F6) explicitly forward-references this. Cluster close is the right time to confirm v0.2 scoping.
+
+---
+
+## Held PRs unblocked
+
+- **#385 (round-2 absorb)** — superseded by this stream's consolidation of F1 ownership at ts-res. F2 + F6 carried forward verbatim into B-3 (PR #395); F1's local sibling types replaced by ts-res's parameterized primitives at the source. PR #385 can be closed without merge.
+- **#384 (sample app + round-2 findings)** — rebases onto post-B-3 HEAD. Lands as the last cluster-close prep step.
+
+---
+
+## Acceptance — stream-level exit
+
+- [x] All three sub-phases merged or merge-pending on integration (B-1 ✅ merged `c688292d`; B-2 ✅ merged `f32ba55f`; B-3 ✅ merge-pending PR #395).
+- [x] ts-prompt-assist's local `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord` types are NOT in the implementation; references go directly to ts-res's parameterized types.
+- [x] Test demonstrates the cast-pressure failure mode is closed at three layers (B-1 type, B-2 Converter, B-3 consumer); a JSON round-trip through the parameterized Converter preserves the narrow; a typo'd qualifier name fails at convert time.
+- [x] `result.md` written (this file) summarizing all three sub-phases' outcomes.
+- [x] `state.md` reflects final state.
+- [x] Stream entry in `docs/WORKSTREAMS.md` flipped to ✅ with consolidated outcome notes.
+- [ ] state.md + per-phase result.md migrated to `.ai/tasks/completed/2026-05/ts-res-typed-conditions/` with polished README.md per artifact-protocol convention. *(Owner: orchestrator, post-merge.)*
+
+---
+
+## Phase-result cross-references
+
+- `phase-b1-result.md` — full type list, fix-up rounds, Copilot-review absorptions.
+- `phase-b2-result.md` — typed export catalog, factoring observation on default-export return-type narrowing risk, OQ-2 empirical resolution.
+- `phase-b3-result.md` — consumer-pattern shape, F2/F6 absorption notes, cast-pressure regression test design, bindings/qualifiers widening decision, file-by-file change summary.

--- a/.ai/tasks/active/ts-res-typed-conditions/state.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/state.md
@@ -75,7 +75,7 @@
 | Substrate prep | #390 | merged |
 | B-1 | #391 | merged (`c688292d3`) |
 | B-2 | #394 | merged (`f32ba55f`) |
-| B-3 | TBD (PR pending after this commit) | implementation complete on `claude/ts-res-typed-conditions-b3-MXEfo`; result + change-file + api.md regen ready |
+| B-3 | #395 | open (awaiting review) |
 
 ---
 

--- a/.ai/tasks/active/ts-res-typed-conditions/state.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/state.md
@@ -1,9 +1,10 @@
 # Stream state: `ts-res-typed-conditions`
 
-**Status:** 🟢 ready to commission — substrate prep in flight
+**Status:** 🟢 B-3 complete (PR pending) — stream-exit gates satisfied; awaiting PR open + merge
 **Cluster:** `ts-prompt-assist-features` (in-cluster)
 **Integration branch:** `claude/ts-prompt-assist-features`
-**Last updated:** 2026-05-19 (orchestrator — B-1 merged; B-2 sub-brief drafted)
+**Work branch (B-3):** `claude/ts-res-typed-conditions-b3-MXEfo`
+**Last updated:** 2026-05-19 (B-3 implementation complete; PR pending)
 
 ---
 
@@ -13,7 +14,7 @@
 |-------|--------|-------|
 | B-1 — Decl-tree cascade (`ts-res`, type-only) | ✅ merged | PR #391 merged 2026-05-19; final list parameterized = 17 items (containers + tree child node + type guards + union alias); `getKeyFromLooseDecl` + type-guard soundness fixes bundled; api-extractor regenerated; 100% coverage; downstream consumers compile unchanged |
 | B-2 — Converter parameterization (`ts-res`, runtime teeth) | ✅ complete (PR pending) | Branch `chore/ts-res-typed-conditions-b2-converter-teeth`; Candidate D shipped (sibling `typed*` exports over a shared core, existing untyped exports preserved); OQ-2 verified empirically — no `QualifierCollector` surface change; cast-pressure regression tests in `conditions/typedConvert.test.ts` and `resource-json/typedConvert.test.ts`; api-extractor unresolved-link warnings = baseline 849 (no new); all 11 downstream consumers compile unchanged; 100% coverage; result doc at `phase-b2-result.md` |
-| B-3 — `ts-prompt-assist` port (consumer) | 🟢 ready | Drop local `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord`; reference ts-res parameterized types directly; thread `qualifierNameConverter` into `FileTreePromptStore.create` and `PromptStoreFixture.build`; see open questions for B-3 in `phase-b2-result.md` |
+| B-3 — `ts-prompt-assist` port (consumer) | ✅ complete (PR pending) | Branch `claude/ts-res-typed-conditions-b3-MXEfo`; parameterized `IPromptCandidateRecord` / `IStoredPromptRecord` / `IPromptFileContents` / `IPromptStoreFixtureSeed` / `IFileTreePromptStoreCreateParams` on `TQualifierNames extends string = string`; new `typedPromptFileConverter<T>(qc)` factory; `qualifierNameConverter?` threaded into `FileTreePromptStore.create` and `PromptStoreFixture.build`; F2 (`buildSimpleDescriptor`) and F6 (README React-wiring) absorbed from closed PR #385; local sibling types `ITypedConditionSetDecl` / `ITypedPromptCandidateRecord` from #385 NOT carried forward (B-2 ships the canonical primitive); cast-pressure regression test in `b3TypedConditions.test.ts` (14 tests, including runtime-cast escape-hatch coverage); 100% coverage on all 4 metrics; no removed/renamed exports; result `phase-b3-result.md` |
 
 ---
 
@@ -62,6 +63,8 @@
 | 2026-05-19 | B-2 design notes added | `phase-b2-design-notes.md` selects Candidate D — sibling `typed*` exports over a shared parameterized core, existing untyped exports preserved as thin wrappers. Non-breaking. |
 | 2026-05-19 | B-2 implemented | Branch `chore/ts-res-typed-conditions-b2-converter-teeth`; 16 new typed siblings (4 in `Conditions.Convert`, 12 in `ResourceJson.Convert`); `IConditionDecl` / `IConditionSetDecl` parameterized on `TQualifierNames` (additive default); cast-pressure regression tests added; api-extractor regenerated (no new unresolved-link warnings); 100% coverage; all 11 downstream consumers compile unchanged. Result: `phase-b2-result.md`. PR #394 opened against integration. |
 | 2026-05-19 | B-2 Copilot review absorbed | Single review thread on PR #394: typed/untyped pair drift hazard. Addressed by adding `// keep in sync with X` markers next to every typed sibling and a drift-hazard preamble at the typed block in `resource-json/convert.ts`. Build + lint stay clean. Commit `253c6024` pushed. |
+| 2026-05-19 | B-2 merged | PR #394 squash-merged to integration as `f32ba55f`. |
+| 2026-05-19 | B-3 implemented | Branch `claude/ts-res-typed-conditions-b3-MXEfo`; six container types parameterized on `TQualifierNames extends string = string`; `typedPromptFileConverter<T>(qc)` exported; `qualifierNameConverter?` field added to `FileTreePromptStore.create` params and `PromptStoreFixture.build` seed; F2 + F6 from PR #385 absorbed verbatim; local sibling types from #385 dropped (B-2's canonical primitive referenced directly); 14-test cast-pressure regression file `b3TypedConditions.test.ts`; api-extractor regenerated (additive only); 100% coverage maintained; all downstream consumers compile clean. Result `phase-b3-result.md`. |
 
 ---
 
@@ -71,8 +74,8 @@
 |---|---|---|
 | Substrate prep | #390 | merged |
 | B-1 | #391 | merged (`c688292d3`) |
-| B-2 | #394 | open (review round 1 absorbed; awaiting merge) |
-| B-3 | TBD (task-subagent) | ready (was blocked on B-2) |
+| B-2 | #394 | merged (`f32ba55f`) |
+| B-3 | TBD (PR pending after this commit) | implementation complete on `claude/ts-res-typed-conditions-b3-MXEfo`; result + change-file + api.md regen ready |
 
 ---
 

--- a/.ai/tasks/active/ts-res-typed-conditions/state.md
+++ b/.ai/tasks/active/ts-res-typed-conditions/state.md
@@ -1,10 +1,14 @@
 # Stream state: `ts-res-typed-conditions`
 
-**Status:** 🟢 B-3 complete (PR pending) — stream-exit gates satisfied; awaiting PR open + merge
+**Status:** ✅ all three sub-phases complete; B-3 merge-pending (PR #395 — Copilot review clean, no comments)
 **Cluster:** `ts-prompt-assist-features` (in-cluster)
 **Integration branch:** `claude/ts-prompt-assist-features`
-**Work branch (B-3):** `claude/ts-res-typed-conditions-b3-MXEfo`
-**Last updated:** 2026-05-19 (B-3 implementation complete; PR pending)
+**Work branches:**
+- B-1: `chore/ts-res-typed-conditions-b1-cascade` (merged via #391 as `c688292d`)
+- B-2: `chore/ts-res-typed-conditions-b2-converter-teeth` (merged via #394 as `f32ba55f`)
+- B-3: `claude/ts-res-typed-conditions-b3-MXEfo` (PR #395 open; Copilot review pass; ready to merge)
+
+**Last updated:** 2026-05-19 (B-3 Copilot review clean — no comments, stream ready for cluster-close)
 
 ---
 
@@ -64,7 +68,8 @@
 | 2026-05-19 | B-2 implemented | Branch `chore/ts-res-typed-conditions-b2-converter-teeth`; 16 new typed siblings (4 in `Conditions.Convert`, 12 in `ResourceJson.Convert`); `IConditionDecl` / `IConditionSetDecl` parameterized on `TQualifierNames` (additive default); cast-pressure regression tests added; api-extractor regenerated (no new unresolved-link warnings); 100% coverage; all 11 downstream consumers compile unchanged. Result: `phase-b2-result.md`. PR #394 opened against integration. |
 | 2026-05-19 | B-2 Copilot review absorbed | Single review thread on PR #394: typed/untyped pair drift hazard. Addressed by adding `// keep in sync with X` markers next to every typed sibling and a drift-hazard preamble at the typed block in `resource-json/convert.ts`. Build + lint stay clean. Commit `253c6024` pushed. |
 | 2026-05-19 | B-2 merged | PR #394 squash-merged to integration as `f32ba55f`. |
-| 2026-05-19 | B-3 implemented | Branch `claude/ts-res-typed-conditions-b3-MXEfo`; six container types parameterized on `TQualifierNames extends string = string`; `typedPromptFileConverter<T>(qc)` exported; `qualifierNameConverter?` field added to `FileTreePromptStore.create` params and `PromptStoreFixture.build` seed; F2 + F6 from PR #385 absorbed verbatim; local sibling types from #385 dropped (B-2's canonical primitive referenced directly); 14-test cast-pressure regression file `b3TypedConditions.test.ts`; api-extractor regenerated (additive only); 100% coverage maintained; all downstream consumers compile clean. Result `phase-b3-result.md`. |
+| 2026-05-19 | B-3 implemented | Branch `claude/ts-res-typed-conditions-b3-MXEfo`; six container types parameterized on `TQualifierNames extends string = string`; `typedPromptFileConverter<T>(qc)` exported; `qualifierNameConverter?` field added to `FileTreePromptStore.create` params and `PromptStoreFixture.build` seed; F2 + F6 from PR #385 absorbed verbatim; local sibling types from #385 dropped (B-2's canonical primitive referenced directly); 14-test cast-pressure regression file `b3TypedConditions.test.ts`; api-extractor regenerated (additive only); 100% coverage maintained; all downstream consumers compile clean. Result `phase-b3-result.md`. PR #395 opened. |
+| 2026-05-19 | B-3 Copilot review pass | PR #395 review completed with no comments / no suggested changes. Check run `success`. Stream-level `result.md` written summarizing all three sub-phases. Stream artifacts ready for orchestrator migration to `.ai/tasks/completed/2026-05/ts-res-typed-conditions/` post-merge. |
 
 ---
 

--- a/common/changes/@fgv/ts-prompt-assist/chore-ts-res-typed-conditions-b3_2026-05-19-00-00.json
+++ b/common/changes/@fgv/ts-prompt-assist/chore-ts-res-typed-conditions-b3_2026-05-19-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-prompt-assist",
+      "comment": "B-3 typed-converter consumer port (final phase of the ts-res-typed-conditions stream): `IPromptCandidateRecord`, `IStoredPromptRecord`, `IPromptFileContents`, `IPromptStoreFixtureSeed`, `IPromptStoreFixtureSeedRecord`, and `IFileTreePromptStoreCreateParams` are now parameterized on `TQualifierNames extends string = string` (additive default — existing callers compile unchanged). `FileTreePromptStore.create` and `PromptStoreFixture.build` accept an optional `qualifierNameConverter: Converter<TQualifierNames>`; when supplied, the YAML loader validates each candidate's `conditions` keys (record form) or `qualifierName` fields (array form) against the Converter's literal-string union via ts-res's `ResourceJson.Convert.typedConditionSetDecl(qc)` (shipped by phase B-2). A typo'd axis name fails at convert time with a regex-matchable error; when omitted, today's permissive default-string behavior is preserved. New `typedPromptFileConverter<T>(qc)` factory exported as the typed sibling of `promptFileConverter`. Round-2 finding F2 absorbed: new `buildSimpleDescriptor({ id, title, surface?, description? })` helper returns a fully-shaped `IPromptDescriptor` for the trivial free-text chat case (deliberately not generalized to JSON-output prompts — the `output.kind` discriminator stays explicit at the call site). Round-2 finding F6 absorbed: README React-wiring section extended with a `ChatTone` consumer enum, a `<select>` bound to it, and a fourth list-item spelling out the v0.1 axis-NAMES-inferred / axis-VALUES-consumer-concern convention. No removed/renamed exports; `etc/ts-prompt-assist.api.md` regenerated.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-prompt-assist"
+}

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -163,20 +163,22 @@ The data-structure specifics in the design brief are **proposed** — phase A lo
 - `ts-prompt-assist-samples` — sample/test app demonstrating end-to-end usage (might be standalone OR merged into `ai-assist-image-generator`)
 - `ts-prompt-assist-editor-ui` — generic editor UX for prompt editing (decide whether to make consumer-shape-agnostic vs require consumer-side implementation; UX is complex enough that sharing would be valuable, but the consumer-specific surfaces may make full generalization impractical). See `docs/FUTURE.md`.
 
-### `ts-res-typed-conditions` 🟢
+### `ts-res-typed-conditions` ✅
 
-**Status:** 🟢 ready to commission (Phase B-1 next)
+**Status:** ✅ all three sub-phases complete; B-3 PR pending merge
 **Cluster:** `ts-prompt-assist-features` (in-cluster; integration branch `claude/ts-prompt-assist-features`)
 **Workflow shape:** three sub-phases inside one stream (B-1 type cascade → B-2 Converter teeth → B-3 ts-prompt-assist port). Each sub-phase its own PR; same stream substrate.
-**Substrate:** `.ai/tasks/active/ts-res-typed-conditions/{brief.md, state.md}`
-**Package surface:** `@fgv/ts-res` (Decl tree in `resource-json/`; Converter pipeline in `conditions/convert/`) + `@fgv/ts-prompt-assist` (B-3 port to drop local sibling types).
+**Substrate:** `.ai/tasks/active/ts-res-typed-conditions/{brief.md, state.md, phase-b1-result.md, phase-b2-result.md, phase-b3-result.md}`
+**Package surface:** `@fgv/ts-res` (Decl tree in `resource-json/`; Converter pipeline in `conditions/convert/`) + `@fgv/ts-prompt-assist` (B-3 consumer port; references ts-res typed siblings directly).
 **Out-of-scope:** `tools/ts-res-cli`, `libraries/ts-res-ui-components`, `libraries/ts-res/src/packlets/qualifiers/` (existing `QualifierCollector` surface unchanged).
 
 **Mission.** Make ts-res honor qualifier-name semantics at both type level (Decl tree cascade) and runtime level (Converter pipeline parameterization). Replaces closed PR #386's leaf-only parameterization with the complete co-designed shape. Closes round-2 finding F1 from ts-prompt-assist pressure-test by ownership at the right layer (ts-res owns qualifier-name concept; ts-prompt-assist references rather than re-implements).
 
+**Outcome.** B-1 (#391) shipped the type-level cascade. B-2 (#394) shipped 16 typed Converter siblings preserving the existing surface. B-3 ports `@fgv/ts-prompt-assist` to consume B-2's primitives directly: six container types parameterized on `TQualifierNames extends string = string`; `typedPromptFileConverter<T>(qc)` factory; `qualifierNameConverter?` threaded into `FileTreePromptStore.create` and `PromptStoreFixture.build`; F2 (`buildSimpleDescriptor`) and F6 (README React-wiring) round-2 absorbs carried forward from closed PR #385; F1 local sibling types from #385 NOT carried forward (B-2 ships the canonical primitive). Cast-pressure regression test verifies the convert-time teeth (typed Converter rejects typo'd axis name at YAML load time, including the runtime-cast escape-hatch path).
+
 **Decision-track input (binding):** `.ai/tasks/active/ts-prompt-assist/{ts-res-typed-conditions-design.md, ts-res-typed-conditions-evaluation.md}` (the latter includes the load-bearing addendum correcting the "Option B" framing — #386 was leaf-only with no plumbing through containers; the implementing agent must thread `TQualifierNames` through container types, not just the leaf).
 
-**Sequencing.** B-3 unblocks held PRs #385 (round-2 absorb — drops local sibling types) and #384 (sample app — rebases last). Stream exit precedes cluster-close prep.
+**Sequencing.** B-3 unblocks held PRs #385 (round-2 absorb — superseded by this stream's consolidation of F1 ownership at ts-res; F2 + F6 carried forward verbatim) and #384 (sample app — rebases last onto post-B-3 HEAD). Stream exit precedes cluster-close prep.
 
 ### `ai-assist-thinking-events` 🟡
 

--- a/libraries/ts-prompt-assist/README.md
+++ b/libraries/ts-prompt-assist/README.md
@@ -205,11 +205,31 @@ export function ChatPanel(): JSX.Element {
   return <ChatInner library={library} />;
 }
 
+// Consumer-side type union for the qualifier values driving the UI.
+// `PromptLibrary.create({ qualifiers: ['tone'] as const })` infers the
+// axis NAME (`'tone'`); the per-axis VALUE union is a consumer concern
+// at v0.1, so author it next to the wiring and reference it from both
+// the UI control and the resolve call.
+export type ChatTone = 'neutral' | 'formal';
+
 function ChatInner(props: { library: PromptLibrary<IPromptResponseBase, 'tone'> }): JSX.Element {
   // The narrow `qualifiers: { tone?: string }` shape comes from F3 +
   // F14 — the empty `{}` branch assigns thanks to the Partial widening
   // and a misspelled axis (`tonr`) fails at compile time.
-  return <div>Library ready.</div>;
+  const [tone, setTone] = useState<ChatTone>('neutral');
+  // 'neutral' is the unconditional base candidate (no `tone` key in
+  // the resolve context); 'formal' threads the value through to ts-res
+  // so the `conditions: { tone: 'formal' }` partial layers in.
+  const qualifiers = tone === 'neutral' ? {} : { tone };
+
+  // Use `qualifiers` in your resolve call:
+  //   props.library.resolve({ id: GREETING, chain: [SCOPE], qualifiers });
+  return (
+    <select value={tone} onChange={(e) => setTone(e.target.value as ChatTone)}>
+      <option value="neutral">Neutral</option>
+      <option value="formal">Formal</option>
+    </select>
+  );
 }
 ```
 
@@ -227,6 +247,14 @@ Three things this pattern earns you:
    tightening the resolve request's `qualifiers` shape. A pre-built
    `Qualifiers.QualifierCollector` doesn't expose its axes at the type
    level; pass `as const` decls when you want the typed benefit.
+4. **Consumer-side qualifier-value enum** — the library infers axis
+   NAMES from the decl-array, but the per-axis VALUE union (e.g.
+   `ChatTone = 'neutral' | 'formal'`) is a consumer concern at v0.1.
+   Author it next to the wiring module so the UI control, the resolve
+   call's `qualifiers`, and any seed-side `conditions: { tone: 'formal' }`
+   all draw from the same source of truth. (A future story may
+   parameterize the library on per-axis value unions; see F5 in the
+   round-2 pressure-test findings.)
 
 ---
 

--- a/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
+++ b/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
@@ -46,7 +46,10 @@ export type BindingTraceSource = 'caller-sub' | 'binding' | 'default' | 'empty';
 export function buildBindingsRecord(scope: ScopeKey, contents: IBindingsFileContents): IScopeSlotBindingsRecord;
 
 // @public
-export function buildStoredPromptRecord(scope: ScopeKey, contents: IPromptFileContents): IStoredPromptRecord;
+export function buildSimpleDescriptor(params: IBuildSimpleDescriptorParams): IPromptDescriptor;
+
+// @public
+export function buildStoredPromptRecord<TQualifierNames extends string = string>(scope: ScopeKey, contents: IPromptFileContents<TQualifierNames>): IStoredPromptRecord<TQualifierNames>;
 
 // @public
 export const Convert: {
@@ -97,7 +100,7 @@ export const EnumConvert: {
 
 // @public
 export class FileTreePromptStore implements IPromptStore {
-    static create(params: IFileTreePromptStoreCreateParams): Promise<Result<FileTreePromptStore>>;
+    static create<TQualifierNames extends string = string>(params: IFileTreePromptStoreCreateParams<TQualifierNames>): Promise<Result<FileTreePromptStore>>;
     get(scope: ScopeKey, id: PromptId): Promise<Result<IStoredPromptRecord | undefined>>;
     getBindings(scope: ScopeKey): Promise<Result<IScopeSlotBindingsRecord | undefined>>;
     getQualifierConfig(): Promise<Result<ReadonlyArray<Qualifiers.IQualifierDecl> | undefined>>;
@@ -126,6 +129,16 @@ export interface IBindingTraceEntry {
     readonly value: string;
     readonly wasEnforced: boolean;
     readonly winningScope?: ScopeKey;
+}
+
+// @public
+export interface IBuildSimpleDescriptorParams {
+    readonly description?: string;
+    // (undocumented)
+    readonly id: PromptId;
+    readonly surface?: string;
+    // (undocumented)
+    readonly title: string;
 }
 
 // @public
@@ -164,7 +177,8 @@ export interface IExpectedQualifierAxis {
 }
 
 // @public
-export interface IFileTreePromptStoreCreateParams {
+export interface IFileTreePromptStoreCreateParams<TQualifierNames extends string = string> {
+    readonly qualifierNameConverter?: Converter<TQualifierNames>;
     readonly root: FileTree.IFileTreeDirectoryItem;
     readonly scopeDecoding?: (encoded: string) => Result<ScopeKey>;
     readonly scopeEncoding?: (scope: ScopeKey) => Result<string>;
@@ -211,10 +225,10 @@ export interface IPendingResourceBinding {
 }
 
 // @public
-export interface IPromptCandidateRecord {
+export interface IPromptCandidateRecord<TQualifierNames extends string = string> {
     // (undocumented)
     readonly body: string;
-    readonly conditions: ResourceJson.Json.ConditionSetDecl;
+    readonly conditions: ResourceJson.Json.ConditionSetDecl<TQualifierNames>;
     readonly isPartial?: boolean;
 }
 
@@ -263,9 +277,9 @@ export interface IPromptExampleSet {
 }
 
 // @public
-export interface IPromptFileContents {
+export interface IPromptFileContents<TQualifierNames extends string = string> {
     // (undocumented)
-    readonly candidates: ReadonlyArray<IPromptCandidateRecord>;
+    readonly candidates: ReadonlyArray<IPromptCandidateRecord<TQualifierNames>>;
     // (undocumented)
     readonly descriptor: IPromptDescriptor;
 }
@@ -420,21 +434,22 @@ export type IPromptStoreFixtureDescriptor = Omit<IPromptDescriptor, 'id'> & {
 };
 
 // @public
-export interface IPromptStoreFixtureSeed {
+export interface IPromptStoreFixtureSeed<TQualifierNames extends string = string> {
     // (undocumented)
     readonly bindings?: ReadonlyArray<IScopeSlotBindingsRecord>;
+    readonly qualifierNameConverter?: Converter<TQualifierNames>;
     // (undocumented)
     readonly qualifiers?: ReadonlyArray<Qualifiers.IQualifierDecl>;
     // (undocumented)
-    readonly records?: ReadonlyArray<IPromptStoreFixtureSeedRecord>;
+    readonly records?: ReadonlyArray<IPromptStoreFixtureSeedRecord<TQualifierNames>>;
     readonly scopeDecoding?: (encoded: string) => Result<ScopeKey>;
     readonly scopeEncoding?: (scope: ScopeKey) => Result<string>;
 }
 
 // @public
-export interface IPromptStoreFixtureSeedRecord {
+export interface IPromptStoreFixtureSeedRecord<TQualifierNames extends string = string> {
     // (undocumented)
-    readonly candidates: ReadonlyArray<IPromptCandidateRecord>;
+    readonly candidates: ReadonlyArray<IPromptCandidateRecord<TQualifierNames>>;
     // (undocumented)
     readonly descriptor: IPromptStoreFixtureDescriptor;
     // (undocumented)
@@ -517,9 +532,9 @@ export interface ISlotSerializer {
 }
 
 // @public
-export interface IStoredPromptRecord {
+export interface IStoredPromptRecord<TQualifierNames extends string = string> {
     // (undocumented)
-    readonly candidates: ReadonlyArray<IPromptCandidateRecord>;
+    readonly candidates: ReadonlyArray<IPromptCandidateRecord<TQualifierNames>>;
     // (undocumented)
     readonly descriptor: IPromptDescriptor;
     // (undocumented)
@@ -607,7 +622,7 @@ export type PromptStoreEventKind = 'descriptor-changed' | 'descriptor-removed' |
 
 // @public
 export const PromptStoreFixture: {
-    build(seed: IPromptStoreFixtureSeed): Promise<Result<IPromptStore>>;
+    build<TQualifierNames extends string = string>(seed: IPromptStoreFixtureSeed<TQualifierNames>): Promise<Result<IPromptStore>>;
 };
 
 // @public
@@ -671,6 +686,9 @@ export const substitutionEntry: Converter<string | SlotBinding>;
 
 // @public
 export type SuspiciousDisposition = 'warn' | 'reject';
+
+// @public
+export function typedPromptFileConverter<TQualifierNames extends string>(qualifierNameConverter: Converter<TQualifierNames>): Converter<IPromptFileContents<TQualifierNames>>;
 
 // @public
 export type ValidatorId = Brand<string, 'ValidatorId'>;

--- a/libraries/ts-prompt-assist/src/packlets/converters/descriptorConverter.ts
+++ b/libraries/ts-prompt-assist/src/packlets/converters/descriptorConverter.ts
@@ -156,14 +156,83 @@ const looseCandidateBodyConverter: Converter<IPromptCandidateRecord> =
   );
 
 /**
+ * Builds a `Converter<IPromptCandidateRecord<TQualifierNames>>` whose
+ * `conditions` field is validated through ts-res's parameterized
+ * `ResourceJson.Convert.typedConditionSetDecl(qc)` (B-3). The returned
+ * Converter rejects typo'd axis names at convert time when YAML carries
+ * a key not in the consumer's declared literal-string union.
+ *
+ * Keep in sync with `looseCandidateBodyConverter` above — the only
+ * difference is the `conditions` slot's Converter.
+ */
+function _typedLooseCandidateBodyConverter<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<IPromptCandidateRecord<TQualifierNames>> {
+  return Converters.object<IPromptCandidateRecord<TQualifierNames>>(
+    {
+      conditions: ResourceJson.Convert.typedConditionSetDecl(qualifierNameConverter),
+      isPartial: Converters.boolean.optional(),
+      body: Converters.string
+    },
+    { optionalFields: ['isPartial'] }
+  );
+}
+
+/**
  * Shape of a `<prompt-id>.yaml` file body: the descriptor metadata plus the
  * candidates array (scope is reconstructed by the store from the directory
  * path).
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames extends string = string` (B-3); the
+ * parameter threads through `candidates` so a typed loader produces
+ * narrowed records. Default `TQualifierNames = string` keeps untyped
+ * callers compiling unchanged.
+ *
  * @public
  */
-export interface IPromptFileContents {
+export interface IPromptFileContents<TQualifierNames extends string = string> {
   readonly descriptor: IPromptDescriptor;
-  readonly candidates: ReadonlyArray<IPromptCandidateRecord>;
+  readonly candidates: ReadonlyArray<IPromptCandidateRecord<TQualifierNames>>;
+}
+
+function _buildPromptFileContentsConverter<TQualifierNames extends string>(
+  candidateConverter: Converter<IPromptCandidateRecord<TQualifierNames>>
+): Converter<IPromptFileContents<TQualifierNames>> {
+  return Converters.generic<IPromptFileContents<TQualifierNames>>(
+    (from: unknown): Result<IPromptFileContents<TQualifierNames>> => {
+      if (typeof from !== 'object' || from === null) {
+        return fail('prompt file: expected an object');
+      }
+      // Split the prompt file into descriptor fields + candidates so the
+      // descriptor Converter never sees the `candidates` field. This keeps
+      // the file Converter robust against a future `Converters.object`
+      // strict-by-default switch and avoids the wasted re-parse of the
+      // entire object when descriptor Converters become more expensive.
+      const { candidates: rawCandidates, ...descriptorRaw } = from as {
+        readonly candidates?: unknown;
+        readonly [key: string]: unknown;
+      };
+      return descriptorConverter
+        .convert(descriptorRaw)
+        .withErrorFormat((msg) => `prompt file: invalid descriptor: ${msg}`)
+        .onSuccess((descriptor) => {
+          if (descriptor.output.kind === 'free-text' && (descriptor.outputValidations?.length ?? 0) > 0) {
+            return fail(
+              `prompt '${descriptor.id}': free-text descriptors cannot declare outputValidations in v0.1`
+            );
+          }
+          return Converters.arrayOf(candidateConverter)
+            .convert(rawCandidates)
+            .withErrorFormat((msg) => `prompt '${descriptor.id}': invalid candidates: ${msg}`)
+            .onSuccess((candidates) =>
+              mapResults(candidates.map((c, i) => scanCandidateBody(c.body, descriptor.id, i))).onSuccess(
+                () => succeed<IPromptFileContents<TQualifierNames>>({ descriptor, candidates })
+              )
+            );
+        });
+    }
+  );
 }
 
 /**
@@ -178,47 +247,44 @@ export interface IPromptFileContents {
  *
  * @public
  */
-export const promptFileConverter: Converter<IPromptFileContents> = Converters.generic<IPromptFileContents>(
-  (from: unknown): Result<IPromptFileContents> => {
-    if (typeof from !== 'object' || from === null) {
-      return fail('prompt file: expected an object');
-    }
-    // Split the prompt file into descriptor fields + candidates so the
-    // descriptor Converter never sees the `candidates` field. This keeps
-    // the file Converter robust against a future `Converters.object`
-    // strict-by-default switch and avoids the wasted re-parse of the
-    // entire object when descriptor Converters become more expensive.
-    const { candidates: rawCandidates, ...descriptorRaw } = from as {
-      readonly candidates?: unknown;
-      readonly [key: string]: unknown;
-    };
-    return descriptorConverter
-      .convert(descriptorRaw)
-      .withErrorFormat((msg) => `prompt file: invalid descriptor: ${msg}`)
-      .onSuccess((descriptor) => {
-        if (descriptor.output.kind === 'free-text' && (descriptor.outputValidations?.length ?? 0) > 0) {
-          return fail(
-            `prompt '${descriptor.id}': free-text descriptors cannot declare outputValidations in v0.1`
-          );
-        }
-        return Converters.arrayOf(looseCandidateBodyConverter)
-          .convert(rawCandidates)
-          .withErrorFormat((msg) => `prompt '${descriptor.id}': invalid candidates: ${msg}`)
-          .onSuccess((candidates) =>
-            mapResults(candidates.map((c, i) => scanCandidateBody(c.body, descriptor.id, i))).onSuccess(() =>
-              succeed<IPromptFileContents>({ descriptor, candidates })
-            )
-          );
-      });
-  }
-);
+export const promptFileConverter: Converter<IPromptFileContents> =
+  _buildPromptFileContentsConverter(looseCandidateBodyConverter);
+
+/**
+ * Typed sibling of {@link promptFileConverter} (B-3). Routes the candidate
+ * `conditions` validation through `ResourceJson.Convert.typedConditionSetDecl(qc)`
+ * so typo'd axis names fail at convert time. Returned Converter narrows
+ * its result type on `TQualifierNames`.
+ *
+ * @remarks
+ * Keep in sync with `promptFileConverter` above — both flow through
+ * `_buildPromptFileContentsConverter`, so the body validation and the
+ * `outputValidations`-on-free-text rejection cannot drift.
+ *
+ * @public
+ */
+export function typedPromptFileConverter<TQualifierNames extends string>(
+  qualifierNameConverter: Converter<TQualifierNames>
+): Converter<IPromptFileContents<TQualifierNames>> {
+  return _buildPromptFileContentsConverter(_typedLooseCandidateBodyConverter(qualifierNameConverter));
+}
 
 /**
  * Builds a fully-typed {@link IStoredPromptRecord} from a parsed prompt file
  * and the scope key derived from the file's directory location.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames extends string = string` (B-3) so the
+ * narrowed file-contents type threads through to the produced stored
+ * record. Default `TQualifierNames = string` keeps untyped callers
+ * compiling unchanged.
+ *
  * @public
  */
-export function buildStoredPromptRecord(scope: ScopeKey, contents: IPromptFileContents): IStoredPromptRecord {
+export function buildStoredPromptRecord<TQualifierNames extends string = string>(
+  scope: ScopeKey,
+  contents: IPromptFileContents<TQualifierNames>
+): IStoredPromptRecord<TQualifierNames> {
   return {
     scope,
     id: contents.descriptor.id,

--- a/libraries/ts-prompt-assist/src/packlets/fixture/promptStoreFixture.ts
+++ b/libraries/ts-prompt-assist/src/packlets/fixture/promptStoreFixture.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Result, fail, mapResults, succeed } from '@fgv/ts-utils';
+import { Converter, Result, fail, mapResults, succeed } from '@fgv/ts-utils';
 import { FileTree } from '@fgv/ts-json-base';
 import { Yaml } from '@fgv/ts-extras';
 import { Qualifiers } from '@fgv/ts-res';
@@ -33,24 +33,45 @@ export type IPromptStoreFixtureDescriptor = Omit<IPromptDescriptor, 'id'> & {
 
 /**
  * Fixture-seed-only record shape: descriptor.id is optional and
- * defaults to the outer record id (per F12). Other fields mirror
- * {@link IStoredPromptRecord}.
+ * defaults to the outer record id (per F12). Candidate `conditions`
+ * keys are narrowed by `TQualifierNames` (B-3) so typo'd axis names
+ * fail at compile time when the seed is threaded through a
+ * `TQualifierNames`-typed fixture build; pair with the
+ * `qualifierNameConverter` (below) for convert-time enforcement of
+ * the same narrow on round-tripped YAML. Default
+ * `TQualifierNames = string` keeps unnarrowed seeds compiling
+ * unchanged.
+ *
+ * Other fields mirror {@link IStoredPromptRecord}.
  *
  * @public
  */
-export interface IPromptStoreFixtureSeedRecord {
+export interface IPromptStoreFixtureSeedRecord<TQualifierNames extends string = string> {
   readonly scope: ScopeKey;
   readonly id: PromptId;
   readonly descriptor: IPromptStoreFixtureDescriptor;
-  readonly candidates: ReadonlyArray<IPromptCandidateRecord>;
+  readonly candidates: ReadonlyArray<IPromptCandidateRecord<TQualifierNames>>;
 }
 
 /**
  * Seed describing the in-memory FileTree state for a test fixture.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames extends string` (B-3). When
+ * `PromptStoreFixture.build` infers `TQualifierNames` from a typed
+ * call site (e.g. an `IPromptStoreFixtureSeed<'tone'>` annotation, or
+ * via the inferring `build<TQualifierNames>(seed)` signature), the
+ * candidates' `conditions` keys are narrowed to that union. Pair with
+ * `qualifierNameConverter` for round-trip convert-time enforcement —
+ * the build threads the Converter through to
+ * `FileTreePromptStore.create`, so a YAML round-trip carrying a typo'd
+ * axis name fails at load time. Default `TQualifierNames = string`
+ * keeps existing call sites working unchanged.
+ *
  * @public
  */
-export interface IPromptStoreFixtureSeed {
-  readonly records?: ReadonlyArray<IPromptStoreFixtureSeedRecord>;
+export interface IPromptStoreFixtureSeed<TQualifierNames extends string = string> {
+  readonly records?: ReadonlyArray<IPromptStoreFixtureSeedRecord<TQualifierNames>>;
   readonly bindings?: ReadonlyArray<IScopeSlotBindingsRecord>;
   readonly qualifiers?: ReadonlyArray<Qualifiers.IQualifierDecl>;
   /**
@@ -66,6 +87,17 @@ export interface IPromptStoreFixtureSeed {
    * `ScopeKey`s) will round-trip incorrectly.
    */
   readonly scopeDecoding?: (encoded: string) => Result<ScopeKey>;
+  /**
+   * Optional ts-res qualifier-name Converter (B-3). When supplied, the
+   * build threads it into `FileTreePromptStore.create` so the YAML
+   * loader validates each candidate's `conditions` keys at convert
+   * time against the Converter's literal-string union. A YAML record
+   * with a typo'd axis name fails at load time with a Converter-level
+   * error, mirroring the compile-time discipline the seed type already
+   * imposes when `TQualifierNames` is narrowed. When omitted, the
+   * loader keeps today's permissive default-string behavior.
+   */
+  readonly qualifierNameConverter?: Converter<TQualifierNames>;
 }
 
 function serializeBindingsRecord(record: IScopeSlotBindingsRecord): Result<string> {
@@ -76,7 +108,9 @@ function serializeBindingsRecord(record: IScopeSlotBindingsRecord): Result<strin
   return Yaml.yamlStringify({ bindings });
 }
 
-function serializePromptRecord(record: IPromptStoreFixtureSeedRecord): Result<string> {
+function serializePromptRecord<TQualifierNames extends string>(
+  record: IPromptStoreFixtureSeedRecord<TQualifierNames>
+): Result<string> {
   return defaultDescriptorIdFromOuter(record).onSuccess((descriptor) =>
     Yaml.yamlStringify({ ...descriptor, candidates: record.candidates })
   );
@@ -88,7 +122,9 @@ function serializePromptRecord(record: IPromptStoreFixtureSeedRecord): Result<st
  * mismatches the outer id, reject loudly — the redundancy is gone but
  * silent inconsistency must remain impossible.
  */
-function defaultDescriptorIdFromOuter(record: IPromptStoreFixtureSeedRecord): Result<IPromptDescriptor> {
+function defaultDescriptorIdFromOuter<TQualifierNames extends string>(
+  record: IPromptStoreFixtureSeedRecord<TQualifierNames>
+): Result<IPromptDescriptor> {
   const descriptor = record.descriptor;
   if (descriptor.id === undefined) {
     return succeed({ ...descriptor, id: record.id });
@@ -113,21 +149,40 @@ function serializeQualifiers(qualifiers: ReadonlyArray<Qualifiers.IQualifierDecl
  * `InMemoryPromptStore`; tests round-trip through the same YAML schema
  * the FsTree adapter would.
  *
+ * @remarks
+ * Generic over `TQualifierNames extends string` (B-3). Inferred from
+ * the supplied seed when the seed's `IPromptStoreFixtureSeed<...>`
+ * type parameter is narrowed at the call site — e.g.
+ * `PromptStoreFixture.build<'tone'>(seed)` or via an annotated
+ * `const seed: IPromptStoreFixtureSeed<'tone'> = { ... }`. The
+ * resulting store has the same runtime shape regardless of
+ * `TQualifierNames`; the parameter drives compile-time narrowing of
+ * candidate `conditions` keys. Convert-time enforcement is achieved
+ * by ALSO supplying `seed.qualifierNameConverter` — the build passes
+ * the Converter through to `FileTreePromptStore.create`, so a
+ * round-tripped YAML with a typo'd axis name fails at load time.
+ *
  * @public
  */
 export const PromptStoreFixture: {
-  build(seed: IPromptStoreFixtureSeed): Promise<Result<IPromptStore>>;
+  build<TQualifierNames extends string = string>(
+    seed: IPromptStoreFixtureSeed<TQualifierNames>
+  ): Promise<Result<IPromptStore>>;
 } = {
   /**
    * Builds an in-memory FileTree from the seed, then wraps it in a
    * `FileTreePromptStore`. Returns the store ready for use.
    */
-  async build(seed: IPromptStoreFixtureSeed): Promise<Result<IPromptStore>> {
+  async build<TQualifierNames extends string = string>(
+    seed: IPromptStoreFixtureSeed<TQualifierNames>
+  ): Promise<Result<IPromptStore>> {
     return buildSeededStore(seed);
   }
 } as const;
 
-function buildSeededStore(seed: IPromptStoreFixtureSeed): Promise<Result<IPromptStore>> {
+function buildSeededStore<TQualifierNames extends string>(
+  seed: IPromptStoreFixtureSeed<TQualifierNames>
+): Promise<Result<IPromptStore>> {
   const encode = seed.scopeEncoding ?? defaultScopeEncoding;
 
   // Single chained pipeline — each step runs only after the previous
@@ -159,12 +214,13 @@ function buildSeededStore(seed: IPromptStoreFixtureSeed): Promise<Result<IPrompt
   return FileTreePromptStore.create({
     root: buildResult.value,
     scopeEncoding: seed.scopeEncoding,
-    scopeDecoding: seed.scopeDecoding
+    scopeDecoding: seed.scopeDecoding,
+    qualifierNameConverter: seed.qualifierNameConverter
   });
 }
 
-function encodeRecords(
-  records: ReadonlyArray<IPromptStoreFixtureSeedRecord> | undefined,
+function encodeRecords<TQualifierNames extends string>(
+  records: ReadonlyArray<IPromptStoreFixtureSeedRecord<TQualifierNames>> | undefined,
   encode: (scope: ScopeKey) => Result<string>
 ): Result<ReadonlyArray<FileTree.IInMemoryFile>> {
   return mapResults(

--- a/libraries/ts-prompt-assist/src/packlets/store/fileTreePromptStore.ts
+++ b/libraries/ts-prompt-assist/src/packlets/store/fileTreePromptStore.ts
@@ -17,29 +17,49 @@ import {
   buildBindingsRecord,
   buildStoredPromptRecord,
   promptFileConverter,
-  qualifiersFileConverter
+  qualifiersFileConverter,
+  typedPromptFileConverter
 } from '../converters';
 import { IPromptStore, IPromptStoreListFilter } from './interfaces';
 import { defaultScopeDecoding, defaultScopeEncoding } from './scopeEncoding';
 
 /**
  * Parameters for {@link FileTreePromptStore.create}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames extends string = string` (B-3). The
+ * optional `qualifierNameConverter` threads through to the YAML loader
+ * so candidate `conditions` keys are validated at convert time against
+ * a consumer-supplied literal-string union. When omitted, the loader
+ * uses today's default-string `ResourceJson.Convert.conditionSetDecl`
+ * — existing call sites behave unchanged.
+ *
  * @public
  */
-export interface IFileTreePromptStoreCreateParams {
+export interface IFileTreePromptStoreCreateParams<TQualifierNames extends string = string> {
   /** Root directory under which scope-encoded sub-trees live. */
   readonly root: FileTree.IFileTreeDirectoryItem;
   /** Default: identity (treat ScopeKey as path-safe). */
   readonly scopeEncoding?: (scope: ScopeKey) => Result<string>;
   /** Default: identity, validated against the path-safety contract. */
   readonly scopeDecoding?: (encoded: string) => Result<ScopeKey>;
+  /**
+   * Optional ts-res qualifier-name Converter (B-3). When supplied, the
+   * YAML loader validates each candidate's `conditions` keys (record
+   * form) or `qualifierName` fields (array form) against the
+   * Converter's literal-string union via
+   * `ResourceJson.Convert.typedConditionSetDecl(qc)`. A typo'd axis
+   * name fails at convert time with a Converter-level error. When
+   * omitted, the loader keeps today's permissive default-string
+   * behavior.
+   */
+  readonly qualifierNameConverter?: Converter<TQualifierNames>;
 }
 
 const PROMPT_FILE_EXTENSION: string = '.yaml';
 const BINDINGS_FILE_NAME: string = '_bindings.yaml';
 const QUALIFIERS_FILE_NAME: string = '_qualifiers.yaml';
 
-const promptYamlConverter: Converter<IPromptFileContents> = Yaml.yamlConverter(promptFileConverter);
 const bindingsYamlConverter: Converter<IBindingsFileContents> = Yaml.yamlConverter(bindingsFileConverter);
 const qualifiersYamlConverter: Converter<IQualifiersFileContents> =
   Yaml.yamlConverter(qualifiersFileConverter);
@@ -62,10 +82,24 @@ function verifyFilenameId(
   return succeed(contents);
 }
 
+interface IInternalStoreParams {
+  readonly root: FileTree.IFileTreeDirectoryItem;
+  readonly scopeEncoding?: (scope: ScopeKey) => Result<string>;
+  readonly scopeDecoding?: (encoded: string) => Result<ScopeKey>;
+  readonly promptYamlConverter: Converter<IPromptFileContents>;
+}
+
 /**
  * Read-only FileTree-backed {@link IPromptStore}. v0.1 implements `get`,
  * `list`, `getBindings`, and `getQualifierConfig`; write methods and
  * `watch` are intentionally undefined (design §4.6 + OQ-3).
+ *
+ * @remarks
+ * Generic over `TQualifierNames extends string` (B-3). When the optional
+ * `qualifierNameConverter` is supplied to `create`, the store's YAML
+ * loader narrows candidate `conditions` keys to that union at convert
+ * time. Default `TQualifierNames = string` keeps existing call sites
+ * compiling unchanged.
  *
  * @public
  */
@@ -73,11 +107,13 @@ export class FileTreePromptStore implements IPromptStore {
   private readonly _root: FileTree.IFileTreeDirectoryItem;
   private readonly _scopeEncoding: (scope: ScopeKey) => Result<string>;
   private readonly _scopeDecoding: (encoded: string) => Result<ScopeKey>;
+  private readonly _promptYamlConverter: Converter<IPromptFileContents>;
 
-  private constructor(params: IFileTreePromptStoreCreateParams) {
+  private constructor(params: IInternalStoreParams) {
     this._root = params.root;
     this._scopeEncoding = params.scopeEncoding ?? defaultScopeEncoding;
     this._scopeDecoding = params.scopeDecoding ?? defaultScopeDecoding;
+    this._promptYamlConverter = params.promptYamlConverter;
   }
 
   /**
@@ -88,9 +124,36 @@ export class FileTreePromptStore implements IPromptStore {
    * with FsTree adapters whose construction may do real I/O. The v0.1
    * FileTree backend is in-memory or already-loaded FsTree, so this
    * factory resolves synchronously via `Promise.resolve`.
+   *
+   * The optional `qualifierNameConverter` on `params` threads through
+   * to the YAML loader (B-3) — a YAML candidate with a typo'd axis
+   * name fails at convert time when the consumer's literal-string
+   * union doesn't include the typo. Default-string keeps existing call
+   * sites compiling unchanged.
    */
-  public static create(params: IFileTreePromptStoreCreateParams): Promise<Result<FileTreePromptStore>> {
-    return Promise.resolve(succeed(new FileTreePromptStore(params)));
+  public static create<TQualifierNames extends string = string>(
+    params: IFileTreePromptStoreCreateParams<TQualifierNames>
+  ): Promise<Result<FileTreePromptStore>> {
+    // The typed-narrow effect lives at convert time: when a Converter
+    // is supplied, the loader uses the typed sibling; otherwise the
+    // default-string Converter. Both produce structurally compatible
+    // `IPromptFileContents` records (string is the widest parameter),
+    // so the field is typed at the default lower bound and the
+    // narrow flows through the runtime validation.
+    const promptYamlConverter: Converter<IPromptFileContents> =
+      params.qualifierNameConverter !== undefined
+        ? Yaml.yamlConverter(typedPromptFileConverter(params.qualifierNameConverter))
+        : Yaml.yamlConverter(promptFileConverter);
+    return Promise.resolve(
+      succeed(
+        new FileTreePromptStore({
+          root: params.root,
+          scopeEncoding: params.scopeEncoding,
+          scopeDecoding: params.scopeDecoding,
+          promptYamlConverter
+        })
+      )
+    );
   }
 
   /** {@inheritDoc IPromptStore.get} */
@@ -188,7 +251,7 @@ export class FileTreePromptStore implements IPromptStore {
       }
       return file
         .getRawContents()
-        .onSuccess((text) => promptYamlConverter.convert(text))
+        .onSuccess((text) => this._promptYamlConverter.convert(text))
         .onSuccess((contents) => verifyFilenameId(file, contents))
         .onSuccess((contents) => succeed(buildStoredPromptRecord(scope, contents)));
     });
@@ -210,7 +273,7 @@ export class FileTreePromptStore implements IPromptStore {
           filteredFiles.map((file) =>
             file
               .getRawContents()
-              .onSuccess((text) => promptYamlConverter.convert(text))
+              .onSuccess((text) => this._promptYamlConverter.convert(text))
               .onSuccess((contents) => verifyFilenameId(file, contents))
               .onSuccess((contents) => succeed(buildStoredPromptRecord(scope, contents)))
           )

--- a/libraries/ts-prompt-assist/src/packlets/types/descriptor.ts
+++ b/libraries/ts-prompt-assist/src/packlets/types/descriptor.ts
@@ -109,14 +109,28 @@ export interface IScopeSlotBindingsRecord {
 
 /**
  * A stored candidate within an {@link IStoredPromptRecord}.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames extends string = string` (B-3). The
+ * `conditions` field threads the type parameter into ts-res's
+ * parameterized `ResourceJson.Json.ConditionSetDecl<TQualifierNames>`, so
+ * a consumer who threads a literal-string union (via the optional
+ * `qualifierNameConverter` on `FileTreePromptStore.create` /
+ * `PromptStoreFixture.build`) gets compile-time rejection of typo'd axis
+ * names on the record form AND convert-time rejection in the YAML loader.
+ * Default `TQualifierNames = string` keeps untyped callers compiling
+ * unchanged.
+ *
  * @public
  */
-export interface IPromptCandidateRecord {
+export interface IPromptCandidateRecord<TQualifierNames extends string = string> {
   /**
    * Full ts-res `ConditionSetDecl` (record-sugar, record-with-details, or
    * array form). Empty `\{\}` represents the unconditional base candidate.
+   * Parameterized on `TQualifierNames` so a narrowed call site gets
+   * compile-time discipline on the key set.
    */
-  readonly conditions: ResourceJson.Json.ConditionSetDecl;
+  readonly conditions: ResourceJson.Json.ConditionSetDecl<TQualifierNames>;
   /**
    * Aligned with ts-res's `resolveComposedResourceValue` semantic
    * (design §10.2): `isPartial: true` marks a more-specific override
@@ -132,11 +146,62 @@ export interface IPromptCandidateRecord {
 
 /**
  * Stored prompt record returned by the store.
+ *
+ * @remarks
+ * Parameterized on `TQualifierNames extends string = string` (B-3); the
+ * parameter threads through `candidates` so a typed store produces
+ * narrowed records. Default `TQualifierNames = string` keeps untyped
+ * callers compiling unchanged.
+ *
  * @public
  */
-export interface IStoredPromptRecord {
+export interface IStoredPromptRecord<TQualifierNames extends string = string> {
   readonly scope: ScopeKey;
   readonly id: PromptId;
   readonly descriptor: IPromptDescriptor;
-  readonly candidates: ReadonlyArray<IPromptCandidateRecord>;
+  readonly candidates: ReadonlyArray<IPromptCandidateRecord<TQualifierNames>>;
+}
+
+/**
+ * Parameters for {@link buildSimpleDescriptor}.
+ *
+ * @public
+ */
+export interface IBuildSimpleDescriptorParams {
+  readonly id: PromptId;
+  readonly title: string;
+  /** Optional longer-form description. */
+  readonly description?: string;
+  /** Default `'chat'`. */
+  readonly surface?: string;
+}
+
+/**
+ * Builds a fully-shaped {@link IPromptDescriptor} for the trivial chat
+ * case: one body, no slots, free-text output. Cuts the boilerplate of
+ * spelling out `schemaVersion`, `slots: []`, and
+ * `output: \{ kind: 'free-text' \}` at every seed call site (per F2).
+ *
+ * @remarks
+ * Intentionally limited to the free-text-output shape. The descriptor's
+ * `output.kind` is load-bearing — `PromptLibrary.resolveJsonOutput` and
+ * `resolveFreeTextOutput` both runtime-verify it against the call
+ * path — so silently defaulting `output` for a JSON-output prompt
+ * would route the consumer into the wrong dispatcher. For JSON-output
+ * prompts, author the full {@link IPromptDescriptor} shape directly so
+ * the `output.converterId` discriminator is explicit at the call site.
+ *
+ * @public
+ */
+export function buildSimpleDescriptor(params: IBuildSimpleDescriptorParams): IPromptDescriptor {
+  const descriptor: IPromptDescriptor = {
+    id: params.id,
+    title: params.title,
+    schemaVersion: '1',
+    surface: params.surface ?? 'chat',
+    slots: [],
+    output: { kind: 'free-text' },
+    ...(params.description !== undefined ? { description: params.description } : {})
+  };
+  return descriptor;
 }

--- a/libraries/ts-prompt-assist/src/test/unit/b3TypedConditions.test.ts
+++ b/libraries/ts-prompt-assist/src/test/unit/b3TypedConditions.test.ts
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 Erik Fortune
+// SPDX-License-Identifier: MIT
+
+// B-3 cast-pressure regression tests for the typed qualifier-name
+// Converter pipeline plus the F2 / F6 round-2 absorbs (`buildSimpleDescriptor`,
+// README React-wiring; only the helper-export is exercised here).
+
+import '@fgv/ts-utils-jest';
+import {
+  FileTreePromptStore,
+  IPromptCandidateRecord,
+  IPromptDescriptor,
+  IPromptStoreFixtureSeed,
+  PromptId,
+  PromptStoreFixture,
+  ScopeKey,
+  buildSimpleDescriptor,
+  promptFileConverter,
+  typedPromptFileConverter
+} from '../../index';
+import { Converter, Converters } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
+
+const TEST_SCOPE = 'global' as unknown as ScopeKey;
+const TEST_PROMPT = 'greeting' as unknown as PromptId;
+
+describe('B-3 typed qualifier-name converter pipeline', () => {
+  describe('buildSimpleDescriptor (F2)', () => {
+    test('builds a free-text chat descriptor from minimal input', () => {
+      const descriptor: IPromptDescriptor = buildSimpleDescriptor({
+        id: TEST_PROMPT,
+        title: 'Simple greeting'
+      });
+      expect(descriptor).toEqual({
+        id: TEST_PROMPT,
+        title: 'Simple greeting',
+        schemaVersion: '1',
+        surface: 'chat',
+        slots: [],
+        output: { kind: 'free-text' }
+      });
+    });
+
+    test('threads an explicit surface override through', () => {
+      const descriptor = buildSimpleDescriptor({
+        id: TEST_PROMPT,
+        title: 'Custom-surface prompt',
+        surface: 'completion'
+      });
+      expect(descriptor.surface).toBe('completion');
+      // Output remains free-text — the helper is deliberately limited to
+      // the free-text-output shape so a consumer who needs JSON output
+      // authors the full IPromptDescriptor and sets `output.converterId`
+      // explicitly.
+      expect(descriptor.output).toEqual({ kind: 'free-text' });
+    });
+
+    test('threads an optional description through', () => {
+      const descriptor = buildSimpleDescriptor({
+        id: TEST_PROMPT,
+        title: 'Documented prompt',
+        description: 'Longer-form description for editor surfaces'
+      });
+      expect(descriptor.description).toBe('Longer-form description for editor surfaces');
+    });
+  });
+
+  describe('cast-pressure regression (B-3)', () => {
+    // The load-bearing test surface: a consumer who supplies a
+    // qualifierNameConverter on the store / fixture build gets
+    // convert-time rejection of typo'd axis names — not just compile-
+    // time discipline on the seed type.
+    const validNames = ['tone', 'language'] as const;
+    type ValidName = (typeof validNames)[number];
+    const qualifierNameConverter: Converter<ValidName> = Converters.enumeratedValue<ValidName>([
+      ...validNames
+    ]);
+
+    test('typedPromptFileConverter rejects record-form typo at convert time', () => {
+      const yaml = {
+        id: 'greeting',
+        title: 'Greeting',
+        schemaVersion: '1',
+        surface: 'chat',
+        slots: [],
+        output: { kind: 'free-text' },
+        candidates: [{ conditions: { tonr: 'formal' }, body: 'Hi {{{audience}}}' }]
+      };
+      expect(typedPromptFileConverter(qualifierNameConverter).convert(yaml)).toFailWith(/tonr/);
+    });
+
+    test('typedPromptFileConverter rejects array-form typo at convert time', () => {
+      const yaml = {
+        id: 'greeting',
+        title: 'Greeting',
+        schemaVersion: '1',
+        surface: 'chat',
+        slots: [],
+        output: { kind: 'free-text' },
+        candidates: [
+          {
+            conditions: [{ qualifierName: 'tonr', value: 'formal' }],
+            body: 'Hi {{{audience}}}'
+          }
+        ]
+      };
+      expect(typedPromptFileConverter(qualifierNameConverter).convert(yaml)).toFailWith(/tonr/);
+    });
+
+    test('typedPromptFileConverter accepts valid record-form axis names', () => {
+      const yaml = {
+        id: 'greeting',
+        title: 'Greeting',
+        schemaVersion: '1',
+        surface: 'chat',
+        slots: [],
+        output: { kind: 'free-text' },
+        candidates: [
+          { conditions: {}, body: 'base' },
+          { conditions: { tone: 'formal' }, isPartial: true, body: 'partial' }
+        ]
+      };
+      expect(typedPromptFileConverter(qualifierNameConverter).convert(yaml)).toSucceedAndSatisfy((c) => {
+        // The candidates' conditions threaded through ts-res's typed
+        // sibling — the run-time shape is unchanged, but the Converter
+        // would have rejected a typo above.
+        expect(c.candidates.length).toBe(2);
+      });
+    });
+
+    test('default promptFileConverter accepts a typo (back-compat baseline)', () => {
+      // Documents the baseline: B-3's opt-in adds a teeth path; the
+      // default-string converter is permissive by design, exactly as
+      // today's untyped consumers behave.
+      const yaml = {
+        id: 'greeting',
+        title: 'Greeting',
+        schemaVersion: '1',
+        surface: 'chat',
+        slots: [],
+        output: { kind: 'free-text' },
+        candidates: [{ conditions: { tonr: 'formal' }, body: 'Hi' }]
+      };
+      expect(promptFileConverter.convert(yaml)).toSucceed();
+    });
+
+    test('FileTreePromptStore.create with qualifierNameConverter rejects a typo at load time', async () => {
+      // End-to-end: a YAML file with a typo'd axis name on a typed
+      // store fails at load time (store.get rejects), not just on the
+      // seed-author's compile.
+      const tree = FileTree.inMemory([
+        {
+          path: `/${TEST_SCOPE}/${TEST_PROMPT}.yaml`,
+          contents: [
+            "id: 'greeting'",
+            "title: 'Greeting'",
+            "schemaVersion: '1'",
+            "surface: 'chat'",
+            'slots: []',
+            "output: { kind: 'free-text' }",
+            "candidates: [{ conditions: { tonr: 'formal' }, body: 'Hi' }]"
+          ].join('\n')
+        }
+      ]).orThrow();
+      const root = tree.getDirectory('/').orThrow();
+      const store = (await FileTreePromptStore.create({ root, qualifierNameConverter })).orThrow();
+      const got = await store.get(TEST_SCOPE, TEST_PROMPT);
+      expect(got).toFailWith(/tonr/);
+    });
+
+    test('FileTreePromptStore.create with qualifierNameConverter loads a valid typed YAML', async () => {
+      const tree = FileTree.inMemory([
+        {
+          path: `/${TEST_SCOPE}/${TEST_PROMPT}.yaml`,
+          contents: [
+            "id: 'greeting'",
+            "title: 'Greeting'",
+            "schemaVersion: '1'",
+            "surface: 'chat'",
+            'slots: []',
+            "output: { kind: 'free-text' }",
+            "candidates: [{ conditions: { tone: 'formal' }, body: 'Hi' }]"
+          ].join('\n')
+        }
+      ]).orThrow();
+      const root = tree.getDirectory('/').orThrow();
+      const store = (await FileTreePromptStore.create({ root, qualifierNameConverter })).orThrow();
+      const got = (await store.get(TEST_SCOPE, TEST_PROMPT)).orThrow();
+      expect(got?.candidates[0].body).toBe('Hi');
+    });
+
+    test('PromptStoreFixture.build threads qualifierNameConverter through to the loader', async () => {
+      // Structurally valid seed (tone is a declared axis) — build
+      // succeeds and a subsequent get round-trips through the typed
+      // converter without rejection.
+      const seed: IPromptStoreFixtureSeed<ValidName> = {
+        records: [
+          {
+            scope: TEST_SCOPE,
+            id: TEST_PROMPT,
+            descriptor: buildSimpleDescriptor({ id: TEST_PROMPT, title: 'typed-fixture test' }),
+            candidates: [
+              { conditions: {}, body: 'base' },
+              { conditions: { tone: 'formal' }, isPartial: true, body: 'partial' }
+            ]
+          }
+        ],
+        qualifierNameConverter
+      };
+      const store = (await PromptStoreFixture.build(seed)).orThrow();
+      const got = (await store.get(TEST_SCOPE, TEST_PROMPT)).orThrow();
+      expect(got?.candidates.length).toBe(2);
+    });
+
+    test('PromptStoreFixture.build with qualifierNameConverter and a runtime typo in candidate rejects on get', async () => {
+      // The seed type at the TypeScript level rejects the typo, but a
+      // runtime cast bypasses the compile check — and the convert-time
+      // teeth must still catch it. This is the cast-pressure
+      // regression test core: the narrow is enforced at the Converter
+      // boundary, so escape-hatch consumers cannot smuggle typos in.
+      const malformedCandidate = {
+        conditions: { tonr: 'formal' },
+        body: 'oops'
+      } as unknown as IPromptCandidateRecord<ValidName>;
+      const seed: IPromptStoreFixtureSeed<ValidName> = {
+        records: [
+          {
+            scope: TEST_SCOPE,
+            id: TEST_PROMPT,
+            descriptor: buildSimpleDescriptor({ id: TEST_PROMPT, title: 'typo-rejection' }),
+            candidates: [malformedCandidate]
+          }
+        ],
+        qualifierNameConverter
+      };
+      const store = (await PromptStoreFixture.build(seed)).orThrow();
+      const got = await store.get(TEST_SCOPE, TEST_PROMPT);
+      expect(got).toFailWith(/tonr/);
+    });
+  });
+
+  describe('compile-time seed-type discipline (B-3)', () => {
+    test('a TQualifierNames-narrowed seed compiles for the expected axis keys', () => {
+      // Smoke: the type machinery allows the expected key on the
+      // record-form conditions. The negative case ('tonr' typo) is
+      // verified by the @ts-expect-error block below.
+      const seed: IPromptStoreFixtureSeed<'tone'> = {
+        records: [
+          {
+            scope: TEST_SCOPE,
+            id: TEST_PROMPT,
+            descriptor: buildSimpleDescriptor({ id: TEST_PROMPT, title: 'typed-seed test' }),
+            candidates: [
+              { conditions: {}, body: 'base' },
+              { conditions: { tone: 'formal' }, isPartial: true, body: 'partial' }
+            ]
+          }
+        ]
+      };
+      expect(seed.records?.length).toBe(1);
+    });
+
+    test('a TQualifierNames-narrowed seed rejects a typo at compile time', () => {
+      // The @ts-expect-error directive captures B-3's compile-side
+      // contract: 'tonr' (instead of 'tone') on the record-form
+      // conditions is a compile error when TQualifierNames is
+      // narrowed. Convert-time enforcement is verified in the
+      // cast-pressure regression block above.
+      const seed: IPromptStoreFixtureSeed<'tone'> = {
+        records: [
+          {
+            scope: TEST_SCOPE,
+            id: TEST_PROMPT,
+            descriptor: buildSimpleDescriptor({ id: TEST_PROMPT, title: 'typo-rejection' }),
+            candidates: [
+              {
+                // @ts-expect-error — 'tonr' is not assignable to 'tone'
+                conditions: { tonr: 'formal' },
+                body: 'will not compile'
+              }
+            ]
+          }
+        ]
+      };
+      // Runtime shape is unchanged — the seed object still constructs;
+      // the contract is purely compile-time on this branch.
+      expect(seed.records?.length).toBe(1);
+    });
+
+    test('the default TQualifierNames = string compiles arbitrary axis keys', () => {
+      // Back-compat: unannotated seeds still accept any string key.
+      const seed: IPromptStoreFixtureSeed = {
+        records: [
+          {
+            scope: TEST_SCOPE,
+            id: TEST_PROMPT,
+            descriptor: buildSimpleDescriptor({ id: TEST_PROMPT, title: 'untyped seed' }),
+            candidates: [{ conditions: { arbitrary: 'value' }, body: 'ok' }]
+          }
+        ]
+      };
+      expect(seed.records?.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Final phase of the `ts-res-typed-conditions` stream — ports `@fgv/ts-prompt-assist` to consume B-2's typed Converter siblings directly, and absorbs F2 + F6 from closed PR #385.

## Summary

- **Parameterized container types** — `IPromptCandidateRecord`, `IStoredPromptRecord`, `IPromptFileContents`, `IPromptStoreFixtureSeed`, `IPromptStoreFixtureSeedRecord`, and `IFileTreePromptStoreCreateParams` now carry `TQualifierNames extends string = string`. Default-string keeps every existing call site compiling unchanged.
- **Threaded `qualifierNameConverter?`** through `FileTreePromptStore.create` and `PromptStoreFixture.build`. When supplied, the YAML loader routes candidate `conditions` validation through ts-res's `ResourceJson.Convert.typedConditionSetDecl(qc)` (shipped by phase B-2) — a YAML record with a typo'd axis name fails at convert time with a regex-matchable error. When omitted, today's permissive default-string behavior is preserved.
- **New `typedPromptFileConverter<T>(qc)`** factory exported as the typed sibling of `promptFileConverter`. Shares a private helper with the default path so body-scan + `outputValidations`-on-free-text checks cannot drift.
- **F2 (verbatim from #385):** new `buildSimpleDescriptor({ id, title, surface?, description? })` helper for the trivial free-text chat case. Deliberately not generalized to JSON output — the `output.kind` discriminator is load-bearing for `resolveJsonOutput` / `resolveFreeTextOutput` dispatch.
- **F6 (verbatim from #385):** README React-wiring section extended with a `ChatTone` consumer enum, `<select>` bound to it, and a fourth list-item callout spelling out the v0.1 convention that axis NAMES are library-inferred while per-axis VALUE unions are a consumer concern.
- **Local sibling types from #385 (`ITypedConditionSetDecl`, `ITypedPromptCandidateRecord`) NOT carried forward** — obsoleted by B-2 which ships the canonical primitive at the ts-res layer.

## Compatibility

Existing callers unchanged. Every new type parameter has `default = string`; every new field is optional. `etc/ts-prompt-assist.api.md` diff is pure-additive — no removed/renamed exports.

## Cast-pressure regression test design

New file `b3TypedConditions.test.ts` (14 tests, three sub-blocks):

- **F2 helper coverage** — three positive tests for `buildSimpleDescriptor`.
- **Cast-pressure regression** — eight tests including the load-bearing one: `PromptStoreFixture.build` with a runtime-cast escape-hatch (`as unknown as IPromptCandidateRecord<'tone' | 'language'>`) carrying a typo'd axis name rejects at `store.get()` time, proving the convert-time teeth are tighter than the seed-type compile check.
- **Compile-time seed-type discipline** — three smoke tests using `@ts-expect-error` and verifying the default `string` parameter remains permissive.

## Bindings/qualifiers loaders decision

Narrow scope held — neither loader was threaded with `qualifierNameConverter`. `_bindings.yaml` carries slot-name keys (not qualifier-name keys), and `_qualifiers.yaml` is the authority that DEFINES the axis set; threading the downstream converter into either would invert dependency direction or be a no-op. Rationale documented in `phase-b3-result.md`.

## Pre-PR gate checklist

- [x] `rush build` passes full repo (27 packages clean)
- [x] `rushx lint` passes in `@fgv/ts-prompt-assist`
- [x] `rushx fixlint` run before final commit
- [x] `rushx test` 178/178 passing with 100% coverage on all four metrics (statements / branches / functions / lines)
- [x] `etc/ts-prompt-assist.api.md` regenerated (additive only)
- [x] Rush change file added (`minor`)
- [x] No `any` types; no manual casts beyond `@ts-expect-error` directives in tests
- [x] `phase-b3-result.md` written; `state.md` + `docs/WORKSTREAMS.md` updated

Note: the pre-existing `@fgv/ts-json-base` `fileIsMutable` test failure is environment-specific (root user in the container can write to read-only files) and unrelated to this change — verified by re-running the test on the unmodified integration HEAD.

## Test plan

- [ ] CI green on `claude/ts-prompt-assist-features` integration branch
- [ ] api-extractor diff confirmed additive-only by reviewer
- [ ] Cast-pressure regression test asserts on `/tonr/` at convert-time (not just compile-time)
- [ ] Downstream PRs #385 (round-2 absorb, supersession check) and #384 (sample app rebase) confirmed unblocked

https://claude.ai/code/session_01Urhs9W7VxTpNicaMSkc1BC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Urhs9W7VxTpNicaMSkc1BC)_