### PR TITLE
fix(ts-extras): expose @types/luxon as a runtime dependency

### DIFF
--- a/common/changes/@fgv/ts-extras/fix-luxon-types-export_2026-05-22-00-00.json
+++ b/common/changes/@fgv/ts-extras/fix-luxon-types-export_2026-05-22-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Move @types/luxon from devDependencies to dependencies. The rolled-up public .d.ts references `DateTime` from luxon; consumers without their own @types/luxon dev-dep were getting a TS7016 implicit-any on import. As a transitive runtime dep, @types/luxon now installs automatically alongside the runtime luxon dep.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -352,6 +352,9 @@ importers:
       '@fgv/ts-json-base':
         specifier: workspace:*
         version: link:../ts-json-base
+      '@types/luxon':
+        specifier: ^3.7.1
+        version: 3.7.1
       fflate:
         specifier: ~0.8.2
         version: 0.8.2
@@ -410,9 +413,6 @@ importers:
       '@types/js-yaml':
         specifier: ~4.0.9
         version: 4.0.9
-      '@types/luxon':
-        specifier: ^3.7.1
-        version: 3.7.1
       '@types/mustache':
         specifier: ^4.2.5
         version: 4.2.6

--- a/libraries/ts-extras/package.json
+++ b/libraries/ts-extras/package.json
@@ -72,7 +72,6 @@
     "@microsoft/api-documenter": "^7.28.2",
     "@microsoft/api-extractor": "^7.55.2",
     "@types/jest": "^29.5.14",
-    "@types/luxon": "^3.7.1",
     "@types/mustache": "^4.2.5",
     "@types/node": "^20.14.9",
     "@types/papaparse": "^5.3.14",
@@ -104,6 +103,7 @@
     "typedoc-plugin-markdown": "~4.9.0"
   },
   "dependencies": {
+    "@types/luxon": "^3.7.1",
     "luxon": "^3.7.2",
     "mustache": "^4.2.0",
     "papaparse": "^5.4.1",


### PR DESCRIPTION
## Summary

Consumer hit TS7016 implicit-any on `luxon` when their tsc walked the rolled `@fgv/ts-extras` `.d.ts` after upgrading to `5.1.0-29`. The rolled `etc/ts-extras.d.ts` line 9 has `import { DateTime } from 'luxon'` (public-surface type reference, fine on its own), but `@types/luxon` was only in `devDependencies` — so consumers without their own `@types/luxon` dev-dep got the implicit-any error.

## Fix

Moves `@types/luxon` from `devDependencies` to `dependencies` in `libraries/ts-extras/package.json`. Now installs transitively alongside the runtime `luxon` dep that's already in `dependencies`. `pnpm-lock.yaml` regenerated via `rush update`.

## Compatibility

Patch-level. No API surface change. Consumers who already had `@types/luxon` as their own dev-dep see no diff.

## Consumer workaround (until publish)

`pnpm add -D @types/luxon` (or npm/yarn equivalent) in the consumer project. TypeScript picks it up automatically; same effect as the transitive dep this PR introduces.

## Pre-PR gates

- [x] `rush update` regenerated pnpm-lock.yaml
- [x] `rushx build` clean in `@fgv/ts-extras`
- [x] `rushx lint` clean (separate gate from build)
- [x] `rushx test` 100% coverage (unaffected — metadata-only change)
- [x] Rush change file added (`type: patch`)
- [x] No code changes; no api-extractor diff expected

## Survey of other third-party type leaks (none)

Verified that `@types/luxon` is the only third-party type leak in `etc/ts-extras.api.md`:

```
$ grep -nE "from '[^.@]" libraries/ts-extras/etc/ts-extras.api.md
import { DateTime } from 'luxon';
```

`mustache`, `papaparse`, `fflate`, `argon2` types are all wrapped by fgv-owned exports — no leak. Fix is narrow to luxon.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_