### PR TITLE
chore(local-ai-exploration): substrate prep — testbed + transformers-facade cluster

### DIFF
--- a/.ai/tasks/active/local-ai-exploration/brief.md
+++ b/.ai/tasks/active/local-ai-exploration/brief.md
@@ -1,0 +1,259 @@
+# Stream brief: `local-ai-exploration`
+
+**Status:** 🟢 ready to commission
+**Integration branch:** `local-ai-exploration` (off `release`)
+**Workflow shape:** design-triage-implement-refine cluster
+**Package surface:**
+- **New:** `samples/testbed/` (sample browser app, web + CLI)
+- **New (provisional):** `@fgv/ts-extras-transformers` + `@fgv/ts-web-extras-transformers` (Result-integration boundary over `@huggingface/transformers`)
+- **Touch (additive):** `docs/FUTURE.md`, `docs/TECH_DEBT.md`, `docs/WORKSTREAMS.md`
+
+---
+
+## Mission
+
+Two intertwined goals, deliberately:
+
+1. **Build a long-lived sample browser app (`samples/testbed`)** as the canonical home for fgv-capability scenarios. Web-first; CLI-secondary. Sample-browser UX: sidebar lists scenarios by category, main area mounts selected scenario, collapsible message panel at bottom. Grows over time as fgv adds capabilities or as we want a worked example of an existing one.
+
+2. **Use that testbed to evaluate whether a Result-shaped facade over `@huggingface/transformers` (per the local-models research note) earns its keep.** The research recommended Option 2 (sibling Result-integration packages mirroring the `@fgv/ts-extras-webauthn` discipline) but noted the wrapper is so thin that consumers could trivially write it themselves. The testbed gives us a concrete consumer in which to test that thinness.
+
+**Done-or-discard decision criteria — locked at B-3 exit, before B-4 is commissioned:**
+
+- Does the facade let scenario code read meaningfully cleaner than `pipeline()` direct?
+- Does the boundary survive when a second scenario pulls in a different model type (classifier vs embedder vs small generator)?
+- Does Result composition with the rest of fgv feel natural (e.g. composing with ts-prompt-assist's safety backend)?
+
+If all yes → ship the facade as a real package pair. If meaningful friction → abandon the facade, pivot the scenario to consume `@huggingface/transformers` directly, document the decision in `phase-result.md`, **keep the sample**.
+
+---
+
+## Required reading (decision-track input)
+
+1. **`.ai/notes/orchestrator/research/local-models-incorporation.md`** (on `local-ai-exploration`) — the research note that frames the three options and recommends Option 2 with timing "next open stream slot, not urgent."
+2. **`@fgv/ts-extras-webauthn` + `@fgv/ts-web-extras-webauthn`** (production code in `libraries/`) — the canonical Result-integration boundary pattern. Six primitives; zero opinionated orchestration; explicit "NOT in scope" list. The transformers facade mirrors this exactly.
+3. **`@fgv/ts-app-shell`** (production code in `libraries/ts-app-shell/`) — packlets confirmed available for testbed: `messages` (MessagesProvider, useLogReporter, StatusBar, ToastContainer), `url-sync` (useUrlSync), `top-bar`, `modal`, `sidebar`, `keyboard`. All needed shell primitives exist; no extension required.
+4. **`tools/ks/`** — `ks` CLI tool. The testbed's CLI shell mirrors its env-var conventions verbatim (`FGV_KS_PASSWORD` / `KS_PASSWORD`; `~/.fgv-ks`; `--keystore` / `--password-env` / `--password-file` / `--password-stdin` flags).
+5. **Chocolate-lab recon findings** (in this brief; see "Patterns inherited from chocolate-lab" section below) — data-pipeline pattern, keystore-on-web pattern, sample-browser shell pattern.
+6. **`.ai/instructions/CODING_STANDARDS.md` § "Extending Core Libraries Over Working Around Them"** — fgv discipline around when to extend libraries vs add new ones. The gap-then-fix tenet in this brief operationalizes that discipline at sample-author scale.
+
+---
+
+## Tenets (binding for the testbed)
+
+1. **Showcase fgv best practices at the latest revision.** Result pattern everywhere; Converters/Validators for untyped input; ILogger/LogReporter for observability; FileTree for I/O; bcp-47 for any locale-touching code; ts-res for any context-conditional behavior; ts-prompt-assist for any prompt resolution. No exceptions for sample-class brevity.
+
+2. **Gap-then-fix tenet — load-bearing.** If a scenario discovers a missing or broken fgv capability, the answer is:
+   - **Preferred:** extend/fix fgv first, then continue the scenario. Surface as a separate small PR before continuing the testbed work if the extension is non-trivial.
+   - **Fallback:** apply a workaround in the scenario, tag with `// TESTBED-WORKAROUND: <description> — see <work-item-link>`, and file the tracked work item.
+   - **Never:** build complicated sample-only behavior that a real consumer would also need. If the scenario is reaching for download primitives, FileTree adapters, secret-resolution helpers, ILogger backends — those go in `@fgv/*` libraries, not in the testbed.
+
+3. **Sample-browser UX.** Web shell is a browse-select-run experience, not a single-purpose demo. Scenarios are first-class entities with searchable/filterable metadata. Adding a new scenario is a single-file (plus one-line registration) PR; the UX exposes it automatically.
+
+4. **Documentation in code.** Use comments to explain subtle or complex parts (e.g. why a particular fgv primitive was chosen; what convention is being demonstrated). Avoid unnecessary clutter — sample code should READ as exemplary code, not as a tutorial transcript.
+
+5. **100% test coverage on testbed shell + scenarios.** Entry points (`cli.ts`, `web/index.tsx`) can be `c8 ignore`-marked as orchestration glue; everything else gets full coverage. Samples worth copying need to be trustworthy.
+
+---
+
+## Locked design
+
+### Scenario contract
+
+```typescript
+type ScenarioCategory =
+  | 'ai'           // ai-assist, local-ai
+  | 'i18n'         // bcp-47, locale handling
+  | 'crypto'       // keystore, encryption
+  | 'prompts'      // ts-prompt-assist
+  | 'resources'    // ts-res
+  | 'general';     // utility-shaped scenarios
+
+interface ISecretSpec {
+  readonly id: string;            // KeyStore-compatible id (e.g. 'openai-api-key')
+  readonly envVarName: string;    // fallback env var (e.g. 'OPENAI_API_KEY')
+  readonly description: string;   // for missing-secret diagnostic
+}
+
+interface IScenarioContext {
+  readonly logger: ILogReporter;          // shell-initialized; bridged to MessagesProvider on web
+  readonly keyStore: KeyStore | undefined; // undefined if no keystore unlocked yet
+  readonly resolveSecret: (spec: ISecretSpec) => Promise<Result<string>>;
+  readonly dataTree: IFileTreeRootItem;    // testbed's in-memory data tree
+}
+
+interface IScenarioBase {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly category: ScenarioCategory;
+  readonly tags: readonly string[];        // capabilities exercised: ['ts-res', 'local-ai', 'classification', ...]
+  readonly requiredSecrets?: readonly ISecretSpec[];
+}
+
+interface IWebScenarioImpl {
+  readonly component: ComponentType<{ context: IScenarioContext }>;
+  readonly initialize?: (context: IScenarioContext) => Promise<Result<boolean>>;
+  // boolean = "ready to mount the component"; allows async setup (model load, secret resolve)
+  // to gate component mounting cleanly.
+}
+
+interface ICliScenarioImpl {
+  run(context: IScenarioContext): Promise<Result<string>>;
+  // string = scenario-shaped completion summary (e.g. "Classified 12 inputs; wrote results to data/output/classifications.json")
+}
+
+interface IScenario extends IScenarioBase {
+  readonly web?: IWebScenarioImpl;
+  readonly cli?: ICliScenarioImpl;
+}
+```
+
+### Web shell layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ fgv testbed                                       [secrets] │  ← top-bar
+├──────────────┬──────────────────────────────────────────────┤
+│ [search…]    │  <selected scenario title>                   │
+│              │  <description; tags as chips>                │
+│ ─ AI ─       │                                              │
+│   ▸ Local    │  ┌────────────────────────────────────────┐ │
+│     classify │  │                                        │ │
+│   ▸ RAG      │  │   <scenario component>                 │ │
+│              │  │                                        │ │
+│ ─ Prompts ─  │  │                                        │ │
+│   ▸ Resolve  │  └────────────────────────────────────────┘ │
+│              │  ─── messages ──────────────────────  [▾]   │ ← collapsible, default collapsed
+│ ─ i18n ─     │  [info] loading model gpt-2-finetuned…      │
+│   ▸ BCP-47   │  [info] ready in 1.2s                       │
+└──────────────┴──────────────────────────────────────────────┘
+```
+
+- **Top-bar:** ts-app-shell `top-bar`. Testbed name + secrets button (opens modal).
+- **Sidebar:** ts-app-shell `sidebar` packlet, scenarios grouped by category, search/filter by tag.
+- **Main area:** selected scenario's component (`useUrlSync` for deep-linking via `/scenarios/<id>`).
+- **Messages panel:** ts-app-shell `StatusBar` + `MessagesProvider`/`useLogReporter`. **Bottom-of-main collapsible; collapsed by default.** Toast notifications via `ToastContainer` for transient events (model loaded, error, etc.).
+- **Secrets modal:** ts-app-shell `modal`. Lists `requiredSecrets` from currently-selected scenario; shows status (resolved from keystore / resolved from env var / unresolved); KeyStore unlock/create flow integrated.
+
+### CLI shell
+
+- Node entry point: `src/cli.ts`.
+- Flag-based scenario selection: `--scenario <id>` or interactive picker if omitted.
+- KeyStore flags mirroring `ks`: `--keystore <path>`, `--password-env <NAME>`, `--password-file <PATH>`, `--password-stdin`.
+- Env-var fallbacks: `FGV_KS_PASSWORD` / `KS_PASSWORD` for password; `~/.fgv-ks` for default keystore path.
+- `.env.local` for non-KeyStore secrets (raw env vars).
+- `MessagesLogger` (or equivalent console-shaped reporter) writing to stderr.
+- Scenario's `run` returns `Result<string>`; CLI prints the success string or fails with structured error.
+
+### Data pipeline (chocolate-lab pattern)
+
+- `samples/testbed/data/` — source YAML/JSON.
+- `samples/testbed/scripts/build-data.ts` — manually invoked via `rushx build:data`. Walks `data/`, emits TS source.
+- `samples/testbed/src/generated/dataFileTree.ts` — **checked in** (chocolate-lab convention). Exports a `FileTree.inMemory()`-ready data structure or pre-built tree.
+- Scenarios import from `src/generated/dataFileTree.ts` and consume via `FileTree.inMemory()`.
+- Binary data excluded from the pipeline; scenarios that need binary fetch at runtime or omit.
+
+### KeyStore integration
+
+- **Web:** `FileApiTreeAccessors.createFromLocalStorage(...)` from `@fgv/ts-web-extras` (per chocolate-lab pattern) hosts the keystore blob at `/keystore`. Password prompted via ts-app-shell `modal`; held in memory for session. Create/unlock/change-password flow via dedicated modal modes. First-run: missing keystore → "create" mode.
+- **CLI:** `~/.fgv-ks` + `FGV_KS_PASSWORD` env (`ks`-compatible).
+- Shared `resolveSecret(spec)` helper: keystore-first, env-var fallback, structured failure with both ids named.
+- Local keystore-storage helpers (`loadKeystoreFromTree`, `saveKeystoreToFile`, etc.) live in `src/shell/keystore/` — chocolate-lab keeps these app-local; we mirror unless a second consumer materializes.
+
+### Sample-browser navigation pattern (chocolate-lab-derived)
+
+- State-driven shell, not React Router.
+- `useUrlSync` from ts-app-shell for URL-sync of selected scenario (`#scenario=<id>`).
+- Single-mode (no `ModeSelector` — testbed doesn't need that surface area). Just sidebar + main + messages.
+- Adding a scenario = drop a file + register in `scenarios/index.ts` (manual list, explicit beats clever).
+
+---
+
+## Patterns inherited from chocolate-lab
+
+Per the chocolate-lab recon (in this session):
+
+| Pattern | Source | Adaptation |
+|---|---|---|
+| Generated-data-as-checked-in-TS | `libraries/ts-chocolate/scripts/build-library-data.js` → `src/packlets/built-in/builtInData.generated.ts` | Same shape; `rushx build:data` script; checked-in artifact. |
+| `FileTree` everywhere | `FileTree.inMemory(...)` for generated data; `FileApiTreeAccessors.createFromLocalStorage(...)` for keystore | Same. |
+| State-driven shell + URL sync | `App.tsx` uses `useUrlSync` from ts-app-shell | Same hook; simpler shell (no three-mode-selector). |
+| `MessagesProvider` + `useLogReporter` + `StatusBar` | `apps/chocolate-lab-web/src/App.tsx` mounts these | Same wiring; `StatusBar` wrapped in a collapsible container. |
+| KeyStore on web via localStorage-backed FileTree | `libraries/chocolate-lab-ui/src/packlets/workspace/browserPlatformInit.ts` | Same; password-modal pattern from `UnlockDialog` / `PublishingKeystorePasswordDialog`. |
+| Graceful fallback on missing/corrupt persisted data | Throughout chocolate-lab | Apply uniformly. |
+
+**Not copied:**
+- Domain-specific vocabulary (ingredients/fillings/molds/etc.).
+- Three-top-level-mode shell (testbed doesn't need that).
+- Heavy storage topology (mitigated-root / cloud-root / publishing-root).
+- Trading-post publishing workflow.
+
+---
+
+## Sub-phase shape
+
+| Phase | Scope | Output |
+|---|---|---|
+| **B-1: Scaffold** | `samples/testbed/` package + web shell skeleton + CLI shell skeleton + data-pipeline script + initial `conventions.md`. Empty but compilable (`rushx build` clean). Provisional `@fgv/ts-extras-transformers` + `@fgv/ts-web-extras-transformers` package skeletons (empty surface; `index.ts` exports `{}`). | Branch + PR onto `local-ai-exploration`; all gates green for empty packages. |
+| **B-2: Facade primitives** | Implement the 5-8 transformers facade primitives in both packages (Node + browser). `loadPipeline`, `classify`, `embed`, possibly `generate`. Mirror WebAuthn discipline: no opinionated orchestration; explicit "NOT in scope" list in package READMEs. Tests + coverage in both packages. | Branch + PR onto `local-ai-exploration`. 100% coverage on packages. |
+| **B-3: First scenario — local classifier as `IPromptSafetyPolicy` backend** | Build the scenario in `samples/testbed/src/scenarios/localClassifierSafety.tsx`. Consumes the B-2 facade; composes into a `PromptLibrary` instance via the `IPromptSafetyPolicy` interface. Demonstrates the facade-to-ts-prompt-assist seam. Web component-shaped; supports a typed `Convert.enumeratedValue` for classifier labels. | Branch + PR onto `local-ai-exploration`. |
+| **B-3 exit gate (orchestrator-led)** | Apply the done-or-discard criteria. Decision: ship facade OR abandon-and-pivot. Document outcome + reasoning in `phase-result.md`. | Decision recorded; B-4 commissioned per the decision. |
+| **B-4a: Ship the facade** (if B-3 decides yes) | Polish facade for ship-quality: README, JSDoc, second scenario type to confirm boundary survives (e.g. embedding scenario), edge-case tests. Add to `LIBRARY_CAPABILITIES.md`. | Two packages ready for `release` promotion alongside the cluster. |
+| **B-4b: Pivot to native** (if B-3 decides no) | Refactor the scenario to consume `@huggingface/transformers` directly. Remove the facade packages from `local-ai-exploration`. Document why in `phase-result.md` and a lessons-pending entry. | Sample stays; facade discarded. |
+| **Cluster close** | Promotion `local-ai-exploration` → `release`. | Cluster shipped. |
+
+---
+
+## In-scope paths
+
+- `samples/testbed/` — full new package.
+- `libraries/ts-extras-transformers/` — new package (provisional; may be discarded at B-4b).
+- `libraries/ts-web-extras-transformers/` — new package (provisional; may be discarded at B-4b).
+- `docs/FUTURE.md` — absorb `ts-prompt-assist-samples` queued entry into `samples/testbed`.
+- `docs/TECH_DEBT.md` — new P3 entry: port `samples/ai-image-gen-sample` scenarios into the testbed (sometime after testbed is established).
+- `docs/WORKSTREAMS.md` — new active stream entry; flip on cluster close.
+- `.ai/instructions/LIBRARY_CAPABILITIES.md` — if facade ships at B-4a, add entries for new packages.
+
+## Out-of-scope (deferred)
+
+- Porting `samples/ai-image-gen-sample`'s existing scenarios into the testbed. Tech-debt entry created; not in this cluster.
+- Anti-jailbreak content library (consumer-supplied per ts-prompt-assist design).
+- LLM-call orchestration beyond what existing ai-assist provides.
+- Streaming UX patterns (worth a separate scenario eventually, not v1).
+
+---
+
+## Acceptance criteria (cluster-level, per sub-phase)
+
+Same as every fgv stream:
+
+- [ ] `rush build` passes full repo on every sub-phase PR.
+- [ ] `rushx lint` passes in every modified package (separate gate from build).
+- [ ] `rushx fixlint` run before final commit.
+- [ ] `rushx test` 100% coverage in every modified package (samples included; orchestration entry points may be `c8 ignore`-d with rationale).
+- [ ] api-extractor regenerated where public surface changed (transformers packages at B-2/B-4a).
+- [ ] Rush change file added under appropriate `common/changes/` dirs.
+- [ ] No `any` types; no manual casts beyond `@ts-expect-error` test assertions.
+- [ ] Per-phase `phase-result.md` written; `state.md` history updated.
+
+---
+
+## Resume protocol
+
+To pick up cold from a future orchestrator session:
+
+1. Read this brief.
+2. Read `state.md` — phase status + decisions log + history.
+3. Read `.ai/notes/orchestrator/research/local-models-incorporation.md` (decision-track input).
+4. Check open PRs targeting `local-ai-exploration` integration branch.
+5. If a sub-phase is in flight, read its `phase-N-brief.md` (drafted at commission time) and `phase-N-result.md` (written by implementing agent on completion).
+
+---
+
+## Branch + PR posture
+
+- **Integration branch:** `local-ai-exploration` (existing).
+- **Substrate-prep PR:** this PR — `chore/local-ai-exploration-prep`.
+- **Sub-phase work branches:** `chore/local-ai-exploration-b<N>-<short>` (cloud-agent harness may suffix; document actual branch in state.md per L2).
+- **Sub-phase PRs:** target `local-ai-exploration`, NOT `release`. Cluster-close prep + promotion is the final PR cluster → `release`.

--- a/.ai/tasks/active/local-ai-exploration/state.md
+++ b/.ai/tasks/active/local-ai-exploration/state.md
@@ -1,0 +1,81 @@
+# Stream state: `local-ai-exploration`
+
+**Status:** 🟢 ready to commission — substrate prep in flight
+**Integration branch:** `local-ai-exploration` (off `release`)
+**Last updated:** 2026-05-22 (orchestrator — substrate prep)
+
+---
+
+## Phase status
+
+| Phase | Status | Notes |
+|---|---|---|
+| Research | ✅ complete | Local-model incorporation analysis at `.ai/notes/orchestrator/research/local-models-incorporation.md`. Recommendation: Option 2 (Result-shaped facade over `@huggingface/transformers`). Erik merged via #402 onto this branch. |
+| B-1 — Scaffold | 🟢 ready (next) | testbed package + facade package skeletons (provisional). Empty but compilable. |
+| B-2 — Facade primitives | ⏸ blocked on B-1 | 5-8 ops mirroring WebAuthn discipline. |
+| B-3 — First scenario (local classifier → IPromptSafetyPolicy) | ⏸ blocked on B-2 | Done-or-discard gate at exit. |
+| B-4a or B-4b — Ship or pivot | ⏸ blocked on B-3 exit | Decided per B-3 evaluation. |
+| Cluster close | ⏸ blocked on B-4 outcome | Promotion `local-ai-exploration` → `release`. |
+
+---
+
+## Decisions log (orchestrator, substrate prep)
+
+| Decision | Rationale |
+|---|---|
+| Build testbed + facade together; outcome-gated at B-3 | Erik (2026-05-22): "build the proposed AI surface; create a multi-scenario AI sample app; iterate until we're either happy with the code shape or decide to abandon it." Done-or-discard criteria locked at B-3 exit. |
+| Testbed name: `samples/testbed` (not `samples/ai-sample`) | Erik (2026-05-22): "we might want to take 'ai' out of the name so we can use it for other fgv capabilities." Long-lived showcase app for all fgv capabilities, not AI-specific. |
+| Web-first, CLI-secondary | Erik (2026-05-22): "prioritize web — the existing image samples are much harder to understand and work with via CLI." Some scenarios web-only by design (interactive React); CLI for batch-style or testable-from-pipeline. |
+| Sample-browser UX framing | Erik (2026-05-22): "we probably want to think of the web UX as a sample browser and make sure the UX is prepared for that." Sidebar list + main area + collapsible (default-collapsed) message panel. |
+| Manual scenario registration (no auto-discovery) | Erik (2026-05-22): "manual. dependencies etc already mandate changes for most consumers, so one more registration is not a barrier." |
+| 100% coverage on testbed code | Repo standard; samples worth copying need to be trustworthy. Entry points (`cli.ts`, `web/index.tsx`) may be `c8 ignore`-d as orchestration glue. |
+| Absorb `ts-prompt-assist-samples` FUTURE entry into testbed | Erik (2026-05-22) confirmed in design discussion. One general showcase that grows scenarios over time > two parallel demo apps. |
+| Port existing `ai-image-gen-sample` scenarios → P3 tech debt | Erik (2026-05-22): "we should probably add tech debt to port the ai image scenarios over as well." Not in cluster scope; queued for after testbed is established. |
+| Data pipeline = chocolate-lab pattern (checked-in generated TS) | Recon confirmed chocolate-lab's `data/published/<category>/*.yaml` → `scripts/build-library-data.js` → `src/packlets/built-in/builtInData.generated.ts` (checked in). Same shape; `rushx build:data` manual invocation. |
+| KeyStore on web = `FileApiTreeAccessors.createFromLocalStorage` (existing ts-web-extras primitive) | Confirmed in chocolate-lab recon; primitive already exists. No new fgv extension required. Local helpers (`loadKeystoreFromTree`, etc.) stay app-local per chocolate-lab pattern. |
+| First scenario: local classifier → `IPromptSafetyPolicy` backend | Simpler than RAG/routing scenarios; one model + one integration seam; concentrates on facade-to-ts-prompt-assist composition; abandons fast if facade reads wrong. |
+| Tenet: gap-then-fix (preferred) OR workaround-with-tracked-workitem | Erik (2026-05-22) — load-bearing for the testbed-as-forcing-function role. Workaround comments tagged `// TESTBED-WORKAROUND:` (greppable). Tracked items go to `docs/TECH_DEBT.md` or `docs/FUTURE.md`. |
+
+---
+
+## Open questions
+
+### To resolve at sub-phase brief-authoring time
+
+| ID | Question | Phase |
+|---|---|---|
+| OQ-1 | Exact facade surface (5-8 ops): naming, signature, browser vs Node behavior differences | B-2 sub-brief |
+| OQ-2 | Whether `loadPipeline` returns an opaque type or a thin Result-wrapped reference to the upstream `Pipeline` | B-2 sub-brief |
+| OQ-3 | Whether the testbed's web shell should support keyboard shortcuts for scenario navigation (ts-app-shell `keyboard` packlet is available) | B-1 sub-brief |
+| OQ-4 | Whether to land a second scenario type at B-4a to confirm facade survives across model types (likely yes if shipping) | B-3 exit gate |
+
+### Deferred (not this cluster's concern)
+
+| ID | Question | Where it lives |
+|---|---|---|
+| F-1 | Port `samples/ai-image-gen-sample` scenarios into testbed | `docs/TECH_DEBT.md` (this cluster files the entry) |
+| F-2 | Editor UX as a separate `ts-prompt-assist-editor-ui` stream | `docs/FUTURE.md` (already queued; unchanged) |
+| F-3 | Sidecar/HTTP local LLM path (Ollama/LM Studio via existing ai-assist baseUrl) | Documentable independent of this cluster (research note surprise #1); flagged for a separate small chore PR if Erik wants |
+
+---
+
+## History
+
+| Date | Event | Notes |
+|---|---|---|
+| 2026-05-19 | Research note authored | `.ai/notes/orchestrator/research/local-models-incorporation.md` via #402; recommended Option 2 with timing "next slot, not urgent." |
+| 2026-05-22 | Erik merged research to `local-ai-exploration` branch; commissioned the build-and-evaluate journey | "Build the proposed AI surface; create multi-scenario sample app; iterate until happy or abandon." |
+| 2026-05-22 | Substrate prep | Brief + state + WORKSTREAMS + FUTURE absorbs + TECH_DEBT entry for ai-image port. This PR. |
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Research | #402 | merged to `local-ai-exploration` |
+| Substrate prep | (this PR) | open |
+| B-1 | TBD | not yet commissioned |
+| B-2 | TBD | not yet commissioned |
+| B-3 | TBD | not yet commissioned |
+| B-4a/b | TBD | gated on B-3 exit |

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -43,16 +43,7 @@ Arguments against: every consumer's scope hierarchy is bespoke; editor screens t
 
 ## Samples app for `@fgv/ts-prompt-assist`
 
-The `ts-prompt-assist` v0.1 stream ships only the library + test collateral. A samples app would demonstrate end-to-end usage: a small consumer with a scope hierarchy, a handful of YAML descriptors, scope-level bindings, qualifier axes, resource-binding fragments, output validation. Two shapes considered:
-
-1. **Standalone samples app** (modeled on `ai-assist-image-generator`) — a small CLI or web app under `apps/` that exercises the library against a fixture FileTree.
-2. **Folded into `ai-assist-image-generator`** — extend the existing image-generator surface to also exercise prompt-assist for the image-generation prompts themselves. Cross-pollinates the two libraries.
-
-**Why deferred**: v0.1 hasn't shipped yet; consumer pressure-test is the primary validator. Samples app earns its keep once the library API has stabilized and we want a clean reference for new consumers to learn from.
-
-**Dependencies**: `ts-prompt-assist` v0.1 shipped; consumer port settled enough that the API is unlikely to churn out from under the samples.
-
-**Reference**: `.ai/tasks/active/ts-prompt-assist/brief.md` (stream commission discussion).
+**Status: superseded by `samples/testbed` (2026-05-22).** Absorbed into the general-purpose `samples/testbed` sample-browser being built under the `local-ai-exploration` cluster. The testbed will demonstrate `@fgv/ts-prompt-assist` scenarios alongside scenarios for other fgv capabilities (ai-assist, ts-res, bcp-47, crypto, etc.) — one general showcase that grows scenarios over time beats two parallel demo apps. See `.ai/tasks/active/local-ai-exploration/brief.md`.
 
 ---
 

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -116,6 +116,19 @@ opportunistically when the right surface area is touched.
 
 ## P3 — Opportunistic cleanup
 
+- **[P3] Port `samples/ai-image-gen-sample` scenarios into `samples/testbed`.**
+  The new general-purpose `samples/testbed` sample-browser (commissioned via `local-ai-exploration` cluster, 2026-05-22) is the canonical home for fgv-capability scenarios going forward. The existing `samples/ai-image-gen-sample` predates the testbed and has its own webpack pipeline + scenario shapes; its content (image generation against multiple providers, prompt-assist round-2 demo, etc.) should be ported into the testbed once the testbed shell is established.
+
+  **Trigger**: after `local-ai-exploration` cluster ships and the testbed has at least 2-3 native scenarios proving the shell + scenario contract are stable.
+
+  **Scope sketch**: port each `ai-image-gen-sample` scenario as a testbed `IScenario` web impl. Pull data from the existing sample's fixture pattern into the testbed's `data/` pipeline. Decide whether to retire `samples/ai-image-gen-sample` entirely (lean: retire — one canonical sample app, not two) or keep it as a "minimal sample skeleton" reference for consumers who want a single-purpose app shape.
+
+  **Not a P1**: existing sample works as-is; consumer-visible behavior unchanged either way.
+
+  **Not a P2**: the testbed has to land + stabilize before the port has a real target. P3 reflects "do this once the testbed earns the right to absorb."
+
+  **Reference**: `local-ai-exploration` cluster brief at `.ai/tasks/active/local-ai-exploration/brief.md`; Erik 2026-05-22 ("we should probably add tech debt to port the ai image scenarios over as well").
+
 - **[P3] New pure-library packages must declare `"sideEffects": false` in `package.json`.**
   Every `libraries/` package whose `src/index.ts` exports only functions and types (no module-level side effects) carries `"sideEffects": false` so bundlers can tree-shake it. This was caught in PR review on `crypto-batch-2-webauthn`: `@fgv/ts-extras-webauthn` was missing the field; `@fgv/ts-web-extras-webauthn` had it. Fixed in-stream, but the gap reveals a scaffolding-checklist hole — the standard "new package" template doesn't enforce it.
 

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -128,6 +128,32 @@ substrate. Don't queue streams against them here.
 
 ## Active workstreams
 
+### `local-ai-exploration` 🟢
+
+**Status:** 🟢 substrate prep in flight; B-1 ready to commission after merge
+**Integration branch:** `local-ai-exploration` (off `release`)
+**Workflow shape:** design-triage-implement-refine cluster with outcome gate at B-3
+**Substrate:** `.ai/tasks/active/local-ai-exploration/{brief.md, state.md}`
+**Package surface (new):**
+- `samples/testbed/` — long-lived sample-browser app, web + CLI, web-first
+- `@fgv/ts-extras-transformers` + `@fgv/ts-web-extras-transformers` — Result-integration boundary over `@huggingface/transformers` (provisional; may be discarded at B-4b if the experiment shows the facade doesn't earn its keep)
+
+**Mission.** Two intertwined goals: (1) build a long-lived sample browser app at `samples/testbed/` as the canonical home for fgv-capability demonstration scenarios; (2) use that testbed to evaluate whether a Result-shaped facade over `@huggingface/transformers` earns its keep, with an explicit done-or-discard decision gate at B-3 exit.
+
+**Decision-track input (binding):** `.ai/notes/orchestrator/research/local-models-incorporation.md` (merged via #402) recommends Option 2 with timing "next slot, not urgent." This cluster takes the slot and runs the experiment.
+
+**Sub-phase shape:**
+- B-1 scaffold (testbed + facade package skeletons)
+- B-2 facade primitives (5-8 ops mirroring `@fgv/ts-extras-webauthn` discipline)
+- B-3 first scenario (local classifier → `IPromptSafetyPolicy` backend)
+- B-3 exit gate (done-or-discard decision per criteria locked in brief)
+- B-4a (ship the facade) OR B-4b (pivot scenario to native)
+- Cluster close (promotion `local-ai-exploration` → `release`)
+
+**Out-of-scope (this cluster):** porting `samples/ai-image-gen-sample` scenarios into the testbed (P3 tech debt, queued); editor UX (queued); LLM-call orchestration beyond existing ai-assist; sidecar/HTTP local LLM path (separate small chore opportunity).
+
+**Origin.** Erik's question 2026-05-22: "ai-assist is all about communicating with distant LLMs for pretty meaty tasks. But in the real world, smaller models like classifiers and recognizers often run locally. How does that work and is it something we could/should incorporate?" Research note answered the framing; this cluster runs the experiment.
+
 ### `ai-assist-thinking-events` 🟡
 
 **Status:** 🟡 ready; sequencing after `ai-assist-thinking-config` phase B lands (now satisfied; ai-assist cluster shipped via #336)


### PR DESCRIPTION
Substrate prep for the `local-ai-exploration` cluster. Two intertwined goals codified:

1. **Build `samples/testbed/`** — long-lived sample-browser app (web-first, CLI-secondary) as the canonical home for fgv-capability demonstration scenarios. Sidebar lists scenarios by category with tag search; main area mounts selected scenario; **collapsible message panel at bottom, default collapsed**. ts-app-shell composed (no extension required).

2. **Evaluate the Result-shaped facade over `@huggingface/transformers`** per the local-models research note (#402). Provisional packages `@fgv/ts-extras-transformers` + `@fgv/ts-web-extras-transformers` mirror the `@fgv/ts-extras-webauthn` discipline. **Done-or-discard gate at B-3 exit**; B-4a ships or B-4b pivots scenario to native and discards facade (sample stays).

## Files

- **`.ai/tasks/active/local-ai-exploration/brief.md`** — stream brief: locked design, scenario contract, web/CLI shell shapes, data pipeline + KeyStore patterns (chocolate-lab-derived), sub-phase decomposition, done-or-discard criteria, gap-then-fix tenet.
- **`.ai/tasks/active/local-ai-exploration/state.md`** — phase status, decisions log, open questions, history.
- **`docs/WORKSTREAMS.md`** — new active-stream entry above `ai-assist-thinking-events`.
- **`docs/FUTURE.md`** — `Samples app for @fgv/ts-prompt-assist` marked superseded by `samples/testbed` (absorbed).
- **`docs/TECH_DEBT.md`** — new P3 entry: port `samples/ai-image-gen-sample` scenarios into testbed once testbed is established (post-cluster).

## Sub-phase shape

| Phase | Scope |
|---|---|
| B-1 | Scaffold testbed package + provisional facade package skeletons. Empty but compilable. |
| B-2 | Implement facade primitives (5-8 ops mirroring WebAuthn discipline). |
| B-3 | First scenario — local classifier → `IPromptSafetyPolicy` backend. |
| B-3 exit gate | Apply done-or-discard criteria → B-4a or B-4b. |
| B-4a | Ship facade (if B-3 passes the gate): README, JSDoc, second-scenario validation. |
| B-4b | Pivot scenario to native (if B-3 fails the gate); discard facade. Sample stays. |
| Cluster close | Promotion `local-ai-exploration` → `release`. |

## Tenets locked in the brief

1. Showcase fgv best practices at the latest revision (Result, Converters, ILogger, FileTree, bcp-47, ts-res, ts-prompt-assist — no exceptions for sample-class brevity).
2. **Gap-then-fix**: scenario discovers fgv gap → extend fgv first (preferred), or workaround with greppable `// TESTBED-WORKAROUND:` tag + tracked work item. Never build complicated sample-only behavior a real consumer would also need.
3. Sample-browser UX (browse-select-run; first-class scenarios).
4. Comments explain subtle/complex parts; avoid clutter; sample code reads as exemplary code.
5. 100% test coverage on testbed shell + scenarios (entry points may be `c8 ignore`-d as orchestration glue).

## Patterns inherited from chocolate-lab (per recon)

- Data pipeline: `data/` source → `scripts/build-data.ts` (manual `rushx build:data`) → checked-in `src/generated/dataFileTree.ts` → consumed via `FileTree.inMemory()`.
- KeyStore on web: `FileApiTreeAccessors.createFromLocalStorage(...)` (already in `@fgv/ts-web-extras` — no extension needed).
- State-driven shell + `useUrlSync` for deep-linking.
- `MessagesProvider` + `useLogReporter` + `StatusBar` wiring.

No code changes; substrate only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_