### PR TITLE
feat(local-ai): B-4a — ship the transformers facade (embed + classifyAll + embedding scenario)

### DIFF
--- a/.ai/instructions/LIBRARY_CAPABILITIES.md
+++ b/.ai/instructions/LIBRARY_CAPABILITIES.md
@@ -164,6 +164,30 @@ For anything not in the table above, **use `@simplewebauthn/server` or `@simplew
 
 ---
 
+### `@fgv/ts-extras-transformers` + `@fgv/ts-web-extras-transformers` — local transformers (HuggingFace) Result boundary
+
+[libraries/ts-extras-transformers](https://github.com/ErikFortune/fgv/tree/release/libraries/ts-extras-transformers)
+[libraries/ts-web-extras-transformers](https://github.com/ErikFortune/fgv/tree/release/libraries/ts-web-extras-transformers)
+
+**A Result-integration boundary over `@huggingface/transformers` (transformers.js) for running models locally — not an opinionated ML helper.** Like the WebAuthn pair, these add exactly one thing: thin `captureAsyncResult` wrappers that convert the upstream throw-on-failure calls into `Promise<Result<T>>`, with **no opinionated orchestration** (no pipeline cache, no model-download management, no device/quantization policy). The two packages expose an **identical surface**; pick the package at the composition root — Node uses the native ONNX backend, browser uses the WASM/WebGPU backend.
+
+| Package | Function | Return |
+|---|---|---|
+| both | `loadPipeline(task, model?, options?)` | `Promise<Result<AllTasks[T]>>` (the upstream pipeline instance) |
+| both | `classify(classifier, text, options?)` | `Promise<Result<TextClassificationOutput>>` (upstream default / top label unless `options.top_k` set) |
+| both | `classifyAll(classifier, text, options?)` | `Promise<Result<TextClassificationOutput>>` — forces `top_k: null`, so the **full per-label vector** is returned; use when you compare every label against thresholds |
+| both | `embed(extractor, text, options?)` | `Promise<Result<Tensor>>` — raw upstream `Tensor`, no pooling/normalisation applied (pass `{ pooling: 'mean', normalize: true }` via `options` for a sentence vector; extract a JS array with the Tensor's `.tolist()`) |
+
+`Tensor`, `TextClassificationPipeline`, `TextClassificationOutput`, `FeatureExtractionPipeline`, `AllTasks`, `PipelineType` are re-exported from both packages. Get an extractor via `loadPipeline('feature-extraction', modelId)`, a classifier via `loadPipeline('text-classification', modelId)`.
+
+**Explicitly NOT in scope:** pipeline cache / lifecycle / dispose, model registry or download management, GPU/CPU/WebGPU device-selection policy, quantization selection, embedding-store integration, classifier label allowlists, request batching, IndexedDB cache configuration. `generate` (text generation) is deferred until a concrete consumer needs it. For any of these, use `@huggingface/transformers` directly with `captureAsyncResult`.
+
+**Consuming from a dual web/CLI bundle (load-bearing pattern):** when one module is reachable from a browser bundle, keep your reusable core **facade-agnostic** — take the facade function (`classify`/`classifyAll`/`embed`) as an injected parameter and import facade types as `import type` only (erased, so no runtime facade enters the bundle). Import the **browser** facade on the web path; load the **Node** facade on the CLI path via `import(/* webpackIgnore: true */ '@fgv/ts-extras-transformers')` so its node-native deps never reach the browser graph. Validate the browser bundle with the real bundler (`webpack`/etc.) — type-check + jsdom tests do not exercise it. The `samples/testbed` `local-classifier-safety` and `local-embedding-search` scenarios are the reference consumers.
+
+**Upstream:** `@huggingface/transformers` `~4.2.0` (a runtime dep of both packages; `skipLibCheck` is required for its type definitions).
+
+---
+
 ## Cross-runtime interfaces
 
 Several core abstractions are defined once and have separate Node and browser implementations. Code against the interface; pick the implementation at the composition root.
@@ -175,6 +199,7 @@ Several core abstractions are defined once and have separate Node and browser im
 | Hash normalizer | `Md5Normalizer` (`ts-extras/hash`), `Crc32Normalizer` (`ts-utils/hash`) | `Md5Normalizer.browser` (`ts-extras/hash`), `BrowserHashProvider` (`ts-web-extras/crypto-utils`) | `Crc32Normalizer` is pure JS and runs everywhere. |
 | `IEncryptionProvider` (`@fgv/ts-extras/crypto-utils`) | `KeyStore`, `DirectEncryptionProvider` | same (back with `BrowserCryptoProvider`) | The provider is runtime-agnostic; only the underlying `ICryptoProvider` differs. |
 | `IArgon2idProvider` (`@fgv/ts-extras/crypto-utils`) | `NodeArgon2Provider` (`ts-extras-argon2`) | `BrowserArgon2Provider` (`ts-web-extras-argon2`) | Pure-WASM browser impl is byte-identical to Node impl for same inputs. |
+| Local transformers facade (`loadPipeline`/`classify`/`classifyAll`/`embed`) | `@fgv/ts-extras-transformers` (native ONNX) | `@fgv/ts-web-extras-transformers` (WASM/WebGPU) | Identical surface; thin `Result` boundary over `@huggingface/transformers`. In a browser bundle keep the core facade-agnostic and load the Node side via `webpackIgnore` dynamic import. |
 
 ---
 
@@ -215,6 +240,7 @@ Several core abstractions are defined once and have separate Node and browser im
 - **Generating images from an LLM provider?** → `AiAssist.callProviderImageGeneration({ descriptor, apiKey, params })` from `@fgv/ts-extras/ai-assist`. Use `callProxiedImageGeneration(proxyUrl, ...)` to route through a proxy when direct browser calls are CORS-restricted. Pass top-level options (`size`, `quality`, `seed`, `count`) and a `models` array for provider-specific config blocks.
 - **Declaring image generation capability on a provider?** → Add `imageGeneration: IAiImageModelCapability[]` to `IAiProviderDescriptor`. Each capability entry carries `format` (`'openai-images' | 'xai-images' | 'xai-images-edits' | 'gemini-imagen' | 'gemini-image-out'`), `modelPrefix`, and optional flags like `acceptsImageReferenceInput`, `defaultOutputMimeType`, `outputParamStyle`, `supportsQualityParam`, `maxCount`.
 - **Enabling extended thinking / reasoning on LLM completions?** → Pass `thinking: IThinkingConfig` to `callProviderCompletion` or `callProviderCompletionStream`. `IThinkingConfig` supports a cross-provider generic `effort?: 'low' | 'medium' | 'high'` shorthand and an optional `providers[]` array for per-provider config blocks. Provider-specific types: `IAnthropicThinkingConfig` (effort), `IOpenAiThinkingConfig` (effort, including `'none'` to re-enable temperature), `IGeminiThinkingConfig` (thinkingBudget integer), `IXAiThinkingConfig` (effort). Model-specific and `'other'` escape-hatch blocks let you override for individual models without affecting others. Merge precedence: generic effort → provider-generic blocks → model-specific/other blocks (later declaration wins within a tier). **Temperature + thinking conflicts**: Anthropic and OpenAI (non-`'none'` effort) and xAI return `Result.fail`; Gemini accepts both. Thinking content is discarded in this phase; caller-visible thinking-event surfacing is the scope of the followup stream `ai-assist-thinking-events`. Unknown/unsupported providers silently ignore the `thinking` field.
+- **Running a HuggingFace model locally (text classification / embeddings) with a Result boundary?** → `loadPipeline` + `classify` / `classifyAll` / `embed` from `@fgv/ts-extras-transformers` (Node) or `@fgv/ts-web-extras-transformers` (browser). Thin `Result`-wrapped facade over `@huggingface/transformers` — no caching/device/quantization policy (use the upstream lib directly for that). Use `classifyAll` when you need the full per-label vector (it bakes in `top_k: null`); `embed` returns the raw `Tensor` (pass `{ pooling: 'mean', normalize: true }` for a sentence vector). **In a browser bundle, keep your core facade-agnostic (inject the fn, type-only imports) and load the Node facade only via `import(/* webpackIgnore: true */ ...)` on the CLI path** — see the `samples/testbed` `local-classifier-safety` / `local-embedding-search` scenarios.
 - **Parsing / comparing language tags?** → `@fgv/ts-bcp47`.
 - **Context-conditional resources?** → `@fgv/ts-res`.
 - **Authoring, versioning, or resolving LLM prompts that need to vary on context (tenant / language / tone / region) or compose partial fragments?** → `PromptLibrary.create` from `@fgv/ts-prompt-assist`. One YAML file per `(scope, prompt-id)` carries the descriptor + ts-res-conditional candidates; scope-level `_bindings.yaml` supplies slot bindings; root-level `_qualifiers.yaml` (optional) carries the qualifier config. `PromptLibrary.resolve` chain-walks scopes, runs ts-res candidate selection, merges bindings, renders via Mustache with `escape: 'none'`, and returns body + full `IPromptResolveTrace`. **Do not roll your own LLM-prompt loader / renderer; the verbatim Mustache + double-brace rejection are load-bearing.**

--- a/.ai/tasks/active/local-ai-exploration/phase-b4a-brief.md
+++ b/.ai/tasks/active/local-ai-exploration/phase-b4a-brief.md
@@ -1,0 +1,90 @@
+# B-4a kickoff: ship the transformers facade
+
+**Phase:** B-4a of `local-ai-exploration` (the **SHIP** branch of the done-or-discard gate)
+**Integration branch:** `local-ai-exploration` (off `release`)
+**Work branch:** `claude/local-ai-exploration-b4a`
+**PR target:** `local-ai-exploration`, **NOT** `release` (cluster-close handles promotion)
+
+---
+
+## Why we're here
+
+The B-3 done-or-discard gate decided **SHIP**: the facade read cleaner than raw `pipeline()`, the boundary survived a real composition, and Result/screener composition was natural. Review hardened the story further (the dual-target facade pattern below). B-4a polishes the two transformers facades to ship-quality and proves the boundary survives a **second model type**.
+
+## Scope (four deliverables)
+
+1. **`embed` primitive** in BOTH facades (`@fgv/ts-extras-transformers` Node + `@fgv/ts-web-extras-transformers` browser). Result-wrapped thin facade over `@huggingface/transformers` feature-extraction, mirroring the discipline of `loadPipeline`/`classify` (one-line `captureAsyncResult`, no opinionated orchestration). 100% coverage both packages.
+2. **`classifyAll()` convenience** in BOTH facades — bakes `top_k: null` into the signature so the all-labels path is type-evident (closes the B-3 gap where `top_k: null` was a silent author-side contract). The B-3 classifier scenario should switch to `classifyAll()`.
+3. **Embedding / semantic-search scenario** in `samples/testbed` (OQ-4: the different-model-type proof). Consumes `embed`; demonstrates a feature-extraction model (e.g. `Xenova/all-MiniLM-L6-v2`) producing vectors → cosine-similarity nearest-neighbour over a small in-scenario corpus. Dual web/CLI per the pattern below. 100% coverage; `build:web` must pass.
+4. **`LIBRARY_CAPABILITIES.md` entries** for both facade packages (orchestrator will likely do this at close; agents may draft).
+
+Plus: **change files** for every modified published package; **README "in scope / NOT in scope"** updates for the new primitives.
+
+## The dual-target scenario pattern (MANDATORY — learned in B-3 review)
+
+The testbed bundles for the browser (webpack, `src/web/index.tsx` entry, node modules stubbed). The B-3 review established the canonical pattern any dual web/CLI scenario MUST follow — the embedding scenario is **not** exempt:
+
+- **Scenario core stays facade-agnostic.** Put the reusable logic (e.g. the embed→similarity ranking) in a pure unit that takes the facade function (`embed`) as an **injected parameter** and uses **type-only** facade imports (erased by webpack, pull no runtime facade into the bundle). See `samples/testbed/src/scenarios/localClassifierSafety/classifierScreener.ts` (`ClassifyFn` injection) as the reference.
+- **Web path** imports the **browser** facade (`@fgv/ts-web-extras-transformers`).
+- **CLI path** loads the **Node** facade via `import(/* webpackIgnore: true */ '@fgv/ts-extras-transformers')` inside the `run()` body, so node-native deps never enter the web bundle's static graph.
+- **`build:web` is a hard gate.** `heft build` (tsc) + `heft test` (jsdom, facade mocked) do NOT exercise the real browser bundle. You MUST run `webpack --mode production` (the `build:web` script) and confirm it compiles. B-3's facade defect was latent precisely because this gate was skipped.
+
+## Facade-package note (context, not a task)
+
+B-3 fixed a latent packaging bug in `@fgv/ts-web-extras-transformers`: its `exports` `.` default (browser) condition pointed at a never-emitted `lib/index.browser.js`; it now points at `lib/index.js` (the source is isomorphic — no separate browser build yet). If `embed`/`classifyAll` ever need browser-specific behaviour, that's a real `index.browser.ts` split + a `package.json` `exports` change — **stop and surface**, don't guess.
+
+## Package / file surface (collision map)
+
+In scope:
+- `libraries/ts-extras-transformers/src/**` + tests + README + change file
+- `libraries/ts-web-extras-transformers/src/**` + tests + README + change file
+- `samples/testbed/src/scenarios/<embedding-scenario>/**` + registration in `scenarios/index.ts` + tests + change file
+- `samples/testbed/src/scenarios/localClassifierSafety/**` (switch to `classifyAll()`)
+- `.ai/instructions/LIBRARY_CAPABILITIES.md` (entries; orchestrator may own)
+- `.ai/tasks/active/local-ai-exploration/state.md` + `phase-b4a-result.md` (ledger)
+
+Do NOT touch: `@fgv/ts-prompt-assist`, `ts-app-shell`, any package outside the two facades + testbed (a change there is a stop-and-surface).
+
+## Testing & mocking (mirror B-3)
+
+- `jest.mock(...)` of the facade(s) as the FIRST statements (hoist-jest-mock rule). For the scenario tests, mock the **browser** facade for the component + `web.initialize`, and the **Node** facade (dynamic-import path) for the CLI `run()`.
+- Pure core (the similarity/ranking unit) gets exhaustive unit tests with an injected mock `embed` returning canned vectors. No model download in tests.
+- Component tested via `@testing-library/react` (jsdom IS available — do NOT blanket-`c8 ignore` the component; narrow honest defensive ignores only, per `conventions.md` §4).
+
+## Acceptance gates (hard exit)
+
+- [ ] `rush build` passes full repo
+- [ ] `rushx lint` clean in every modified package (separate gate; run `rushx fixlint` first)
+- [ ] `rushx test` 100% coverage all 4 metrics in every modified package
+- [ ] **`build:web` (production webpack) compiles cleanly** — browser bundle verified, Node facade excluded
+- [ ] No `any`; fallible ops return `Result<T>`; no `Result<void>`; no unsafe casts beyond branded test assertions
+- [ ] Embedding scenario registered; appears in shell; follows the dual-target pattern
+- [ ] B-3 classifier scenario switched to `classifyAll()`
+- [ ] Change files for every modified published package
+- [ ] `embed` + `classifyAll` documented in both READMEs (in-scope / NOT-in-scope lists)
+- [ ] `LIBRARY_CAPABILITIES.md` entries added (or explicitly handed to orchestrator)
+- [ ] `phase-b4a-result.md` written; `state.md` updated
+
+## Stop-and-surface triggers
+
+- The chosen embedding model id doesn't resolve as a transformers.js feature-extraction model, or its output shape doesn't fit a simple vector/cosine approach.
+- `embed`'s upstream output type (Tensor vs nested array) doesn't compose cleanly into the similarity core — surface before casting around it.
+- Either facade needs a genuine browser-specific build (an `index.browser.ts` + `exports` change) — that's a real packaging change, stop and surface.
+- The dual-target pattern can't carry the embedding scenario for some reason — that's signal, surface it.
+
+## Skills to load
+
+| When | Skill |
+|---|---|
+| Writing the facade primitives / Result chains | `/result-pattern` |
+| Writing tests | `/result-tests` |
+| Before reaching for utility code | `/published-primitives-reflex` |
+| Any file I/O (corpus fixtures) | `/filetree-io` |
+| Emitting diagnostics | `/ts-utils-logging` |
+
+## Execution shape (orchestrator-managed)
+
+Commissioned in sequence on `claude/local-ai-exploration-b4a` (dependencies: scenario needs `embed`):
+1. **Facade primitives** — `embed` + `classifyAll()` in both packages, tests, READMEs, change files.
+2. **Embedding scenario** — dual-target, + switch B-3 scenario to `classifyAll()`, + `build:web`.
+3. **Orchestrator** — `LIBRARY_CAPABILITIES.md` entries, final gate, PR to `local-ai-exploration`.

--- a/.ai/tasks/active/local-ai-exploration/phase-b4a-result.md
+++ b/.ai/tasks/active/local-ai-exploration/phase-b4a-result.md
@@ -53,3 +53,11 @@ This confirms the pattern is teachable/repeatable — the second scenario cost f
 
 - Promote `local-ai-exploration` → `release` (cluster-close PR cluster).
 - Possible follow-on (not scheduled): `embedVector()` convenience returning `Result<number[]>` if a second embedding consumer appears.
+
+## Review (PR #409)
+
+Three rounds of Copilot + Erik review, all addressed on-branch (gates re-run green each round):
+- **Result chaining (Erik):** `embedText`, `searchCorpus`, and `handleSearch` refactored from imperative `isFailure()` checks to `withErrorFormat`/`thenOnSuccess`/`onSuccess`/`onFailure` chains.
+- **Doc accuracy (Copilot):** corrected the cosine-range claim (cosine ∈ [−1, 1]; L2 normalization doesn't force [0, 1]) and the sibling element-range claim in the adapter; fixed a stale "sequentially" comment (concurrent `Promise.all`); updated the classifier header-doc example to `classifyAll`.
+- **Coverage annotations (Copilot):** reworded two `c8 ignore` rationales to be definitive (the `?? 'none'` fallback; the `.catch` that is unreachable because `loadPipeline` returns `Result.fail` rather than rejecting).
+- **Test mock (Copilot):** `makeMockTensor.tolist()` typed `number[][]` to reflect the real pooled shape.

--- a/.ai/tasks/active/local-ai-exploration/phase-b4a-result.md
+++ b/.ai/tasks/active/local-ai-exploration/phase-b4a-result.md
@@ -1,0 +1,55 @@
+# B-4a Result: ship the transformers facade
+
+**Branch:** `claude/local-ai-exploration-b4a` → PR to `local-ai-exploration`
+**Outcome:** facade shipped; OQ-4 answered (boundary survives a second model type).
+
+## What shipped
+
+| Deliverable | Where | Notes |
+|---|---|---|
+| `embed` primitive | both facades | `embed(extractor, text, options?) → Promise<Result<Tensor>>`. Thin wrapper; no pooling/normalisation imposed (passed through via `options`). 100% coverage. |
+| `classifyAll()` | both facades | Forces `top_k: null` so the full per-label vector is type-evident. Delegates to `classify`. Closes the B-3 "silent author-side contract" gap. |
+| `local-embedding-search` scenario | `samples/testbed` | `Xenova/all-MiniLM-L6-v2` sentence embeddings → cosine-similarity ranking over a fixed corpus. The OQ-4 second-model-type proof. |
+| B-3 scenario switched to `classifyAll()` | `samples/testbed` | screener drops the explicit `{ top_k: null }`. |
+| `LIBRARY_CAPABILITIES.md` entries | `.ai/instructions/` | facade pair section + decision shortcut + cross-runtime row. |
+| Change files | `common/changes/@fgv/*` | `minor` for both facades; `none` for testbed. api-extractor reports regenerated for both facades. |
+
+## OQ-4 — does the boundary survive a second model type?
+
+**Yes.** The embedding scenario exercises a fundamentally different output shape (a `Tensor` vector, vs the classifier's label-score array) and the facade boundary held:
+
+- `loadPipeline` is already generic over `PipelineType`, so `loadPipeline('feature-extraction', model)` needed no facade change.
+- `embed` returned the upstream `Tensor` cleanly as `Result<Tensor>` with no cast at the facade level.
+- The one friction point is downstream of the facade, in the consumer: `Tensor.tolist()` is typed `any[]` upstream, so the scenario's `embedAdapter` needs a single bounded `as number[][]` cast to extract the sentence vector (shape `[1, D]` from `pooling: 'mean'`). This is a consumer-side extraction detail, documented with the shape rationale + a narrow defensive `c8 ignore` on the structurally-impossible empty case — not a facade defect. A future `embedVector()` convenience that returns `Result<number[]>` could absorb this, but it's out of the minimal-surface scope for now (note for a possible follow-on if a second embedding consumer appears).
+
+## Dual-target pattern reuse (the B-3 lesson held)
+
+The embedding scenario followed the canonical pattern with no rediscovery cost:
+- Facade-agnostic core: `similarity.ts` (pure, no facade dep) + `embedAdapter.ts` (injected `EmbedFn`, type-only facade imports).
+- Web path imports the browser facade; CLI path loads the Node facade via `import(/* webpackIgnore: true */ '@fgv/ts-extras-transformers')`.
+- **`build:web` verified**: production webpack bundle compiles; the Node facade is excluded from the static graph (only the `webpackIgnore` import literal remains).
+
+This confirms the pattern is teachable/repeatable — the second scenario cost far less than the first because the pattern was written down in the B-4a brief.
+
+## Judgment calls
+
+- **`embed` options type:** `FeatureExtractionPipelineOptions` is not exported from `@huggingface/transformers`' top level. Used `Parameters<FeatureExtractionPipeline['_call']>[1]` to surface the correct upstream options type without importing a non-exported symbol.
+- **`embed` return:** raw `Tensor` (no reshaping) — matches the "thin boundary, no opinionated orchestration" discipline.
+- **`classifyAll` naming in the B-3 screener:** the injected option is still named `classify` (typed `ClassifyFn`); it now receives `classifyAll`. Documented rather than renamed (cosmetic; avoids churn).
+
+## Gates
+
+- [x] `rushx build` / `heft build` clean — both facades + testbed
+- [x] `rushx lint` clean — all modified packages
+- [x] `rushx test` 100% coverage all 4 metrics — facades 23 tests each; testbed 111 tests
+- [x] **`build:web` (production webpack) compiles cleanly**; Node facade excluded from the browser bundle
+- [x] `rush build` (full repo) — final gate before PR
+- [x] No `any`; fallible ops return `Result<T>`; no `Result<void>`; one documented bounded cast in the embed adapter (consumer-side Tensor extraction)
+- [x] Embedding scenario registered; snapshot updated to both ids
+- [x] Change files for all modified published packages; api reports regenerated
+- [x] `LIBRARY_CAPABILITIES.md` entries added
+
+## Remaining for cluster close (not B-4a)
+
+- Promote `local-ai-exploration` → `release` (cluster-close PR cluster).
+- Possible follow-on (not scheduled): `embedVector()` convenience returning `Result<number[]>` if a second embedding consumer appears.

--- a/.ai/tasks/active/local-ai-exploration/state.md
+++ b/.ai/tasks/active/local-ai-exploration/state.md
@@ -1,9 +1,9 @@
 # Stream state: `local-ai-exploration`
 
-**Status:** 🟢 B-3 merged; done-or-discard gate → **SHIP**; B-4a in progress
+**Status:** 🟢 B-4a complete (PR open); cluster-close (promotion) next
 **Integration branch:** `local-ai-exploration` (off `release`)
 **B-4a work branch:** `claude/local-ai-exploration-b4a`
-**Last updated:** 2026-05-24 (orchestrator — gate decided, B-4a commissioned)
+**Last updated:** 2026-05-24 (orchestrator — B-4a implemented, embedding scenario + classifyAll/embed shipped)
 
 ---
 
@@ -16,9 +16,9 @@
 | B-2 — Facade primitives | ✅ complete | PR #405. `loadPipeline` + `classify` shipped. `embed` + `generate` deferred. 100% coverage both packages. See `phase-b2-result.md`. |
 | B-3 — First scenario (local classifier → IPromptSafetyPolicy) | ✅ merged | PR #408 (merged → local-ai-exploration as `d85a462e`). 100% coverage; web/Node facade split + `@fgv/ts-web-extras-transformers` `exports` packaging fix landed via review. See `phase-b3-result.md`. |
 | **B-3 exit gate** | ✅ **SHIP** | All three done-or-discard criteria positive (facade cleaner than raw `pipeline()`; boundary survived a real composition; Result/screener composition natural). Hardened under review (dual-target facade pattern). Decision: ship → B-4a. See `phase-b4a-brief.md`. |
-| B-4a — Ship the facade | 🟢 in progress | Branch `claude/local-ai-exploration-b4a`. Scope: `embed` + `classifyAll()` in both facades; embedding/semantic-search scenario (OQ-4 second model type); `LIBRARY_CAPABILITIES.md` entries; promotion-ready. See `phase-b4a-brief.md`. |
+| B-4a — Ship the facade | ✅ complete (PR open) | `embed` + `classifyAll()` in both facades; `local-embedding-search` scenario (OQ-4 ✅ — boundary survived the embedding model type); B-3 switched to `classifyAll()`; `LIBRARY_CAPABILITIES.md` entries. Full `rush build` + `build:web` green; facades 23 tests each, testbed 111 tests, all 100%. See `phase-b4a-result.md`. |
 | ~~B-4b — Pivot to native~~ | ⬛ not taken | Gate decided ship; pivot path discarded. |
-| Cluster close | ⏸ blocked on B-4a | Promotion `local-ai-exploration` → `release`. |
+| Cluster close | 🟢 next | Promotion `local-ai-exploration` → `release` once B-4a PR merges. |
 
 ---
 
@@ -79,6 +79,7 @@
 | 2026-05-23 | B-1 scaffold complete | Three new packages (`@fgv/testbed`, `@fgv/ts-extras-transformers`, `@fgv/ts-web-extras-transformers`) scaffolded empty-but-compilable. Rig + c8-scope + src-layout decisions locked via AskUserQuestion pre-scaffold. 100% coverage on testbed. PR #404. See `phase-b1-result.md` for scaffolding surprises carried into B-2. |
 | 2026-05-23 | B-2 facade primitives complete | `loadPipeline` + `classify` implemented in both transformers packages. `embed` + `generate` deferred. 100% coverage (13 tests each). `@huggingface/transformers` added as runtime dep. `skipLibCheck` required for upstream type-def issues. See `phase-b2-result.md`. |
 | 2026-05-24 | B-3 merged (#408) + gate decided | First scenario merged as `d85a462e`. Review drove the web/Node facade split, a facade-agnostic screener core, and a packaging-bug fix in `@fgv/ts-web-extras-transformers` (`exports` browser target). Done-or-discard gate → **SHIP**. B-4a commissioned. |
+| 2026-05-24 | B-4a implemented | `embed` + `classifyAll()` shipped in both facades (23 tests each, 100%); `local-embedding-search` scenario added + B-3 switched to `classifyAll()` (testbed 111 tests, 100%, `build:web` clean); `LIBRARY_CAPABILITIES.md` entries; full `rush build` green. Two implementing agents (facade primitives; scenario) + orchestrator (caps doc, gates). OQ-4 answered yes. See `phase-b4a-result.md`. |
 
 ---
 
@@ -91,4 +92,4 @@
 | B-1 | #404 | merged to `local-ai-exploration` |
 | B-2 | #405 | merged to `local-ai-exploration` |
 | B-3 | #408 | ✅ merged to `local-ai-exploration` (`d85a462e`) |
-| B-4a | TBD | in progress on `claude/local-ai-exploration-b4a` |
+| B-4a | (PR pending) | open on `claude/local-ai-exploration-b4a` → `local-ai-exploration` |

--- a/.ai/tasks/active/local-ai-exploration/state.md
+++ b/.ai/tasks/active/local-ai-exploration/state.md
@@ -1,8 +1,9 @@
 # Stream state: `local-ai-exploration`
 
-**Status:** 🟢 B-3 complete; awaiting orchestrator done-or-discard gate
+**Status:** 🟢 B-3 merged; done-or-discard gate → **SHIP**; B-4a in progress
 **Integration branch:** `local-ai-exploration` (off `release`)
-**Last updated:** 2026-05-24 (B-3 implementing agent — first scenario complete)
+**B-4a work branch:** `claude/local-ai-exploration-b4a`
+**Last updated:** 2026-05-24 (orchestrator — gate decided, B-4a commissioned)
 
 ---
 
@@ -13,9 +14,11 @@
 | Research | ✅ complete | Local-model incorporation analysis at `.ai/notes/orchestrator/research/local-models-incorporation.md`. Recommendation: Option 2 (Result-shaped facade over `@huggingface/transformers`). Erik merged via #402 onto this branch. |
 | B-1 — Scaffold | ✅ complete | PR #404. Three new packages registered, all gates green, 100% coverage on testbed. See `phase-b1-result.md`. |
 | B-2 — Facade primitives | ✅ complete | PR #405. `loadPipeline` + `classify` shipped. `embed` + `generate` deferred. 100% coverage both packages. See `phase-b2-result.md`. |
-| B-3 — First scenario (local classifier → IPromptSafetyPolicy) | ✅ complete | PR #408 (open, targeting local-ai-exploration). 100% coverage, all gates green. Done-or-discard gate ready for orchestrator. See `phase-b3-result.md`. |
-| B-4a or B-4b — Ship or pivot | ⏸ blocked on B-3 exit | Decided per B-3 evaluation. |
-| Cluster close | ⏸ blocked on B-4 outcome | Promotion `local-ai-exploration` → `release`. |
+| B-3 — First scenario (local classifier → IPromptSafetyPolicy) | ✅ merged | PR #408 (merged → local-ai-exploration as `d85a462e`). 100% coverage; web/Node facade split + `@fgv/ts-web-extras-transformers` `exports` packaging fix landed via review. See `phase-b3-result.md`. |
+| **B-3 exit gate** | ✅ **SHIP** | All three done-or-discard criteria positive (facade cleaner than raw `pipeline()`; boundary survived a real composition; Result/screener composition natural). Hardened under review (dual-target facade pattern). Decision: ship → B-4a. See `phase-b4a-brief.md`. |
+| B-4a — Ship the facade | 🟢 in progress | Branch `claude/local-ai-exploration-b4a`. Scope: `embed` + `classifyAll()` in both facades; embedding/semantic-search scenario (OQ-4 second model type); `LIBRARY_CAPABILITIES.md` entries; promotion-ready. See `phase-b4a-brief.md`. |
+| ~~B-4b — Pivot to native~~ | ⬛ not taken | Gate decided ship; pivot path discarded. |
+| Cluster close | ⏸ blocked on B-4a | Promotion `local-ai-exploration` → `release`. |
 
 ---
 
@@ -38,6 +41,10 @@
 | Testbed rig: Heft dual-rig + webpack hybrid | B-1 implementing agent (2026-05-23) — `samples/ai-image-gen-sample` (named reference) uses webpack-only with no tests, incompatible with the 100%-coverage gate. Adopted `@fgv/heft-dual-rig` (same as `libraries/ts-app-shell`) so heft owns compile/lint/test/api-extractor and a sibling `webpack.config.js` builds the browser bundle. |
 | c8-ignore scope: entry points + generated artifact only | B-1 implementing agent (2026-05-23) — `web/index.tsx` and the `if (require.main === module)` tail of `cli.ts` (orchestration glue with rationale comments), plus `src/generated/` (auto-generated). Everything else at 100% across all four metrics. |
 | src layout: brief's nested form (web/ + cli.ts + shell/ + scenarios/ + generated/) | B-1 implementing agent (2026-05-23) — cleaner web/CLI separation than the flat `src/main.tsx` form `ai-image-gen-sample` uses. |
+| **Done-or-discard gate → SHIP (B-4a)** | Orchestrator (2026-05-24) post-#408-merge. All three criteria positive; B-3 review additionally hardened the facade story (web/Node split via `webpackIgnore`, facade-agnostic screener, packaging-bug fix). No pivot signal. |
+| Dual-target scenario pattern (canonical) | Established in B-3 review: screener/core stays facade-agnostic (injected fn + type-only imports); web path imports the browser facade; CLI path loads the Node facade via `import(/* webpackIgnore: true */ ...)`. B-4a's embedding scenario MUST follow this pattern. |
+| B-4a second scenario = embedding/semantic-search (OQ-4 resolved) | Erik (2026-05-24): exercise a different model *type* (feature-extraction/embeddings, not another classifier) — strongest "boundary survives" evidence. Pulls the deferred `embed` primitive forward. |
+| B-4a adds `classifyAll()` to both facades | Erik (2026-05-24): bake `top_k: null` into the signature so the all-labels path is type-evident (the B-3 gap). B-3 classifier scenario should switch to it. |
 
 ---
 
@@ -50,7 +57,7 @@
 | OQ-1 | Exact facade surface (5-8 ops): naming, signature, browser vs Node behavior differences | B-2 sub-brief |
 | OQ-2 | Whether `loadPipeline` returns an opaque type or a thin Result-wrapped reference to the upstream `Pipeline` | B-2 sub-brief |
 | OQ-3 | Whether the testbed's web shell should support keyboard shortcuts for scenario navigation (ts-app-shell `keyboard` packlet is available) | B-1 sub-brief |
-| OQ-4 | Whether to land a second scenario type at B-4a to confirm facade survives across model types (likely yes if shipping) | B-3 exit gate |
+| ~~OQ-4~~ | ✅ Resolved (2026-05-24): yes — B-4a lands an **embedding/semantic-search** scenario (different model type) to confirm the boundary survives. See decisions log. | ~~B-3 exit gate~~ |
 
 ### Deferred (not this cluster's concern)
 
@@ -71,6 +78,7 @@
 | 2026-05-22 | Substrate prep | Brief + state + WORKSTREAMS + FUTURE absorbs + TECH_DEBT entry for ai-image port. PR #403. |
 | 2026-05-23 | B-1 scaffold complete | Three new packages (`@fgv/testbed`, `@fgv/ts-extras-transformers`, `@fgv/ts-web-extras-transformers`) scaffolded empty-but-compilable. Rig + c8-scope + src-layout decisions locked via AskUserQuestion pre-scaffold. 100% coverage on testbed. PR #404. See `phase-b1-result.md` for scaffolding surprises carried into B-2. |
 | 2026-05-23 | B-2 facade primitives complete | `loadPipeline` + `classify` implemented in both transformers packages. `embed` + `generate` deferred. 100% coverage (13 tests each). `@huggingface/transformers` added as runtime dep. `skipLibCheck` required for upstream type-def issues. See `phase-b2-result.md`. |
+| 2026-05-24 | B-3 merged (#408) + gate decided | First scenario merged as `d85a462e`. Review drove the web/Node facade split, a facade-agnostic screener core, and a packaging-bug fix in `@fgv/ts-web-extras-transformers` (`exports` browser target). Done-or-discard gate → **SHIP**. B-4a commissioned. |
 
 ---
 
@@ -80,7 +88,7 @@
 |---|---|---|
 | Research | #402 | merged to `local-ai-exploration` |
 | Substrate prep | #403 | merged to `local-ai-exploration` |
-| B-1 | #404 | open, targeting `local-ai-exploration` |
-| B-2 | #405 (claude/fervent-hamilton-iuqXX) | open, targeting local-ai-exploration |
-| B-3 | #408 (claude/fervent-hamilton-iuqXX) | open, targeting `local-ai-exploration` |
-| B-4a/b | TBD | gated on B-3 exit |
+| B-1 | #404 | merged to `local-ai-exploration` |
+| B-2 | #405 | merged to `local-ai-exploration` |
+| B-3 | #408 | ✅ merged to `local-ai-exploration` (`d85a462e`) |
+| B-4a | TBD | in progress on `claude/local-ai-exploration-b4a` |

--- a/.ai/tasks/active/local-ai-exploration/state.md
+++ b/.ai/tasks/active/local-ai-exploration/state.md
@@ -3,7 +3,7 @@
 **Status:** 🟢 B-4a complete (PR open); cluster-close (promotion) next
 **Integration branch:** `local-ai-exploration` (off `release`)
 **B-4a work branch:** `claude/local-ai-exploration-b4a`
-**Last updated:** 2026-05-24 (orchestrator — B-4a implemented, embedding scenario + classifyAll/embed shipped)
+**Last updated:** 2026-05-24 (orchestrator — B-4a review rounds addressed; ready to merge)
 
 ---
 
@@ -80,6 +80,7 @@
 | 2026-05-23 | B-2 facade primitives complete | `loadPipeline` + `classify` implemented in both transformers packages. `embed` + `generate` deferred. 100% coverage (13 tests each). `@huggingface/transformers` added as runtime dep. `skipLibCheck` required for upstream type-def issues. See `phase-b2-result.md`. |
 | 2026-05-24 | B-3 merged (#408) + gate decided | First scenario merged as `d85a462e`. Review drove the web/Node facade split, a facade-agnostic screener core, and a packaging-bug fix in `@fgv/ts-web-extras-transformers` (`exports` browser target). Done-or-discard gate → **SHIP**. B-4a commissioned. |
 | 2026-05-24 | B-4a implemented | `embed` + `classifyAll()` shipped in both facades (23 tests each, 100%); `local-embedding-search` scenario added + B-3 switched to `classifyAll()` (testbed 111 tests, 100%, `build:web` clean); `LIBRARY_CAPABILITIES.md` entries; full `rush build` green. Two implementing agents (facade primitives; scenario) + orchestrator (caps doc, gates). OQ-4 answered yes. See `phase-b4a-result.md`. |
+| 2026-05-24 | B-4a review (#409) | Three review rounds (Copilot + Erik) addressed on-branch: Result chaining, doc-accuracy corrections, definitive `c8 ignore` rationales, honest test-mock typing. Gates re-run green each round. Erik to merge. See `phase-b4a-result.md` § Review. |
 
 ---
 

--- a/common/changes/@fgv/testbed/local-ai-exploration-b4a_2026-05-24-00-00.json
+++ b/common/changes/@fgv/testbed/local-ai-exploration-b4a_2026-05-24-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/testbed",
+      "comment": "B-4a: add local-embedding-search scenario (sentence embeddings → cosine-similarity ranking over a fixed corpus via Xenova/all-MiniLM-L6-v2); switch B-3 classifier screener to use classifyAll (top_k: null baked in). 100% coverage all 4 metrics.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/testbed",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-extras-transformers/local-ai-exploration-b4a_2026-05-24-00-00.json
+++ b/common/changes/@fgv/ts-extras-transformers/local-ai-exploration-b4a_2026-05-24-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras-transformers",
+      "comment": "B-4a: add classifyAll (top_k: null convenience wrapper) and embed (FeatureExtractionPipeline Result wrapper returning Tensor) to the Node facade.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-transformers",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-web-extras-transformers/local-ai-exploration-b4a_2026-05-24-00-00.json
+++ b/common/changes/@fgv/ts-web-extras-transformers/local-ai-exploration-b4a_2026-05-24-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-web-extras-transformers",
+      "comment": "B-4a: add classifyAll (top_k: null convenience wrapper) and embed (FeatureExtractionPipeline Result wrapper returning Tensor) to the browser facade.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras-transformers",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras-transformers/README.md
+++ b/libraries/ts-extras-transformers/README.md
@@ -31,19 +31,20 @@ These items were considered and explicitly deferred — use `@huggingface/transf
 - Request batching
 - Pipeline dispose semantics
 
-## Two primitives. Nothing else.
+## Four primitives. Nothing else.
 
 | Function | Return | Wraps |
 |---|---|---|
 | `loadPipeline(task, model?, options?)` | `Promise<Result<AllTasks[T]>>` | `pipeline()` |
 | `classify(pipeline, text, options?)` | `Promise<Result<TextClassificationOutput>>` | `TextClassificationPipeline` call |
+| `classifyAll(pipeline, text, options?)` | `Promise<Result<TextClassificationOutput>>` | `classify` with `top_k: null` forced |
+| `embed(extractor, text, options?)` | `Promise<Result<Tensor>>` | `FeatureExtractionPipeline` call |
 
-**Deferred (not in scope at B-2):**
+**Deferred (not in scope):**
 
 | Function | Rationale |
 |---|---|
-| `embed(pipeline, text, options?)` | No concrete B-3 consumer use case; feature-extraction returns `Tensor`, not `Float32Array` — normalisation adds opinions the boundary should not take. Add at B-4a if B-3 surfaces an embedding scenario. |
-| `generate(pipeline, text, options?)` | No concrete B-3 consumer use case; text-generation output shape is more complex (single/batch/chat variants). Defer until a scenario exercises it. |
+| `generate(pipeline, text, options?)` | No concrete consumer use case; text-generation output shape is more complex (single/batch/chat variants). Defer until a scenario exercises it. |
 
 ---
 

--- a/libraries/ts-extras-transformers/etc/ts-extras-transformers.api.md
+++ b/libraries/ts-extras-transformers/etc/ts-extras-transformers.api.md
@@ -10,6 +10,7 @@ import { pipeline } from '@huggingface/transformers';
 import { PipelineType } from '@huggingface/transformers';
 import { PretrainedModelOptions } from '@huggingface/transformers';
 import { Result } from '@fgv/ts-utils';
+import { Tensor } from '@huggingface/transformers';
 import { TextClassificationOutput } from '@huggingface/transformers';
 import { TextClassificationPipeline } from '@huggingface/transformers';
 
@@ -17,6 +18,12 @@ export { AllTasks }
 
 // @public
 export function classify(classifier: TextClassificationPipeline, text: string, options?: Parameters<TextClassificationPipeline>[1]): Promise<Result<TextClassificationOutput>>;
+
+// @public
+export function classifyAll(classifier: TextClassificationPipeline, text: string, options?: Parameters<TextClassificationPipeline>[1]): Promise<Result<TextClassificationOutput>>;
+
+// @public
+export function embed(extractor: FeatureExtractionPipeline, text: string | string[], options?: Parameters<FeatureExtractionPipeline['_call']>[1]): Promise<Result<Tensor>>;
 
 export { FeatureExtractionPipeline }
 
@@ -26,6 +33,8 @@ export function loadPipeline<T extends PipelineType>(task: T, model?: string, op
 export { PipelineType }
 
 export { PretrainedModelOptions }
+
+export { Tensor }
 
 export { TextClassificationOutput }
 

--- a/libraries/ts-extras-transformers/src/index.ts
+++ b/libraries/ts-extras-transformers/src/index.ts
@@ -6,9 +6,9 @@
  * mirroring the discipline established by `@fgv/ts-extras-webauthn`: one-line `captureAsyncResult`
  * wrappers around upstream primitives with **no opinionated orchestration** above the boundary.
  *
- * **In scope:** `loadPipeline`, `classify` — the minimal surface needed by the B-3 local-classifier
- * scenario. `embed` and `generate` are explicitly deferred until a concrete consumer use case
- * surfaces (see `phase-b2-result.md`).
+ * **In scope:** `loadPipeline`, `classify`, `classifyAll`, `embed` — the surface needed by the
+ * B-3/B-4a local-classifier and embedding scenarios. `generate` is explicitly deferred until a
+ * concrete consumer use case surfaces (see `phase-b2-result.md`).
  *
  * **Explicitly NOT in scope:**
  * - Pipeline cache / lifecycle management
@@ -31,6 +31,7 @@ import {
   type TextClassificationPipeline,
   type TextClassificationOutput,
   type FeatureExtractionPipeline,
+  type Tensor,
   type AllTasks,
   type PipelineType
 } from '@huggingface/transformers';
@@ -40,6 +41,7 @@ export type {
   TextClassificationPipeline,
   TextClassificationOutput,
   FeatureExtractionPipeline,
+  Tensor,
   AllTasks,
   PipelineType
 };
@@ -123,4 +125,55 @@ export async function classify(
     const result = await classifier(text, options);
     return flattenIfNeeded(result);
   });
+}
+
+/**
+ * Convenience wrapper over `classify` that forces `top_k: null` so the full per-label vector
+ * is returned for every call. Callers no longer need to remember to pass `{ top_k: null }`.
+ *
+ * Any caller-supplied options are honoured except `top_k`, which is always overridden to `null`.
+ *
+ * Returns `Promise<Result<TextClassificationOutput>>`; upstream errors are captured as `Failure`
+ * with the original message.
+ *
+ * @param classifier - A `TextClassificationPipeline` obtained from `loadPipeline`.
+ * @param text - The text to classify.
+ * @param options - Optional upstream classification options. `top_k` is always set to `null`
+ *   regardless of any value supplied here.
+ *
+ * @see https://huggingface.co/docs/transformers.js
+ * @public
+ */
+export async function classifyAll(
+  classifier: TextClassificationPipeline,
+  text: string,
+  options?: Parameters<TextClassificationPipeline>[1]
+): Promise<Result<TextClassificationOutput>> {
+  return classify(classifier, text, { ...options, top_k: null });
+}
+
+/**
+ * Result-integration wrapper that invokes a `FeatureExtractionPipeline` on a text input.
+ * Returns the upstream `Tensor` Result-wrapped — no pooling, normalisation, or reshaping is
+ * applied. Callers receive the raw output and are responsible for any downstream processing.
+ *
+ * Callers should retrieve the extractor via `loadPipeline('feature-extraction', modelId)`.
+ *
+ * Returns `Promise<Result<Tensor>>`; upstream errors (inference failures, tokenisation errors)
+ * are captured as `Failure` with the original message.
+ *
+ * @param extractor - A `FeatureExtractionPipeline` obtained from `loadPipeline`.
+ * @param text - The text (or texts) to embed.
+ * @param options - Optional upstream feature-extraction options (e.g. `pooling`, `normalize`).
+ *   Passed through verbatim to the pipeline call.
+ *
+ * @see https://huggingface.co/docs/transformers.js
+ * @public
+ */
+export async function embed(
+  extractor: FeatureExtractionPipeline,
+  text: string | string[],
+  options?: Parameters<FeatureExtractionPipeline['_call']>[1]
+): Promise<Result<Tensor>> {
+  return captureAsyncResult(() => extractor(text, options));
 }

--- a/libraries/ts-extras-transformers/src/test/unit/transformers.test.ts
+++ b/libraries/ts-extras-transformers/src/test/unit/transformers.test.ts
@@ -5,8 +5,12 @@ import * as upstream from '@huggingface/transformers';
 import {
   loadPipeline,
   classify,
+  classifyAll,
+  embed,
   type TextClassificationPipeline,
   type TextClassificationOutput,
+  type FeatureExtractionPipeline,
+  type Tensor,
   type AllTasks
 } from '../../index';
 
@@ -141,6 +145,123 @@ describe('classify', () => {
     mockClassifier.mockRejectedValueOnce(new Error('Tokenisation failed: unexpected token'));
 
     const result = await classify(mockClassifier, 'bad input');
+    expect(result).toFailWith(/tokenisation failed/i);
+  });
+});
+
+// ─── classifyAll ──────────────────────────────────────────────────────────────
+
+describe('classifyAll', () => {
+  let mockClassifier: jest.MockedFunction<TextClassificationPipeline>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockClassifier = jest.fn() as unknown as jest.MockedFunction<TextClassificationPipeline>;
+  });
+
+  test('forces top_k: null on the underlying classify call', async () => {
+    const mockOutput: TextClassificationOutput = [
+      { label: 'POSITIVE', score: 0.9998 },
+      { label: 'NEGATIVE', score: 0.0002 }
+    ];
+    mockClassifier.mockResolvedValueOnce(mockOutput);
+
+    await classifyAll(mockClassifier, 'hello');
+    expect(mockClassifier).toHaveBeenCalledWith('hello', { top_k: null });
+  });
+
+  test('overrides caller-supplied top_k with null', async () => {
+    const mockOutput: TextClassificationOutput = [
+      { label: 'POSITIVE', score: 0.9998 },
+      { label: 'NEGATIVE', score: 0.0002 }
+    ];
+    mockClassifier.mockResolvedValueOnce(mockOutput);
+
+    await classifyAll(mockClassifier, 'hello', { top_k: 1 });
+    expect(mockClassifier).toHaveBeenCalledWith('hello', { top_k: null });
+  });
+
+  test('returns all labels on success', async () => {
+    const mockOutput: TextClassificationOutput = [
+      { label: 'POSITIVE', score: 0.9998 },
+      { label: 'NEGATIVE', score: 0.0002 }
+    ];
+    mockClassifier.mockResolvedValueOnce(mockOutput);
+
+    const result = await classifyAll(mockClassifier, 'I love transformers!');
+    expect(result).toSucceedWith(mockOutput);
+  });
+
+  test('propagates upstream inference failure as Failure', async () => {
+    mockClassifier.mockRejectedValueOnce(new Error('Inference session error: out of memory'));
+
+    const result = await classifyAll(mockClassifier, 'some text');
+    expect(result).toFailWith(/inference session error/i);
+  });
+});
+
+// ─── embed ────────────────────────────────────────────────────────────────────
+
+describe('embed', () => {
+  let mockExtractor: jest.MockedFunction<FeatureExtractionPipeline>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockExtractor = jest.fn() as unknown as jest.MockedFunction<FeatureExtractionPipeline>;
+  });
+
+  test('returns Success wrapping the upstream Tensor on success', async () => {
+    const mockTensor = {
+      type: 'float32',
+      data: new Float32Array([0.1, 0.2, 0.3]),
+      dims: [1, 3]
+    } as unknown as Tensor;
+    mockExtractor.mockResolvedValueOnce(mockTensor);
+
+    const result = await embed(mockExtractor, 'This is a test.');
+    expect(result).toSucceedWith(mockTensor);
+  });
+
+  test('passes text to the upstream extractor', async () => {
+    const mockTensor = { type: 'float32', data: new Float32Array([0.1]), dims: [1, 1] } as unknown as Tensor;
+    mockExtractor.mockResolvedValueOnce(mockTensor);
+
+    await embed(mockExtractor, 'hello world');
+    expect(mockExtractor).toHaveBeenCalledWith('hello world', undefined);
+  });
+
+  test('passes string array to the upstream extractor', async () => {
+    const mockTensor = {
+      type: 'float32',
+      data: new Float32Array([0.1, 0.2]),
+      dims: [2, 1]
+    } as unknown as Tensor;
+    mockExtractor.mockResolvedValueOnce(mockTensor);
+
+    await embed(mockExtractor, ['text one', 'text two']);
+    expect(mockExtractor).toHaveBeenCalledWith(['text one', 'text two'], undefined);
+  });
+
+  test('passes options through to the upstream extractor', async () => {
+    const mockTensor = { type: 'float32', data: new Float32Array([0.5]), dims: [1, 1] } as unknown as Tensor;
+    mockExtractor.mockResolvedValueOnce(mockTensor);
+
+    const opts = { pooling: 'mean' as const, normalize: true };
+    await embed(mockExtractor, 'some text', opts);
+    expect(mockExtractor).toHaveBeenCalledWith('some text', opts);
+  });
+
+  test('returns Failure capturing upstream inference error', async () => {
+    mockExtractor.mockRejectedValueOnce(new Error('Inference session error: out of memory'));
+
+    const result = await embed(mockExtractor, 'some text');
+    expect(result).toFailWith(/inference session error/i);
+  });
+
+  test('returns Failure capturing upstream tokenisation error', async () => {
+    mockExtractor.mockRejectedValueOnce(new Error('Tokenisation failed: input too long'));
+
+    const result = await embed(mockExtractor, 'bad input');
     expect(result).toFailWith(/tokenisation failed/i);
   });
 });

--- a/libraries/ts-web-extras-transformers/README.md
+++ b/libraries/ts-web-extras-transformers/README.md
@@ -38,19 +38,20 @@ These items were considered and explicitly deferred — use `@huggingface/transf
 - Pipeline dispose semantics
 - IndexedDB cache configuration
 
-## Two primitives. Nothing else.
+## Four primitives. Nothing else.
 
 | Function | Return | Wraps |
 |---|---|---|
 | `loadPipeline(task, model?, options?)` | `Promise<Result<AllTasks[T]>>` | `pipeline()` |
 | `classify(pipeline, text, options?)` | `Promise<Result<TextClassificationOutput>>` | `TextClassificationPipeline` call |
+| `classifyAll(pipeline, text, options?)` | `Promise<Result<TextClassificationOutput>>` | `classify` with `top_k: null` forced |
+| `embed(extractor, text, options?)` | `Promise<Result<Tensor>>` | `FeatureExtractionPipeline` call |
 
-**Deferred (not in scope at B-2):**
+**Deferred (not in scope):**
 
 | Function | Rationale |
 |---|---|
-| `embed(pipeline, text, options?)` | No concrete B-3 consumer use case; feature-extraction returns `Tensor`, not `Float32Array` — normalisation adds opinions the boundary should not take. Add at B-4a if B-3 surfaces an embedding scenario. |
-| `generate(pipeline, text, options?)` | No concrete B-3 consumer use case; text-generation output shape is more complex (single/batch/chat variants). Defer until a scenario exercises it. |
+| `generate(pipeline, text, options?)` | No concrete consumer use case; text-generation output shape is more complex (single/batch/chat variants). Defer until a scenario exercises it. |
 
 ---
 

--- a/libraries/ts-web-extras-transformers/etc/ts-web-extras-transformers.api.md
+++ b/libraries/ts-web-extras-transformers/etc/ts-web-extras-transformers.api.md
@@ -10,6 +10,7 @@ import { pipeline } from '@huggingface/transformers';
 import { PipelineType } from '@huggingface/transformers';
 import { PretrainedModelOptions } from '@huggingface/transformers';
 import { Result } from '@fgv/ts-utils';
+import { Tensor } from '@huggingface/transformers';
 import { TextClassificationOutput } from '@huggingface/transformers';
 import { TextClassificationPipeline } from '@huggingface/transformers';
 
@@ -17,6 +18,12 @@ export { AllTasks }
 
 // @public
 export function classify(classifier: TextClassificationPipeline, text: string, options?: Parameters<TextClassificationPipeline>[1]): Promise<Result<TextClassificationOutput>>;
+
+// @public
+export function classifyAll(classifier: TextClassificationPipeline, text: string, options?: Parameters<TextClassificationPipeline>[1]): Promise<Result<TextClassificationOutput>>;
+
+// @public
+export function embed(extractor: FeatureExtractionPipeline, text: string | string[], options?: Parameters<FeatureExtractionPipeline['_call']>[1]): Promise<Result<Tensor>>;
 
 export { FeatureExtractionPipeline }
 
@@ -26,6 +33,8 @@ export function loadPipeline<T extends PipelineType>(task: T, model?: string, op
 export { PipelineType }
 
 export { PretrainedModelOptions }
+
+export { Tensor }
 
 export { TextClassificationOutput }
 

--- a/libraries/ts-web-extras-transformers/src/index.ts
+++ b/libraries/ts-web-extras-transformers/src/index.ts
@@ -14,9 +14,9 @@
  * discipline: separate entry points preserve tree-shaking and allow divergence at B-4a if
  * browser-specific options surface (e.g. WebGPU device hints, IndexedDB cache configuration).
  *
- * **In scope:** `loadPipeline`, `classify` — the minimal surface needed by the B-3 local-classifier
- * scenario. `embed` and `generate` are explicitly deferred until a concrete consumer use case
- * surfaces (see `phase-b2-result.md`).
+ * **In scope:** `loadPipeline`, `classify`, `classifyAll`, `embed` — the surface needed by the
+ * B-3/B-4a local-classifier and embedding scenarios. `generate` is explicitly deferred until a
+ * concrete consumer use case surfaces (see `phase-b2-result.md`).
  *
  * **Explicitly NOT in scope:**
  * - Pipeline cache / lifecycle management
@@ -40,6 +40,7 @@ import {
   type TextClassificationPipeline,
   type TextClassificationOutput,
   type FeatureExtractionPipeline,
+  type Tensor,
   type AllTasks,
   type PipelineType
 } from '@huggingface/transformers';
@@ -49,6 +50,7 @@ export type {
   TextClassificationPipeline,
   TextClassificationOutput,
   FeatureExtractionPipeline,
+  Tensor,
   AllTasks,
   PipelineType
 };
@@ -139,4 +141,58 @@ export async function classify(
     const result = await classifier(text, options);
     return flattenIfNeeded(result);
   });
+}
+
+/**
+ * Convenience wrapper over `classify` that forces `top_k: null` so the full per-label vector
+ * is returned for every call. Callers no longer need to remember to pass `{ top_k: null }`.
+ *
+ * Any caller-supplied options are honoured except `top_k`, which is always overridden to `null`.
+ *
+ * Returns `Promise<Result<TextClassificationOutput>>`; upstream errors are captured as `Failure`
+ * with the original message.
+ *
+ * @param classifier - A `TextClassificationPipeline` obtained from `loadPipeline`.
+ * @param text - The text to classify.
+ * @param options - Optional upstream classification options. `top_k` is always set to `null`
+ *   regardless of any value supplied here.
+ *
+ * @see https://huggingface.co/docs/transformers.js
+ * @public
+ */
+export async function classifyAll(
+  classifier: TextClassificationPipeline,
+  text: string,
+  options?: Parameters<TextClassificationPipeline>[1]
+): Promise<Result<TextClassificationOutput>> {
+  return classify(classifier, text, { ...options, top_k: null });
+}
+
+/**
+ * Result-integration wrapper that invokes a `FeatureExtractionPipeline` on a text input for
+ * browser consumers.
+ *
+ * Returns the upstream `Tensor` Result-wrapped — no pooling, normalisation, or reshaping is
+ * applied. Callers receive the raw output and are responsible for any downstream processing.
+ *
+ * Callers should retrieve the extractor via `loadPipeline('feature-extraction', modelId)`. The
+ * upstream library automatically uses the ONNX web backend and WebGPU when available.
+ *
+ * Returns `Promise<Result<Tensor>>`; upstream errors (inference failures, tokenisation errors)
+ * are captured as `Failure` with the original message.
+ *
+ * @param extractor - A `FeatureExtractionPipeline` obtained from `loadPipeline`.
+ * @param text - The text (or texts) to embed.
+ * @param options - Optional upstream feature-extraction options (e.g. `pooling`, `normalize`).
+ *   Passed through verbatim to the pipeline call.
+ *
+ * @see https://huggingface.co/docs/transformers.js
+ * @public
+ */
+export async function embed(
+  extractor: FeatureExtractionPipeline,
+  text: string | string[],
+  options?: Parameters<FeatureExtractionPipeline['_call']>[1]
+): Promise<Result<Tensor>> {
+  return captureAsyncResult(() => extractor(text, options));
 }

--- a/libraries/ts-web-extras-transformers/src/test/unit/transformers.test.ts
+++ b/libraries/ts-web-extras-transformers/src/test/unit/transformers.test.ts
@@ -5,8 +5,12 @@ import * as upstream from '@huggingface/transformers';
 import {
   loadPipeline,
   classify,
+  classifyAll,
+  embed,
   type TextClassificationPipeline,
   type TextClassificationOutput,
+  type FeatureExtractionPipeline,
+  type Tensor,
   type AllTasks
 } from '../../index';
 
@@ -141,6 +145,123 @@ describe('classify', () => {
     mockClassifier.mockRejectedValueOnce(new Error('Tokenisation failed: unexpected token'));
 
     const result = await classify(mockClassifier, 'bad input');
+    expect(result).toFailWith(/tokenisation failed/i);
+  });
+});
+
+// ─── classifyAll ──────────────────────────────────────────────────────────────
+
+describe('classifyAll', () => {
+  let mockClassifier: jest.MockedFunction<TextClassificationPipeline>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockClassifier = jest.fn() as unknown as jest.MockedFunction<TextClassificationPipeline>;
+  });
+
+  test('forces top_k: null on the underlying classify call', async () => {
+    const mockOutput: TextClassificationOutput = [
+      { label: 'POSITIVE', score: 0.9998 },
+      { label: 'NEGATIVE', score: 0.0002 }
+    ];
+    mockClassifier.mockResolvedValueOnce(mockOutput);
+
+    await classifyAll(mockClassifier, 'hello');
+    expect(mockClassifier).toHaveBeenCalledWith('hello', { top_k: null });
+  });
+
+  test('overrides caller-supplied top_k with null', async () => {
+    const mockOutput: TextClassificationOutput = [
+      { label: 'POSITIVE', score: 0.9998 },
+      { label: 'NEGATIVE', score: 0.0002 }
+    ];
+    mockClassifier.mockResolvedValueOnce(mockOutput);
+
+    await classifyAll(mockClassifier, 'hello', { top_k: 1 });
+    expect(mockClassifier).toHaveBeenCalledWith('hello', { top_k: null });
+  });
+
+  test('returns all labels on success', async () => {
+    const mockOutput: TextClassificationOutput = [
+      { label: 'POSITIVE', score: 0.9998 },
+      { label: 'NEGATIVE', score: 0.0002 }
+    ];
+    mockClassifier.mockResolvedValueOnce(mockOutput);
+
+    const result = await classifyAll(mockClassifier, 'I love transformers!');
+    expect(result).toSucceedWith(mockOutput);
+  });
+
+  test('propagates upstream inference failure as Failure', async () => {
+    mockClassifier.mockRejectedValueOnce(new Error('Inference session error: out of memory'));
+
+    const result = await classifyAll(mockClassifier, 'some text');
+    expect(result).toFailWith(/inference session error/i);
+  });
+});
+
+// ─── embed ────────────────────────────────────────────────────────────────────
+
+describe('embed', () => {
+  let mockExtractor: jest.MockedFunction<FeatureExtractionPipeline>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockExtractor = jest.fn() as unknown as jest.MockedFunction<FeatureExtractionPipeline>;
+  });
+
+  test('returns Success wrapping the upstream Tensor on success', async () => {
+    const mockTensor = {
+      type: 'float32',
+      data: new Float32Array([0.1, 0.2, 0.3]),
+      dims: [1, 3]
+    } as unknown as Tensor;
+    mockExtractor.mockResolvedValueOnce(mockTensor);
+
+    const result = await embed(mockExtractor, 'This is a test.');
+    expect(result).toSucceedWith(mockTensor);
+  });
+
+  test('passes text to the upstream extractor', async () => {
+    const mockTensor = { type: 'float32', data: new Float32Array([0.1]), dims: [1, 1] } as unknown as Tensor;
+    mockExtractor.mockResolvedValueOnce(mockTensor);
+
+    await embed(mockExtractor, 'hello world');
+    expect(mockExtractor).toHaveBeenCalledWith('hello world', undefined);
+  });
+
+  test('passes string array to the upstream extractor', async () => {
+    const mockTensor = {
+      type: 'float32',
+      data: new Float32Array([0.1, 0.2]),
+      dims: [2, 1]
+    } as unknown as Tensor;
+    mockExtractor.mockResolvedValueOnce(mockTensor);
+
+    await embed(mockExtractor, ['text one', 'text two']);
+    expect(mockExtractor).toHaveBeenCalledWith(['text one', 'text two'], undefined);
+  });
+
+  test('passes options through to the upstream extractor', async () => {
+    const mockTensor = { type: 'float32', data: new Float32Array([0.5]), dims: [1, 1] } as unknown as Tensor;
+    mockExtractor.mockResolvedValueOnce(mockTensor);
+
+    const opts = { pooling: 'mean' as const, normalize: true };
+    await embed(mockExtractor, 'some text', opts);
+    expect(mockExtractor).toHaveBeenCalledWith('some text', opts);
+  });
+
+  test('returns Failure capturing upstream inference error', async () => {
+    mockExtractor.mockRejectedValueOnce(new Error('Inference session error: out of memory'));
+
+    const result = await embed(mockExtractor, 'some text');
+    expect(result).toFailWith(/inference session error/i);
+  });
+
+  test('returns Failure capturing upstream tokenisation error', async () => {
+    mockExtractor.mockRejectedValueOnce(new Error('Tokenisation failed: input too long'));
+
+    const result = await embed(mockExtractor, 'bad input');
     expect(result).toFailWith(/tokenisation failed/i);
   });
 });

--- a/samples/testbed/src/scenarios/index.ts
+++ b/samples/testbed/src/scenarios/index.ts
@@ -11,9 +11,10 @@
 
 import type { IScenario } from '../shell';
 import { localClassifierSafetyScenario } from './localClassifierSafety';
+import { localEmbeddingSearchScenario } from './localEmbeddingSearch';
 
 /**
  * All scenarios surfaced by the testbed shell (web sidebar + CLI list).
  * @public
  */
-export const scenarios: readonly IScenario[] = [localClassifierSafetyScenario];
+export const scenarios: readonly IScenario[] = [localClassifierSafetyScenario, localEmbeddingSearchScenario];

--- a/samples/testbed/src/scenarios/localClassifierSafety/classifierScreener.ts
+++ b/samples/testbed/src/scenarios/localClassifierSafety/classifierScreener.ts
@@ -22,10 +22,13 @@ import type { TextClassificationPipeline, TextClassificationOutput } from '@fgv/
 import type { ISafeguardFinding, IScreener, IScreenerContext, SlotName } from '@fgv/ts-prompt-assist';
 
 /**
- * The `classify` operation as exposed by either transformers facade
+ * The `classifyAll` operation as exposed by either transformers facade
  * (`@fgv/ts-extras-transformers` for Node, `@fgv/ts-web-extras-transformers` for
  * the browser). Injected into {@link createClassifierScreener} so the screener
  * core depends on neither concrete facade.
+ *
+ * `classifyAll` always returns the full per-label vector (it bakes in `top_k: null`)
+ * so callers do not need to pass `{ top_k: null }` explicitly.
  *
  * @public
  */
@@ -204,9 +207,10 @@ export interface IClassifierScreenerOptions {
    */
   readonly pipeline: TextClassificationPipeline;
   /**
-   * The `classify` function from the active facade — `@fgv/ts-web-extras-transformers`
+   * The `classifyAll` function from the active facade — `@fgv/ts-web-extras-transformers`
    * on the browser, `@fgv/ts-extras-transformers` in Node. Injected (rather than
    * imported) so this core never statically references a runtime facade.
+   * `classifyAll` bakes in `top_k: null` so callers do not need to pass it.
    */
   readonly classify: ClassifyFn;
   /**
@@ -231,8 +235,9 @@ export interface IClassifierScreenerOptions {
  * Mirrors the structure of `createPatternScreener` from `@fgv/ts-prompt-assist`
  * — the canonical built-in screener shape. Key behaviours:
  *
- * - `classify` is called with `{ top_k: null }` to retrieve the full label
- *   vector — this is required for per-label threshold comparison.
+ * - `classify` (expected to be `classifyAll` from the active facade) returns the
+ *   full per-label vector without the caller needing to pass `{ top_k: null }` —
+ *   `classifyAll` bakes that in so per-label threshold comparison always works.
  * - A `classify` failure propagates as `Result.fail()` (operational failure,
  *   not a safeguard finding) per the `IScreener` contract.
  * - An empty `TextClassificationOutput` returns `[]` (no finding).
@@ -242,7 +247,7 @@ export interface IClassifierScreenerOptions {
  * **Facade evaluation note:** the screener body reduces to three lines of
  * fgv-idiomatic chain:
  * ```
- * classify(pipeline, ctx.value, { top_k: null })
+ * classify(pipeline, ctx.value)
  *   .thenOnSuccess(...interpretClassification...)
  * ```
  * vs. the equivalent captureAsyncResult + flattenIfNeeded inline would be
@@ -257,7 +262,7 @@ export function createClassifierScreener(options: IClassifierScreenerOptions): I
   return {
     name,
     screen: async (ctx: IScreenerContext): Promise<Result<ReadonlyArray<ISafeguardFinding>>> => {
-      const classifyResult = await classify(pipeline, ctx.value, { top_k: null });
+      const classifyResult = await classify(pipeline, ctx.value);
       if (classifyResult.isFailure()) {
         return fail(`${name}: classify failed for slot '${ctx.slot.name}': ${classifyResult.message}`);
       }

--- a/samples/testbed/src/scenarios/localClassifierSafety/index.tsx
+++ b/samples/testbed/src/scenarios/localClassifierSafety/index.tsx
@@ -22,7 +22,7 @@
  *
  * The screener body in `classifierScreener.ts` reduces to:
  * ```typescript
- * const result = await classify(pipeline, ctx.value, { top_k: null });
+ * const result = await classifyAll(pipeline, ctx.value); // classifyAll bakes in top_k: null
  * ```
  * vs. the raw equivalent:
  * ```typescript

--- a/samples/testbed/src/scenarios/localClassifierSafety/index.tsx
+++ b/samples/testbed/src/scenarios/localClassifierSafety/index.tsx
@@ -43,7 +43,7 @@ import type { Result } from '@fgv/ts-utils';
 // (WASM ONNX + Web Crypto — no node-native deps). The CLI path uses the Node
 // facade, but loads it via a `webpackIgnore` dynamic import (see `cliImpl.run`)
 // so it never enters the web bundle's static graph.
-import { loadPipeline, classify } from '@fgv/ts-web-extras-transformers';
+import { loadPipeline, classifyAll } from '@fgv/ts-web-extras-transformers';
 import type { TextClassificationPipeline } from '@fgv/ts-web-extras-transformers';
 import {
   Convert,
@@ -206,7 +206,11 @@ function LocalClassifierSafetyComponent({
           setIsLoading(false);
           return;
         }
-        const libResult = await buildPromptLibrary(pipeResult.value, classify, DEFAULT_TOXIC_BERT_THRESHOLDS);
+        const libResult = await buildPromptLibrary(
+          pipeResult.value,
+          classifyAll,
+          DEFAULT_TOXIC_BERT_THRESHOLDS
+        );
         /* c8 ignore next 3 - unmount guard after buildPromptLibrary: requires precise timing (unmount between loadPipeline resolve and buildPromptLibrary resolve) which is not deterministic in jsdom */
         if (!mounted) {
           return;
@@ -380,7 +384,7 @@ const cliImpl: ICliScenarioImpl = {
 
     const libResult = await buildPromptLibrary(
       pipeResult.value,
-      nodeFacade.classify,
+      nodeFacade.classifyAll,
       DEFAULT_TOXIC_BERT_THRESHOLDS
     );
     /* c8 ignore next 3 - buildPromptLibrary fails only if PromptStoreFixture/PromptLibrary.create has a bug; not reachable via mocked loadPipeline tests */

--- a/samples/testbed/src/scenarios/localEmbeddingSearch/embedAdapter.ts
+++ b/samples/testbed/src/scenarios/localEmbeddingSearch/embedAdapter.ts
@@ -73,19 +73,17 @@ export async function embedText(
   text: string,
   embedFn: EmbedFn
 ): Promise<Result<number[]>> {
-  const tensorResult = await embedFn(extractor, text, { pooling: 'mean', normalize: true });
-  if (tensorResult.isFailure()) {
-    return fail(`embed failed for text "${text.slice(0, 40)}…": ${tensorResult.message}`);
-  }
-
-  // tolist() is typed as any[] by the upstream library. The [1, D] Tensor produced
-  // by pooling: 'mean' on a single string returns [[...D floats...]]. The cast to
-  // number[][] is safe given the known output shape.
-  const nested = tensorResult.value.tolist() as number[][];
-  /* c8 ignore next 3 - defensive: tolist() on a valid pooled Tensor always returns a non-empty nested array */
-  if (nested.length === 0 || nested[0] === undefined || nested[0].length === 0) {
-    return fail(`embed produced an empty Tensor for text "${text.slice(0, 40)}…"`);
-  }
-
-  return succeed(nested[0]);
+  return (await embedFn(extractor, text, { pooling: 'mean', normalize: true }))
+    .withErrorFormat((message) => `embed failed for text "${text.slice(0, 40)}…": ${message}`)
+    .onSuccess((tensor) => {
+      // tolist() is typed as any[] by the upstream library. The [1, D] Tensor produced
+      // by pooling: 'mean' on a single string returns [[...D floats...]]. The cast to
+      // number[][] is safe given the known output shape.
+      const nested = tensor.tolist() as number[][];
+      /* c8 ignore next 3 - defensive: tolist() on a valid pooled Tensor always returns a non-empty nested array */
+      if (nested.length === 0 || nested[0] === undefined || nested[0].length === 0) {
+        return fail(`embed produced an empty Tensor for text "${text.slice(0, 40)}…"`);
+      }
+      return succeed(nested[0]);
+    });
 }

--- a/samples/testbed/src/scenarios/localEmbeddingSearch/embedAdapter.ts
+++ b/samples/testbed/src/scenarios/localEmbeddingSearch/embedAdapter.ts
@@ -1,0 +1,91 @@
+/**
+ * Thin embedding adapter — the only facade-touching surface in the scenario.
+ *
+ * Wraps the injected `embed` function (from either `@fgv/ts-extras-transformers`
+ * for Node or `@fgv/ts-web-extras-transformers` for the browser) and extracts a
+ * plain `number[]` from the returned `Tensor`.
+ *
+ * ## Facade agnosticism via injection
+ *
+ * `embedText` takes `embedFn` as a parameter rather than importing either
+ * facade directly. Only type-only imports from `@fgv/ts-web-extras-transformers`
+ * are present here — they are erased at compile time and pull no runtime facade
+ * into the bundle. The web shell passes the browser facade's `embed`; the CLI
+ * shell passes the Node facade's `embed` (loaded via a `webpackIgnore` dynamic
+ * import).
+ *
+ * ## Tensor extraction
+ *
+ * `embed` is called with `{ pooling: 'mean', normalize: true }` so each input
+ * string yields one normalized sentence vector. The resulting Tensor has shape
+ * `[1, D]` for a single string input (batch size 1, D embedding dimensions).
+ * `tensor.tolist()` returns a nested `any[][]`; row 0 (`result[0]`) is the
+ * flat `number[]` vector for the first (and only) sentence.
+ *
+ * `tolist()` is typed as `any[]` by `@huggingface/transformers`. A single
+ * bounded cast to `number[][]` is required to access the inner array; this is
+ * safe because:
+ *  - `pooling: 'mean'` reduces the token dimension → one row per input.
+ *  - `normalize: true` keeps elements in [−1, 1] (in practice [0, 1] for MiniLM).
+ *  - The outer list length equals the number of input strings (1 here).
+ *
+ * @packageDocumentation
+ */
+
+import { Result, fail, succeed } from '@fgv/ts-utils';
+// Type-only imports — erased by the TypeScript compiler; no runtime facade
+// reference enters the web bundle from this module.
+import type { FeatureExtractionPipeline, Tensor } from '@fgv/ts-web-extras-transformers';
+
+/**
+ * The `embed` operation as exposed by either transformers facade.
+ * Injected into {@link embedText} so the adapter core depends on neither
+ * concrete facade at runtime.
+ *
+ * @public
+ */
+export type EmbedFn = (
+  extractor: FeatureExtractionPipeline,
+  text: string | string[],
+  options?: Parameters<FeatureExtractionPipeline['_call']>[1]
+) => Promise<Result<Tensor>>;
+
+/**
+ * Embed a single text string and extract a `number[]` sentence vector.
+ *
+ * Uses `{ pooling: 'mean', normalize: true }` so the Tensor has shape `[1, D]`
+ * and each element is a normalized float. Row 0 of `tolist()` is the vector.
+ *
+ * Returns `Result.fail` when:
+ * - the `embed` call fails (e.g. inference error, model not loaded), or
+ * - `tolist()` does not produce a non-empty nested array (defensive — should
+ *   not occur with a valid `FeatureExtractionPipeline` + `pooling: 'mean'`).
+ *
+ * @param extractor - A `FeatureExtractionPipeline` obtained from `loadPipeline`.
+ * @param text - The text to embed.
+ * @param embedFn - Injected facade function.
+ * @returns The sentence embedding as a `number[]`.
+ *
+ * @public
+ */
+export async function embedText(
+  extractor: FeatureExtractionPipeline,
+  text: string,
+  embedFn: EmbedFn
+): Promise<Result<number[]>> {
+  const tensorResult = await embedFn(extractor, text, { pooling: 'mean', normalize: true });
+  if (tensorResult.isFailure()) {
+    return fail(`embed failed for text "${text.slice(0, 40)}…": ${tensorResult.message}`);
+  }
+
+  // tolist() is typed as any[] by the upstream library. The [1, D] Tensor produced
+  // by pooling: 'mean' on a single string returns [[...D floats...]]. The cast to
+  // number[][] is safe given the known output shape.
+  const nested = tensorResult.value.tolist() as number[][];
+  /* c8 ignore next 3 - defensive: tolist() on a valid pooled Tensor always returns a non-empty nested array */
+  if (nested.length === 0 || nested[0] === undefined || nested[0].length === 0) {
+    return fail(`embed produced an empty Tensor for text "${text.slice(0, 40)}…"`);
+  }
+
+  return succeed(nested[0]);
+}

--- a/samples/testbed/src/scenarios/localEmbeddingSearch/embedAdapter.ts
+++ b/samples/testbed/src/scenarios/localEmbeddingSearch/embedAdapter.ts
@@ -26,7 +26,7 @@
  * bounded cast to `number[][]` is required to access the inner array; this is
  * safe because:
  *  - `pooling: 'mean'` reduces the token dimension → one row per input.
- *  - `normalize: true` keeps elements in [−1, 1] (in practice [0, 1] for MiniLM).
+ *  - `normalize: true` scales the vector to unit length; element values stay in [−1, 1] (and may be negative).
  *  - The outer list length equals the number of input strings (1 here).
  *
  * @packageDocumentation

--- a/samples/testbed/src/scenarios/localEmbeddingSearch/index.tsx
+++ b/samples/testbed/src/scenarios/localEmbeddingSearch/index.tsx
@@ -1,0 +1,301 @@
+/**
+ * B-4a scenario: local embedding-based semantic search.
+ *
+ * Demonstrates a `FeatureExtractionPipeline` (model `Xenova/all-MiniLM-L6-v2`)
+ * producing sentence vectors → cosine-similarity nearest-neighbour ranking over a
+ * small in-scenario corpus. No remote API is required.
+ *
+ * ## Architecture
+ *
+ * Mirrors the B-3 dual-target split exactly:
+ *
+ * - `similarity.ts` — pure ranking math (no facade dependency; trivially unit-tested).
+ * - `embedAdapter.ts` — thin `embedText` adapter that injects `embed` from the active
+ *   facade, extracts a `number[]` from the returned Tensor. Facade-agnostic via
+ *   injection and type-only imports.
+ * - `index.tsx` (this file) — web React component (browser facade) + CLI `run()`
+ *   (Node facade via `webpackIgnore` dynamic import).
+ *
+ * @packageDocumentation
+ */
+
+import React, { useState, useCallback } from 'react';
+import { fail, succeed, mapResults } from '@fgv/ts-utils';
+import type { Result } from '@fgv/ts-utils';
+// Browser facade — WASM ONNX, no node-native deps.
+import { loadPipeline, embed } from '@fgv/ts-web-extras-transformers';
+import type { FeatureExtractionPipeline } from '@fgv/ts-web-extras-transformers';
+
+import type { IScenario, IScenarioContext, IWebScenarioImpl, ICliScenarioImpl } from '../../shell';
+import { embedText } from './embedAdapter';
+import { rankBySimilarity } from './similarity';
+import type { EmbedFn } from './embedAdapter';
+import type { ICorpusEntry, IRankedResult } from './similarity';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** HuggingFace Hub model id for the transformers.js-compatible ONNX export. */
+const MODEL_ID: string = 'Xenova/all-MiniLM-L6-v2';
+
+/**
+ * Fixed in-scenario corpus. Small enough to embed in a few seconds on CPU;
+ * diverse enough to demonstrate meaningful similarity differences.
+ */
+const CORPUS_TEXTS: readonly string[] = [
+  'The quick brown fox jumps over the lazy dog.',
+  'Machine learning models learn patterns from training data.',
+  'Paris is the capital city of France.',
+  'Neural networks are composed of layers of artificial neurons.',
+  'The Eiffel Tower is located in Paris.',
+  'A dog is a domesticated mammal often kept as a pet.',
+  'Gradient descent optimizes model parameters by minimizing a loss function.',
+  'London is the capital of England and the United Kingdom.',
+  'Cats and dogs are popular household pets around the world.',
+  'Transformers revolutionized natural language processing in 2017.'
+];
+
+// ---------------------------------------------------------------------------
+// Module-level pipeline cache (same pattern as B-3)
+// ---------------------------------------------------------------------------
+
+let _cachedExtractor: FeatureExtractionPipeline | undefined;
+
+// ---------------------------------------------------------------------------
+// Shared embedding logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Embed all corpus texts and the query, then rank. Returns a `Result` so the
+ * calling code (web or CLI) stays in the Result-chain idiom.
+ */
+async function searchCorpus(
+  extractor: FeatureExtractionPipeline,
+  embedFn: EmbedFn,
+  query: string
+): Promise<Result<readonly IRankedResult[]>> {
+  // Embed query
+  const queryVecResult = await embedText(extractor, query, embedFn);
+  if (queryVecResult.isFailure()) {
+    return fail(`query embedding failed: ${queryVecResult.message}`);
+  }
+
+  // Embed all corpus texts sequentially (small corpus — parallelism adds noise)
+  const corpusEmbedResults = await Promise.all(
+    CORPUS_TEXTS.map(async (text) => embedText(extractor, text, embedFn))
+  );
+
+  const corpusResult = mapResults(corpusEmbedResults);
+  if (corpusResult.isFailure()) {
+    return fail(`corpus embedding failed: ${corpusResult.message}`);
+  }
+
+  const corpus: ICorpusEntry[] = CORPUS_TEXTS.map((text, i) => ({
+    text,
+    vec: corpusResult.value[i]!
+  }));
+
+  return rankBySimilarity(queryVecResult.value, corpus);
+}
+
+// ---------------------------------------------------------------------------
+// Web component
+// ---------------------------------------------------------------------------
+
+interface ISearchState {
+  readonly query: string;
+  readonly results: readonly IRankedResult[];
+  readonly error?: string;
+}
+
+/**
+ * Web component for the local-embedding-search scenario.
+ *
+ * Accepts a user query string, embeds it and the corpus via the cached
+ * `FeatureExtractionPipeline`, then displays corpus entries ranked by
+ * cosine-similarity score.
+ */
+function LocalEmbeddingSearchComponent({
+  context
+}: {
+  readonly context: IScenarioContext;
+}): React.ReactElement {
+  const [extractor, setExtractor] = React.useState<FeatureExtractionPipeline | null>(null);
+  const [queryText, setQueryText] = useState('');
+  const [searchState, setSearchState] = useState<ISearchState | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load the pipeline on mount (reuse cached instance when initialize() ran first).
+  React.useEffect(() => {
+    let mounted: boolean = true;
+    const pipePromise: Promise<Result<FeatureExtractionPipeline>> =
+      _cachedExtractor !== undefined
+        ? Promise.resolve(succeed(_cachedExtractor))
+        : loadPipeline('feature-extraction', MODEL_ID);
+
+    pipePromise
+      .then((pipeResult) => {
+        if (!mounted) {
+          return;
+        }
+        if (pipeResult.isFailure()) {
+          context.logger.error(`Failed to load model: ${pipeResult.message}`);
+          setIsLoading(false);
+          return;
+        }
+        context.logger.info(`Model ${MODEL_ID} loaded.`);
+        setExtractor(pipeResult.value);
+        setIsLoading(false);
+      })
+      /* c8 ignore next 5 - catch only fires if the then-chain throws synchronously (not from a rejected promise); not reachable in tests */
+      .catch((err: unknown) => {
+        if (mounted) {
+          context.logger.error(`Unexpected error loading model: ${String(err)}`);
+          setIsLoading(false);
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSearch = useCallback(async () => {
+    if (extractor === null || queryText.trim() === '') {
+      return;
+    }
+
+    const rankResult = await searchCorpus(extractor, embed, queryText);
+
+    if (rankResult.isFailure()) {
+      setSearchState({ query: queryText, results: [], error: rankResult.message });
+      context.logger.error(`Search failed: ${rankResult.message}`);
+    } else {
+      setSearchState({ query: queryText, results: rankResult.value });
+      /* c8 ignore next 1 - ?? 'none' only fires for an empty ranked list; CORPUS_TEXTS is always non-empty */
+      context.logger.info(`Search complete. Top result: "${rankResult.value[0]?.text ?? 'none'}"`);
+    }
+  }, [extractor, queryText, context.logger]);
+
+  if (isLoading) {
+    return (
+      <div data-testid="embedding-loading">
+        <p>Loading model {MODEL_ID}…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="embedding-scenario">
+      <div data-testid="embedding-input-area">
+        <label htmlFor="embedding-query">Search query:</label>
+        <input
+          id="embedding-query"
+          data-testid="embedding-query"
+          type="text"
+          value={queryText}
+          onChange={(e) => setQueryText(e.target.value)}
+        />
+        <button data-testid="embedding-search-btn" onClick={handleSearch} disabled={extractor === null}>
+          Search
+        </button>
+      </div>
+      {searchState !== null && (
+        <div data-testid="embedding-results">
+          {searchState.error !== undefined ? (
+            <div data-testid="embedding-error">{searchState.error}</div>
+          ) : (
+            <ol data-testid="embedding-ranked-list">
+              {searchState.results.map((r, i) => (
+                <li key={i} data-testid={`embedding-result-${i}`}>
+                  <span data-testid={`embedding-score-${i}`}>{r.score.toFixed(4)}</span>
+                  {' — '}
+                  <span data-testid={`embedding-text-${i}`}>{r.text}</span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Web impl (IWebScenarioImpl)
+// ---------------------------------------------------------------------------
+
+const webImpl: IWebScenarioImpl = {
+  component: LocalEmbeddingSearchComponent,
+
+  async initialize(context: IScenarioContext): Promise<Result<boolean>> {
+    context.logger.info(`Loading model ${MODEL_ID}…`);
+    const result = await loadPipeline('feature-extraction', MODEL_ID);
+    if (result.isFailure()) {
+      context.logger.error(`Model load failed: ${result.message}`);
+      return fail(`model load failed: ${result.message}`);
+    }
+    _cachedExtractor = result.value;
+    context.logger.info(`Model ${MODEL_ID} ready.`);
+    return succeed(true);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// CLI implementation (ICliScenarioImpl)
+// ---------------------------------------------------------------------------
+
+/** Fixed demo query for the CLI demonstration. */
+const CLI_DEMO_QUERY: string = 'capital cities in Europe';
+
+const cliImpl: ICliScenarioImpl = {
+  async run(context: IScenarioContext): Promise<Result<string>> {
+    context.logger.info(`Loading model ${MODEL_ID} for CLI demo…`);
+    // Load the Node facade lazily so webpack never includes node-native ONNX deps
+    // in the browser bundle. The `webpackIgnore` magic comment is load-bearing.
+    const nodeFacade = await import(/* webpackIgnore: true */ '@fgv/ts-extras-transformers');
+    const pipeResult = await nodeFacade.loadPipeline('feature-extraction', MODEL_ID);
+    if (pipeResult.isFailure()) {
+      return fail(pipeResult.message);
+    }
+
+    const rankResult = await searchCorpus(pipeResult.value, nodeFacade.embed, CLI_DEMO_QUERY);
+    if (rankResult.isFailure()) {
+      return fail(rankResult.message);
+    }
+
+    const lines = rankResult.value.slice(0, 5).map((r, i) => `  ${i + 1}. [${r.score.toFixed(4)}] ${r.text}`);
+
+    return succeed(
+      `B-4a local-embedding-search demo\nQuery: "${CLI_DEMO_QUERY}"\nTop results:\n${lines.join('\n')}`
+    );
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Scenario export
+// ---------------------------------------------------------------------------
+
+/**
+ * `localEmbeddingSearch` scenario: sentence embedding + cosine-similarity ranking
+ * over a fixed corpus using a local `Xenova/all-MiniLM-L6-v2` pipeline.
+ *
+ * @public
+ */
+export const localEmbeddingSearchScenario: IScenario = {
+  id: 'local-embedding-search',
+  title: 'Local Embedding Search',
+  description:
+    'Demonstrates a local `Xenova/all-MiniLM-L6-v2` feature-extraction pipeline ' +
+    'producing sentence vectors → cosine-similarity nearest-neighbour ranking over a ' +
+    'small fixed corpus. No remote API required.',
+  category: 'ai',
+  tags: ['local-ai', 'embeddings', 'semantic-search'],
+  web: webImpl,
+  cli: cliImpl
+};
+
+// Re-export internals for tests (same pattern as B-3).
+export { embedText, rankBySimilarity, searchCorpus, MODEL_ID, CORPUS_TEXTS };
+export { cosineSimilarity } from './similarity';
+export type { EmbedFn, ICorpusEntry, IRankedResult };

--- a/samples/testbed/src/scenarios/localEmbeddingSearch/index.tsx
+++ b/samples/testbed/src/scenarios/localEmbeddingSearch/index.tsx
@@ -75,28 +75,20 @@ async function searchCorpus(
   embedFn: EmbedFn,
   query: string
 ): Promise<Result<readonly IRankedResult[]>> {
-  // Embed query
-  const queryVecResult = await embedText(extractor, query, embedFn);
-  if (queryVecResult.isFailure()) {
-    return fail(`query embedding failed: ${queryVecResult.message}`);
-  }
-
-  // Embed all corpus texts sequentially (small corpus — parallelism adds noise)
-  const corpusEmbedResults = await Promise.all(
-    CORPUS_TEXTS.map(async (text) => embedText(extractor, text, embedFn))
-  );
-
-  const corpusResult = mapResults(corpusEmbedResults);
-  if (corpusResult.isFailure()) {
-    return fail(`corpus embedding failed: ${corpusResult.message}`);
-  }
-
-  const corpus: ICorpusEntry[] = CORPUS_TEXTS.map((text, i) => ({
-    text,
-    vec: corpusResult.value[i]!
-  }));
-
-  return rankBySimilarity(queryVecResult.value, corpus);
+  return (await embedText(extractor, query, embedFn))
+    .withErrorFormat((message) => `query embedding failed: ${message}`)
+    .thenOnSuccess(async (queryVec) => {
+      // Embed all corpus texts concurrently (small fixed corpus).
+      const corpusEmbedResults = await Promise.all(
+        CORPUS_TEXTS.map((text) => embedText(extractor, text, embedFn))
+      );
+      return mapResults(corpusEmbedResults)
+        .withErrorFormat((message) => `corpus embedding failed: ${message}`)
+        .onSuccess((vecs) => {
+          const corpus: ICorpusEntry[] = CORPUS_TEXTS.map((text, i) => ({ text, vec: vecs[i]! }));
+          return rankBySimilarity(queryVec, corpus);
+        });
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -165,16 +157,18 @@ function LocalEmbeddingSearchComponent({
       return;
     }
 
-    const rankResult = await searchCorpus(extractor, embed, queryText);
-
-    if (rankResult.isFailure()) {
-      setSearchState({ query: queryText, results: [], error: rankResult.message });
-      context.logger.error(`Search failed: ${rankResult.message}`);
-    } else {
-      setSearchState({ query: queryText, results: rankResult.value });
-      /* c8 ignore next 1 - ?? 'none' only fires for an empty ranked list; CORPUS_TEXTS is always non-empty */
-      context.logger.info(`Search complete. Top result: "${rankResult.value[0]?.text ?? 'none'}"`);
-    }
+    (await searchCorpus(extractor, embed, queryText))
+      .onSuccess((results) => {
+        setSearchState({ query: queryText, results });
+        /* c8 ignore next 1 - ?? 'none' only fires for an empty ranked list; CORPUS_TEXTS is always non-empty */
+        context.logger.info(`Search complete. Top result: "${results[0]?.text ?? 'none'}"`);
+        return succeed(results);
+      })
+      .onFailure((message) => {
+        setSearchState({ query: queryText, results: [], error: message });
+        context.logger.error(`Search failed: ${message}`);
+        return fail(message);
+      });
   }, [extractor, queryText, context.logger]);
 
   if (isLoading) {

--- a/samples/testbed/src/scenarios/localEmbeddingSearch/index.tsx
+++ b/samples/testbed/src/scenarios/localEmbeddingSearch/index.tsx
@@ -160,7 +160,7 @@ function LocalEmbeddingSearchComponent({
     (await searchCorpus(extractor, embed, queryText))
       .onSuccess((results) => {
         setSearchState({ query: queryText, results });
-        /* c8 ignore next 1 - ?? 'none' only fires for an empty ranked list; CORPUS_TEXTS is always non-empty */
+        /* c8 ignore next 1 - the 'none' fallback is unreachable: a successful ranking over the non-empty CORPUS_TEXTS always has a top entry */
         context.logger.info(`Search complete. Top result: "${results[0]?.text ?? 'none'}"`);
         return succeed(results);
       })

--- a/samples/testbed/src/scenarios/localEmbeddingSearch/index.tsx
+++ b/samples/testbed/src/scenarios/localEmbeddingSearch/index.tsx
@@ -140,7 +140,7 @@ function LocalEmbeddingSearchComponent({
         setExtractor(pipeResult.value);
         setIsLoading(false);
       })
-      /* c8 ignore next 5 - catch only fires if the then-chain throws synchronously (not from a rejected promise); not reachable in tests */
+      /* c8 ignore next 5 - unreachable: the promise never rejects — loadPipeline returns Result.fail rather than throwing, the cached path is Promise.resolve(succeed(...)), and the .then handler only sets state */
       .catch((err: unknown) => {
         if (mounted) {
           context.logger.error(`Unexpected error loading model: ${String(err)}`);

--- a/samples/testbed/src/scenarios/localEmbeddingSearch/similarity.ts
+++ b/samples/testbed/src/scenarios/localEmbeddingSearch/similarity.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure cosine-similarity and nearest-neighbour ranking — no facade dependency.
+ *
+ * This unit is the algorithmic core of the `local-embedding-search` scenario.
+ * It operates entirely on plain `number[]` vectors so it can be exhaustively
+ * unit-tested without any model infrastructure.
+ *
+ * Design choice: `rankBySimilarity` accepts pre-embedded corpus entries so the
+ * caller is responsible for embedding; this keeps the ranking logic trivially
+ * testable and separates the pure-math unit from the facade-touching adapter.
+ *
+ * @packageDocumentation
+ */
+
+import { Result, fail, succeed } from '@fgv/ts-utils';
+
+/**
+ * One entry in the corpus: a text string and its embedding vector.
+ * @public
+ */
+export interface ICorpusEntry {
+  readonly text: string;
+  readonly vec: readonly number[];
+}
+
+/**
+ * One ranked result from {@link rankBySimilarity}: the corpus text and its
+ * cosine-similarity score against the query vector.
+ * @public
+ */
+export interface IRankedResult {
+  readonly text: string;
+  readonly score: number;
+}
+
+/**
+ * Compute the cosine similarity between two equal-length vectors.
+ *
+ * Returns `Result.fail` when the vectors have different dimensions or when either
+ * vector has zero magnitude (preventing division by zero).
+ *
+ * Scores range from −1 (opposite direction) to 1 (identical direction). Normalized
+ * sentence embeddings from `all-MiniLM-L6-v2` always land in [0, 1] because the
+ * model's output vectors point into the positive orthant after normalization.
+ *
+ * @public
+ */
+export function cosineSimilarity(a: readonly number[], b: readonly number[]): Result<number> {
+  if (a.length !== b.length) {
+    return fail(`dimension mismatch: vector a has ${a.length} dimensions, vector b has ${b.length}`);
+  }
+  if (a.length === 0) {
+    return fail('cannot compute cosine similarity of zero-length vectors');
+  }
+
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i]! * b[i]!;
+    magA += a[i]! * a[i]!;
+    magB += b[i]! * b[i]!;
+  }
+
+  const denom = Math.sqrt(magA) * Math.sqrt(magB);
+  if (denom === 0) {
+    return fail('cannot compute cosine similarity: one or both vectors have zero magnitude');
+  }
+
+  return succeed(dot / denom);
+}
+
+/**
+ * Rank all corpus entries by descending cosine similarity to the query vector.
+ *
+ * Returns `Result.fail` if any pair has a dimension mismatch (i.e. the corpus
+ * was embedded with a different model than the query).
+ *
+ * @param queryVec - Embedding of the search query.
+ * @param corpus - Pre-embedded corpus entries. Order is not assumed.
+ * @returns Corpus entries sorted highest-similarity-first.
+ *
+ * @public
+ */
+export function rankBySimilarity(
+  queryVec: readonly number[],
+  corpus: readonly ICorpusEntry[]
+): Result<readonly IRankedResult[]> {
+  const ranked: IRankedResult[] = [];
+
+  for (const entry of corpus) {
+    const simResult = cosineSimilarity(queryVec, entry.vec);
+    if (simResult.isFailure()) {
+      return fail(`failed to rank corpus entry "${entry.text}": ${simResult.message}`);
+    }
+    ranked.push({ text: entry.text, score: simResult.value });
+  }
+
+  ranked.sort((a, b) => b.score - a.score);
+  return succeed(ranked);
+}

--- a/samples/testbed/src/scenarios/localEmbeddingSearch/similarity.ts
+++ b/samples/testbed/src/scenarios/localEmbeddingSearch/similarity.ts
@@ -39,9 +39,10 @@ export interface IRankedResult {
  * Returns `Result.fail` when the vectors have different dimensions or when either
  * vector has zero magnitude (preventing division by zero).
  *
- * Scores range from −1 (opposite direction) to 1 (identical direction). Normalized
- * sentence embeddings from `all-MiniLM-L6-v2` always land in [0, 1] because the
- * model's output vectors point into the positive orthant after normalization.
+ * Scores range from −1 (opposite direction) through 0 (orthogonal) to 1 (identical
+ * direction). L2-normalized sentence embeddings do not constrain the sign — related
+ * text tends to score positive in practice, but negative scores are possible and are
+ * not excluded by normalization.
  *
  * @public
  */

--- a/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
+++ b/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
@@ -3,5 +3,6 @@
 exports[`@fgv/testbed scenario registry registry exposes the expected scenario ids (snapshot) 1`] = `
 Array [
   "local-classifier-safety",
+  "local-embedding-search",
 ]
 `;

--- a/samples/testbed/src/test/unit/scenarios.test.ts
+++ b/samples/testbed/src/test/unit/scenarios.test.ts
@@ -14,4 +14,10 @@ describe('@fgv/testbed scenario registry', () => {
     expect(found).toBeDefined();
     expect(found?.category).toBe('ai');
   });
+
+  test('contains the local-embedding-search scenario', () => {
+    const found = scenarios.find((s) => s.id === 'local-embedding-search');
+    expect(found).toBeDefined();
+    expect(found?.category).toBe('ai');
+  });
 });

--- a/samples/testbed/src/test/unit/scenarios/localClassifierSafety.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/localClassifierSafety.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for the `localClassifierSafety` scenario.
  *
  * `@fgv/ts-extras-transformers` is mocked at module load time (the `jest.mock` call
- * precedes all imports per `@rushstack/hoist-jest-mock`). The `classify` and
+ * precedes all imports per `@rushstack/hoist-jest-mock`). The `classifyAll` and
  * `loadPipeline` exports become `jest.fn()` stubs controlled via `jest.mocked()`.
  * No model download occurs during tests.
  *
@@ -48,13 +48,13 @@ import type { ClassifierThresholdMap } from '../../../scenarios/localClassifierS
 // ---------------------------------------------------------------------------
 
 // Node facade (drives the CLI path via dynamic import; also injected as the
-// screener's `classify` in the facade-agnostic core tests — its concrete origin
+// screener's `classifyAll` in the facade-agnostic core tests — its concrete origin
 // is irrelevant there, it is just a correctly-typed stub).
-const mockClassify = jest.mocked(transformers.classify);
+const mockClassifyAll = jest.mocked(transformers.classifyAll);
 const mockLoadPipeline = jest.mocked(transformers.loadPipeline);
 
 // Browser facade (drives the web component + web.initialize).
-const mockWebClassify = jest.mocked(webTransformers.classify);
+const mockWebClassifyAll = jest.mocked(webTransformers.classifyAll);
 const mockWebLoadPipeline = jest.mocked(webTransformers.loadPipeline);
 
 // ---------------------------------------------------------------------------
@@ -144,7 +144,7 @@ function makeScenarioCtx(): IScenarioContext {
 describe('LocalClassifierSafetyComponent', () => {
   beforeEach(() => {
     mockWebLoadPipeline.mockReset();
-    mockWebClassify.mockReset();
+    mockWebClassifyAll.mockReset();
   });
 
   afterEach(() => {
@@ -236,7 +236,7 @@ describe('LocalClassifierSafetyComponent', () => {
 
   test('handleScreen: returns early when input is empty', async () => {
     mockWebLoadPipeline.mockResolvedValue(succeed(DUMMY_PIPELINE));
-    mockWebClassify.mockResolvedValue(succeed(CLEAN_OUTPUT));
+    mockWebClassifyAll.mockResolvedValue(succeed(CLEAN_OUTPUT));
 
     render(React.createElement(localClassifierSafetyScenario.web!.component, { context: makeScenarioCtx() }));
 
@@ -251,7 +251,7 @@ describe('LocalClassifierSafetyComponent', () => {
 
   test('shows clean verdict after a successful resolve with no findings', async () => {
     mockWebLoadPipeline.mockResolvedValue(succeed(DUMMY_PIPELINE));
-    mockWebClassify.mockResolvedValue(succeed(CLEAN_OUTPUT));
+    mockWebClassifyAll.mockResolvedValue(succeed(CLEAN_OUTPUT));
 
     const ctx = makeScenarioCtx();
     render(React.createElement(localClassifierSafetyScenario.web!.component, { context: ctx }));
@@ -274,7 +274,7 @@ describe('LocalClassifierSafetyComponent', () => {
 
   test('shows findings list after a successful resolve with warn findings', async () => {
     mockWebLoadPipeline.mockResolvedValue(succeed(DUMMY_PIPELINE));
-    mockWebClassify.mockResolvedValue(succeed(WARN_ONLY_OUTPUT));
+    mockWebClassifyAll.mockResolvedValue(succeed(WARN_ONLY_OUTPUT));
 
     const ctx = makeScenarioCtx();
     render(React.createElement(localClassifierSafetyScenario.web!.component, { context: ctx }));
@@ -295,7 +295,7 @@ describe('LocalClassifierSafetyComponent', () => {
 
   test('shows error div when resolve fails (reject disposition)', async () => {
     mockWebLoadPipeline.mockResolvedValue(succeed(DUMMY_PIPELINE));
-    mockWebClassify.mockResolvedValue(succeed(SINGLE_LABEL_TOXIC));
+    mockWebClassifyAll.mockResolvedValue(succeed(SINGLE_LABEL_TOXIC));
 
     const ctx = makeScenarioCtx();
     render(React.createElement(localClassifierSafetyScenario.web!.component, { context: ctx }));
@@ -322,7 +322,7 @@ describe('LocalClassifierSafetyComponent', () => {
 
     // Reset so we can detect if it's called again
     mockWebLoadPipeline.mockReset();
-    mockWebClassify.mockResolvedValue(succeed(CLEAN_OUTPUT));
+    mockWebClassifyAll.mockResolvedValue(succeed(CLEAN_OUTPUT));
 
     render(React.createElement(localClassifierSafetyScenario.web!.component, { context: makeScenarioCtx() }));
 
@@ -510,13 +510,13 @@ describe('interpretClassification', () => {
 
 describe('createClassifierScreener', () => {
   beforeEach(() => {
-    mockClassify.mockReset();
+    mockClassifyAll.mockReset();
   });
 
   test('default name is "local-classifier-screener"', () => {
     const screener = createClassifierScreener({
       pipeline: DUMMY_PIPELINE,
-      classify: mockClassify,
+      classify: mockClassifyAll,
       thresholds: DEFAULT_TOXIC_BERT_THRESHOLDS
     });
     expect(screener.name).toBe('local-classifier-screener');
@@ -525,29 +525,29 @@ describe('createClassifierScreener', () => {
   test('uses the provided name', () => {
     const screener = createClassifierScreener({
       pipeline: DUMMY_PIPELINE,
-      classify: mockClassify,
+      classify: mockClassifyAll,
       thresholds: DEFAULT_TOXIC_BERT_THRESHOLDS,
       name: 'my-screener'
     });
     expect(screener.name).toBe('my-screener');
   });
 
-  test('calls classify with top_k: null', async () => {
-    mockClassify.mockResolvedValue(succeed(CLEAN_OUTPUT));
+  test('calls classifyAll without options (top_k: null is baked in)', async () => {
+    mockClassifyAll.mockResolvedValue(succeed(CLEAN_OUTPUT));
     const screener = createClassifierScreener({
       pipeline: DUMMY_PIPELINE,
-      classify: mockClassify,
+      classify: mockClassifyAll,
       thresholds: DEFAULT_TOXIC_BERT_THRESHOLDS
     });
     await screener.screen(makeCtx('hello'));
-    expect(mockClassify).toHaveBeenCalledWith(DUMMY_PIPELINE, 'hello', { top_k: null });
+    expect(mockClassifyAll).toHaveBeenCalledWith(DUMMY_PIPELINE, 'hello');
   });
 
   test('returns empty findings for clean text', async () => {
-    mockClassify.mockResolvedValue(succeed(CLEAN_OUTPUT));
+    mockClassifyAll.mockResolvedValue(succeed(CLEAN_OUTPUT));
     const screener = createClassifierScreener({
       pipeline: DUMMY_PIPELINE,
-      classify: mockClassify,
+      classify: mockClassifyAll,
       thresholds: DEFAULT_TOXIC_BERT_THRESHOLDS
     });
     const result = await screener.screen(makeCtx('hello'));
@@ -557,10 +557,10 @@ describe('createClassifierScreener', () => {
   });
 
   test('returns a reject finding for toxic text', async () => {
-    mockClassify.mockResolvedValue(succeed(SINGLE_LABEL_TOXIC));
+    mockClassifyAll.mockResolvedValue(succeed(SINGLE_LABEL_TOXIC));
     const screener = createClassifierScreener({
       pipeline: DUMMY_PIPELINE,
-      classify: mockClassify,
+      classify: mockClassifyAll,
       thresholds: DEFAULT_TOXIC_BERT_THRESHOLDS
     });
     const result = await screener.screen(makeCtx('bad text'));
@@ -572,10 +572,10 @@ describe('createClassifierScreener', () => {
   });
 
   test('returns a warn finding for text in the warn band', async () => {
-    mockClassify.mockResolvedValue(succeed(WARN_ONLY_OUTPUT));
+    mockClassifyAll.mockResolvedValue(succeed(WARN_ONLY_OUTPUT));
     const screener = createClassifierScreener({
       pipeline: DUMMY_PIPELINE,
-      classify: mockClassify,
+      classify: mockClassifyAll,
       thresholds: DEFAULT_TOXIC_BERT_THRESHOLDS
     });
     const result = await screener.screen(makeCtx('mildly bad text'));
@@ -586,10 +586,10 @@ describe('createClassifierScreener', () => {
   });
 
   test('propagates classify failure as Result.fail (operational failure)', async () => {
-    mockClassify.mockResolvedValue(fail('model inference error'));
+    mockClassifyAll.mockResolvedValue(fail('model inference error'));
     const screener = createClassifierScreener({
       pipeline: DUMMY_PIPELINE,
-      classify: mockClassify,
+      classify: mockClassifyAll,
       thresholds: DEFAULT_TOXIC_BERT_THRESHOLDS,
       name: 'test-screener'
     });
@@ -598,10 +598,10 @@ describe('createClassifierScreener', () => {
   });
 
   test('handles empty TextClassificationOutput gracefully', async () => {
-    mockClassify.mockResolvedValue(succeed([]));
+    mockClassifyAll.mockResolvedValue(succeed([]));
     const screener = createClassifierScreener({
       pipeline: DUMMY_PIPELINE,
-      classify: mockClassify,
+      classify: mockClassifyAll,
       thresholds: DEFAULT_TOXIC_BERT_THRESHOLDS
     });
     const result = await screener.screen(makeCtx('empty model output'));
@@ -611,10 +611,10 @@ describe('createClassifierScreener', () => {
   });
 
   test('multi-label: returns one reject finding', async () => {
-    mockClassify.mockResolvedValue(succeed(MULTI_LABEL_TOXIC));
+    mockClassifyAll.mockResolvedValue(succeed(MULTI_LABEL_TOXIC));
     const screener = createClassifierScreener({
       pipeline: DUMMY_PIPELINE,
-      classify: mockClassify,
+      classify: mockClassifyAll,
       thresholds: DEFAULT_TOXIC_BERT_THRESHOLDS
     });
     const result = await screener.screen(makeCtx('very bad text'));
@@ -625,10 +625,10 @@ describe('createClassifierScreener', () => {
   });
 
   test('finding carries the screener name', async () => {
-    mockClassify.mockResolvedValue(succeed(SINGLE_LABEL_TOXIC));
+    mockClassifyAll.mockResolvedValue(succeed(SINGLE_LABEL_TOXIC));
     const screener = createClassifierScreener({
       pipeline: DUMMY_PIPELINE,
-      classify: mockClassify,
+      classify: mockClassifyAll,
       thresholds: DEFAULT_TOXIC_BERT_THRESHOLDS,
       name: 'named-screener'
     });
@@ -645,18 +645,18 @@ describe('createClassifierScreener', () => {
 
 describe('buildPromptLibrary + PromptLibrary.resolve (mocked classify)', () => {
   beforeEach(() => {
-    mockClassify.mockReset();
+    mockClassifyAll.mockReset();
   });
 
   test('builds a PromptLibrary successfully', async () => {
-    const result = await buildPromptLibrary(DUMMY_PIPELINE, mockClassify, DEFAULT_TOXIC_BERT_THRESHOLDS);
+    const result = await buildPromptLibrary(DUMMY_PIPELINE, mockClassifyAll, DEFAULT_TOXIC_BERT_THRESHOLDS);
     expect(result).toSucceed();
   });
 
   test('resolve succeeds for clean text', async () => {
-    mockClassify.mockResolvedValue(succeed(CLEAN_OUTPUT));
+    mockClassifyAll.mockResolvedValue(succeed(CLEAN_OUTPUT));
     const lib = (
-      await buildPromptLibrary(DUMMY_PIPELINE, mockClassify, DEFAULT_TOXIC_BERT_THRESHOLDS)
+      await buildPromptLibrary(DUMMY_PIPELINE, mockClassifyAll, DEFAULT_TOXIC_BERT_THRESHOLDS)
     ).orThrow();
     const result = await lib.resolve({
       id: SCENARIO_PROMPT_ID,
@@ -671,9 +671,9 @@ describe('buildPromptLibrary + PromptLibrary.resolve (mocked classify)', () => {
   });
 
   test('resolve surfaces warn findings in trace.safeguardFindings', async () => {
-    mockClassify.mockResolvedValue(succeed(WARN_ONLY_OUTPUT));
+    mockClassifyAll.mockResolvedValue(succeed(WARN_ONLY_OUTPUT));
     const lib = (
-      await buildPromptLibrary(DUMMY_PIPELINE, mockClassify, DEFAULT_TOXIC_BERT_THRESHOLDS)
+      await buildPromptLibrary(DUMMY_PIPELINE, mockClassifyAll, DEFAULT_TOXIC_BERT_THRESHOLDS)
     ).orThrow();
     const result = await lib.resolve({
       id: SCENARIO_PROMPT_ID,
@@ -688,9 +688,9 @@ describe('buildPromptLibrary + PromptLibrary.resolve (mocked classify)', () => {
   });
 
   test('resolve fails with a reject finding for toxic text', async () => {
-    mockClassify.mockResolvedValue(succeed(SINGLE_LABEL_TOXIC));
+    mockClassifyAll.mockResolvedValue(succeed(SINGLE_LABEL_TOXIC));
     const lib = (
-      await buildPromptLibrary(DUMMY_PIPELINE, mockClassify, DEFAULT_TOXIC_BERT_THRESHOLDS)
+      await buildPromptLibrary(DUMMY_PIPELINE, mockClassifyAll, DEFAULT_TOXIC_BERT_THRESHOLDS)
     ).orThrow();
     const result = await lib.resolve({
       id: SCENARIO_PROMPT_ID,
@@ -702,9 +702,9 @@ describe('buildPromptLibrary + PromptLibrary.resolve (mocked classify)', () => {
   });
 
   test('resolve fails when classify returns an error', async () => {
-    mockClassify.mockResolvedValue(fail('inference error'));
+    mockClassifyAll.mockResolvedValue(fail('inference error'));
     const lib = (
-      await buildPromptLibrary(DUMMY_PIPELINE, mockClassify, DEFAULT_TOXIC_BERT_THRESHOLDS)
+      await buildPromptLibrary(DUMMY_PIPELINE, mockClassifyAll, DEFAULT_TOXIC_BERT_THRESHOLDS)
     ).orThrow();
     const result = await lib.resolve({
       id: SCENARIO_PROMPT_ID,
@@ -781,7 +781,7 @@ describe('localClassifierSafetyScenario (IScenario shape)', () => {
 describe('web impl: initialize()', () => {
   beforeEach(() => {
     mockWebLoadPipeline.mockReset();
-    mockWebClassify.mockReset();
+    mockWebClassifyAll.mockReset();
   });
 
   test('initialize succeeds when loadPipeline succeeds', async () => {
@@ -806,13 +806,13 @@ describe('web impl: initialize()', () => {
 describe('cli impl: run()', () => {
   beforeEach(() => {
     mockLoadPipeline.mockReset();
-    mockClassify.mockReset();
+    mockClassifyAll.mockReset();
   });
 
   test('run succeeds when all inputs are clean', async () => {
     mockLoadPipeline.mockResolvedValue(succeed(DUMMY_PIPELINE));
     // All inputs clean
-    mockClassify.mockResolvedValue(succeed(CLEAN_OUTPUT));
+    mockClassifyAll.mockResolvedValue(succeed(CLEAN_OUTPUT));
     const ctx: IScenarioContext = makeScenarioCtx();
     const result = await localClassifierSafetyScenario.cli!.run(ctx);
     expect(result).toSucceedAndSatisfy((summary: string) => {
@@ -824,7 +824,7 @@ describe('cli impl: run()', () => {
   test('run includes REJECTED line when classify returns toxic', async () => {
     mockLoadPipeline.mockResolvedValue(succeed(DUMMY_PIPELINE));
     // First call clean, remainder toxic to demonstrate mixed output
-    mockClassify
+    mockClassifyAll
       .mockResolvedValueOnce(succeed(CLEAN_OUTPUT))
       .mockResolvedValueOnce(succeed(CLEAN_OUTPUT))
       .mockResolvedValueOnce(succeed(WARN_ONLY_OUTPUT))

--- a/samples/testbed/src/test/unit/scenarios/localEmbeddingSearch.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/localEmbeddingSearch.test.ts
@@ -1,0 +1,530 @@
+/**
+ * Unit tests for the `localEmbeddingSearch` scenario.
+ *
+ * Both facades are mocked at module load time (hoisted by `@rushstack/hoist-jest-mock`).
+ * The `embed` and `loadPipeline` exports become `jest.fn()` stubs. No model download
+ * or ONNX inference occurs during these tests.
+ *
+ * Tensor shape: `embed` with `{ pooling: 'mean', normalize: true }` on a single string
+ * produces a `[1, D]` Tensor. `tolist()` on that returns `[[...D floats...]]`. The mock
+ * Tensor returned here has a `tolist()` that returns this nested shape.
+ *
+ * @packageDocumentation
+ */
+
+// jest.mock must precede all imports (hoist-jest-mock rule).
+jest.mock('@fgv/ts-extras-transformers');
+jest.mock('@fgv/ts-web-extras-transformers');
+
+import '@fgv/ts-utils-jest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { fail, succeed } from '@fgv/ts-utils';
+import * as transformers from '@fgv/ts-extras-transformers';
+import * as webTransformers from '@fgv/ts-web-extras-transformers';
+import type { FeatureExtractionPipeline, Tensor } from '@fgv/ts-extras-transformers';
+import type { IScenarioContext } from '../../../shell';
+
+// ---------------------------------------------------------------------------
+// Subject under test (imported after mocks are registered)
+// ---------------------------------------------------------------------------
+
+import {
+  cosineSimilarity,
+  rankBySimilarity,
+  embedText,
+  searchCorpus,
+  MODEL_ID,
+  CORPUS_TEXTS,
+  localEmbeddingSearchScenario
+} from '../../../scenarios/localEmbeddingSearch';
+import type { EmbedFn, ICorpusEntry } from '../../../scenarios/localEmbeddingSearch';
+
+// ---------------------------------------------------------------------------
+// Convenience accessors for mocked functions
+// ---------------------------------------------------------------------------
+
+// Node facade (backs the CLI path via dynamic import).
+const mockEmbed = jest.mocked(transformers.embed);
+const mockLoadPipeline = jest.mocked(transformers.loadPipeline);
+
+// Browser facade (backs the web component + web.initialize).
+const mockWebEmbed = jest.mocked(webTransformers.embed);
+const mockWebLoadPipeline = jest.mocked(webTransformers.loadPipeline);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Dummy pipeline reference (no-op; embed is mocked). */
+const DUMMY_EXTRACTOR = {} as FeatureExtractionPipeline;
+
+/**
+ * Produce a mock `Tensor` whose `tolist()` returns `[[...vec...]]` — the shape
+ * emitted by `embed(text, { pooling: 'mean', normalize: true })` for a single string.
+ */
+function makeMockTensor(vec: number[]): Tensor {
+  return {
+    tolist: () => [vec] as unknown as number[]
+  } as unknown as Tensor;
+}
+
+/** Minimal `IScenarioContext` for web/CLI impl tests. */
+function makeScenarioCtx(): IScenarioContext {
+  return {
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      verbose: jest.fn()
+    } as unknown as IScenarioContext['logger'],
+    keyStore: undefined,
+    resolveSecret: jest.fn(),
+    dataTree: {} as IScenarioContext['dataTree']
+  };
+}
+
+/**
+ * A normalized 3-D unit vector pointing along axis 0.
+ * Two equal vectors → cosine = 1.0; orthogonal vectors → cosine = 0.
+ */
+const VEC_A: number[] = [1, 0, 0];
+const VEC_B: number[] = [0, 1, 0];
+const VEC_C: number[] = [0.707, 0.707, 0]; // ~45° from A and B
+
+// ---------------------------------------------------------------------------
+// cosineSimilarity (pure math — no facade)
+// ---------------------------------------------------------------------------
+
+describe('cosineSimilarity', () => {
+  test('returns 1.0 for identical unit vectors', () => {
+    expect(cosineSimilarity(VEC_A, VEC_A)).toSucceedWith(1);
+  });
+
+  test('returns 0 for orthogonal unit vectors', () => {
+    expect(cosineSimilarity(VEC_A, VEC_B)).toSucceedAndSatisfy((score) => {
+      expect(score).toBeCloseTo(0);
+    });
+  });
+
+  test('returns approximately 0.707 for 45-degree vectors', () => {
+    expect(cosineSimilarity(VEC_A, VEC_C)).toSucceedAndSatisfy((score) => {
+      expect(score).toBeCloseTo(0.707, 2);
+    });
+  });
+
+  test('fails for vectors of different dimensions', () => {
+    expect(cosineSimilarity([1, 0], [1, 0, 0])).toFailWith(/dimension mismatch/i);
+  });
+
+  test('fails for zero-length vectors', () => {
+    expect(cosineSimilarity([], [])).toFailWith(/zero-length/i);
+  });
+
+  test('fails when a vector has zero magnitude', () => {
+    expect(cosineSimilarity([0, 0, 0], [1, 0, 0])).toFailWith(/zero magnitude/i);
+  });
+
+  test('symmetric: sim(a, b) === sim(b, a)', () => {
+    const ab = cosineSimilarity(VEC_A, VEC_C).orThrow();
+    const ba = cosineSimilarity(VEC_C, VEC_A).orThrow();
+    expect(ab).toBeCloseTo(ba);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rankBySimilarity (pure — no facade)
+// ---------------------------------------------------------------------------
+
+describe('rankBySimilarity', () => {
+  const corpus: ICorpusEntry[] = [
+    { text: 'alpha', vec: VEC_A },
+    { text: 'beta', vec: VEC_B },
+    { text: 'gamma', vec: VEC_C }
+  ];
+
+  test('returns corpus entries sorted by descending similarity', () => {
+    // Query is VEC_A: similarity to alpha=1, gamma≈0.707, beta=0.
+    expect(rankBySimilarity(VEC_A, corpus)).toSucceedAndSatisfy((results) => {
+      expect(results[0]!.text).toBe('alpha');
+      expect(results[0]!.score).toBeCloseTo(1);
+      expect(results[1]!.text).toBe('gamma');
+      expect(results[2]!.text).toBe('beta');
+    });
+  });
+
+  test('returns empty array for empty corpus', () => {
+    expect(rankBySimilarity(VEC_A, [])).toSucceedAndSatisfy((results) => {
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  test('fails when corpus entry has dimension mismatch', () => {
+    const badCorpus: ICorpusEntry[] = [{ text: 'bad', vec: [1, 0] }];
+    expect(rankBySimilarity(VEC_A, badCorpus)).toFailWith(/dimension mismatch/i);
+  });
+
+  test('propagates dimension-mismatch error with corpus entry text', () => {
+    const badCorpus: ICorpusEntry[] = [{ text: 'the-bad-entry', vec: [1, 0] }];
+    expect(rankBySimilarity(VEC_A, badCorpus)).toFailWith(/the-bad-entry/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// embedText (adapter — facade injected)
+// ---------------------------------------------------------------------------
+
+describe('embedText', () => {
+  const mockEmbedFn: EmbedFn = jest.fn();
+
+  beforeEach(() => {
+    (mockEmbedFn as jest.Mock).mockReset();
+  });
+
+  test('calls embedFn with mean pooling and normalization options', async () => {
+    const tensor = makeMockTensor(VEC_A);
+    (mockEmbedFn as jest.Mock).mockResolvedValue(succeed(tensor));
+
+    await embedText(DUMMY_EXTRACTOR, 'hello world', mockEmbedFn);
+
+    expect(mockEmbedFn).toHaveBeenCalledWith(DUMMY_EXTRACTOR, 'hello world', {
+      pooling: 'mean',
+      normalize: true
+    });
+  });
+
+  test('returns the number[] row from tolist()[0]', async () => {
+    const tensor = makeMockTensor(VEC_A);
+    (mockEmbedFn as jest.Mock).mockResolvedValue(succeed(tensor));
+
+    expect(await embedText(DUMMY_EXTRACTOR, 'hello', mockEmbedFn)).toSucceedAndSatisfy((vec) => {
+      expect(vec).toEqual(VEC_A);
+    });
+  });
+
+  test('propagates embed failure as Result.fail', async () => {
+    (mockEmbedFn as jest.Mock).mockResolvedValue(fail('inference error'));
+
+    expect(await embedText(DUMMY_EXTRACTOR, 'hello', mockEmbedFn)).toFailWith(/inference error/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchCorpus (integration-level, mocked embed)
+// ---------------------------------------------------------------------------
+
+describe('searchCorpus', () => {
+  beforeEach(() => {
+    mockEmbed.mockReset();
+  });
+
+  test('ranks corpus entries by similarity to the query', async () => {
+    // Query → VEC_A; corpus items get sequentially increasing vectors.
+    // Call order: 1 query + CORPUS_TEXTS.length corpus calls.
+    // Query is first.
+    let callCount = 0;
+    mockEmbed.mockImplementation(async () => {
+      const idx = callCount++;
+      // query → VEC_A; all corpus items → VEC_B (for simplicity)
+      const vec = idx === 0 ? VEC_A : VEC_B;
+      return succeed(makeMockTensor(vec));
+    });
+
+    const result = await searchCorpus(DUMMY_EXTRACTOR, mockEmbed, 'test query');
+    expect(result).toSucceedAndSatisfy((ranked) => {
+      expect(ranked.length).toBe(CORPUS_TEXTS.length);
+      // All corpus entries should have equal similarity (all VEC_B vs query VEC_A ≈ 0).
+      expect(ranked[0]!.score).toBeCloseTo(0);
+    });
+  });
+
+  test('fails when query embedding fails', async () => {
+    mockEmbed.mockResolvedValue(fail('model not loaded'));
+
+    const result = await searchCorpus(DUMMY_EXTRACTOR, mockEmbed, 'query');
+    expect(result).toFailWith(/model not loaded/i);
+  });
+
+  test('fails when a corpus embedding fails', async () => {
+    // First call (query) succeeds; second call (first corpus entry) fails.
+    mockEmbed
+      .mockResolvedValueOnce(succeed(makeMockTensor(VEC_A)))
+      .mockResolvedValue(fail('corpus embed error'));
+
+    const result = await searchCorpus(DUMMY_EXTRACTOR, mockEmbed, 'query');
+    expect(result).toFailWith(/corpus embed error/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LocalEmbeddingSearchComponent (web component tests via @testing-library/react)
+// NOTE: These tests must come before initialize() is called so _cachedExtractor
+// is undefined for the uncached-path test.
+// ---------------------------------------------------------------------------
+
+describe('LocalEmbeddingSearchComponent', () => {
+  beforeEach(() => {
+    mockWebLoadPipeline.mockReset();
+    mockWebEmbed.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('shows loading state on initial render before pipeline resolves', async () => {
+    let resolvePipeline!: (v: unknown) => void;
+    mockWebLoadPipeline.mockReturnValue(
+      new Promise<unknown>((resolve) => {
+        resolvePipeline = resolve;
+      }) as ReturnType<typeof mockWebLoadPipeline>
+    );
+
+    render(React.createElement(localEmbeddingSearchScenario.web!.component, { context: makeScenarioCtx() }));
+
+    expect(screen.getByTestId('embedding-loading')).not.toBeNull();
+
+    // Resolve to avoid open handles
+    resolvePipeline(succeed(DUMMY_EXTRACTOR));
+    await waitFor(() => screen.getByTestId('embedding-scenario'));
+  });
+
+  test('unmount guard: component unmounted before pipeline resolves does not set state', async () => {
+    let resolvePipeline!: (v: unknown) => void;
+    mockWebLoadPipeline.mockReturnValue(
+      new Promise<unknown>((resolve) => {
+        resolvePipeline = resolve;
+      }) as ReturnType<typeof mockWebLoadPipeline>
+    );
+
+    const { unmount } = render(
+      React.createElement(localEmbeddingSearchScenario.web!.component, { context: makeScenarioCtx() })
+    );
+
+    unmount();
+
+    resolvePipeline(succeed(DUMMY_EXTRACTOR));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Passes if no "can't perform state update on unmounted component" error fires.
+  });
+
+  test('uncached path: calls loadPipeline and renders scenario UI after success', async () => {
+    mockWebLoadPipeline.mockResolvedValue(succeed(DUMMY_EXTRACTOR));
+
+    render(React.createElement(localEmbeddingSearchScenario.web!.component, { context: makeScenarioCtx() }));
+
+    await waitFor(() => screen.getByTestId('embedding-scenario'));
+    expect(mockWebLoadPipeline).toHaveBeenCalledWith('feature-extraction', MODEL_ID);
+    expect(screen.getByTestId('embedding-search-btn')).not.toBeNull();
+  });
+
+  test('shows non-loading state (extractor=null) when loadPipeline fails', async () => {
+    mockWebLoadPipeline.mockResolvedValue(fail('model not found'));
+
+    const ctx = makeScenarioCtx();
+    render(React.createElement(localEmbeddingSearchScenario.web!.component, { context: ctx }));
+
+    await waitFor(() => screen.getByTestId('embedding-scenario'));
+    expect(
+      (ctx.logger.error as jest.Mock).mock.calls.some((c: unknown[]) =>
+        String(c[0]).includes('model not found')
+      )
+    ).toBe(true);
+    expect((screen.getByTestId('embedding-search-btn') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('handleSearch: returns early when extractor is null (loadPipeline failed)', async () => {
+    mockWebLoadPipeline.mockResolvedValue(fail('no model'));
+
+    render(React.createElement(localEmbeddingSearchScenario.web!.component, { context: makeScenarioCtx() }));
+
+    await waitFor(() => screen.getByTestId('embedding-scenario'));
+
+    const input = screen.getByTestId('embedding-query') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'test query' } });
+    fireEvent.click(screen.getByTestId('embedding-search-btn'));
+
+    // No results div — handleSearch returned early due to extractor === null
+    expect(screen.queryByTestId('embedding-results')).toBeNull();
+  });
+
+  test('handleSearch: returns early when query is empty', async () => {
+    mockWebLoadPipeline.mockResolvedValue(succeed(DUMMY_EXTRACTOR));
+    mockWebEmbed.mockResolvedValue(succeed(makeMockTensor(VEC_A)));
+
+    render(React.createElement(localEmbeddingSearchScenario.web!.component, { context: makeScenarioCtx() }));
+
+    await waitFor(() => screen.getByTestId('embedding-scenario'));
+
+    // Do NOT type anything
+    fireEvent.click(screen.getByTestId('embedding-search-btn'));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByTestId('embedding-results')).toBeNull();
+  });
+
+  test('shows ranked results after a successful search', async () => {
+    mockWebLoadPipeline.mockResolvedValue(succeed(DUMMY_EXTRACTOR));
+    // All embeds return VEC_A so every corpus entry gets similarity 1.0.
+    mockWebEmbed.mockResolvedValue(succeed(makeMockTensor(VEC_A)));
+
+    const ctx = makeScenarioCtx();
+    render(React.createElement(localEmbeddingSearchScenario.web!.component, { context: ctx }));
+
+    await waitFor(() => screen.getByTestId('embedding-scenario'));
+
+    const input = screen.getByTestId('embedding-query') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'machine learning' } });
+    fireEvent.click(screen.getByTestId('embedding-search-btn'));
+
+    await waitFor(() => screen.getByTestId('embedding-results'));
+    expect(screen.getByTestId('embedding-ranked-list')).not.toBeNull();
+    expect(screen.getByTestId('embedding-result-0')).not.toBeNull();
+    expect(
+      (ctx.logger.info as jest.Mock).mock.calls.some((c: unknown[]) =>
+        String(c[0]).includes('Search complete')
+      )
+    ).toBe(true);
+  });
+
+  test('shows error when searchCorpus fails', async () => {
+    mockWebLoadPipeline.mockResolvedValue(succeed(DUMMY_EXTRACTOR));
+    mockWebEmbed.mockResolvedValue(fail('embed failed during search'));
+
+    const ctx = makeScenarioCtx();
+    render(React.createElement(localEmbeddingSearchScenario.web!.component, { context: ctx }));
+
+    await waitFor(() => screen.getByTestId('embedding-scenario'));
+
+    const input = screen.getByTestId('embedding-query') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'failing query' } });
+    fireEvent.click(screen.getByTestId('embedding-search-btn'));
+
+    await waitFor(() => screen.getByTestId('embedding-results'));
+    expect(screen.getByTestId('embedding-error')).not.toBeNull();
+    expect(
+      (ctx.logger.error as jest.Mock).mock.calls.some((c: unknown[]) =>
+        String(c[0]).includes('Search failed')
+      )
+    ).toBe(true);
+  });
+
+  test('cached path: after initialize(), component does not call loadPipeline again', async () => {
+    // Populate _cachedExtractor by calling initialize()
+    mockWebLoadPipeline.mockResolvedValue(succeed(DUMMY_EXTRACTOR));
+    await localEmbeddingSearchScenario.web!.initialize!(makeScenarioCtx());
+
+    // Reset so we can detect any spurious call
+    mockWebLoadPipeline.mockReset();
+    mockWebEmbed.mockResolvedValue(succeed(makeMockTensor(VEC_A)));
+
+    render(React.createElement(localEmbeddingSearchScenario.web!.component, { context: makeScenarioCtx() }));
+
+    await waitFor(() => screen.getByTestId('embedding-scenario'));
+    expect(mockWebLoadPipeline).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// web impl: initialize()
+// ---------------------------------------------------------------------------
+
+describe('web impl: initialize()', () => {
+  beforeEach(() => {
+    mockWebLoadPipeline.mockReset();
+  });
+
+  test('initialize succeeds when loadPipeline succeeds', async () => {
+    mockWebLoadPipeline.mockResolvedValue(succeed(DUMMY_EXTRACTOR));
+    const ctx = makeScenarioCtx();
+    const result = await localEmbeddingSearchScenario.web!.initialize!(ctx);
+    expect(result).toSucceedWith(true);
+  });
+
+  test('initialize fails when loadPipeline fails', async () => {
+    mockWebLoadPipeline.mockResolvedValue(fail('network error'));
+    const ctx = makeScenarioCtx();
+    const result = await localEmbeddingSearchScenario.web!.initialize!(ctx);
+    expect(result).toFailWith(/network error/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI impl: run()
+// ---------------------------------------------------------------------------
+
+describe('cli impl: run()', () => {
+  beforeEach(() => {
+    mockLoadPipeline.mockReset();
+    mockEmbed.mockReset();
+  });
+
+  test('run succeeds and returns a ranked summary', async () => {
+    mockLoadPipeline.mockResolvedValue(succeed(DUMMY_EXTRACTOR));
+    mockEmbed.mockResolvedValue(succeed(makeMockTensor(VEC_A)));
+
+    const ctx = makeScenarioCtx();
+    const result = await localEmbeddingSearchScenario.cli!.run(ctx);
+    expect(result).toSucceedAndSatisfy((summary: string) => {
+      expect(summary).toMatch(/B-4a local-embedding-search demo/i);
+      expect(summary).toMatch(/Top results/i);
+    });
+  });
+
+  test('run fails when loadPipeline fails', async () => {
+    mockLoadPipeline.mockResolvedValue(fail('load failed'));
+
+    const ctx = makeScenarioCtx();
+    const result = await localEmbeddingSearchScenario.cli!.run(ctx);
+    expect(result).toFailWith(/load failed/i);
+  });
+
+  test('run fails when embed fails', async () => {
+    mockLoadPipeline.mockResolvedValue(succeed(DUMMY_EXTRACTOR));
+    mockEmbed.mockResolvedValue(fail('inference error'));
+
+    const ctx = makeScenarioCtx();
+    const result = await localEmbeddingSearchScenario.cli!.run(ctx);
+    expect(result).toFailWith(/inference error/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario metadata
+// ---------------------------------------------------------------------------
+
+describe('localEmbeddingSearchScenario (IScenario shape)', () => {
+  test('has the expected id', () => {
+    expect(localEmbeddingSearchScenario.id).toBe('local-embedding-search');
+  });
+
+  test('has category "ai"', () => {
+    expect(localEmbeddingSearchScenario.category).toBe('ai');
+  });
+
+  test('has the expected tags', () => {
+    expect(localEmbeddingSearchScenario.tags).toContain('local-ai');
+    expect(localEmbeddingSearchScenario.tags).toContain('embeddings');
+    expect(localEmbeddingSearchScenario.tags).toContain('semantic-search');
+  });
+
+  test('has a web impl with a component and an initialize fn', () => {
+    expect(localEmbeddingSearchScenario.web).toBeDefined();
+    expect(localEmbeddingSearchScenario.web!.component).toBeDefined();
+    expect(typeof localEmbeddingSearchScenario.web!.initialize).toBe('function');
+  });
+
+  test('has a cli impl with a run fn', () => {
+    expect(localEmbeddingSearchScenario.cli).toBeDefined();
+    expect(typeof localEmbeddingSearchScenario.cli!.run).toBe('function');
+  });
+
+  test('MODEL_ID is the expected MiniLM hub id', () => {
+    expect(MODEL_ID).toBe('Xenova/all-MiniLM-L6-v2');
+  });
+
+  test('CORPUS_TEXTS is non-empty', () => {
+    expect(CORPUS_TEXTS.length).toBeGreaterThan(0);
+  });
+});

--- a/samples/testbed/src/test/unit/scenarios/localEmbeddingSearch.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/localEmbeddingSearch.test.ts
@@ -64,8 +64,9 @@ const DUMMY_EXTRACTOR = {} as FeatureExtractionPipeline;
  * emitted by `embed(text, { pooling: 'mean', normalize: true })` for a single string.
  */
 function makeMockTensor(vec: number[]): Tensor {
+  // tolist() on a pooled single-string embedding returns number[][] ([[...vec...]]).
   return {
-    tolist: () => [vec] as unknown as number[]
+    tolist: (): number[][] => [vec]
   } as unknown as Tensor;
 }
 


### PR DESCRIPTION
## Summary

B-4a of `local-ai-exploration` — the **SHIP** branch of the done-or-discard gate (B-3 merged in #408 with all three criteria positive). Polishes the two transformers facades to ship-quality and proves the boundary survives a second model type (OQ-4).

**Facade primitives (both `@fgv/ts-extras-transformers` + `@fgv/ts-web-extras-transformers`, identical surface):**
- `embed(extractor, text, options?) → Promise<Result<Tensor>>` — thin wrapper over a feature-extraction pipeline; no pooling/normalisation imposed.
- `classifyAll(classifier, text, options?)` — forces `top_k: null` so the full per-label vector is type-evident (closes the B-3 "silent author-side contract" gap).
- api-extractor reports regenerated; `minor` change files.

**Testbed:**
- New **`local-embedding-search`** scenario: `Xenova/all-MiniLM-L6-v2` sentence embeddings → cosine-similarity ranking over a fixed corpus. The OQ-4 different-model-type proof.
- B-3 `local-classifier-safety` switched to `classifyAll()`.
- Both follow the canonical dual-target pattern (facade-agnostic core + injected fn + type-only imports; browser facade on web, Node facade via `webpackIgnore` on CLI).

**Docs:** `LIBRARY_CAPABILITIES.md` entries (operations table, NOT-in-scope, dual-target consumption pattern, decision shortcut, cross-runtime row).

## OQ-4 — does the facade boundary survive a second model type?

**Yes.** The embedding scenario exercises a different output shape (`Tensor` vector vs label-score array) and the facade held with no facade-level change. The one friction point is consumer-side: `Tensor.tolist()` is typed `any[]` upstream, so the scenario's `embedAdapter` uses a single documented bounded `as number[][]` cast (shape `[1, D]` from `pooling: 'mean'`) with a narrow defensive `c8 ignore`. Not a facade defect; a future `embedVector()` could absorb it (noted, out of minimal-surface scope). Full reasoning in `phase-b4a-result.md`.

## Gates (verified)
- [x] `rush build` (full repo) — green
- [x] `rushx lint` clean — all modified packages
- [x] `rushx test` 100% all 4 metrics — facades 23 tests each; testbed 111 tests
- [x] **production `build:web` compiles** — Node facade excluded from the browser bundle
- [x] No `any`; `Result<T>` throughout; one documented consumer-side cast
- [x] Change files (`minor` ×2 facades, `none` testbed); api reports regenerated

## Test plan
- [x] Facade unit tests (embed success/failure; classifyAll forces top_k:null, all-labels, failure)
- [x] Embedding scenario: pure similarity core, embed adapter (mocked Tensor), web component (@testing-library/react), CLI run
- [x] B-3 scenario regression after classifyAll switch
- [ ] Reviewer pass; then cluster-close (promotion to `release`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G45v6MtMCK6rJjRacqYSgm)_