### PR TITLE
chore(local-summarization): substrate prep — local summarize facade primitive

### DIFF
--- a/.ai/tasks/active/local-summarization/brief.md
+++ b/.ai/tasks/active/local-summarization/brief.md
@@ -40,8 +40,9 @@ summarize(
 **Shape the scenario as a thoughtful consumer would — you have latitude here.** The testbed's purpose is to *see what real consumer code naturally looks like*, so this section is guidance, not a spec to implement literally. Use your judgment on structure, input, and presentation. Two firm guardrails and the rest is yours:
 
 - **Firm: CLI runtime** (no `web` impl). Mirrors personaility's backend-Node reality and avoids pulling a ~300MB summarization model into a browser bundle. This one's load-bearing — the scenario should demonstrate the runtime the consumer actually uses.
+- **Firm: realistic-length input.** Summarize a realistic multi-turn transcript or paragraph-scale document, NOT a toy sentence. The forcing-function payoff of this scenario is eyeballing summary quality-for-recall — that's only observable on realistic input. A one-sentence demo proves the wiring but hides the thing we actually want to evaluate (is local summarization good enough for personaility's simple-case use). Pin the input at a scale where quality is visible.
 - **Firm (tenet, not micromanagement): don't build complicated sample-only behavior a real consumer would also need.** A full local-vs-cloud *routing engine* is application logic, not facade or sample concern — if the local-vs-cloud framing is worth showing, surface it at whatever depth reads naturally (a comment, a printed note, a simple length check), but the escalation *policy* belongs to the consumer, not the sample.
-- **Your latitude:** what text it summarizes, how it presents the result, whether/how it frames the local-vs-cloud decision, the model choice (a small well-known summarization model — distilbart-cnn class is a reasonable default), tags/category, internal structure. Match the existing scenarios' registration pattern; otherwise build it the way a real consumer would and we'll learn from the shape.
+- **Your latitude:** how it presents the result, whether/how it frames the local-vs-cloud decision, the model choice (a small well-known summarization model — distilbart-cnn class is a reasonable default), tags/category, internal structure. Match the existing scenarios' registration pattern; otherwise build it the way a real consumer would and we'll learn from the shape.
 
 ### LIBRARY_CAPABILITIES update
 
@@ -87,7 +88,7 @@ personaility runs summarization on the **backend in Node**. So:
 - [ ] api-extractor regenerated in both facade packages.
 - [ ] Rush change files (`minor`) for touched packages.
 - [ ] LIBRARY_CAPABILITIES updated (facade entries + decision shortcut).
-- [ ] No `any`; no manual casts beyond `@ts-expect-error`; no `Result<void>`.
+- [ ] No `any`; no unsafe casts; no `Result<void>`. (`summarize`'s `[{ summary_text }]` output is cleaner than `embed`'s `.tolist()`, so likely no cast at all.)
 - [ ] `result.md` written; substrate migrated to `.ai/tasks/completed/<YYYY-MM>/local-summarization/` with polished README as part of the PR.
 
 ## Required reading
@@ -111,7 +112,7 @@ personaility runs summarization on the **backend in Node**. So:
 
 - The `@huggingface/transformers` summarization pipeline output shape differs materially from `classify`/`embed` in a way that complicates the facade signature — surface before improvising.
 - The summarization model the scenario picks is impractically large even for Node tests (mock should avoid any real download; if the scenario itself can't run without a multi-hundred-MB download in the test env, the scenario test should mock or skip the actual inference and assert wiring).
-- Adding `summarize` surfaces a gap in the existing facade structure (e.g. `loadPipeline`'s task-type typing doesn't cleanly extend to `'summarization'`) — surface; that's a facade-design question.
+- Adding `summarize` surfaces a gap in the existing facade structure (e.g. `loadPipeline`'s task-type typing doesn't cleanly extend to `'summarization'`) — surface; that's a facade-design question. **This will almost certainly be fine:** `'summarization'` should already be in the upstream `PipelineType` union `loadPipeline` is generic over (same as `'text-classification'` / `'feature-extraction'`). If it's not, it's a small real facade-typing extension — surface it rather than casting around it.
 
 ## fgv-conventions pre-load (per L22)
 

--- a/.ai/tasks/active/local-summarization/brief.md
+++ b/.ai/tasks/active/local-summarization/brief.md
@@ -37,10 +37,11 @@ summarize(
 
 ### CLI testbed scenario: `local-summarization`
 
-- **CLI runtime only** (no `web` impl). Mirrors personaility's backend-Node reality and avoids pulling a ~300MB summarization model into a browser bundle.
-- Loads a summarization pipeline (distilbart-cnn class — pick a small, well-known summarization model), summarizes input text, prints the summary + a one-line note on the local-vs-cloud decision (when to escalate to ai-assist).
-- Demonstrates the LOCAL primitive cleanly. **Do NOT build a local-vs-cloud routing orchestrator** — the decision of when to escalate to cloud is application logic, not facade or sample concern (per the testbed's gap-then-fix / "no complicated sample-only behavior a consumer would also need" tenet). A doc-comment noting "escalate to ai-assist for long/complex docs" is the right depth; a built dual-path router is not.
-- Registers in `samples/testbed/src/scenarios/index.ts`; category `ai`; tags `['local-ai', 'summarization', 'ts-extras-transformers']`.
+**Shape the scenario as a thoughtful consumer would — you have latitude here.** The testbed's purpose is to *see what real consumer code naturally looks like*, so this section is guidance, not a spec to implement literally. Use your judgment on structure, input, and presentation. Two firm guardrails and the rest is yours:
+
+- **Firm: CLI runtime** (no `web` impl). Mirrors personaility's backend-Node reality and avoids pulling a ~300MB summarization model into a browser bundle. This one's load-bearing — the scenario should demonstrate the runtime the consumer actually uses.
+- **Firm (tenet, not micromanagement): don't build complicated sample-only behavior a real consumer would also need.** A full local-vs-cloud *routing engine* is application logic, not facade or sample concern — if the local-vs-cloud framing is worth showing, surface it at whatever depth reads naturally (a comment, a printed note, a simple length check), but the escalation *policy* belongs to the consumer, not the sample.
+- **Your latitude:** what text it summarizes, how it presents the result, whether/how it frames the local-vs-cloud decision, the model choice (a small well-known summarization model — distilbart-cnn class is a reasonable default), tags/category, internal structure. Match the existing scenarios' registration pattern; otherwise build it the way a real consumer would and we'll learn from the shape.
 
 ### LIBRARY_CAPABILITIES update
 

--- a/.ai/tasks/active/local-summarization/brief.md
+++ b/.ai/tasks/active/local-summarization/brief.md
@@ -124,7 +124,9 @@ personaility runs summarization on the **backend in Node**. So:
 
 ## Branch + PR posture
 
+- **Integration branch:** `local-summarization` (off `release`). Substrate-prep, the implementation PR, and any review-round fixups all land here.
 - **Work branch stem:** `feat/local-summarization` (harness may suffix).
-- **PR target:** `release` (single-PR feature; facade is already shipped on release; no integration branch).
+- **PR target:** `local-summarization` (integration branch), NOT `release` directly.
 - **PR title:** `feat(transformers): add summarize primitive + local-summarization testbed scenario`
 - **PR body:** the `summarize` signature; the CLI scenario; the local-vs-cloud decision framing (local cheap/fast, cloud for quality); pre-PR gate checklist; explicit "third facade task type — more evidence the facade earns its keep."
+- **Close:** when the implementation lands and gates pass, **squash-merge `local-summarization` → `release`** as a single clean commit (keeps `release` history uncluttered — substrate + impl + fixups collapse to one commit for this small additive feature). Migrate substrate to `completed/` as part of the implementation PR before the squash.

--- a/.ai/tasks/active/local-summarization/brief.md
+++ b/.ai/tasks/active/local-summarization/brief.md
@@ -1,0 +1,128 @@
+# Stream brief: `local-summarization`
+
+**Status:** 🟢 ready to commission
+**Branch base:** `release`
+**Workflow shape:** single-PR additive feature (facade primitive + CLI testbed scenario)
+**Package surface:** `@fgv/ts-extras-transformers` + `@fgv/ts-web-extras-transformers` (add `summarize` primitive) + `samples/testbed` (CLI scenario) + `.ai/instructions/LIBRARY_CAPABILITIES.md`
+
+---
+
+## Mission
+
+Add a local text-summarization primitive to the transformers facade shipped by the `local-ai-exploration` cluster, plus a CLI testbed scenario demonstrating it. Consumer-driven: personaility currently summarizes in the cloud via `@fgv/ts-extras/ai-assist`, but cloud is slow + expensive for simple cases where a small local model is good enough. Local summarization is the cheap/fast path; cloud (ai-assist) stays for quality on long/complex documents.
+
+This is the third task type on the facade (`classify` → `embed` → `summarize`), continuing the "grow the facade as real consumers need it" path the cluster established. The facade's existence is already proven (B-3 SHIP); the only question this stream answers is "does `summarize` earn its primitive" — one CLI scenario answers it.
+
+---
+
+## Locked design
+
+### `summarize` primitive
+
+Task-specific, mirroring the existing `classify` / `embed` primitives (NOT the deferred general `generate`):
+
+```typescript
+// shape — match the existing facade primitives' signature style; verify against
+// the actual @huggingface/transformers summarization pipeline output
+summarize(
+  pipeline: SummarizationPipeline,        // from loadPipeline('summarization', model)
+  text: string,
+  options?: { minLength?: number; maxLength?: number; /* upstream summarization opts */ }
+): Promise<Result<SummarizationOutput>>   // upstream shape: [{ summary_text: string }]
+```
+
+- Wraps the `@huggingface/transformers` `summarization` pipeline task via `captureAsyncResult`.
+- Same Node/browser split discipline as the existing primitives: the canonical type source is the Node package (`@fgv/ts-extras-transformers`); the browser package (`@fgv/ts-web-extras-transformers`) re-exports types + implements the browser path. **Both packages get `summarize` for surface parity** even though the testbed scenario only exercises the Node path.
+- Options pass `min_length` / `max_length` (and whatever else the upstream summarization pipeline accepts) through; default behavior is the upstream default.
+
+### CLI testbed scenario: `local-summarization`
+
+- **CLI runtime only** (no `web` impl). Mirrors personaility's backend-Node reality and avoids pulling a ~300MB summarization model into a browser bundle.
+- Loads a summarization pipeline (distilbart-cnn class — pick a small, well-known summarization model), summarizes input text, prints the summary + a one-line note on the local-vs-cloud decision (when to escalate to ai-assist).
+- Demonstrates the LOCAL primitive cleanly. **Do NOT build a local-vs-cloud routing orchestrator** — the decision of when to escalate to cloud is application logic, not facade or sample concern (per the testbed's gap-then-fix / "no complicated sample-only behavior a consumer would also need" tenet). A doc-comment noting "escalate to ai-assist for long/complex docs" is the right depth; a built dual-path router is not.
+- Registers in `samples/testbed/src/scenarios/index.ts`; category `ai`; tags `['local-ai', 'summarization', 'ts-extras-transformers']`.
+
+### LIBRARY_CAPABILITIES update
+
+- Add `summarize` to the transformers facade entries.
+- Decision-shortcut line: "Local summarization (cheap/fast/offline, small model) → `summarize` from `@fgv/ts-extras-transformers`; cloud summarization (quality on long/complex docs) → `AiAssist.generateJsonCompletion` / completion from `@fgv/ts-extras/ai-assist`."
+
+---
+
+## Runtime context (resolves the model-size question)
+
+personaility runs summarization on the **backend in Node**. So:
+- Model size (~300MB distilbart-cnn class) is a one-time server-side cache — not a browser-download UX concern.
+- The CLI scenario is the faithful demonstration of the consumer's actual usage.
+- The browser `summarize` primitive ships for surface parity but isn't the validated path.
+
+---
+
+## In-scope
+
+- `libraries/ts-extras-transformers/src/` — add `summarize` + tests (100% coverage; mock the upstream pipeline, don't download models in tests).
+- `libraries/ts-web-extras-transformers/src/` — add `summarize` (browser path; surface parity) + tests.
+- Both `etc/*.api.md` — regenerated.
+- `samples/testbed/src/scenarios/localSummarization.ts` (CLI scenario) + register in `scenarios/index.ts`.
+- `samples/testbed/data/` — any sample input text the scenario summarizes (via the data pipeline if non-trivial; an inline string is fine for a single short fixture).
+- `.ai/instructions/LIBRARY_CAPABILITIES.md` — facade entries + decision shortcut.
+- `common/changes/` — rush change files (`minor`; additive) for the touched packages.
+
+## Out-of-scope
+
+- Web summarization scenario (would demo a runtime personaility isn't using + a 300MB browser download).
+- Local-vs-cloud routing orchestrator (application concern; a doc-comment note is the right depth).
+- The deferred general `generate` primitive (summarization is task-specific; `generate` stays deferred until a concrete consumer needs it).
+- Cloud summarization changes to ai-assist (it already does this via completions; no change needed).
+
+## Acceptance criteria
+
+- [ ] `summarize` in both facade packages; surface parity; Node/browser split mirrors existing primitives.
+- [ ] `rush build` full repo clean.
+- [ ] `rushx lint` clean in every modified package (separate gate from build).
+- [ ] `rushx fixlint` run before final commit.
+- [ ] `rushx test` 100% coverage all 4 metrics in both facade packages + testbed. Upstream pipeline mocked in facade tests.
+- [ ] CLI scenario runs: `--scenario local-summarization` loads a summarization pipeline, summarizes input, prints summary + the escalation note. Returns `Result<string>` summary per the scenario contract.
+- [ ] api-extractor regenerated in both facade packages.
+- [ ] Rush change files (`minor`) for touched packages.
+- [ ] LIBRARY_CAPABILITIES updated (facade entries + decision shortcut).
+- [ ] No `any`; no manual casts beyond `@ts-expect-error`; no `Result<void>`.
+- [ ] `result.md` written; substrate migrated to `.ai/tasks/completed/<YYYY-MM>/local-summarization/` with polished README as part of the PR.
+
+## Required reading
+
+1. This brief.
+2. `libraries/ts-extras-transformers/src/` + `libraries/ts-web-extras-transformers/src/` — the existing `classify` / `embed` primitives. **Mirror their signature style, Node/browser split, test-mocking strategy exactly.**
+3. `.ai/tasks/completed/2026-05/local-ai-exploration/` (brief + result docs) — the facade design discipline + the testbed scenario contract.
+4. `samples/testbed/src/scenarios/` — the two existing scenarios (`local-classifier-safety`, `local-embedding-search`) + `src/shell/` for the `IScenario` / `ICliScenarioImpl` contract. **The new scenario mirrors the CLI shape of these.**
+5. `samples/testbed/conventions.md` — house style + gap-then-fix tenet.
+6. `CLAUDE.md` + `.ai/instructions/CODING_STANDARDS.md`.
+
+## Skills to load
+
+| When | Skill |
+|---|---|
+| Before writing the primitive | `/result-pattern` (`captureAsyncResult`) |
+| Before writing tests | `/result-tests` |
+| Before reaching for utility code | `/published-primitives-reflex` |
+
+## Stop-and-surface
+
+- The `@huggingface/transformers` summarization pipeline output shape differs materially from `classify`/`embed` in a way that complicates the facade signature — surface before improvising.
+- The summarization model the scenario picks is impractically large even for Node tests (mock should avoid any real download; if the scenario itself can't run without a multi-hundred-MB download in the test env, the scenario test should mock or skip the actual inference and assert wiring).
+- Adding `summarize` surfaces a gap in the existing facade structure (e.g. `loadPipeline`'s task-type typing doesn't cleanly extend to `'summarization'`) — surface; that's a facade-design question.
+
+## fgv-conventions pre-load (per L22)
+
+- No re-exports from sibling `@fgv/*` packages.
+- All fallible ops return `Result<T>`; no `Result<void>`; `captureAsyncResult` for async upstream wrapping.
+- Mirror the existing facade primitives' discipline (WebAuthn-style thin boundary) — don't add opinionated orchestration.
+- `rushx lint` is a separate gate from `rushx build`.
+- Both transformers packages are active-development surface; additive change; no breaking concerns.
+
+## Branch + PR posture
+
+- **Work branch stem:** `feat/local-summarization` (harness may suffix).
+- **PR target:** `release` (single-PR feature; facade is already shipped on release; no integration branch).
+- **PR title:** `feat(transformers): add summarize primitive + local-summarization testbed scenario`
+- **PR body:** the `summarize` signature; the CLI scenario; the local-vs-cloud decision framing (local cheap/fast, cloud for quality); pre-PR gate checklist; explicit "third facade task type — more evidence the facade earns its keep."

--- a/.ai/tasks/active/local-summarization/state.md
+++ b/.ai/tasks/active/local-summarization/state.md
@@ -24,6 +24,7 @@
 | Local as cheap/fast path; cloud (ai-assist) stays for quality | Erik (2026-05-24): personaility summarizes in cloud via ai-assist today, but it's overkill (slow + expensive) for simple cases. Local is the next obvious step for those. Cloud remains for long/complex docs. |
 | No local-vs-cloud routing orchestrator in the scenario | When to escalate to cloud is application logic, not facade or sample concern (testbed's "no complicated sample-only behavior a consumer would also need" tenet). Doc-comment note is the right depth. |
 | Model size non-issue | Backend Node → ~300MB model is a one-time server-side cache, not a browser-download UX concern. |
+| Integration branch `local-summarization` + squash to release | Erik (2026-05-24): use an integration branch and squash to release to keep release history clean. Substrate + impl + fixups (3-4 commits for one small additive feature) collapse to a single release commit. L26/L35 reasoning applied proactively — code-light enough that the per-PR commits would be noise on release. |
 
 ---
 

--- a/.ai/tasks/active/local-summarization/state.md
+++ b/.ai/tasks/active/local-summarization/state.md
@@ -1,0 +1,50 @@
+# Stream state: `local-summarization`
+
+**Status:** 🟢 ready to commission — substrate prep in flight
+**Branch base:** `release`
+**Last updated:** 2026-05-24 (orchestrator — substrate prep)
+
+---
+
+## Phase status
+
+| Phase | Status | Notes |
+|---|---|---|
+| Implementation | 🟢 ready | Single-PR additive: `summarize` primitive in both facade packages + CLI testbed scenario. Design locked in brief. |
+
+---
+
+## Decisions log
+
+| Decision | Rationale |
+|---|---|
+| Add `summarize` to the transformers facade (vs new package) | Third task type on the facade shipped by `local-ai-exploration` (`classify` → `embed` → `summarize`). Continues the "grow the facade as real consumers need it" path. More evidence the facade earns its keep. |
+| Task-specific `summarize`, not the deferred general `generate` | Summarization has a distinct shape (input → shorter text, min/max length). Mirrors `classify`/`embed`'s task-specific discipline. `generate` stays deferred until a concrete consumer needs it. |
+| Both facade packages get `summarize` (surface parity); scenario is CLI-only | personaility runs summarization backend-Node. Surface parity keeps the Node/browser pair identical, but the validated path + testbed scenario is Node/CLI. No web scenario — would demo a runtime personaility isn't using + pull a ~300MB model into the browser. |
+| Local as cheap/fast path; cloud (ai-assist) stays for quality | Erik (2026-05-24): personaility summarizes in cloud via ai-assist today, but it's overkill (slow + expensive) for simple cases. Local is the next obvious step for those. Cloud remains for long/complex docs. |
+| No local-vs-cloud routing orchestrator in the scenario | When to escalate to cloud is application logic, not facade or sample concern (testbed's "no complicated sample-only behavior a consumer would also need" tenet). Doc-comment note is the right depth. |
+| Model size non-issue | Backend Node → ~300MB model is a one-time server-side cache, not a browser-download UX concern. |
+
+---
+
+## Origin
+
+Consumer-driven (personaility). Currently summarizing in cloud via `@fgv/ts-extras/ai-assist`; cloud is slow + expensive for simple cases. Local summarization via the transformers facade is the cheap/fast path. Textbook stability-via-consumption: a real consumer's concrete pain justifies growing the facade.
+
+---
+
+## History
+
+| Date | Event | Notes |
+|---|---|---|
+| 2026-05-24 | Stream requested | Erik floated local summarization as a candidate (personaility short-list). Confirmed: cloud-via-ai-assist today, overkill for simple cases; local is next step; backend-Node runtime. |
+| 2026-05-24 | Substrate prep | brief.md + state.md + WORKSTREAMS entry. This PR. |
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep | (this PR) | open |
+| Implementation | TBD | not yet commissioned |

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -128,6 +128,19 @@ substrate. Don't queue streams against them here.
 
 ## Active workstreams
 
+### `local-summarization` 🟢
+
+**Status:** 🟢 ready to commission (substrate prep in flight)
+**Branch base:** `release`
+**Workflow shape:** single-PR additive feature
+**Substrate:** `.ai/tasks/active/local-summarization/{brief.md, state.md}`
+**Package surface:** `@fgv/ts-extras-transformers` + `@fgv/ts-web-extras-transformers` (add `summarize`) + `samples/testbed` (CLI scenario) + `.ai/instructions/LIBRARY_CAPABILITIES.md`
+**Out-of-scope:** web summarization scenario; local-vs-cloud routing orchestrator (application concern); the deferred general `generate` primitive; ai-assist cloud-summarization changes.
+
+**Mission.** Add a local text-summarization primitive (`summarize`) to the transformers facade shipped by `local-ai-exploration`, plus a CLI testbed scenario. Third facade task type (`classify` → `embed` → `summarize`). Consumer-driven: personaility summarizes in cloud via `@fgv/ts-extras/ai-assist` today, but cloud is slow + expensive for simple cases — local is the cheap/fast path; cloud stays for quality on long/complex docs. Runs backend-Node (model size is a server-side cache, not a browser UX concern; scenario is CLI).
+
+**Origin.** Consumer-driven (personaility short-list). Stability-via-consumption: a real consumer's concrete pain (cloud overkill for simple summaries) justifies growing the facade. More evidence the facade earns its keep.
+
 ### `prompt-assist-screeners` 🟢
 
 **Status:** 🟢 ready to commission (substrate prep in flight)


### PR DESCRIPTION
Substrate prep for the `local-summarization` stream. Adds a local text-summarization primitive (`summarize`) to the transformers facade shipped by `local-ai-exploration`, plus a CLI testbed scenario.

## Why

Consumer-driven (personaility short-list). personaility summarizes in the cloud via `@fgv/ts-extras/ai-assist` today, but cloud is slow + expensive for simple cases. **Local summarization is the cheap/fast path; cloud stays for quality on long/complex docs.** Third facade task type (`classify` → `embed` → `summarize`) — more evidence the facade earns its keep. Textbook stability-via-consumption.

## Locked design

- **`summarize` primitive** — task-specific (transformers.js `summarization` task), `minLength`/`maxLength` options, mirrors `classify`/`embed`. NOT the deferred general `generate`.
- **Both facade packages** get it (surface parity); **testbed scenario is CLI-only** — mirrors personaility's backend-Node reality, avoids pulling a ~300MB model into a browser bundle.
- **No local-vs-cloud routing orchestrator** in the scenario — when to escalate to cloud is application logic (testbed tenet); a doc-comment note is the right depth.
- **Off `release`** (facade already shipped via #412; `local-ai-exploration` closed). Single-PR additive feature.

## Runtime context

Backend Node → model size (~300MB) is a one-time server-side cache, not a browser UX concern. Scenario is CLI; browser `summarize` ships for surface parity but isn't the validated path.

## Files

- `.ai/tasks/active/local-summarization/brief.md` — locked design + acceptance + scope boundary.
- `.ai/tasks/active/local-summarization/state.md` — decisions log, origin, history.
- `docs/WORKSTREAMS.md` — new active stream entry.

No code changes; substrate only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_