### PR TITLE
chore(logging-observability): substrate prep — RetainingLogger + MultiLogger

### DIFF
--- a/.ai/notes/cross-repo-handoffs/logging-observability-2026-05.md
+++ b/.ai/notes/cross-repo-handoffs/logging-observability-2026-05.md
@@ -1,0 +1,55 @@
+# Cross-repo handoff: logging-packlet observability primitives
+
+**Date received:** 2026-05-25
+**Source:** personaility orchestrator → fgv orchestrator (orchestrator-to-orchestrator handoff, via chat)
+**Destination stream:** `logging-observability` (`.ai/tasks/active/logging-observability/`)
+**Pattern:** L9 cross-repo handoff (archived here per the push-model convention; the request arrived via chat rather than a PR drop, so the fgv orchestrator archives it on receipt).
+
+---
+
+## The request (as received)
+
+A downstream `@fgv/ts-utils` consumer building in-app log visibility hit two gaps in the `logging` packlet. The consumer judged them trivial to build locally — which is exactly why they should be built once, in fgv: general logging capabilities, not consumer-specific, and logging is core durable infrastructure. Building them downstream would create migration debt the moment fgv ships the real thing.
+
+### The gap
+
+To serve an owner-gated log-query endpoint (`?level=warning&since=<cursor>`) that filters by severity and pages incrementally, a pinned logger must (a) **retain structured records** that keep their level + an ordering cursor, and (b) write every record to **both** stdout and that retainer. Neither exists today:
+
+- **`InMemoryLogger` is insufficient.** Stores formatted strings only (`get logged(): string[]`); its `_log(message, __level)` **discards the level**. No timestamp, no sequence/cursor, no bound (unbounded growth). Can't answer "everything at `warning`+ since seq N."
+- **No composite/tee logger.** Nothing fans a single log call out to multiple child loggers, so there's no way to feed both `ConsoleLogger` (stdout) and a retainer from one pinned `ILogger`.
+
+The client-display half is already covered by `@fgv/ts-app-shell`'s `messages` packlet. This is purely the server-side retention + fan-out gap.
+
+### Requested primitive 1 — record-retaining logger
+
+A `LoggerBase` subclass retaining structured records in a bounded most-recent-N ring, with a query API supporting min-severity + since-cursor. `ILogRecord` = `{ seq, timestamp, level, message }`. Class `RetainingLogger(logLevel?, maxRecords?)` with `records`, `lastSeq`, `getRecords({ minLevel?, sinceSeq?, limit? })`, `clear()`.
+
+Behavior: records carry the real level; `seq` monotonic + stable across eviction; bounded; respects `logLevel`; `getRecords` `minLevel` uses `shouldLog`.
+
+### Requested primitive 2 — composite / fan-out logger
+
+`MultiLogger implements ILogger` forwarding every call to N children, each applying its own threshold. `logLevel` = most-verbose child. Returns formatted message if any child logged, else `undefined`. Raw-forward (each child formats per its own rules; avoids double-format).
+
+### Open questions (as posed)
+
+- Q1 naming: `RetainingLogger`/`RecordingLogger`/`HistoryLogger`; `MultiLogger`/`BroadcastLogger`/`TeeLogger`.
+- Q2 defaults: `maxRecords` (1000?); retain level (`detail` vs `all`).
+- Q3 `limit` semantics: most-recent-N or oldest-N. Proposed most-recent-N, oldest-first.
+- Q4 test clock: injected `now: () => number`?
+- Q5 record shape: formatted string only, or structured `message`+`params`?
+
+### Requesting orchestrator's peer assessment
+
+Sound, well-scoped. Three subtle calls all correct (raw-forward; `logLevel` = most-verbose; `seq` stable across eviction). Q5 the one to decide deliberately — leaned toward capturing structured too, "cheap on day one, expensive after consumers depend on the shape." Q1 either name fine; Q2 `maxRecords: 1000` + retain at `detail`; Q3 most-recent-N oldest-first; Q4 yes. Soft-blocker for one downstream observability stream (paused pending these primitives).
+
+---
+
+## fgv orchestrator's adjudication (2026-05-25)
+
+Accepted. Dispositions Q1–Q4 per the request/peer. **Q5 resolved differently** after grounding against the actual `LoggerBase`:
+
+- `LoggerBase.log()` formats inside `_format` and the abstract `_log(message, level)` seam only ever receives the **formatted string** — the structured `(message, params)` are gone by then. So the peer's "structured is cheap" assumption was wrong: capturing it would require either a fragile `_format`-side-effect hack or a breaking `_log`-seam change rippling to every subclass.
+- **Resolution (Erik):** add an *additive* optional `_logStructured(level, formatted, message?, params?)` hook to `LoggerBase` — default no-op (existing subclasses unaffected), fired alongside `_log` in the `shouldLog` branch. `RetainingLogger` overrides it to build the full record. This makes structured-capture cheap and additive after all, so **Q5 = capture structured** (`ILogRecord.args?: readonly unknown[]` alongside the formatted `message`).
+- fgv's `_format` does no template substitution (stringify+join), so there's no separate "template" — `args` (the raw `[message, ...params]`) is the structured form.
+
+Full design in `.ai/tasks/active/logging-observability/brief.md`.

--- a/.ai/tasks/active/logging-observability/brief.md
+++ b/.ai/tasks/active/logging-observability/brief.md
@@ -1,0 +1,221 @@
+# Stream brief: `logging-observability`
+
+**Status:** 🟢 ready to commission
+**Integration branch:** `logging-observability` (off `release`)
+**Workflow shape:** single implementation PR onto the integration branch → squash to `release`
+**Package surface:** `@fgv/ts-utils` logging packlet (`LoggerBase` additive hook + two new classes + `ILogRecord`) + `.ai/instructions/LIBRARY_CAPABILITIES.md`
+
+---
+
+## Mission
+
+Add two observability primitives to `@fgv/ts-utils`'s `logging` packlet, requested by a downstream consumer (personaility) building an owner-gated log-query endpoint:
+
+1. **`RetainingLogger`** — a `LoggerBase` subclass that retains structured log records in a bounded most-recent-N ring, with a query API supporting min-severity filtering + since-cursor incremental paging.
+2. **`MultiLogger`** — an `ILogger` that fans every log call out to N child loggers, each applying its own threshold (so one pinned logger can feed both `ConsoleLogger` (stdout) and a `RetainingLogger`).
+
+Plus the enabler that makes structured retention clean:
+
+3. **`LoggerBase._logStructured` additive hook** — a new optional protected method (default no-op) that exposes the structured `(level, formatted, message, params)` to subclasses that want it, without changing the existing `_log(formatted, level)` seam.
+
+**Origin:** cross-repo handoff, archived at `.ai/notes/cross-repo-handoffs/logging-observability-2026-05.md`. Soft-blocker for a downstream observability stream. Textbook extend-the-primitive: general logging infra, not consumer-specific; logging is core durable surface; building downstream would create migration debt.
+
+`@fgv/ts-utils` is an **established** surface — additive-only, careful public shapes, 100% coverage mandatory (not active-development).
+
+---
+
+## Why `_logStructured` (the design crux)
+
+`LoggerBase.log()` formats via `_format(message, ...params)` and then calls the abstract `_log(formatted, level)`. The `_log` seam — the only override point — receives **only the formatted string**; the structured `(message, params)` are consumed inside `_format` before `_log` runs. So a retaining subclass extending the existing seam could capture formatted-message + level only, NOT the raw structured form.
+
+Rather than break the `_log` seam (which would ripple to every subclass — `ConsoleLogger`, `InMemoryLogger`, `LogReporter`'s logger), add an **additive optional hook**:
+
+```typescript
+// LoggerBase — NEW, additive. Default no-op → existing subclasses unaffected.
+protected _logStructured(
+  __level: MessageLogLevel,
+  __formatted: string,
+  __message?: unknown,
+  __parameters?: readonly unknown[]
+): void {
+  /* no-op; subclasses that retain structured records override this */
+}
+
+// LoggerBase.log() — add the call alongside _log, in the shouldLog branch only:
+public log(level, message?, ...parameters): Success<string | undefined> {
+  if (shouldLog(level, this.logLevel)) {
+    const formatted = this._format(message, ...parameters);
+    this._logStructured(level, formatted, message, parameters);   // NEW
+    return this._log(formatted, level);
+  }
+  return this._suppressLog(level, message, ...parameters);
+}
+```
+
+This is the only change to `LoggerBase`. It's additive (new no-op method + one internal call); no public-API change; no subclass behavior change. **It IS a change to a foundational base class, so it requires a test asserting existing subclasses are behaviorally unaffected** (the no-op default guarantees it; the test pins it).
+
+Note: fgv's `_format` does no template substitution (it stringifies + joins `[message, ...params]`), so there's no separate "template" to retain — the structured form is the raw `args = [message, ...parameters]`. `ILogRecord` carries `args`, not `template`+`params`.
+
+---
+
+## Primitive 1 — `RetainingLogger`
+
+```typescript
+/**
+ * A retained log record. Preserves the level and an ordering cursor so consumers
+ * can filter by severity and page incrementally.
+ * @public
+ */
+export interface ILogRecord {
+  /** Monotonic 1-based sequence number, stable across ring eviction. */
+  readonly seq: number;
+  /** ms since epoch when the record was logged (from the injected clock). */
+  readonly timestamp: number;
+  /** The level the record was logged at. */
+  readonly level: MessageLogLevel;
+  /** The formatted message (same formatting LoggerBase._format produces). */
+  readonly message: string;
+  /** The raw structured inputs `[message, ...parameters]` before formatting. */
+  readonly args?: readonly unknown[];
+}
+
+export declare class RetainingLogger extends LoggerBase {
+  constructor(logLevel?: ReporterLogLevel, maxRecords?: number, now?: () => number);
+  get records(): ReadonlyArray<ILogRecord>;
+  get lastSeq(): number;
+  getRecords(options?: {
+    readonly minLevel?: ReporterLogLevel;
+    readonly sinceSeq?: number;
+    readonly limit?: number;
+  }): ReadonlyArray<ILogRecord>;
+  clear(): void;
+}
+```
+
+**Behavior contract:**
+- Captures the full record via the new `_logStructured` hook (level + formatted message + raw `args`). Implements the abstract `_log` as a trivial no-op emit (a pure retainer writes nowhere) returning `succeed(formatted)`.
+- `seq` monotonic 1-based, **stable across eviction** — a client holding `sinceSeq` never re-sees or skips records; evicted records simply scroll off the bottom. `clear()` does NOT reset the counter.
+- Bounded — past `maxRecords`, oldest evicted; no unbounded growth.
+- Respects `logLevel` — records below threshold are not retained (hook fires only in the `shouldLog` branch).
+- `getRecords`: oldest-first. `minLevel` uses `shouldLog(level, minLevel)`. `sinceSeq` includes only `seq > sinceSeq`. `limit` returns the most-recent N (tail), still oldest-first (Q3).
+- `now?: () => number` injected clock (default `() => Date.now()`) for deterministic timestamp/ordering tests (Q4).
+
+**Defaults (Q2):** `logLevel` default `'detail'` (retain broad, filter at query time — deliberately more verbose than `LoggerBase`'s `'info'` default); `maxRecords` default `1000`.
+
+---
+
+## Primitive 2 — `MultiLogger`
+
+```typescript
+export declare class MultiLogger implements ILogger {
+  constructor(loggers: ReadonlyArray<ILogger>);
+  readonly logLevel: ReporterLogLevel;   // most-verbose (most-permissive) child's level
+  log(level, message?, ...params): Success<string | undefined>;
+  detail(message?, ...params): Success<string | undefined>;
+  info(message?, ...params): Success<string | undefined>;
+  warn(message?, ...params): Success<string | undefined>;
+  error(message?, ...params): Success<string | undefined>;
+}
+```
+
+**Behavior contract:**
+- Forwards raw `(level, message, ...params)` to each child's **public** method, so each child formats per its own rules (avoids double-formatting). Does NOT extend `LoggerBase` — it's a thin `ILogger` that delegates.
+- Each child filters by its own `logLevel`; the composite does NOT pre-filter.
+- Returns the formatted message if any child logged it, else `undefined`.
+- `logLevel` reports the most-verbose/most-permissive child's level (so an upstream `shouldLog` gate — e.g. a `LogReporter` wrapping the `MultiLogger` — doesn't suppress before fan-out). Compute via the `shouldLog` ordering; derive once or on access (implementer's call; if children's `logLevel` can change, compute on access).
+- **`ILogger` only**, NOT `IDetailLogger`. `errorWithDetail`/`warnWithDetail` fan-out is out of scope (future addition if a consumer needs it).
+
+---
+
+## Composition (informs the contract; not part of the ask)
+
+```typescript
+const retainer = new Logging.RetainingLogger('detail', 1000);
+const realLogger = new Logging.MultiLogger([
+  new Logging.ConsoleLogger('info'),   // stdout, as today
+  retainer                              // observability buffer
+]);
+bootLogger.ready(realLogger);           // existing pin call, unchanged
+// the service keeps `retainer`; its log-query endpoint reads retainer.getRecords({...}).
+```
+
+---
+
+## Open-question dispositions (LOCKED)
+
+| Q | Decision | Rationale |
+|---|---|---|
+| Q1 naming | `RetainingLogger` + `MultiLogger` | Both proposed names read cleanly; matches packlet style. |
+| Q2 defaults | `maxRecords: 1000`; retain at `'detail'` | Capture broad, filter at query time. |
+| Q3 `limit` | most-recent N (tail), returned oldest-first | Natural log-viewer semantics. |
+| Q4 clock | inject `now?: () => number`, default `Date.now` | Deterministic seq/timestamp tests; precedent in fgv for injectable clocks. |
+| Q5 record shape | **structured** — `args?: readonly unknown[]` alongside formatted `message` | Made cheap + additive by the `_logStructured` hook (see design crux). Richer canonical record on day one; no permanence trap. |
+
+---
+
+## In-scope
+
+- `libraries/ts-utils/src/packlets/logging/logger.ts` — add `_logStructured` hook to `LoggerBase` + the one call in `log()`; add `RetainingLogger` + `ILogRecord` + `MultiLogger` (or split into sibling files if that matches packlet structure — match existing layout).
+- `libraries/ts-utils/src/packlets/logging/index.ts` — barrel exports (`Logging.RetainingLogger`, `Logging.MultiLogger`, `ILogRecord`).
+- `libraries/ts-utils/src/test/unit/...logging...` — tests (see acceptance).
+- `libraries/ts-utils/etc/ts-utils.api.md` — regenerated.
+- `.ai/instructions/LIBRARY_CAPABILITIES.md` — logging packlet entry: add `RetainingLogger` / `MultiLogger` / `_logStructured`.
+- `common/changes/@fgv/ts-utils/` — rush change file (`minor`; additive).
+
+## Out-of-scope
+
+- Changing the existing `_log(formatted, level)` seam or `InMemoryLogger`'s behavior (additive only).
+- `IDetailLogger` fan-out on `MultiLogger`.
+- Template-substitution formatting (fgv's `_format` doesn't do it; `args` is the raw form).
+- The consumer's `MessageLogLevel` → display-severity mapping (consumer concern).
+- The log-query endpoint / display panel (consumer side; `ts-app-shell` messages packlet already covers display).
+
+## Acceptance criteria
+
+- [ ] `_logStructured` additive hook on `LoggerBase` (default no-op); `log()` calls it in the `shouldLog` branch.
+- [ ] **Test asserting existing subclasses (`ConsoleLogger`, `InMemoryLogger`, `LogReporter`'s logger) are behaviorally unaffected** by the hook addition.
+- [ ] `RetainingLogger` + `ILogRecord` + `MultiLogger` exported from the logging barrel (`Logging.X`).
+- [ ] `rush build` full repo clean; `rushx lint` clean (separate gate); `rushx fixlint` run before final commit.
+- [ ] `rushx test` 100% coverage all 4 metrics in `@fgv/ts-utils`. Cover: `records`/`getRecords` filtering (minLevel via shouldLog; sinceSeq paging; limit tail); ring eviction; **seq monotonicity across eviction** (client holding sinceSeq never skips/repeats); `clear()` not resetting seq; injected-clock determinism; `MultiLogger` fan-out to multiple children with independent thresholds; `MultiLogger.logLevel` = most-verbose child; return-value (formatted if any child logged, else undefined).
+- [ ] api-extractor regenerated.
+- [ ] Rush change file (`minor`).
+- [ ] LIBRARY_CAPABILITIES updated.
+- [ ] No `any`; no unsafe casts; no `Result<void>`.
+- [ ] `result.md` written; substrate migrated to `.ai/tasks/completed/<YYYY-MM>/logging-observability/` with polished README as part of the implementation PR (before the squash).
+
+## Required reading
+
+1. This brief.
+2. `libraries/ts-utils/src/packlets/logging/logger.ts` — `LoggerBase`, `shouldLog`, `_format`, `InMemoryLogger`, `ILogger`/`IDetailLogger`, `ReporterLogLevel`, `MessageLogLevel`. **Understand the `log → _format → _log` flow before touching it.**
+3. `libraries/ts-utils/src/packlets/logging/{bootLogger.ts, logReporter.ts, index.ts}` — sibling loggers + the barrel + how `ConsoleLogger`/`LogReporter` implement `_log` (these must stay unaffected).
+4. `CLAUDE.md` + `.ai/instructions/CODING_STANDARDS.md`.
+5. `.ai/notes/cross-repo-handoffs/logging-observability-2026-05.md` — origin + the Q5 reasoning, for context.
+
+## Skills to load
+
+| When | Skill |
+|---|---|
+| Before any Result-returning code | `/result-pattern` |
+| Before writing tests | `/result-tests` |
+| Before any logger construction / diagnostic code | `/ts-utils-logging` |
+
+## Stop-and-surface
+
+- Adding `_logStructured` to `LoggerBase` surfaces an existing subclass that already relies on `_log`-only in a way the hook interferes with — surface (shouldn't happen with a no-op default, but verify).
+- `MultiLogger.logLevel`-as-most-verbose can't be cleanly computed from the `shouldLog` ordering (e.g. an unexpected level value) — surface.
+- The packlet's file layout makes "where does `RetainingLogger`/`MultiLogger` live" non-obvious (single file vs sibling files) — match the existing structure; if unclear, surface.
+
+## fgv-conventions pre-load (per L22)
+
+- No re-exports from sibling `@fgv/*` packages.
+- All fallible ops return `Result<T>`; no `Result<void>`. (`MultiLogger`'s methods return `Success<string | undefined>` per `ILogger`.)
+- `@fgv/ts-utils` is established surface — additive-only; no breaking changes to existing exports or the `_log` seam.
+- `rushx lint` is a separate gate from `rushx build`.
+
+## Branch + PR posture
+
+- **Integration branch:** `logging-observability` (off `release`). Substrate-prep + implementation + any fixups land here.
+- **Work branch stem:** `feat/logging-observability` (harness may suffix; record actual name in state.md).
+- **PR target:** `logging-observability` (integration branch), NOT `release`.
+- **PR title:** `feat(ts-utils): RetainingLogger + MultiLogger observability primitives`
+- **Close:** orchestrator squash-merges `logging-observability` → `release` as one clean commit after gates pass + substrate migrated.

--- a/.ai/tasks/active/logging-observability/state.md
+++ b/.ai/tasks/active/logging-observability/state.md
@@ -1,0 +1,53 @@
+# Stream state: `logging-observability`
+
+**Status:** 🟢 ready to commission — substrate prep in flight
+**Integration branch:** `logging-observability` (off `release`)
+**Last updated:** 2026-05-25 (orchestrator — substrate prep)
+
+---
+
+## Phase status
+
+| Phase | Status | Notes |
+|---|---|---|
+| Implementation | 🟢 ready | Single-PR additive feature. Design fully locked in brief (incl. Q5). |
+
+---
+
+## Decisions log
+
+| Decision | Rationale |
+|---|---|
+| Accept the request into `@fgv/ts-utils` | General logging infra (record retention + fan-out), not consumer-specific; logging is core durable surface; build-once-in-fgv avoids downstream migration debt. Extend-the-primitive discipline. |
+| `_logStructured` additive hook (Erik, 2026-05-25) | The `_log(formatted, level)` seam only sees the formatted string — structured `(message, params)` are gone by then. Rather than break `_log` (ripples to all subclasses), add an optional no-op `_logStructured(level, formatted, message?, params?)` hook fired alongside `_log`. Makes structured capture additive with zero subclass ripple. |
+| Q5 = capture structured (`args`) | The `_logStructured` hook makes structured-now cheap + additive, flipping Q5 from the formatted-only fallback. `ILogRecord.args` = raw `[message, ...params]` (fgv's `_format` does no template substitution, so `args` is the structured form — not `template`+`params`). |
+| Q1 names: `RetainingLogger` + `MultiLogger` | Both proposed read cleanly; packlet style. |
+| Q2: `maxRecords: 1000`, retain at `'detail'` | Capture broad, filter at query. Deliberately more verbose than LoggerBase's `'info'` default. |
+| Q3: `limit` = most-recent N, oldest-first | Natural log-viewer tail semantics. |
+| Q4: injected `now?: () => number` | Deterministic seq/timestamp tests; fgv precedent for injectable clocks. |
+| `MultiLogger` is `ILogger`-only (not `IDetailLogger`) | Per request scope; `errorWithDetail`/`warnWithDetail` fan-out is a future addition if needed. |
+| Integration branch + squash to release | Erik's clean-history preference (same as local-summarization). Substrate + impl + fixups collapse to one release commit. |
+
+---
+
+## Q5 — the deliberate call (record of the divergence from the requesting orchestrator)
+
+Requesting orchestrator leaned "capture structured, cheap on day one." fgv orchestrator grounded against `LoggerBase`: structured is NOT cheap at the existing `_log` seam (formatted-only). Erik's `_logStructured` additive hook resolves it — making structured capture cheap + additive after all. Net: same outcome the requester wanted (structured `ILogRecord`), reached via a mechanism (additive hook) the requester hadn't identified. Captured for the handoff-back so the requesting orchestrator sees the reasoning.
+
+---
+
+## History
+
+| Date | Event | Notes |
+|---|---|---|
+| 2026-05-25 | Cross-repo request received | personaility orchestrator → fgv orchestrator; archived at `.ai/notes/cross-repo-handoffs/logging-observability-2026-05.md`. |
+| 2026-05-25 | Substrate prep + design adjudication | Q1–Q5 dispositions; `_logStructured` hook design; integration branch + brief + state + WORKSTREAMS entry. This PR. |
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep | (this PR) | open → integration branch |
+| Implementation | TBD | not yet commissioned |

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -128,6 +128,19 @@ substrate. Don't queue streams against them here.
 
 ## Active workstreams
 
+### `logging-observability` 🟢
+
+**Status:** 🟢 ready to commission (substrate prep in flight)
+**Integration branch:** `logging-observability` (off `release`) → squash to `release` at close
+**Workflow shape:** single implementation PR onto integration branch
+**Substrate:** `.ai/tasks/active/logging-observability/{brief.md, state.md}`
+**Package surface:** `@fgv/ts-utils` logging packlet (`LoggerBase` additive `_logStructured` hook + `RetainingLogger` + `MultiLogger` + `ILogRecord`) + `.ai/instructions/LIBRARY_CAPABILITIES.md`
+**Out-of-scope:** changing the existing `_log` seam / `InMemoryLogger`; `IDetailLogger` fan-out; template-substitution formatting; the consumer's log-query endpoint + display (consumer side; `ts-app-shell` messages packlet covers display).
+
+**Mission.** Add two observability primitives to `@fgv/ts-utils`'s `logging` packlet (consumer request from personaility): `RetainingLogger` (bounded most-recent-N structured-record ring with severity + since-cursor query API) and `MultiLogger` (fan-out one log call to N children, each with its own threshold — feeds both `ConsoleLogger` and a retainer from one pinned `ILogger`). Plus the enabler: an additive `LoggerBase._logStructured` hook (default no-op) that exposes the structured `(level, formatted, message, params)` to retaining subclasses without breaking the existing `_log` seam.
+
+**Origin.** Cross-repo handoff (`.ai/notes/cross-repo-handoffs/logging-observability-2026-05.md`). Extend-the-primitive: general logging infra, not consumer-specific. `@fgv/ts-utils` established surface → additive-only, 100% coverage. Soft-blocker for a downstream observability stream. Q5 (record shape) resolved to structured via the `_logStructured` hook — see brief.
+
 ### `prompt-assist-screeners` 🟢
 
 **Status:** 🟢 ready to commission (substrate prep in flight)


### PR DESCRIPTION
Substrate prep for the `logging-observability` stream — cross-repo capability request from personaility's orchestrator for two `@fgv/ts-utils` logging primitives.

## What ships (when implemented)

- **`RetainingLogger`** — `LoggerBase` subclass; bounded most-recent-N structured-record ring; `getRecords({ minLevel, sinceSeq, limit })` for severity filter + incremental paging; `seq` monotonic + stable across eviction.
- **`MultiLogger`** — fans one log call to N children, each with its own threshold; `logLevel` = most-verbose child; raw-forward (no double-format).
- **`LoggerBase._logStructured` hook** — additive, default no-op, fired alongside `_log` in the `shouldLog` branch; exposes structured `(level, formatted, message, params)` to retaining subclasses without breaking the existing `_log(formatted, level)` seam.

## Q5 — the deliberate call (diverged from the requesting orchestrator, then re-converged)

Requesting orchestrator leaned "capture structured records, cheap on day one." Grounding against `LoggerBase` showed the `_log` seam only sees the **formatted string** — so structured capture wasn't free at the existing seam (would need a fragile hack or a breaking seam change rippling to all subclasses). Erik's **additive `_logStructured` hook** resolves it: structured capture becomes cheap + additive with zero subclass ripple. So **Q5 = capture structured** after all — `ILogRecord.args?: readonly unknown[]` (raw `[message, ...params]`; fgv's `_format` does no template substitution, so `args` is the structured form). Same outcome the requester wanted, via a mechanism they hadn't identified.

Q1–Q4 disposed per request/peer: names (`RetainingLogger`/`MultiLogger`); `maxRecords: 1000` + retain `'detail'`; `limit` = most-recent-N oldest-first; injected `now` clock.

## Notes

- `@fgv/ts-utils` is an **established** surface → additive-only (no change to existing exports or the `_log` seam), 100% coverage. Acceptance includes a test asserting existing subclasses (`ConsoleLogger`/`InMemoryLogger`/`LogReporter`) are behaviorally unaffected by the hook.
- Request archived per the L9 cross-repo-handoff pattern at `.ai/notes/cross-repo-handoffs/logging-observability-2026-05.md`.
- Integration branch `logging-observability` + squash to `release` (clean history, per recent preference).

## Files

- `.ai/notes/cross-repo-handoffs/logging-observability-2026-05.md` — archived request + adjudication.
- `.ai/tasks/active/logging-observability/{brief.md, state.md}` — locked design + decisions.
- `docs/WORKSTREAMS.md` — new active stream entry.

No code changes; substrate only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_