### PR TITLE
feat(ts-app-shell): StatusBar UX — bounded expanded height, dismiss control, collapsed-by-default (§1–§3)

### DIFF
--- a/.ai/instructions/LIBRARY_CAPABILITIES.md
+++ b/.ai/instructions/LIBRARY_CAPABILITIES.md
@@ -104,6 +104,8 @@ Reusable React shell components: top bar, sidebar, column cascade, modal, keyboa
 
 Create messages level-first: **`createMessage(level, text, options?)`** / **`addMessage(level, text, options?)`** where `options?: ICreateMessageOptions` carries `{ severity?, action? }`. The **`MessagesLogger`** / **`useLogReporter`** bridge implements the ts-utils `ILogger`/`LogReporter` interface and sets `level` straight through from the log call (lossless — `RetainingLogger` levels map 1:1), leaving `severity` undefined so display styling is derived. `DEFAULT_TOAST_CONFIG` stays keyed by the styling `MessageSeverity`. **Import `MessageLogLevel`/`ReporterLogLevel`/`shouldLog` from `@fgv/ts-utils`** — the messages packlet does not re-export them.
 
+**`StatusBar` layout props.** The collapsible log panel takes **`maxExpandedHeight?: string`** (CSS length, default `'40vh'`) — the expanded panel is bounded to this height on both desktop and mobile, with the message list scrolling within the bound while the header/filter controls stay fixed; the mobile expanded view is an in-flow bounded sheet (with a dimming backdrop for tap-to-dismiss), not a `fixed inset-0` viewport takeover. **`defaultExpanded?: boolean`** (default `false`) controls expanded-on-mount. A discoverable collapse control (`✕`) sits in the expanded header on both layouts.
+
 ---
 
 ## Specialized utilities

--- a/.ai/tasks/completed/2026-05/messages-log-levels/README.md
+++ b/.ai/tasks/completed/2026-05/messages-log-levels/README.md
@@ -4,8 +4,10 @@
 **Bucket:** 2026-05
 **Integration branch:** `messages-log-levels` (off `release`) → squash to `release` at close
 **Work branch:** `claude/gracious-pasteur-Gpr4c`
-**PR:** [#421](https://github.com/ErikFortune/fgv/pull/421) — `feat(ts-app-shell)!: align messages packlet to ts-utils log levels (breaking)` (onto `messages-log-levels`)
-**Change type:** `major` (`@fgv/ts-app-shell`)
+**PRs (onto `messages-log-levels`):**
+- §4 log-level alignment — [#421](https://github.com/ErikFortune/fgv/pull/421) `feat(ts-app-shell)!: align messages packlet to ts-utils log levels (breaking)` (merged)
+- §1–§3 StatusBar UX — [#422](https://github.com/ErikFortune/fgv/pull/422) `feat(ts-app-shell): StatusBar UX — bounded expanded height, dismiss control, collapsed-by-default`
+**Change type:** `major` (`@fgv/ts-app-shell`) — `major` (§4) + `minor` sibling (§1–§3 props)
 
 ## What shipped
 

--- a/.ai/tasks/completed/2026-05/messages-log-levels/result.md
+++ b/.ai/tasks/completed/2026-05/messages-log-levels/result.md
@@ -89,8 +89,9 @@ are set explicitly via `addMessage('info', text, { severity: 'success' })`.
 
 ## Amendment — StatusBar UX (§1–§3)
 
-Landed as a second PR onto the same `messages-log-levels` integration branch (post-#421;
-squashes to `release` together). Addresses personaility's S17 StatusBar feedback.
+Landed as [PR #422](https://github.com/ErikFortune/fgv/pull/422) onto the same
+`messages-log-levels` integration branch (post-#421; squashes to `release` together).
+Addresses personaility's S17 StatusBar feedback.
 
 - **§1 bounded expanded height.** New `maxExpandedHeight?: string` prop (default `'40vh'`)
   bounds the expanded panel on **both** layouts via an inline `style={{ maxHeight }}`. The

--- a/.ai/tasks/completed/2026-05/messages-log-levels/result.md
+++ b/.ai/tasks/completed/2026-05/messages-log-levels/result.md
@@ -84,3 +84,38 @@ record half. A consumer wiring a `RetainingLogger` (or any ts-utils `ILogger`) t
 `MessagesLogger`/`useLogReporter` gets lossless level fidelity in the panel, filterable down
 to `detail`. Consumers map their own display enum from `IMessage.level`; `'success'` toasts
 are set explicitly via `addMessage('info', text, { severity: 'success' })`.
+
+---
+
+## Amendment — StatusBar UX (§1–§3)
+
+Landed as a second PR onto the same `messages-log-levels` integration branch (post-#421;
+squashes to `release` together). Addresses personaility's S17 StatusBar feedback.
+
+- **§1 bounded expanded height.** New `maxExpandedHeight?: string` prop (default `'40vh'`)
+  bounds the expanded panel on **both** layouts via an inline `style={{ maxHeight }}`. The
+  panel is a `flex flex-col`; the header/filter controls are `shrink-0` and the message list
+  is `flex-1 min-h-0 overflow-y-auto`, so the list scrolls within the bound while controls
+  stay fixed. The mobile expanded view is now an **in-flow bounded sheet** (`relative z-50`,
+  with the dimming `fixed inset-0` backdrop retained for tap-to-dismiss) — no longer a
+  `fixed inset-x-0 … max-h-[70vh]` panel that escapes consumer layout.
+- **§2 discoverable dismiss.** A labelled `✕` collapse control (`XMarkIcon`,
+  `aria-label="Collapse log panel"`) sits in the `shrink-0` expanded header on both layouts,
+  so §1's bounding keeps it reachable. The mobile backdrop tap is retained.
+- **§3 collapsed-by-default.** New `defaultExpanded?: boolean` (default `false`). The sole
+  in-repo consumer (`samples/testbed`) passes neither new prop and relied on the existing
+  always-collapsed-on-mount behaviour, so default-false is a no-op for it — no breakage.
+
+**Mobile bounded-sheet rework.** Went cleanly. The only `fixed` element is now the backdrop;
+the sheet itself is in document flow (`relative z-50 bg-surface shadow-xl rounded-t-lg`),
+painting above the `z-40` backdrop within the StatusBar's stacking context. Positioning of
+the StatusBar container itself remains the consumer's responsibility (the point of removing
+the `fixed` panel). No conflict surfaced with the testbed chrome; flag to personaility S17 if
+their chrome relied on the old fixed-overlay z-ordering of the *panel* (the backdrop overlay
+behaviour is unchanged).
+
+**Tests / gates.** `StatusBar.test.tsx` grew to 28 tests (added §1 bound + custom height +
+list-scroll + mobile-in-flow; §2 close-control dismiss on both layouts; §3 default-collapsed +
+expanded-on-mount). Messages packlet stays **100% on all four metrics**. `rush build` clean
+across all downstream consumers; `rushx lint` clean; `rushx fixlint` run. Change file extended
+with a `minor` sibling entry; LIBRARY_CAPABILITIES updated with the new `StatusBar` props.

--- a/common/changes/@fgv/ts-app-shell/messages-log-levels_2026-05-27-00-00.json
+++ b/common/changes/@fgv/ts-app-shell/messages-log-levels_2026-05-27-00-00.json
@@ -4,6 +4,11 @@
       "comment": "BREAKING: align the messages packlet to ts-utils canonical log levels. IMessage now carries a required `level: MessageLogLevel` (filter axis) and an optional `severity?: MessageSeverity` (styling axis); `createMessage`/`addMessage` are level-first with an options bag. The status-bar filter threshold is a ReporterLogLevel applied via `shouldLog`, so the panel can filter at `detail` granularity, and the logger bridge sets `level` losslessly. Added `deriveSeverityFromLevel` and `ICreateMessageOptions`.",
       "type": "major",
       "packageName": "@fgv/ts-app-shell"
+    },
+    {
+      "comment": "StatusBar UX: add `maxExpandedHeight?` (CSS length, default '40vh') bounding the expanded panel on both layouts with the message list scrolling within the bound; add a discoverable collapse control on the expanded header (both layouts); add `defaultExpanded?` (default false). The mobile expanded view is now an in-flow bounded sheet rather than a `fixed inset-0` viewport takeover.",
+      "type": "minor",
+      "packageName": "@fgv/ts-app-shell"
     }
   ],
   "packageName": "@fgv/ts-app-shell",

--- a/libraries/ts-app-shell/src/packlets/messages/StatusBar.tsx
+++ b/libraries/ts-app-shell/src/packlets/messages/StatusBar.tsx
@@ -23,7 +23,12 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { Logging } from '@fgv/ts-utils';
-import { FunnelIcon, DocumentDuplicateIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import {
+  FunnelIcon,
+  DocumentDuplicateIcon,
+  MagnifyingGlassIcon,
+  XMarkIcon
+} from '@heroicons/react/24/outline';
 import { CheckIcon } from '@heroicons/react/24/solid';
 
 import { deriveSeverityFromLevel, IMessage, MessageSeverity } from './model';
@@ -96,20 +101,35 @@ export interface IStatusBarProps {
   readonly onClear: () => void;
   /** Initial filter level for the log panel. Defaults to 'all'. */
   readonly initialFilterLevel?: Logging.ReporterLogLevel;
+  /**
+   * Maximum height of the expanded panel as a CSS length (e.g. `'40vh'`, `'320px'`).
+   * The panel is bounded to this height on both desktop and mobile; the message list
+   * scrolls within the bound while the header and filter controls stay fixed. Defaults to `'40vh'`.
+   */
+  readonly maxExpandedHeight?: string;
+  /** Whether the panel is expanded on mount. Defaults to `false` (collapsed). */
+  readonly defaultExpanded?: boolean;
 }
 
 /**
  * Collapsible status bar / log panel at the bottom of the application.
  *
  * Collapsed: shows severity counts.
- * Expanded: filterable, searchable, copyable log of all messages.
+ * Expanded: filterable, searchable, copyable log of all messages, bounded to
+ * {@link IStatusBarProps.maxExpandedHeight} with the list scrolling within the bound.
  * @public
  */
 export function StatusBar(props: IStatusBarProps): React.ReactElement {
-  const { messages, onClear, initialFilterLevel } = props;
+  const {
+    messages,
+    onClear,
+    initialFilterLevel,
+    maxExpandedHeight = '40vh',
+    defaultExpanded = false
+  } = props;
   const { layoutMode } = useResponsive();
   const isMobile = layoutMode === 'mobile';
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const [showFilters, setShowFilters] = useState(false);
   const [filterLevel, setFilterLevel] = useState<Logging.ReporterLogLevel>(initialFilterLevel ?? 'all');
   const [searchTerm, setSearchTerm] = useState('');
@@ -175,18 +195,23 @@ export function StatusBar(props: IStatusBarProps): React.ReactElement {
         <span className="text-muted">{expanded ? '\u25BC' : '\u25B2'}</span>
       </button>
 
-      {/* Expanded log — fixed slide-up sheet on mobile, inline on desktop */}
+      {/* Expanded log — bounded bottom-sheet on mobile, bounded inline panel on desktop.
+          The panel stays in document flow on both layouts (no `fixed` takeover); the mobile
+          backdrop is the only fixed element, dimming the rest and supporting tap-to-dismiss. */}
       {expanded && (
         <>
           {isMobile && (
-            <div className="fixed inset-0 z-40 bg-backdrop" onClick={(): void => setExpanded(false)} />
+            <div
+              className="fixed inset-0 z-40 bg-backdrop"
+              onClick={(): void => setExpanded(false)}
+              aria-hidden="true"
+            />
           )}
           <div
-            className={
-              isMobile
-                ? 'fixed inset-x-0 bottom-8 z-50 flex flex-col bg-surface border-t border-border shadow-xl rounded-t-lg max-h-[70vh]'
-                : 'border-t border-border-subtle'
-            }
+            className={`flex flex-col border-t border-border-subtle ${
+              isMobile ? 'relative z-50 bg-surface shadow-xl rounded-t-lg' : ''
+            }`}
+            style={{ maxHeight: maxExpandedHeight }}
           >
             {/* Header toolbar */}
             <div className="flex items-center justify-between px-4 py-1 bg-surface-alt border-b border-border-subtle shrink-0">
@@ -218,6 +243,14 @@ export function StatusBar(props: IStatusBarProps): React.ReactElement {
                 </button>
                 <button onClick={onClear} className="text-xs text-muted hover:text-secondary ml-1">
                   Clear
+                </button>
+                <button
+                  onClick={(): void => setExpanded(false)}
+                  className="p-1 rounded hover:bg-surface-raised ml-1"
+                  title="Collapse log panel"
+                  aria-label="Collapse log panel"
+                >
+                  <XMarkIcon className="h-3.5 w-3.5 text-muted" />
                 </button>
               </div>
             </div>
@@ -265,8 +298,8 @@ export function StatusBar(props: IStatusBarProps): React.ReactElement {
               </div>
             )}
 
-            {/* Message list */}
-            <div className={`overflow-y-auto ${isMobile ? 'flex-1' : 'max-h-48'}`}>
+            {/* Message list — scrolls within the bounded panel; header/filters stay fixed */}
+            <div className="flex-1 min-h-0 overflow-y-auto">
               {filteredMessages.length === 0 ? (
                 <div className="px-4 py-3 text-xs text-muted text-center">
                   {isFiltered ? 'No messages match the current filter' : 'No messages'}

--- a/libraries/ts-app-shell/src/test/unit/messages/StatusBar.test.tsx
+++ b/libraries/ts-app-shell/src/test/unit/messages/StatusBar.test.tsx
@@ -42,6 +42,8 @@ function renderBar(options?: {
   onClear?: () => void;
   layout?: LayoutMode;
   initialFilterLevel?: Logging.ReporterLogLevel;
+  maxExpandedHeight?: string;
+  defaultExpanded?: boolean;
 }): HTMLElement {
   const { container } = render(
     <ResponsiveProvider forceLayoutMode={options?.layout ?? 'full'}>
@@ -49,10 +51,21 @@ function renderBar(options?: {
         messages={options?.messages ?? sample}
         onClear={options?.onClear ?? jest.fn()}
         initialFilterLevel={options?.initialFilterLevel}
+        maxExpandedHeight={options?.maxExpandedHeight}
+        defaultExpanded={options?.defaultExpanded}
       />
     </ResponsiveProvider>
   );
   return container;
+}
+
+/** Returns the expanded panel element (the flex-column wrapper holding header + list). */
+function expandedPanel(container: HTMLElement): HTMLElement {
+  const panel = container.querySelector<HTMLElement>('div.flex.flex-col');
+  if (panel === null) {
+    throw new Error('expected an expanded panel');
+  }
+  return panel;
 }
 
 /** Clicks the collapsed bar toggle (the first button) to expand the panel. */
@@ -261,6 +274,80 @@ describe('StatusBar', () => {
       const container = renderBar();
       expand(container);
       expect(within(container).getByText(/^6 messages$/)).not.toBeNull();
+    });
+  });
+
+  describe('§1 bounded expanded height', () => {
+    test('bounds the expanded panel to the default 40vh on desktop', () => {
+      const container = renderBar();
+      expand(container);
+      expect(expandedPanel(container).style.maxHeight).toBe('40vh');
+    });
+
+    test('honors a custom maxExpandedHeight on both layouts', () => {
+      const desktop = renderBar({ maxExpandedHeight: '320px' });
+      expand(desktop);
+      expect(expandedPanel(desktop).style.maxHeight).toBe('320px');
+
+      cleanup();
+
+      const mobile = renderBar({ layout: 'mobile', maxExpandedHeight: '50vh' });
+      expand(mobile);
+      expect(expandedPanel(mobile).style.maxHeight).toBe('50vh');
+    });
+
+    test('the message list scrolls within the bound while the panel is a flex column', () => {
+      const container = renderBar();
+      expand(container);
+      const panel = expandedPanel(container);
+      // Panel is a flex column so the shrink-0 header stays fixed and the list flexes.
+      expect(panel.className).toContain('flex-col');
+      const list = panel.querySelector('.overflow-y-auto');
+      expect(list).not.toBeNull();
+      expect((list as HTMLElement).className).toContain('flex-1');
+      expect((list as HTMLElement).className).toContain('min-h-0');
+    });
+
+    test('mobile expanded view is an in-flow bounded sheet, not a fixed-inset-0 takeover', () => {
+      const container = renderBar({ layout: 'mobile' });
+      expand(container);
+      const panel = expandedPanel(container);
+      // The sheet itself is in document flow (relative), bounded by maxHeight — only the
+      // backdrop is fixed. The panel must not escape consumer layout via `fixed`/`inset-0`.
+      expect(panel.className).toContain('relative');
+      expect(panel.className).not.toContain('fixed');
+      expect(panel.className).not.toContain('inset-0');
+      expect(panel.style.maxHeight).toBe('40vh');
+    });
+  });
+
+  describe('§2 discoverable dismiss', () => {
+    test('exposes a labelled collapse control on the expanded header that dismisses the panel', () => {
+      const container = renderBar();
+      expand(container);
+      expect(screen.getByText('info-msg')).not.toBeNull();
+
+      fireEvent.click(screen.getByLabelText('Collapse log panel'));
+      expect(screen.queryByText('info-msg')).toBeNull();
+    });
+
+    test('the collapse control lives in the fixed header on mobile too', () => {
+      const container = renderBar({ layout: 'mobile' });
+      expand(container);
+      fireEvent.click(screen.getByLabelText('Collapse log panel'));
+      expect(screen.queryByText('info-msg')).toBeNull();
+    });
+  });
+
+  describe('§3 collapsed-by-default', () => {
+    test('mounts collapsed by default (no panel content visible)', () => {
+      renderBar();
+      expect(screen.queryByText('info-msg')).toBeNull();
+    });
+
+    test('mounts expanded when defaultExpanded is set', () => {
+      renderBar({ defaultExpanded: true });
+      expect(screen.getByText('info-msg')).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

Amendment to the `messages-log-levels` stream (builds on #421's log-level alignment, already merged into this integration branch). Implements personaility's S17 StatusBar UX feedback (§1–§3). Squashes to `release` together with §4 at stream close.

- **§1 — bounded expanded height.** New `maxExpandedHeight?: string` prop (CSS length, default `'40vh'`) bounds the expanded panel on **both** layouts via inline `style`. The panel is a `flex flex-col`: the `shrink-0` header and filter controls stay fixed while the `flex-1 min-h-0 overflow-y-auto` message list scrolls within the bound. The **mobile expanded view is now an in-flow bounded sheet** (`relative z-50 bg-surface shadow-xl rounded-t-lg`) rather than a `fixed inset-x-0 … max-h-[70vh]` panel that escaped consumer layout. The dimming `fixed inset-0` backdrop is retained for tap-to-dismiss.
- **§2 — discoverable dismiss.** A labelled `✕` collapse control (`XMarkIcon`, `aria-label="Collapse log panel"`) in the `shrink-0` expanded header on both layouts — §1's bounding keeps it reachable.
- **§3 — collapsed-by-default.** New `defaultExpanded?: boolean` (default `false`). Consumers opt into expanded-on-mount.

### New StatusBar props as shipped

```ts
interface IStatusBarProps {
  // …existing: messages, onClear, initialFilterLevel
  readonly maxExpandedHeight?: string;  // CSS length, default '40vh' — bounds the panel; list scrolls within
  readonly defaultExpanded?: boolean;   // default false
}
```

### Mobile bounded-sheet rework / stop-and-surface

The only `fixed` element is now the backdrop; the sheet is in document flow (`relative z-50`), painting above the `z-40` backdrop within the StatusBar's stacking context. Positioning the StatusBar container is (intentionally) the consumer's job. No conflict surfaced with the in-repo testbed chrome — flag to personaility S17 only if their chrome relied on the old **panel** being viewport-fixed (the backdrop overlay behaviour is unchanged).

`defaultExpanded: false` matches the prior always-collapsed-on-mount behaviour; the sole in-repo consumer (`samples/testbed`) passes neither new prop, so no breakage.

## Test plan

- [x] `rush build` clean across all downstream consumers (testbed + ai-image-gen-sample)
- [x] `rushx lint` clean (separate gate); `rushx fixlint` run before final commit
- [x] `rushx test` — **100% on all 4 metrics** for the messages packlet; `StatusBar.test.tsx` 20 → 28 tests covering: bounded height (default + custom, both layouts), list-scroll-within-bound, mobile in-flow sheet (not `fixed inset-0`), close-control dismiss (both layouts), default-collapsed mount, expanded-on-mount via prop
- [x] **No api-extractor regen** — ts-app-shell has none (confirmed in #421)
- [x] Change file extended with a `minor` sibling entry; LIBRARY_CAPABILITIES documents the new props; `result.md` records §1–§3
- [x] No `any`; no unsafe casts; no `Result<void>`

https://claude.ai/code/session_01QVL5FetwyqG6RVB98jKCHP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVL5FetwyqG6RVB98jKCHP)_