### PR TITLE
chore(private-key-storage): substrate prep — IPrivateKeyStorage impls (IDB + encrypted-file)

### DIFF
--- a/.ai/tasks/active/private-key-storage/brief.md
+++ b/.ai/tasks/active/private-key-storage/brief.md
@@ -1,0 +1,177 @@
+# Stream brief: `private-key-storage`
+
+**Status:** 🟢 ready to commission
+**Integration branch:** `private-key-storage` (off `release`) → squash to `release` at close
+**Workflow shape:** single implementation PR onto integration branch (both impls together)
+**Package surface:** `@fgv/ts-extras/crypto-utils` (Node — encrypted-file impl) + `@fgv/ts-web-extras/crypto-utils` (browser — IndexedDB impl) + `.ai/instructions/LIBRARY_CAPABILITIES.md`
+
+---
+
+## Mission
+
+Close the long-standing `IPrivateKeyStorage` implementation gap in the published fgv packages. Ship the two impls the existing JSDoc *promises* but doesn't deliver:
+
+- **`IdbPrivateKeyStorage`** in `@fgv/ts-web-extras/crypto-utils` — IndexedDB-backed; stores `CryptoKey` objects directly; `supportsNonExtractable: true`.
+- **`EncryptedFilePrivateKeyStorage`** (name TBD) in `@fgv/ts-extras/crypto-utils` — directory-on-disk; one file per stored key; AES-256-GCM-encrypted JWK content; `supportsNonExtractable: false` (Node `CryptoKey` round-trips via JWK).
+
+**Origin.** Cross-repo gap surfaced 2026-05-28 by a personaility agent: `KeyStore.addKeyPair` fails with `'No private key storage configured'` unless the consumer supplies an `IPrivateKeyStorage` backend, and ts-extras ships only the interface. The JSDoc on `privateKeyStorage.ts:25-27` claims impls live in `@fgv/ts-web-extras` and `@fgv/ts-chocolate` — neither is true today. Textbook L18 (docs describe design intent, not shipped behavior); textbook gap-then-fix (consumer "would have rolled their own"; we ship in fgv so every consumer benefits + the JSDoc becomes accurate).
+
+**Status of the gap today (verified against code):**
+- `libraries/ts-extras/src/packlets/crypto-utils/keystore/privateKeyStorage.ts` — interface-only.
+- `libraries/ts-extras/src/packlets/crypto-utils/keystore/keyStore.ts:922-924` — `addKeyPair` hard-fails without a backend.
+- `libraries/ts-web-extras/src/packlets/crypto-utils/` — has only `browserCryptoProvider.ts` + `browserHashProvider.ts`. **No** `IdbPrivateKeyStorage`.
+- `@fgv/ts-chocolate` is not in the fgv monorepo; the `IdbPrivateKeyStorage` reference the JSDoc cites lives in chocolate-lab's *consumer* code (`chocolate-lab-ui`), not in any published fgv package.
+
+---
+
+## Locked design — both impls
+
+Each impl satisfies the `IPrivateKeyStorage` interface verbatim (no interface changes). Result-pattern conformant; storage operations return `Promise<Result<...>>`.
+
+### `IdbPrivateKeyStorage` (browser — `@fgv/ts-web-extras/crypto-utils`)
+
+```typescript
+interface IIdbPrivateKeyStorageCreateParams {
+  /** IDB database name. Default: 'fgv-keystore-private-keys'. */
+  readonly databaseName?: string;
+  /** IDB object-store name. Default: 'privateKeys'. */
+  readonly storeName?: string;
+}
+
+class IdbPrivateKeyStorage implements IPrivateKeyStorage {
+  public static create(params?: IIdbPrivateKeyStorageCreateParams): Result<IdbPrivateKeyStorage>;
+  public readonly supportsNonExtractable: true;
+  public store(id: string, key: CryptoKey): Promise<Result<string>>;
+  public load(id: string): Promise<Result<CryptoKey>>;
+  public delete(id: string): Promise<Result<string>>;
+  public list(): Promise<Result<readonly string[]>>;
+}
+```
+
+- IDB stores `CryptoKey` objects **directly** (structured-clone, no JWK round-trip). `supportsNonExtractable = true` enables non-extractable keys for max security on browsers that support it.
+- Lazy DB open + schema migration (current schema version stored in IDB; future migrations additive).
+- Per-call transactions; default IDB serialization semantics (good enough for single-tab use). Multi-tab concurrency is a known limit; document it.
+- `load(missingId)` → `Result.fail` with "key not found".
+- All ops are `Promise<Result<T>>`; never throw across the boundary (use `captureAsyncResult` for IDB request failures).
+
+### `EncryptedFilePrivateKeyStorage` (Node — `@fgv/ts-extras/crypto-utils`)
+
+```typescript
+interface IEncryptedFilePrivateKeyStorageCreateParams {
+  /** Directory holding the encrypted private-key files. */
+  readonly directory: string;
+  /** AES-256-GCM key used to encrypt each file's JWK content. Consumer-provided. */
+  readonly encryptionKey: CryptoKey;
+  /** Crypto provider used for encrypt/decrypt + JWK import/export. */
+  readonly cryptoProvider: ICryptoProvider;
+  /** Optional FileTree override; defaults to FsTree (Node filesystem). */
+  readonly tree?: IFileTreeRootItem;
+}
+
+class EncryptedFilePrivateKeyStorage implements IPrivateKeyStorage {
+  public static create(params: IEncryptedFilePrivateKeyStorageCreateParams): Result<EncryptedFilePrivateKeyStorage>;
+  public readonly supportsNonExtractable: false;
+  // ... interface methods as above
+}
+```
+
+- One file per stored key, named by `id` (id-sanitization required; reject `/`, `..`, etc. — surface as design call if any in-band id format conflicts with safe filenames).
+- File content: AES-256-GCM-encrypted JWK of the private key. JWK round-trip via the supplied `ICryptoProvider` (`exportPublicKeyJwk` is for public — for private, use the Subtle `crypto.subtle.exportKey('jwk', key)` path; the provider's existing `encrypt`/`decrypt` handles AES-GCM).
+- **Consumer supplies the encryption key.** The KeyStore-level password derivation is the consumer's responsibility — typically the same password-derived key the KeyStore vault uses, but kept explicit so the impl stays decoupled. This is the load-bearing design call: **DO NOT** bake password-derivation into this impl; take a `CryptoKey` for AES-256-GCM.
+- Uses `FileTree` (default `FsTree`) for I/O — consistent with the rest of fgv (per `/filetree-io` skill); enables in-memory testing without touching disk.
+- `supportsNonExtractable: false` is mandatory — Node CryptoKey isn't structured-cloneable to disk; must round-trip via JWK, which requires extractable keys.
+- Single-process assumption (no inter-process locking); document.
+
+### The interface stays unchanged
+
+`IPrivateKeyStorage` itself is **not** modified. Both impls satisfy the existing contract verbatim. (If the agent discovers a real interface gap during implementation — surface; the interface is canonical and changing it ripples.)
+
+### JSDoc fix (load-bearing — closes the L18 gap)
+
+Update `libraries/ts-extras/src/packlets/crypto-utils/keystore/privateKeyStorage.ts:25-27` to point at the **actual shipping locations**:
+- `@fgv/ts-web-extras/crypto-utils` for `IdbPrivateKeyStorage`
+- `@fgv/ts-extras/crypto-utils` for `EncryptedFilePrivateKeyStorage`
+
+Remove the now-incorrect `@fgv/ts-chocolate` reference (chocolate-lab's consumer-side impl is informational; not the canonical one).
+
+---
+
+## In-scope
+
+- `libraries/ts-extras/src/packlets/crypto-utils/` — new file (e.g. `keystore/encryptedFilePrivateKeyStorage.ts`); barrel export under `CryptoUtils.KeyStore.EncryptedFilePrivateKeyStorage` (or wherever matches the existing keystore module layout).
+- `libraries/ts-web-extras/src/packlets/crypto-utils/` — new file (e.g. `idbPrivateKeyStorage.ts`); barrel export.
+- `libraries/ts-extras/src/packlets/crypto-utils/keystore/privateKeyStorage.ts` — JSDoc fix.
+- Tests in both packages — 100% coverage. Web tests use `fake-indexeddb` (already in `ts-web-extras` test deps per the existing browser tests).
+- `libraries/ts-extras/etc/ts-extras.api.md` + `libraries/ts-web-extras/etc/ts-web-extras.api.md` — regenerated.
+- `.ai/instructions/LIBRARY_CAPABILITIES.md` — add both impls under the KeyStore decision-shortcuts and the crypto-utils packlet entries.
+- `common/changes/@fgv/ts-extras/` + `common/changes/@fgv/ts-web-extras/` — rush change files (`minor`; pure-additive).
+
+## Out-of-scope
+
+- Changing the `IPrivateKeyStorage` interface (canonical; surface if a real gap).
+- Changing `KeyStore.addKeyPair` semantics (works against the new impls without changes).
+- Multi-process / multi-tab concurrency (single-tab/single-process assumption; document as known limit).
+- Schema-migration story beyond v1 (additive future migrations; not v1 scope).
+- Password-derivation helper for the file impl's encryption key (consumer concern; the impl takes a `CryptoKey` directly).
+- `@fgv/ts-chocolate` — out of scope; not in this monorepo.
+
+## Acceptance criteria
+
+- [ ] `IdbPrivateKeyStorage` ships in `@fgv/ts-web-extras/crypto-utils` satisfying `IPrivateKeyStorage`; `supportsNonExtractable: true`; lazy DB open; default/configurable db/store names.
+- [ ] `EncryptedFilePrivateKeyStorage` ships in `@fgv/ts-extras/crypto-utils` satisfying `IPrivateKeyStorage`; `supportsNonExtractable: false`; consumer-supplied encryption `CryptoKey` (no in-band password derivation); FileTree-based I/O.
+- [ ] **Integration test**: each impl wired into `KeyStore.addKeyPair` end-to-end — generate keypair → store private → retrieve via `KeyStore.getKeyPair` (or whatever the read path is) → sign/verify or wrap/unwrap to prove the loaded key works.
+- [ ] `IPrivateKeyStorage` JSDoc updated to point at the new shipping locations; `@fgv/ts-chocolate` reference removed.
+- [ ] `rush build` full repo clean; `rushx lint` clean in both packages (separate gate); `rushx fixlint` before final commit.
+- [ ] `rushx test` 100% coverage all 4 metrics in both packages. Cover: store/load/delete/list happy path; load-missing → fail; delete-missing → fail or no-op (pick one — surface if ambiguous); list after stores/deletes returns correct ids; concurrent ops on the same id (define semantics); IDB schema-version handling; file-impl encryption round-trip; file-impl id-sanitization rejects unsafe ids.
+- [ ] api-extractor regenerated in both packages.
+- [ ] Rush change files (`minor`) in both packages.
+- [ ] LIBRARY_CAPABILITIES updated.
+- [ ] No `any`; no unsafe casts; no `Result<void>`.
+- [ ] `result.md` written; substrate migrated to `.ai/tasks/completed/2026-05/private-key-storage/` with polished README, in the implementation PR (before the squash).
+
+## Required reading
+
+1. This brief.
+2. `libraries/ts-extras/src/packlets/crypto-utils/keystore/privateKeyStorage.ts` — the interface contract you're implementing. Note the storage-first / vault-second ordering described in the JSDoc — your impls don't drive that ordering (`KeyStore` does), but understand it.
+3. `libraries/ts-extras/src/packlets/crypto-utils/keystore/keyStore.ts:915-960` (`addKeyPair`) + the read path — understand how the keystore drives `IPrivateKeyStorage.store`/`load`/`delete`, what `id` shape it passes, and how it correlates to vault entries.
+4. `libraries/ts-extras/src/packlets/crypto-utils/model.ts` (the `ICryptoProvider` interface — `encrypt`/`decrypt`/`generateRandomBytes`).
+5. `libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts` + `libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts` — runtime-specific provider code; how AES-256-GCM is used.
+6. Existing FileTree-using code in ts-extras for I/O patterns (`/filetree-io` skill).
+7. `CLAUDE.md` + `.ai/instructions/ACTIVE_DEVELOPMENT.md` — note: `ts-extras` crypto surface is **established** (not active-dev). Additive only; no breaking changes. `ts-web-extras` is active-dev but this addition is also pure-additive.
+
+## Skills to load
+
+| When | Skill |
+|---|---|
+| Before any Result-returning code | `/result-pattern` (especially `captureAsyncResult` for IDB and async file ops) |
+| Before writing tests | `/result-tests` |
+| Before any file I/O | `/filetree-io` |
+| Before reaching for utility code | `/published-primitives-reflex` |
+
+## Stop-and-surface
+
+- The file impl's `id`-sanitization needs to reject ids that would escape the storage directory (`/`, `..`, etc.). If `KeyStore`'s `addKeyPair` passes ids that don't fit the safe-filename set, surface — we may need an internal mapping layer (e.g. base64url of the id) rather than rejecting consumer-visible ids.
+- The IDB impl needs `fake-indexeddb` or equivalent for tests; if it's not already a test dep on `@fgv/ts-web-extras`, surface (it likely is — the existing browser tests probably use it).
+- The Node `crypto.subtle.exportKey('jwk', privateKey)` path requires the key to be `extractable: true`. Confirm that's how `KeyStore.addKeyPair` generates keys when `supportsNonExtractable: false` (it should, per the brief's read of the code).
+- The interface's "storage-first, vault-second" ordering claim in the JSDoc — if the impls' tests can't observe that ordering reliably, surface; it's the keystore's contract, not the impl's, but the impls need to behave correctly under partial-failure scenarios.
+
+## fgv-conventions pre-load (per L22)
+
+- No sibling-package re-exports — the IDB impl in `ts-web-extras` imports `IPrivateKeyStorage` directly from `@fgv/ts-extras` (where the interface lives).
+- All fallible ops return `Result<T>`; no `Result<void>`; `captureAsyncResult` for async upstream (IDB requests, file I/O) wrapping.
+- `@fgv/ts-extras` crypto surface is **established** — additive only; no changes to existing exports, the interface, or `KeyStore.addKeyPair`.
+- `rushx lint` is a separate gate from `rushx build`.
+
+## Branch + PR posture
+
+- **Integration branch:** `private-key-storage` (off `release`). Work targets it, NOT `release`.
+- **Work branch stem:** `feat/private-key-storage` (harness may suffix; record in state.md).
+- **PR target:** `private-key-storage`.
+- **PR title:** `feat(crypto-utils): IdbPrivateKeyStorage + EncryptedFilePrivateKeyStorage`
+- **Close (orchestrator-handled):** squash `private-key-storage` → `release` after gates pass + substrate migrated.
+
+---
+
+## Downstream
+
+After ship: handoff-back note appended to the logging-observability cross-repo reply (`.ai/notes/cross-repo-handoffs/...`) noting the IPKS impls landed in the next alpha — closes the gap personaility surfaced.

--- a/.ai/tasks/active/private-key-storage/state.md
+++ b/.ai/tasks/active/private-key-storage/state.md
@@ -1,0 +1,53 @@
+# Stream state: `private-key-storage`
+
+**Status:** 🟢 ready to commission — substrate prep in flight
+**Integration branch:** `private-key-storage` (off `release`)
+**Last updated:** 2026-05-28 (orchestrator — substrate prep)
+
+---
+
+## Phase status
+
+| Phase | Status | Notes |
+|---|---|---|
+| Implementation | 🟢 ready | Single-PR feature; both impls + JSDoc fix + tests + capabilities doc together. |
+
+---
+
+## Decisions log
+
+| Decision | Rationale |
+|---|---|
+| Ship both impls in one PR | Same feature (close the IPrivateKeyStorage gap); each impl is small + bounded; one PR keeps the JSDoc fix coherent with the impls it points at. |
+| **IDB impl (browser)** with `supportsNonExtractable: true` | IDB structured-clones `CryptoKey` directly — no JWK round-trip required — so non-extractable keys are preserved. Max-security on browsers that support it. |
+| **Encrypted-file impl (Node)** with `supportsNonExtractable: false` | Node `CryptoKey` isn't structured-cloneable to disk; must round-trip via JWK, which requires `extractable: true`. Documented limit. |
+| Consumer-supplied encryption `CryptoKey` for the file impl (not in-band password derivation) | Decouples the impl from KeyStore's password lifecycle; consumer derives once (typically the same key the KeyStore vault uses) and passes it in. Keeps the impl Result-pattern-clean and lifecycle-agnostic. |
+| FileTree I/O for the file impl | Consistent with the rest of fgv (`/filetree-io` skill); enables in-memory testing without touching disk. Default `FsTree`; overridable. |
+| Single-process / single-tab assumption | v1 scope. Multi-tab IDB and inter-process file locking are out of scope; documented limits. |
+| Interface unchanged | `IPrivateKeyStorage` is canonical and existing-consumer-facing; both impls satisfy the existing contract verbatim. If the agent surfaces a real interface gap, that's a separate (heavier) discussion. |
+| JSDoc fix in same PR | Closes the L18 gap that surfaced this stream — the existing JSDoc points at impls that don't exist in fgv. Updating it alongside the impls keeps the docs and code in sync from day one. Removes the now-incorrect `@fgv/ts-chocolate` reference. |
+| Integration branch + squash to release | Clean release history (same as recent streams: logging-observability, messages-log-levels, local-summarization). |
+
+---
+
+## Origin
+
+Cross-repo gap surfaced 2026-05-28 by a personaility agent investigating agent/hub private-key persistence: `KeyStore.addKeyPair` fails with `'No private key storage configured'` unless a backend is supplied, and ts-extras ships only the interface. The `IPrivateKeyStorage` JSDoc claims impls live in `@fgv/ts-web-extras` (false — no IDB impl ships) and `@fgv/ts-chocolate` (not in this monorepo). Textbook L18 (docs describe design intent, not shipped behavior). Erik confirmed the gap and commissioned this stream to close it.
+
+---
+
+## History
+
+| Date | Event | Notes |
+|---|---|---|
+| 2026-05-28 | Gap verified against code | personaility agent's claim confirmed: ts-extras has interface only; `addKeyPair` requires a backend; `ts-web-extras` ships no IDB impl; `@fgv/ts-chocolate` not in this monorepo. |
+| 2026-05-28 | Stream commissioned + substrate prep | brief + state + WORKSTREAMS + integration branch + substrate PR. |
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep | (this PR) | open → integration branch |
+| Implementation | TBD | not yet commissioned |

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -128,6 +128,19 @@ substrate. Don't queue streams against them here.
 
 ## Active workstreams
 
+### `private-key-storage` 🟢
+
+**Status:** 🟢 ready to commission (substrate prep in flight)
+**Integration branch:** `private-key-storage` (off `release`) → squash to `release` at close
+**Workflow shape:** single implementation PR onto integration branch (both impls together)
+**Substrate:** `.ai/tasks/active/private-key-storage/{brief.md, state.md}`
+**Package surface:** `@fgv/ts-extras/crypto-utils` (encrypted-file impl, Node) + `@fgv/ts-web-extras/crypto-utils` (IndexedDB impl, browser) + `.ai/instructions/LIBRARY_CAPABILITIES.md`
+**Out-of-scope:** changes to the `IPrivateKeyStorage` interface, to `KeyStore.addKeyPair` semantics, or to `@fgv/ts-chocolate`. Multi-process/multi-tab concurrency (single-process/single-tab assumption; documented limit). Password-derivation helper for the file impl's encryption key (consumer concern).
+
+**Mission.** Ship the two `IPrivateKeyStorage` implementations the existing JSDoc promises but doesn't deliver: `IdbPrivateKeyStorage` in `@fgv/ts-web-extras/crypto-utils` (IndexedDB, `supportsNonExtractable: true`) and `EncryptedFilePrivateKeyStorage` in `@fgv/ts-extras/crypto-utils` (directory-on-disk, AES-256-GCM-encrypted JWK content, FileTree I/O, `supportsNonExtractable: false`). Both satisfy the interface verbatim — additive, no interface changes. Also fixes the JSDoc that points at non-existent impls (textbook L18). Closes the gap personaility's agent surfaced when `KeyStore.addKeyPair` failed with `'No private key storage configured'`.
+
+**Origin.** Cross-repo gap surfaced 2026-05-28 (personaility agent investigating agent/hub private-key persistence). ts-extras crypto surface is **established** → additive only. Gap-then-fix: every `KeyStore.addKeyPair` consumer currently rolls their own backend or skips the feature; we ship in fgv so consumers benefit + the JSDoc becomes accurate.
+
 ### `messages-log-levels` 🟢
 
 **Status:** ✅ implementation complete — PR open onto `messages-log-levels`; ready to squash → `release`


### PR DESCRIPTION
Substrate prep for the `private-key-storage` stream — closes the `IPrivateKeyStorage` impl gap surfaced by personaility's agent.

## The gap (verified against code)

`@fgv/ts-extras` ships `IPrivateKeyStorage` interface only — `keystore/privateKeyStorage.ts` defines the contract; **no implementations ship**. `KeyStore.addKeyPair` hard-fails with `'No private key storage configured'` if not given a backend (`keyStore.ts:922-924`). The JSDoc at `privateKeyStorage.ts:25-27` claims impls live in `@fgv/ts-web-extras` (false — only `browserCryptoProvider.ts` + `browserHashProvider.ts` ship there) and `@fgv/ts-chocolate` (not in this monorepo; chocolate-lab's own `IdbPrivateKeyStorage` lives in their consumer-side `chocolate-lab-ui`).

Textbook L18 (docs describe design intent, not shipped behavior). Every `KeyStore.addKeyPair` consumer today either rolls their own backend or skips the asymmetric-key vault feature entirely.

## What this stream ships (when implemented)

- **`IdbPrivateKeyStorage`** in `@fgv/ts-web-extras/crypto-utils` — IndexedDB-backed; stores `CryptoKey` directly (structured-clone, no JWK round-trip); `supportsNonExtractable: true`; lazy DB open; configurable db/store names.
- **`EncryptedFilePrivateKeyStorage`** in `@fgv/ts-extras/crypto-utils` — directory-on-disk; one file per key; AES-256-GCM-encrypted JWK content; `supportsNonExtractable: false` (Node `CryptoKey` requires JWK round-trip = extractable); FileTree I/O (default `FsTree`); **consumer-supplied encryption `CryptoKey`** (no in-band password derivation — decoupled from KeyStore's lifecycle).
- **JSDoc fix** at `privateKeyStorage.ts:25-27` pointing at the actual shipping locations; removes the `@fgv/ts-chocolate` reference.
- Interface unchanged. `ts-extras` crypto surface is **established** → additive only.

## Notes

- Single-process / single-tab assumption (multi-tab IDB + inter-process file-locking are documented limits, not v1 scope).
- Integration branch `private-key-storage` + squash to `release` at close — clean history (same posture as recent streams).
- Both impls in one PR (small + bounded; JSDoc fix stays coherent with the impls it now points at).

## Files

- `.ai/tasks/active/private-key-storage/{brief.md, state.md}` — locked design + decisions log.
- `docs/WORKSTREAMS.md` — new active stream entry.

No code changes; substrate only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_