### PR TITLE
chore(capture-async-result-upgrade): substrate prep

### DIFF
--- a/.ai/tasks/active/capture-async-result-upgrade/brief.md
+++ b/.ai/tasks/active/capture-async-result-upgrade/brief.md
@@ -1,0 +1,133 @@
+# Stream brief: `capture-async-result-upgrade`
+
+**Status:** 🟢 ready to commission
+**Integration branch:** `capture-async-result-upgrade` (off `release`) → squash to `release` at close
+**Workflow shape:** single implementation PR onto integration branch
+**Package surface:** `@fgv/ts-utils` (`base/result.ts` + tests + api-extractor report) + monorepo-wide verify sweep (no behavioral changes expected at call sites)
+
+---
+
+## Mission
+
+Upgrade `captureAsyncResult<T>` to return `AsyncResult<T>` instead of `Promise<Result<T>>`. Surfaced concretely during `private-key-storage` (`encryptedFilePrivateKeyStorage._encryptAndWrite`) where the bare-Promise return forced an awkward `succeed(key).thenOnSuccess(() => captureAsyncResult(...))` chain seed.
+
+`AsyncResult<T>` is already `@public`, in the api surface, implements `PromiseLike<Result<T>>`, and is the canonical chainable async-Result type. Today the factory hands back a bare `Promise<Result<T>>` so callers can't fluently chain (`.onSuccess` / `.thenOnSuccess` / `.withErrorFormat`) off a `captureAsyncResult(...)` result — they must `await` and re-wrap, or seed a synthetic chain. After this change, callers can chain directly.
+
+Reference (entered as `docs/TECH_DEBT.md` P3 in PR #430):
+> change return type to `AsyncResult<T>` (wrap the existing internal promise in `new AsyncResult(...)`). Type-compatible with all existing `await captureAsyncResult(...)` call sites (`AsyncResult` is `PromiseLike<Result<T>>`, so `await` still yields `Result<T>`). Additive/cleanup for the chained call sites.
+
+---
+
+## Locked design
+
+### The change (one function in `libraries/ts-utils/src/packlets/base/result.ts`)
+
+Current (lines 1520–1526):
+
+```ts
+export async function captureAsyncResult<T>(func: () => Promise<T>): Promise<Result<T>> {
+  try {
+    return succeed(await func());
+  } catch (err: unknown) {
+    return fail(_errorMessage(err));
+  }
+}
+```
+
+After — leveraging the existing `AsyncResult` constructor, which already catches promise rejection and converts to `Failure` (see `result.ts:1365-1367`):
+
+```ts
+export function captureAsyncResult<T>(func: () => Promise<T>): AsyncResult<T> {
+  return new AsyncResult(func().then((value) => succeed(value)));
+}
+```
+
+The `AsyncResult` constructor's catch path subsumes the prior `try/catch` — synchronous throws inside `func()` itself still need to be caught, so the implementation may need to wrap the `func()` invocation in a `try`:
+
+```ts
+export function captureAsyncResult<T>(func: () => Promise<T>): AsyncResult<T> {
+  try {
+    return new AsyncResult(func().then((value) => succeed(value)));
+  } catch (err: unknown) {
+    return AsyncResult.from(fail<T>(_errorMessage(err)));
+  }
+}
+```
+
+The agent decides the exact shape — both forms are correct; pick the simpler one that preserves the existing semantics. **Required behavioral guarantees:**
+- Synchronous throw from `func()` → `AsyncResult` resolving to `Failure` (do **not** propagate as a synchronous throw).
+- Promise rejection from `func()` → `AsyncResult` resolving to `Failure`.
+- Promise resolution from `func()` → `AsyncResult` resolving to `Success` wrapping the value.
+- Existing tests in `libraries/ts-utils/src/test/unit/base/result.test.ts` for `captureAsyncResult` must still pass (or be updated minimally if they assert on the return-type shape rather than the resolved value — `await result` should still yield the same `Result<T>`).
+
+### Call-site compatibility (verified pre-commission)
+
+Monorepo grep: 86 non-test, non-`lib/` references to `captureAsyncResult` across `libraries/`, `tools/`, `samples/`, `apps/`. **Zero** of them chain `.then` / `.catch` / `.finally` directly on the return value — all use `await`. Because `AsyncResult<T>` implements `PromiseLike<Result<T>>`, every existing `await captureAsyncResult(...)` site continues to compile and yields the same `Result<T>`. No call-site code change is **required** for compatibility.
+
+### Opportunistic call-site cleanup (in-scope for this PR, but bounded)
+
+A handful of call sites currently exhibit the chain-seam-awkwardness pattern this change is intended to relieve — they `await captureAsyncResult` and then either chain off the awaited `Result<T>` or seed a synthetic `AsyncResult` to keep chaining. The agent may opportunistically refactor those sites to chain directly off the new `AsyncResult<T>` return when the rewrite is mechanical and obvious.
+
+**Scope guardrails:**
+- Touch **only** sites where the new chainable return materially simplifies existing code (typically 5–15 sites at most across the monorepo).
+- Do **not** rewrite every `await captureAsyncResult` site — `await` remains a perfectly valid usage pattern.
+- Do **not** restructure surrounding logic; only swap the chain-seam shape.
+- Refactor sites that the agent finds during the verify sweep; do not run an exhaustive search-and-rewrite pass.
+- If a site needs more than ~10 lines of change to refactor, leave it alone and flag it in the PR description for follow-up.
+
+### api-extractor
+
+`libraries/ts-utils/etc/ts-utils.api.md` will regenerate to reflect the new return type. Commit the regenerated report.
+
+### Rush change file
+
+Add a `minor` rush change file for `@fgv/ts-utils` describing the additive return-type change ("`captureAsyncResult` now returns `AsyncResult<T>` instead of `Promise<Result<T>>`; existing `await` call sites unaffected since `AsyncResult` implements `PromiseLike<Result<T>>`; new chainable surface for callers that want to keep the chain unbroken").
+
+---
+
+## Acceptance criteria
+
+- [ ] `captureAsyncResult` signature changed to return `AsyncResult<T>`; behavioral guarantees above preserved.
+- [ ] **`rush build` passes across the entire monorepo** — load-bearing sweep; the whole point is verifying the additive return-type change doesn't break any of the 86 call sites.
+- [ ] **`rushx test` passes in every package that consumes `captureAsyncResult`** — this is the real compatibility evidence. Coverage stays at 100% in `ts-utils`.
+- [ ] **`rushx lint` passes** in `libraries/ts-utils` (load-bearing — not transitively run by build).
+- [ ] **`rushx fixlint` was run before the final commit.**
+- [ ] api-extractor report (`libraries/ts-utils/etc/ts-utils.api.md`) regenerated and committed.
+- [ ] `minor` rush change file added for `@fgv/ts-utils`.
+- [ ] Existing `captureAsyncResult` tests in `result.test.ts` pass (update minimally if they assert on the return-type shape; `await result` semantics must be unchanged).
+- [ ] Opportunistic call-site refactors (if any) are mechanical, minimal, and clearly motivated; flagged in the PR description.
+- [ ] No `any` types; no `Result<void>`; Result-pattern conformance preserved.
+- [ ] **`code-reviewer` agent run on the final diff** with findings resolved or dispositioned (per the lessons-pending L32 candidate gate — running early on a focused diff like this is exactly the case the gate is for).
+
+## Out of scope
+
+- **Exhaustive call-site refactor.** Only opportunistic, mechanical cleanups during the verify sweep.
+- **Other `@fgv/ts-utils/base` surface changes** — this stream is narrowly scoped to `captureAsyncResult`. If other `Promise<Result<T>>`-returning helpers exist with the same chain-seam awkwardness, surface as separate follow-ups; don't bundle.
+- **`AsyncResult` API additions or `captureResult` changes** — the sync sibling stays as-is.
+- **Behavioral changes** — the resolved `Result<T>` after `await` must be byte-identical to today.
+- **Documentation rewrites** beyond updating the TSDoc on the function itself to reflect the new return type.
+
+---
+
+## Reading list (start here)
+
+1. `libraries/ts-utils/src/packlets/base/result.ts:1354-1510` — `AsyncResult<T>` class (already exists; constructor catches rejections; many chainable methods).
+2. `libraries/ts-utils/src/packlets/base/result.ts:1520-1526` — current `captureAsyncResult` implementation.
+3. `libraries/ts-utils/src/test/unit/base/result.test.ts` — existing test coverage for `captureAsyncResult` (preserve semantics).
+4. `libraries/ts-utils/etc/ts-utils.api.md` — api-extractor report to regenerate.
+5. `docs/TECH_DEBT.md` (P3 entry on `captureAsyncResult`) — the entry this stream retires.
+6. `.ai/instructions/CODING_STANDARDS.md` — Result-pattern, lint, and Pre-PR Validation Checklist.
+
+## Reference for design context
+
+- `.ai/tasks/completed/2026-05/private-key-storage/result.md` Follow-ups § — the original surfacing, with the specific call-site (`_encryptAndWrite`) that motivated this.
+- Lockstep version policy: a change in `@fgv/ts-utils` ships in the same alpha as every other package's changes; the monorepo-wide verify sweep is the cost of that policy.
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep | (this PR) | open → integration branch |
+| Implementation | TBD | not yet commissioned |

--- a/.ai/tasks/active/capture-async-result-upgrade/state.md
+++ b/.ai/tasks/active/capture-async-result-upgrade/state.md
@@ -1,0 +1,53 @@
+# Stream state: `capture-async-result-upgrade`
+
+**Status:** 🟢 ready to commission — substrate prep in flight
+**Integration branch:** `capture-async-result-upgrade` (off `release`)
+**Last updated:** 2026-05-30 (orchestrator — substrate prep)
+
+---
+
+## Phase status
+
+| Phase | Status | Notes |
+|---|---|---|
+| Implementation | 🟢 ready | Single-PR change; signature flip + verify sweep + opportunistic call-site cleanups. |
+
+---
+
+## Decisions log
+
+| Decision | Rationale |
+|---|---|
+| Change `captureAsyncResult` to return `AsyncResult<T>`, not `Promise<Result<T>>` | `AsyncResult` is already `@public` and `PromiseLike<Result<T>>`. The factory should return the canonical chainable shape so callers don't have to seed synthetic chains. |
+| Type-compatible at all 86 call sites — no required call-site changes | Verified: zero non-test call sites chain `.then` / `.catch` / `.finally` directly on `captureAsyncResult`'s return. All use `await`, which still works because `AsyncResult` implements `PromiseLike<Result<T>>`. |
+| Opportunistic call-site cleanups in-scope but bounded (~5-15 sites max) | Several call sites currently `await captureAsyncResult` then seed a synthetic chain — those are the targets. Don't refactor every `await` site; `await` remains valid. Keep the PR focused. |
+| Out of scope: other `@fgv/ts-utils/base` chain-seam changes | If `captureResult`/other helpers have the same pattern, surface as follow-ups. Don't bundle. |
+| Single PR onto integration branch + squash to release | Standard posture for `@fgv/ts-utils` changes (established surface; clean release history). Same as `private-key-storage`, `logging-observability`, `messages-log-levels`. |
+| Mandatory `code-reviewer` run on final diff | Per L32 (lessons-pending, surfaced from PR #427's six-round Copilot loop). This stream is exactly the focused-diff shape where pre-PR `code-reviewer` shines. |
+
+---
+
+## Origin
+
+Surfaced in `.ai/tasks/completed/2026-05/private-key-storage/result.md` Follow-ups: the implementation agent for `private-key-storage` hit the awkward chain seam in `encryptedFilePrivateKeyStorage._encryptAndWrite` (a `succeed(key).thenOnSuccess(() => captureAsyncResult(...))` seed). Routed to `docs/TECH_DEBT.md` as P3 in PR #430, then commissioned here at Erik's direction ahead of the -33 publish so the cleanup lands in the same alpha as `ts-app-shell-styling-hardening`.
+
+`@fgv/ts-utils` is established surface — per `ACTIVE_DEVELOPMENT.md` this is "handle with care." The change is additive in practice (all 86 call sites continue to compile and execute identically), but the lockstep policy means the monorepo-wide rebuild+test sweep is the gating cost. That's what this stream is for: not "ship the one-line change" but "ship the one-line change plus the verify sweep that proves it's safe."
+
+---
+
+## History
+
+| Date | Event | Notes |
+|---|---|---|
+| 2026-05-29 | Surfaced in `private-key-storage` result.md | Concrete chain-seam in `_encryptAndWrite`. |
+| 2026-05-30 | Routed to `docs/TECH_DEBT.md` P3 | Cluster-close PR #430. |
+| 2026-05-30 | Stream commissioned + substrate prep | brief + state + WORKSTREAMS + integration branch + substrate PR. |
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep | (this PR) | open → integration branch |
+| Implementation | TBD | not yet commissioned |

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -128,6 +128,19 @@ substrate. Don't queue streams against them here.
 
 ## Active workstreams
 
+### `capture-async-result-upgrade` 🟢
+
+**Status:** 🟢 ready to commission — substrate prep in flight
+**Integration branch:** `capture-async-result-upgrade` (off `release`) → squash to `release` at close
+**Workflow shape:** single implementation PR onto integration branch
+**Substrate:** `.ai/tasks/active/capture-async-result-upgrade/{brief.md, state.md}`
+**Package surface:** `@fgv/ts-utils` (`base/result.ts` + tests + api-extractor report) + monorepo-wide verify sweep
+**Out-of-scope:** other `@fgv/ts-utils/base` chain-seam changes; `captureResult` sync sibling; exhaustive call-site refactor (only opportunistic, mechanical cleanups in-scope); behavioral changes (resolved `Result<T>` after `await` must be byte-identical).
+
+**Mission.** Change `captureAsyncResult<T>` to return `AsyncResult<T>` instead of `Promise<Result<T>>` so callers can fluently chain `.onSuccess` / `.thenOnSuccess` / `.withErrorFormat` off the result without seeding a synthetic `succeed(x).thenOnSuccess(() => captureAsyncResult(...))` chain. `AsyncResult<T>` is already `@public` and `PromiseLike<Result<T>>` — all 86 monorepo call sites continue to compile and behave identically because every existing usage is `await captureAsyncResult(...)` (zero `.then`/`.catch`/`.finally` chains on the return). Opportunistic call-site cleanups (5–15 sites at most) included; not an exhaustive refactor.
+
+**Origin.** Surfaced in `.ai/tasks/completed/2026-05/private-key-storage/result.md` Follow-ups (chain seam in `_encryptAndWrite`); routed to `docs/TECH_DEBT.md` P3 in PR #430; commissioned ahead of the -33 publish so it lands in the same alpha as `ts-app-shell-styling-hardening`. `@fgv/ts-utils` is established surface — additive in practice, but the lockstep policy makes the monorepo-wide rebuild+test sweep the gating cost.
+
 ### `private-key-storage` ✅
 
 **Status:** ✅ implemented + reviewed (PR #427, gates green) — ready for squash to `release`


### PR DESCRIPTION
## Summary

Substrate prep for the `captureAsyncResult` → `AsyncResult<T>` return-type upgrade. Surfaced concretely during `private-key-storage` (chain seam in `encryptedFilePrivateKeyStorage._encryptAndWrite`); routed to `docs/TECH_DEBT.md` P3 in PR #430; commissioned ahead of the -33 publish so the cleanup lands in the same alpha as `ts-app-shell-styling-hardening`.

The change itself is one function in `libraries/ts-utils/src/packlets/base/result.ts`:

```ts
// Before
export async function captureAsyncResult<T>(func: () => Promise<T>): Promise<Result<T>> { ... }

// After
export function captureAsyncResult<T>(func: () => Promise<T>): AsyncResult<T> { ... }
```

Why this is safe at all 86 monorepo call sites (verified pre-commission):
- `AsyncResult<T>` is `@public` and implements `PromiseLike<Result<T>>`, so every existing `await captureAsyncResult(...)` site continues to compile and yields the same `Result<T>`.
- Zero non-test call sites chain `.then` / `.catch` / `.finally` directly on the return value (grep confirmed). The `await` pattern is universal.
- Existing behavioral guarantees preserved: sync throw from `func()` → `Failure`; promise rejection → `Failure`; resolution → `Success(value)`.

Opportunistic call-site cleanups (5–15 sites max) are in-scope where the new chainable return materially simplifies existing chain-seam workarounds; an exhaustive refactor is **out of scope**.

## Substrate added

- `.ai/tasks/active/capture-async-result-upgrade/brief.md` — locked design, behavioral guarantees, acceptance criteria, scope guardrails on opportunistic call-site cleanup.
- `.ai/tasks/active/capture-async-result-upgrade/state.md` — decisions log, origin, history.
- `docs/WORKSTREAMS.md` — entry above `private-key-storage`.

## Test plan

- [ ] Substrate-prep only — no functional changes; merge to integration branch `capture-async-result-upgrade`.
- [ ] After merge, commission implementation agent off the integration branch.
- [ ] Squash integration → `release` after the implementation PR is reviewed and merged.
- [ ] Lockstep-policy verify sweep is the gating cost: `rush build` + `rushx test` across the full monorepo in the implementation PR's gate run.

https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_