### PR TITLE
chore: codify review-loop discipline (L31 + L32 + L33 sweep)

### DIFF
--- a/.ai/conventions/workflow/kickoff-prompt-shape.md
+++ b/.ai/conventions/workflow/kickoff-prompt-shape.md
@@ -89,6 +89,21 @@ The interleaved shape:
   with their trigger conditions, not just listed.
 - **Resume protocol.** How to resume from `state.md` if the session
   crosses a context boundary.
+- **Review-loop discipline inherited from `CODING_STANDARDS.md`
+  § "Review-loop discipline".** Every kickoff implicitly requires:
+  - **Layer 1** — `code-reviewer` agent on the final diff before
+    opening the PR; findings resolved or dispositioned with a
+    summary in the PR description.
+  - **Layer 2** — agent-driven Copilot loop: request on the first
+    complete commit; re-request after each round as long as
+    Copilot is adding substantive value; cap at 10 rounds; stop
+    on diminishing returns OR cap and surface the stop with a
+    one-line reason.
+  - Both are part of the standard PR-description gate
+    (`code-reviewer` summary + Copilot-loop status line) — kickoffs
+    don't need to re-state the rules, but they should remind the
+    worker that the discipline is mandatory and reference the
+    `CODING_STANDARDS.md` section.
 
 ## Anti-patterns
 

--- a/.ai/instructions/CODING_STANDARDS.md
+++ b/.ai/instructions/CODING_STANDARDS.md
@@ -588,8 +588,10 @@ Every stream's acceptance criteria list must include:
 - [ ] `rushx test` passes with 100% coverage in every modified package
 - [ ] **`rushx fixlint` was run before the final commit** *(catches the mechanical class)*
 - [ ] No `any` types; all fallible operations return `Result<T>`
+- [ ] **`code-reviewer` agent run on the final diff; findings resolved or dispositioned** *(see "Review-loop discipline" below)*
+- [ ] **Copilot review loop driven by implementer; stopped on diminishing returns or 10-round cap** *(see "Review-loop discipline" below)*
 
-The bolded items above are the gap recently codified — multiple recent streams had lint failures escape into PR-open state, blocking cluster merges.
+The bolded items above are the gap recently codified — multiple recent streams had lint failures escape into PR-open state, blocking cluster merges, and multi-round Copilot ping-pong on PRs that hadn't been internally reviewed first.
 
 ### Why this gate is load-bearing
 
@@ -600,3 +602,54 @@ The local cost of running lint is ~5-10 seconds per package. The downstream cost
 ### For orchestrators
 
 When reviewing an implementing agent's PR before merge (or before bundling into a cluster-close prep), call `mcp__github__pull_request_read` with `method: get_check_runs` and refuse to advance the workflow if any check is `conclusion: failure`. Do this **before** opening downstream prep/promotion PRs — once a failed-CI commit is in the integration branch, unwinding is painful.
+
+---
+
+## Review-loop discipline
+
+PR review is a three-layer stack:
+
+1. **Internal pre-push pass** — implementing agent runs the `code-reviewer` agent on the final diff *before* the first push.
+2. **External post-push loop** — implementing agent drives Copilot's automated review on the open PR, capped and managed.
+3. **Orchestrator gating** — orchestrator confirms CI green + Copilot pass addressed before advancing the workflow.
+
+Each layer has a different purpose; skipping any one compounds cost into the next. Layer 2 in particular bloats into 5-6 ad-hoc rounds when layer 1 hasn't run, because the internal reviewer catches the repo-pattern class of finding that Copilot would otherwise surface piecemeal.
+
+### Layer 1 — `code-reviewer` agent on the final diff (pre-PR)
+
+**Before opening the PR**, run the `code-reviewer` agent on the final diff. Resolve or disposition every finding:
+
+- **P1** findings (CI-blocking — `any` types, Result-pattern violations, manual type checks with unsafe casts): must be fixed.
+- **P2** findings (should-fix — chaining over intermediate variables, missing error context, missed cascade): fix or explicitly disposition (e.g. "intentional; would need a separate refactor").
+- **P3** findings (advisory — style, naming consistency): apply or note.
+
+Summarize the run in the PR description: which findings were found at which priority, what was resolved, what was dispositioned with reasoning. This is part of the standard PR-description gate — not a freeform addendum.
+
+**Why this matters.** A `private-key-storage` style six-round Copilot loop (PR #427) is almost always evidence that layer 1 was skipped. The internal reviewer is built for repo-pattern + edge-case classes (browser-barrel `node:crypto` leaks, types/JS mismatches, JWK cast safety, IDB durability chains, doc-accuracy drift) — exactly what Copilot catches one-at-a-time over several rounds. A single internal pass up front converts multi-round external ping-pong into one round.
+
+### Layer 2 — Copilot review loop, agent-driven with cap
+
+After the first complete commit (gates green, layer-1 findings resolved), the implementing agent **drives** the Copilot loop:
+
+1. **Request Copilot review on the first complete commit** — when the PR is ready, the agent considers it ready, and layer 1 has been run.
+2. **Re-request Copilot review after each round** of resolved comments, for as long as the agent believes Copilot is adding **substantive value** (real findings, not nitpicks or repetition).
+3. **Cap at 10 rounds total.** Most PRs converge well before this; the cap is a safety net to prevent runaway loops.
+4. **Stop conditions: diminishing returns OR cap.** When either fires, the agent stops requesting reviews and surfaces the stop to the orchestrator (or to the user, if no orchestrator is in the loop) with a one-line note: "stopping the Copilot loop after N rounds because [diminishing returns / 10-round cap]; latest round's findings resolved or dispositioned."
+
+The "agent judges diminishing returns" step is load-bearing: agents have full diff + commit-history context and are well-positioned to call when each round is still surfacing substantive findings vs. surfacing ever-smaller issues. The cap exists as a safety net, not the expected stop point.
+
+Include in the PR description: `Copilot review loop driven by implementer; stopped at <N> rounds on [diminishing returns / cap]`.
+
+### Layer 3 — Orchestrator gating (already codified in `.claude/agents/orchestrator.md`)
+
+When reviewing an implementing agent's PR before merge or bundling, the orchestrator:
+
+1. Calls `mcp__github__pull_request_read` with `method: get_check_runs` and refuses to advance if any check is `conclusion: failure`.
+2. Waits for Copilot's automated review pass before merging — the unified-delta pass catches structural findings that per-PR reviews miss (half-cascades, runtime-soundness gaps, TSDoc/impl drift). Allocate ~1–2 rounds at this layer; yield curves down beyond that.
+3. Once CI is green and Copilot's pass is addressed, advances the workflow.
+
+This layer doesn't replace layers 1 and 2 — it audits that they ran and catches the unified-delta class of finding that only emerges when constituent PRs are bundled.
+
+### Why the cap matters
+
+A 10-round cap on layer 2 is the safety net against runaway loops on PRs where Copilot finds ever-smaller issues. The expected stop is the **diminishing-returns judgment**, which fires earlier — typically after 2–4 rounds on a well-prepared PR. If a PR is running into round 5+, that's a signal worth surfacing to the orchestrator: either layer 1 wasn't run thoroughly, or the change is genuinely large enough to warrant the rounds, or Copilot is in nitpick territory and the agent should call diminishing returns.

--- a/.ai/notes/orchestrator/lessons-pending.md
+++ b/.ai/notes/orchestrator/lessons-pending.md
@@ -6,13 +6,15 @@ Cross-cutting lessons surfaced during orchestrator sessions, parked here until e
 
 ## Status
 
-Sessions feeding this inbox: orchestrator sessions through 2026-05-17 (ai-assist cluster + doc-graduation + lint-gate codification + crypto-batch-2 + ts-prompt-assist clusters).
+Sessions feeding this inbox: orchestrator sessions through 2026-05-30 (ai-assist cluster + doc-graduation + lint-gate codification + crypto-batch-2 + ts-prompt-assist clusters + the 2026-05 alpha cycle of single-stream features ending in -33).
 
 Active clusters at most recent sweep point:
 - ✅ ai-assist cluster — shipped to release in #336
 - ✅ crypto-batch-2 cluster — shipped to release; lessons captured (L14–L17)
 - 🟢 ts-prompt-assist cluster — Phase B + B-5 docs merged into integration; surface-tidy round in flight; cluster close pending consumer-port pressure-test (lessons L18–L21 below)
 - 🟡 `ai-assist-thinking-events` — sequencing after thinking-config phase B landed (now satisfied); ready to commission
+
+Last sweep: 2026-05-30 — Review-loop discipline triad (L31, L32, L33) codified. See sweep history at end of file.
 
 ---
 
@@ -440,56 +442,19 @@ The cost: an extra review round whose entire finding-set was about description f
 
 ---
 
-### L31. Copilot is a load-bearing review layer for cluster→release promotion PRs
-
-**Observed:** Across the `ts-prompt-assist-features` cluster, Copilot's automated reviews caught substantive structural findings that the implementing agents missed:
-- **PR #391:** half-cascade on `IResourceTreeRootDecl` — same failure mode as #386 (the bug the stream existed to fix).
-- **PR #391:** type-guard `'id' in decl` runtime soundness — pre-existing latent bug that the B-1 work touched (and was therefore in-scope to fix).
-- **PR #397** (cluster→release promotion): `MustacheTemplateCache.create` cap-validation gap on non-integer values; TSDoc/impl drift on `normalizeSubstitutionEntry`.
-
-The two #397 findings are the load-bearing observation: a promotion PR's per-constituent reviews don't catch unified-delta inconsistencies. Copilot's pass on the unified delta DOES catch them. That's the catch-pattern the orchestrator role doc names for the `release` → `main` sibling-sweep — Copilot is doing the same kind of work on the cluster → release promotion.
-
-**Rule:** Promotion-PR review attention should treat Copilot's pass as a load-bearing layer, not rubber-stamp. Allocate real review-cycle time for it before merging. Per L26's diminishing-returns trajectory observation, ~1-2 rounds is the sweet spot — beyond that the yield curves down.
-
-**Codification candidate:** Add to `.claude/agents/orchestrator.md` § "`release` → `main` promotion" (and the cluster → release equivalent) — explicit line: "Wait for Copilot's automated review pass before merging. The yield from a unified-delta pass is meaningfully different from per-PR reviews on the way in."
-
-**Reference:** PR #391 rounds 1-3 + PR #397's two findings. Sibling/companion to L25 (typed-but-no-runtime-teeth as a critique pattern Copilot has demonstrably caught).
-
----
-
-### L32. `code-reviewer` agent run on the final diff should be a pre-PR gate, not a post-Copilot followup
-
-**Observed:** `private-key-storage` (PR #427) ran build/lint/test green and pushed before any review pass, then absorbed **six rounds** of Copilot review comments — browser-barrel `node:crypto` leak; `./crypto/keystore` types/JS mismatch; unchecked JWK cast; IDB durability + version-bump + stale-handle chain; synchronous-IDB-throw capture; several doc-accuracy drifts. After all six rounds, a single internal `code-reviewer` agent pass on the final diff surfaced a coherent, well-prioritized set of additional findings (imperative-block density / chaining refactor, `key.type`-before-`_algorithmOf` ordering, `importPublicKey`-for-private-key doc-accuracy gap, resolvable api-extractor link warnings) — most of which were exactly the repo-pattern + edge-case classes the agent is built for, and several of which would have pre-empted Copilot rounds had the agent run **before** the first push.
-
-**Rule:** Implementing-agent acceptance criteria should require **"evidence of `code-reviewer` agent run + resolution on the final diff before opening the PR"** as a standard gate alongside the existing `rushx build`/`lint`/`test` gates in `CODING_STANDARDS.md`. Running the internal reviewer up-front converts multi-round external Copilot ping-pong into a single internal pass — cheaper for everyone and keeps the PR converging instead of oscillating.
-
-**Codification candidate:** Add to `.ai/instructions/CODING_STANDARDS.md` § "Pre-PR Validation Checklist" — a new bullet: "`code-reviewer` agent run on the final diff; findings resolved or dispositioned (link/summary in PR description)." Mirror it in the standard implementing-agent kickoff prompt shape (`.ai/conventions/workflow/kickoff-prompt-shape.md`) so every brief inherits it without per-stream copy-paste. The PR-description checklist line: `- [ ] code-reviewer agent run on final diff; findings resolved or dispositioned`.
-
-**Reference:** `.ai/tasks/completed/2026-05/private-key-storage/result.md` Follow-ups § "Process improvement"; PR #427's six Copilot rounds + final code-reviewer pass.
-
----
-
-### L33. Implementing agents should drive the Copilot review loop themselves — request on first complete commit, re-request each round as long as Copilot adds value, cap at 10
-
-**Observed:** Across multiple recent streams, the Copilot review loop has been driven ad-hoc: sometimes the agent waits for the orchestrator/user to request a review, sometimes Copilot runs once and stops without anyone re-requesting after a follow-up commit, sometimes the loop runs indefinitely past the point of diminishing returns. L31 captured Copilot's value as a load-bearing review layer; L32 codified the pre-PR `code-reviewer` agent gate to front-load findings. Both leave the post-push Copilot loop unowned. The implementing agent has the closest read on whether each round is still surfacing substantive findings vs. nitpicking, so the loop should be theirs to drive.
-
-**Rule:** Implementing-agent acceptance criteria should require:
-
-1. **Request Copilot review on the first complete commit** (when the agent considers the PR ready — i.e. all gates green, all in-scope work done, after the pre-PR `code-reviewer` pass per L32).
-2. **Re-request Copilot review after each round** of resolved comments, for as long as the agent believes Copilot is adding substantive value (surfacing real findings, not nitpicks or repetition).
-3. **Cap at 10 rounds total.** Most streams will converge well before this; the cap exists to prevent runaway loops on PRs where Copilot is finding ever-smaller issues.
-4. **Stop conditions: diminishing returns OR 10-round cap.** When either fires, the agent stops requesting reviews and surfaces the stop to the user (orchestrator or Erik) with a one-line note: "stopping the Copilot loop after N rounds because [diminishing returns / 10-round cap]; latest round's findings resolved / dispositioned."
-
-The "agent judges diminishing returns" step is the load-bearing one. Agents have full diff + commit history context and are well-positioned to call this. The cap is a safety net, not the expected stop point.
-
-**Codification candidate:** Add to `.ai/instructions/CODING_STANDARDS.md` § "Pre-PR Validation Checklist" (or a sibling "Review-loop discipline" section) — a numbered procedure for the Copilot loop with the cap and stop conditions named explicitly. Mirror in `.ai/conventions/workflow/kickoff-prompt-shape.md` so every brief inherits it. PR-description checklist line: `- [ ] Copilot review loop driven by implementer; stopped at <N> rounds on [diminishing returns / cap]`.
-
-**Reference:** Erik's guidance 2026-05-30 after the L31 + L32 framing settled. The triad — pre-PR `code-reviewer` (L32) + agent-driven Copilot loop with cap and stop conditions (L33) + orchestrator-side gating of CI green and Copilot review presence on promotion PRs (L31) — covers the review-stack end-to-end.
-
----
-
 ## Sweep history
 
-*(no sweeps yet — this file is being initialized at 2026-05-11)*
+### 2026-05-30 — Review-loop discipline triad (L31, L32, L33) codified
+
+**PR:** `chore/codify-review-loop-discipline` (cluster-close batch).
+
+**Graduated:**
+- **L31. Copilot is a load-bearing review layer for cluster→release promotion PRs** → already codified in `.claude/agents/orchestrator.md` § "Reviewing an agent PR before merge / bundling" step 3. Sweep acknowledgement only; no new content needed. (Reference at codification: PR #391 rounds 1-3 + PR #397's two findings.)
+- **L32. `code-reviewer` agent run on the final diff should be a pre-PR gate, not a post-Copilot followup** → codified in `.ai/instructions/CODING_STANDARDS.md` § "Review-loop discipline" Layer 1, with a corresponding PR-description checklist item in § "Pre-PR Validation Checklist". Mirrored in `.ai/conventions/workflow/kickoff-prompt-shape.md` § "What both shapes share" so every brief inherits it. (Reference at codification: `private-key-storage` PR #427's six Copilot rounds.)
+- **L33. Implementing agents should drive the Copilot review loop themselves — request on first complete commit, re-request each round as long as Copilot adds value, cap at 10** → codified in `.ai/instructions/CODING_STANDARDS.md` § "Review-loop discipline" Layer 2, with a corresponding PR-description checklist item. Mirrored in `.ai/conventions/workflow/kickoff-prompt-shape.md`. (Reference at codification: Erik's guidance 2026-05-30.)
+
+Together the three form the durable form of the review-loop stack: Layer 1 (internal pre-push) + Layer 2 (external loop with cap) + Layer 3 (orchestrator gating on promotion). Future implementing-agent briefs inherit Layers 1 and 2 from the kickoff-prompt-shape; future orchestrator sessions inherit Layer 3 from the agent prompt.
+
+---
 
 When this file or accumulated peer notes get swept to release: append entry here with date, sweep PR link, and which items graduated to durable form (convention / skill / agent-prompt) vs aged out.


### PR DESCRIPTION
## Summary

Codification batch graduating the **review-loop discipline triad** (L31, L32, L33) from `.ai/notes/orchestrator/lessons-pending.md` into the durable instruction + convention substrate. The review stack is now three explicit layers:

- **Layer 1 (internal pre-push, L32)** — `code-reviewer` agent on the final diff before opening the PR; findings resolved or dispositioned with a summary in the PR description.
- **Layer 2 (external post-push loop, L33)** — implementing agent drives Copilot review: request on first complete commit, re-request each round as long as Copilot is adding substantive value, cap at 10, stop on diminishing returns OR cap and surface the stop with a one-line reason.
- **Layer 3 (orchestrator gating, L31)** — already codified in `.claude/agents/orchestrator.md` § "Reviewing an agent PR before merge / bundling" step 3; sweep acknowledgement only.

Together the three close the review-stack end-to-end. Future implementing-agent briefs inherit Layers 1 and 2 from the kickoff-prompt-shape; future orchestrator sessions inherit Layer 3 from the agent prompt.

## Changes

### `.ai/instructions/CODING_STANDARDS.md`

- Added a new **"Review-loop discipline"** top-level section covering all three layers in depth. Layer 1 calls out the P1/P2/P3 finding handling expectation and references PR #427's six-round Copilot loop as the empirical case the codification is built on. Layer 2 carries the full numbered procedure (first commit, re-request each round, cap at 10, stop on diminishing returns OR cap, surface the stop). Layer 3 cross-references the orchestrator agent prompt rather than re-codifying.
- Added two PR-description checklist items to § "Acceptance criteria for any stream's exit":
  - `code-reviewer agent run on the final diff; findings resolved or dispositioned`
  - `Copilot review loop driven by implementer; stopped on diminishing returns or 10-round cap`

### `.ai/conventions/workflow/kickoff-prompt-shape.md`

- Added **"Review-loop discipline inherited from `CODING_STANDARDS.md`"** bullet to § "What both shapes share" — covers Layer 1 + Layer 2 expectations and references the CODING_STANDARDS section. Means every future kickoff inherits the discipline without per-stream copy-paste.

### `.ai/notes/orchestrator/lessons-pending.md`

- Removed L31, L32, L33 entries.
- Updated § Status to reflect the 2026-05-30 sweep point and note the last sweep.
- Added sweep history entry naming the three graduated lessons, their durable destinations, and the reference PRs that surfaced each.

## Why this batch, why now

Erik queued this after PR #427's six-round Copilot ping-pong made the pre-PR `code-reviewer` gap concrete (L32) and after the L31 + L32 framing prompted the natural follow-up question — who owns the post-push loop, and what stops it? (L33). PR #434 (capture-async-result-upgrade) was the test case: the implementing agent ran `code-reviewer` pre-push, opened the PR with the summary, drove a converging Copilot loop, and surfaced the stop. The discipline worked end-to-end before being formally codified; this PR locks it in.

## Test plan

- [ ] Reviewer confirms the three new artifacts read as a coherent codification of the lessons (not a rewrite that adds new policy beyond what L31/L32/L33 captured).
- [ ] Reviewer confirms the sweep history entry accurately attributes graduation destinations.
- [ ] Merge to `release` ahead of -33 publish.

https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_