### PR TITLE
spike(json-schema-converter-alignment): research substrate + agent commission

### DIFF
--- a/.ai/tasks/active/json-schema-converter-alignment/brief.md
+++ b/.ai/tasks/active/json-schema-converter-alignment/brief.md
@@ -1,0 +1,112 @@
+# Spike brief: `json-schema-converter-alignment`
+
+**Status:** 🟡 research spike — single-output deliverable, no code
+**Workflow shape:** parallel research spike (not a full design-triage-implement cycle)
+**Output:** `.ai/tasks/active/json-schema-converter-alignment/research.md`
+**Package surface (target, for context):** likely `@fgv/ts-json-base` (new packlet or extension to existing converters/validators); possibly cross-cuts `@fgv/ts-utils` Converter/Validator surfaces. The spike answers **whether** to extend, not what to ship.
+
+---
+
+## Mission
+
+The `ai-assist-client-tools` Phase A design ([design.md §2.3](../ai-assist-client-tools/design.md)) currently recommends **JSON Schema as the parameter source-of-truth** for client-tool configs — consumers author it directly. Erik flagged this as worth a deeper look: authoring both a JSON Schema AND a typed Converter/Validator for the same shape (one for the wire, one for runtime validation) is **error-prone and likely problematic** — they drift, they disagree at boundary edges, and the consumer pays the alignment cost.
+
+**Spike question:** Is there a fgv-native way to **align** the two so the consumer authors one and gets the other for free? Erik is open to either direction:
+
+- **Generate Converter/Validator from JSON Schema** — consumer authors schema (the wire shape), runtime gets a Converter that produces the typed shape.
+- **Generate JSON Schema from Converter/Validator** — consumer authors Converter (the typed shape), wire format gets emitted on demand.
+- **Status quo** — keep them parallel; rely on tests / code review for alignment.
+
+The spike researches the design space and returns a recommendation. Implementation is **not in scope** — that becomes its own stream if the recommendation is "yes, build it."
+
+---
+
+## What the spike must answer
+
+### 1. Direction A — Schema → Converter
+
+For each option, name the precedent (existing OSS library or fgv pattern that does this), the strengths, and the failure modes:
+
+- TypeScript type generation from JSON Schema (e.g. `json-schema-to-typescript`)
+- Runtime validator generation from JSON Schema (e.g. `ajv`, `zod` schema importers)
+- Fgv-native: a `JsonSchema.toConverter<T>(schema): Converter<T>` factory in `ts-json-base`, leveraging the existing Converter primitives. What's the typing story — does `T` have to be supplied by the consumer, can it be inferred, is it always `unknown` at runtime?
+
+Key constraints:
+- Must produce a `Converter<T>` that conforms to fgv's `Result<T>`-returning contract.
+- Must handle the JSON Schema features actually used by LLM provider function-calling (`type: object`, `properties`, `required`, `description`, `enum`, nested object/array, `additionalProperties`). Out of scope for LLM tool use: `$ref`, `oneOf`/`anyOf`/`allOf` polymorphism, `pattern` regexes, custom format validators (date/time/email/etc.).
+- Loss-of-information concerns: a JSON Schema may not fully constrain the runtime type the consumer wants (branded types, refined types). How does the generated Converter compose with consumer-side refinement?
+
+### 2. Direction B — Converter → Schema
+
+- Add a `toJsonSchema()` capability to the `Converter<T>` surface (or a sibling factory). What's the coverage — which Converter combinators can produce a Schema, which can't (e.g. `Converters.generic` with arbitrary user logic)?
+- Same constraints: handle the JSON Schema features LLM providers actually accept.
+- Loss-of-information concerns in this direction: how does a `Converters.brandedString` map to JSON Schema (drop the brand and emit `string`? Emit `pattern` for branded ID formats? Surface as advisory metadata?).
+- This is the direction that aligns with fgv's preference for code-first typing — but it's the harder of the two if the Converter surface wasn't designed with reflection in mind.
+
+### 3. Direction C — Status quo
+
+Keep authoring both. The spike must take this seriously as the answer: if (A) or (B) would cost ~1000+ lines of generation code to handle the LLM-relevant schema subset, and consumers can verify alignment with a 10-line round-trip test (`Converter.convert(JSON.parse(JSON.stringify(sampleValue))).orThrow()`), the status quo may win on cost/benefit.
+
+Output should explicitly compare:
+- Authoring cost per tool (lines of code, cognitive overhead).
+- Drift detection cost (test setup, CI cycles).
+- New-tool addition cost (consumer onboarding ergonomics).
+
+### 4. Recommendation + scope sketch
+
+If recommending (A) or (B):
+
+- **Sketch the surface** at the level of "what does `JsonSchema.toConverter<T>(schema)` look like for a tool author?" — one code example per direction.
+- **Scope the work**: file count, packlets touched, blast radius. This is a sub-phase sketch, not a phase-by-phase plan.
+- **Sequencing relative to `ai-assist-client-tools`**: can this ship alongside Phase C of `ai-assist-client-tools` (layer 1) so consumers adopt the aligned authoring from day one? Or does it run later as an additive extension?
+
+If recommending (C):
+
+- Sketch the test pattern the spike recommends consumers use to catch drift.
+- Confirm `ai-assist-client-tools` Phase C ships `JsonObject` / JSON Schema as-is.
+
+---
+
+## Cross-link with `ai-assist-client-tools`
+
+This spike runs in parallel with Phase A review of `ai-assist-client-tools`. The spike's output **may** affect Phase C's authoring story for tool parameters — but it does **not** block Phase B (triage) of `ai-assist-client-tools`. The seam (`IAiClientTool` config carrying a JSON Schema) is the right shape regardless; the spike answers whether the consumer authors that schema directly or generates it from a Converter (or vice versa).
+
+Coordinate any cross-references in the spike's research.md.
+
+---
+
+## Out of scope
+
+- **Implementation of any direction.** This is a research spike; the output is `research.md` with a recommendation.
+- **Generalizing to non-LLM use cases.** Future consumers of generated schemas (config validation, REST endpoint schemas, etc.) can drive their own scoping rounds. The LLM tool-use case is the forcing function.
+- **Schema dialects beyond JSON Schema draft-07-ish.** All four LLM providers accept the same conservative subset; the spike doesn't need to cover JSON Schema 2020-12 features, `dependentRequired`, etc.
+- **Runtime perf benchmarking.** Out of scope at the research level; surface as a Phase C question if perf seems load-bearing.
+
+---
+
+## Reading list
+
+1. `libraries/ts-utils/src/packlets/conversion/` — current Converter surface; `Converters.object`, `Converters.string`, etc.
+2. `libraries/ts-utils/src/packlets/validation/` — Validators (the in-place sibling).
+3. `libraries/ts-json-base/src/packlets/converters/` — existing JSON-shaped converters; `Converters.jsonObject`, etc.
+4. `libraries/ts-json-base/src/packlets/validators/` — JSON validators.
+5. `.ai/tasks/active/ai-assist-client-tools/design.md` §2.3 (the JSON-Schema-as-source-of-truth decision this spike pressure-tests).
+6. `.ai/instructions/CODING_STANDARDS.md` §§ Type-Safe Validation; Converter/Validator patterns.
+7. Light external survey of `ajv`, `zod`, `typebox`, `io-ts`, and any OSS library that does schema↔runtime-validator generation in either direction.
+
+---
+
+## Deliverable shape
+
+A single research doc at `.ai/tasks/active/json-schema-converter-alignment/research.md` covering §§ 1–4 above. Suggested length: ~300–600 lines. Reserve for surface sketches the substantial complexity; if the recommendation is "status quo," the doc may be shorter and end with the test pattern sketch.
+
+`state.md` gets updated with the research-complete row when ready.
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep + research output | (this PR) | open → release; research.md added once complete |
+| Follow-on stream (if recommendation is to build) | TBD | not yet commissioned |

--- a/.ai/tasks/active/json-schema-converter-alignment/state.md
+++ b/.ai/tasks/active/json-schema-converter-alignment/state.md
@@ -1,0 +1,51 @@
+# Spike state: `json-schema-converter-alignment`
+
+**Status:** 🔵 research in flight — agent commissioned
+**Workflow shape:** parallel research spike
+**Last updated:** 2026-06-02 (orchestrator — substrate prep + commission)
+
+---
+
+## Phase status
+
+| Phase | Status | Notes |
+|---|---|---|
+| Research | 🔵 in flight | general-purpose agent commissioned; output is `research.md`. |
+| Follow-on stream (conditional) | ⏸ depends on recommendation | If spike recommends building (A) or (B), commission a separate stream then. If recommendation is (C) status quo, no follow-on. |
+
+---
+
+## Decisions log
+
+| Decision | Rationale |
+|---|---|
+| Parallel research spike, not a Phase-A of a triage cycle | This is "is there an alignment story worth building" — single-pass research, not a full design-triage-implement cycle. If the answer is "yes, build," we commission a separate stream with its own Phase A. |
+| general-purpose agent (not senior-developer) | Research-shaped: survey existing libraries, sketch fgv-native options, compare costs. senior-developer is reserved for architectural-design output; this is a design-feasibility scope. |
+| Does NOT block `ai-assist-client-tools` Phase B | The `IAiClientTool` seam is right regardless. The spike answers the authoring story for tool parameters — Phase C can adopt the spike's recommendation if it lands in time, or stick with `JsonObject`/JSON Schema as authored. |
+| Out of scope: implementation | Research only. Follow-on stream commissions if needed. |
+| Out of scope: generalizing beyond LLM tool-use schemas | LLM function-calling is the forcing function; the spike's scope is bounded by what those providers accept. Other use cases can drive their own rounds. |
+
+---
+
+## Origin
+
+2026-06-02. Erik reviewing the `ai-assist-client-tools` Phase A design surfaced authoring concern: a consumer authoring both a JSON Schema (for the wire) and a Converter/Validator (for runtime validation) over the same shape is error-prone and likely to drift. Worth investigating whether fgv can align them — either direction (Schema → Converter, Converter → Schema, or status quo with a drift-detection test pattern).
+
+Spike runs in parallel with Phase B of `ai-assist-client-tools`; output may inform Phase C's authoring story but doesn't block Phase B commission.
+
+---
+
+## History
+
+| Date | Event | Notes |
+|---|---|---|
+| 2026-06-02 | Substrate prepped + agent commissioned | brief.md + state.md + general-purpose agent run with target `research.md`. |
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep + research | (this PR) | open → release; research.md added once complete |
+| Follow-on stream | TBD | not yet commissioned |


### PR DESCRIPTION
## Summary

Parallel research spike commissioned alongside `ai-assist-client-tools` Phase B review. Question surfaced in Erik's review of Phase A design: a consumer authoring both a JSON Schema (wire format) and a Converter/Validator (runtime validation) over the same shape is error-prone and likely to drift. Is there a fgv-native way to align them?

Three directions on the table:

- **(A) Schema → Converter** — consumer authors JSON Schema; runtime gets a Converter.
- **(B) Converter → Schema** — consumer authors Converter; wire format emitted on demand.
- **(C) Status quo** — keep them parallel; rely on a drift-detection test pattern.

Erik open to any direction; the spike's recommendation drives whether we build something or stay with status quo.

## Substrate added

- `.ai/tasks/active/json-schema-converter-alignment/brief.md` — locked spike scope (cross-library precedent survey, fgv-native sketches per direction, cost comparison, recommendation + scope sketch).
- `.ai/tasks/active/json-schema-converter-alignment/state.md` — decisions log (general-purpose agent run; doesn't block `ai-assist-client-tools` Phase B; research only — implementation is a separate stream if recommended).

## What's in flight

general-purpose research agent commissioned against this branch. Output: `.ai/tasks/active/json-schema-converter-alignment/research.md` + PR description with a TL;DR. Suggested length 300–600 lines, shorter if recommendation is status quo.

## Does NOT block `ai-assist-client-tools`

The `IAiClientTool` seam is right regardless of which direction this spike picks. The spike answers the **authoring story for tool parameters** — Phase C of `ai-assist-client-tools` can adopt the spike's recommendation if it lands in time, or stick with `JsonObject` / JSON Schema as authored.

## Test plan

- [ ] Substrate-prep PR (this one) — no functional changes; merge to `release` directly when the research lands, so substrate + research output ship together.
- [ ] Research agent produces `research.md`.
- [ ] Erik reviews `research.md` → decides: status quo, or commission a follow-on stream to build (A) or (B).

https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_