### PR TITLE
chore(json-schema-derives-t): substrate prep — implementation stream commissioned

### DIFF
--- a/.ai/tasks/active/json-schema-converter-alignment/brief.md
+++ b/.ai/tasks/active/json-schema-converter-alignment/brief.md
@@ -1,0 +1,112 @@
+# Spike brief: `json-schema-converter-alignment`
+
+**Status:** 🟡 research spike — single-output deliverable, no code
+**Workflow shape:** parallel research spike (not a full design-triage-implement cycle)
+**Output:** `.ai/tasks/active/json-schema-converter-alignment/research.md`
+**Package surface (target, for context):** likely `@fgv/ts-json-base` (new packlet or extension to existing converters/validators); possibly cross-cuts `@fgv/ts-utils` Converter/Validator surfaces. The spike answers **whether** to extend, not what to ship.
+
+---
+
+## Mission
+
+The `ai-assist-client-tools` Phase A design ([design.md §2.3](../ai-assist-client-tools/design.md)) currently recommends **JSON Schema as the parameter source-of-truth** for client-tool configs — consumers author it directly. Erik flagged this as worth a deeper look: authoring both a JSON Schema AND a typed Converter/Validator for the same shape (one for the wire, one for runtime validation) is **error-prone and likely problematic** — they drift, they disagree at boundary edges, and the consumer pays the alignment cost.
+
+**Spike question:** Is there a fgv-native way to **align** the two so the consumer authors one and gets the other for free? Erik is open to either direction:
+
+- **Generate Converter/Validator from JSON Schema** — consumer authors schema (the wire shape), runtime gets a Converter that produces the typed shape.
+- **Generate JSON Schema from Converter/Validator** — consumer authors Converter (the typed shape), wire format gets emitted on demand.
+- **Status quo** — keep them parallel; rely on tests / code review for alignment.
+
+The spike researches the design space and returns a recommendation. Implementation is **not in scope** — that becomes its own stream if the recommendation is "yes, build it."
+
+---
+
+## What the spike must answer
+
+### 1. Direction A — Schema → Converter
+
+For each option, name the precedent (existing OSS library or fgv pattern that does this), the strengths, and the failure modes:
+
+- TypeScript type generation from JSON Schema (e.g. `json-schema-to-typescript`)
+- Runtime validator generation from JSON Schema (e.g. `ajv`, `zod` schema importers)
+- Fgv-native: a `JsonSchema.toConverter<T>(schema): Converter<T>` factory in `ts-json-base`, leveraging the existing Converter primitives. What's the typing story — does `T` have to be supplied by the consumer, can it be inferred, is it always `unknown` at runtime?
+
+Key constraints:
+- Must produce a `Converter<T>` that conforms to fgv's `Result<T>`-returning contract.
+- Must handle the JSON Schema features actually used by LLM provider function-calling (`type: object`, `properties`, `required`, `description`, `enum`, nested object/array, `additionalProperties`). Out of scope for LLM tool use: `$ref`, `oneOf`/`anyOf`/`allOf` polymorphism, `pattern` regexes, custom format validators (date/time/email/etc.).
+- Loss-of-information concerns: a JSON Schema may not fully constrain the runtime type the consumer wants (branded types, refined types). How does the generated Converter compose with consumer-side refinement?
+
+### 2. Direction B — Converter → Schema
+
+- Add a `toJsonSchema()` capability to the `Converter<T>` surface (or a sibling factory). What's the coverage — which Converter combinators can produce a Schema, which can't (e.g. `Converters.generic` with arbitrary user logic)?
+- Same constraints: handle the JSON Schema features LLM providers actually accept.
+- Loss-of-information concerns in this direction: how does a `Converters.brandedString` map to JSON Schema (drop the brand and emit `string`? Emit `pattern` for branded ID formats? Surface as advisory metadata?).
+- This is the direction that aligns with fgv's preference for code-first typing — but it's the harder of the two if the Converter surface wasn't designed with reflection in mind.
+
+### 3. Direction C — Status quo
+
+Keep authoring both. The spike must take this seriously as the answer: if (A) or (B) would cost ~1000+ lines of generation code to handle the LLM-relevant schema subset, and consumers can verify alignment with a 10-line round-trip test (`Converter.convert(JSON.parse(JSON.stringify(sampleValue))).orThrow()`), the status quo may win on cost/benefit.
+
+Output should explicitly compare:
+- Authoring cost per tool (lines of code, cognitive overhead).
+- Drift detection cost (test setup, CI cycles).
+- New-tool addition cost (consumer onboarding ergonomics).
+
+### 4. Recommendation + scope sketch
+
+If recommending (A) or (B):
+
+- **Sketch the surface** at the level of "what does `JsonSchema.toConverter<T>(schema)` look like for a tool author?" — one code example per direction.
+- **Scope the work**: file count, packlets touched, blast radius. This is a sub-phase sketch, not a phase-by-phase plan.
+- **Sequencing relative to `ai-assist-client-tools`**: can this ship alongside Phase C of `ai-assist-client-tools` (layer 1) so consumers adopt the aligned authoring from day one? Or does it run later as an additive extension?
+
+If recommending (C):
+
+- Sketch the test pattern the spike recommends consumers use to catch drift.
+- Confirm `ai-assist-client-tools` Phase C ships `JsonObject` / JSON Schema as-is.
+
+---
+
+## Cross-link with `ai-assist-client-tools`
+
+This spike runs in parallel with Phase A review of `ai-assist-client-tools`. The spike's output **may** affect Phase C's authoring story for tool parameters — but it does **not** block Phase B (triage) of `ai-assist-client-tools`. The seam (`IAiClientTool` config carrying a JSON Schema) is the right shape regardless; the spike answers whether the consumer authors that schema directly or generates it from a Converter (or vice versa).
+
+Coordinate any cross-references in the spike's research.md.
+
+---
+
+## Out of scope
+
+- **Implementation of any direction.** This is a research spike; the output is `research.md` with a recommendation.
+- **Generalizing to non-LLM use cases.** Future consumers of generated schemas (config validation, REST endpoint schemas, etc.) can drive their own scoping rounds. The LLM tool-use case is the forcing function.
+- **Schema dialects beyond JSON Schema draft-07-ish.** All four LLM providers accept the same conservative subset; the spike doesn't need to cover JSON Schema 2020-12 features, `dependentRequired`, etc.
+- **Runtime perf benchmarking.** Out of scope at the research level; surface as a Phase C question if perf seems load-bearing.
+
+---
+
+## Reading list
+
+1. `libraries/ts-utils/src/packlets/conversion/` — current Converter surface; `Converters.object`, `Converters.string`, etc.
+2. `libraries/ts-utils/src/packlets/validation/` — Validators (the in-place sibling).
+3. `libraries/ts-json-base/src/packlets/converters/` — existing JSON-shaped converters; `Converters.jsonObject`, etc.
+4. `libraries/ts-json-base/src/packlets/validators/` — JSON validators.
+5. `.ai/tasks/active/ai-assist-client-tools/design.md` §2.3 (the JSON-Schema-as-source-of-truth decision this spike pressure-tests).
+6. `.ai/instructions/CODING_STANDARDS.md` §§ Type-Safe Validation; Converter/Validator patterns.
+7. Light external survey of `ajv`, `zod`, `typebox`, `io-ts`, and any OSS library that does schema↔runtime-validator generation in either direction.
+
+---
+
+## Deliverable shape
+
+A single research doc at `.ai/tasks/active/json-schema-converter-alignment/research.md` covering §§ 1–4 above. Suggested length: ~300–600 lines. Reserve for surface sketches the substantial complexity; if the recommendation is "status quo," the doc may be shorter and end with the test pattern sketch.
+
+`state.md` gets updated with the research-complete row when ready.
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep + research output | (this PR) | open → release; research.md added once complete |
+| Follow-on stream (if recommendation is to build) | TBD | not yet commissioned |

--- a/.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility-brief.md
+++ b/.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility-brief.md
@@ -1,0 +1,150 @@
+# Spike brief (phase 2): `json-schema-derives-t-feasibility`
+
+**Status:** 🟡 follow-up spike — single-output deliverable, no code
+**Workflow shape:** focused-feasibility spike (sub-spike of `json-schema-converter-alignment`)
+**Output:** `.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility.md`
+**Predecessor:** `research.md` (Direction A recommendation, AJV-style consumer-supplied `T`)
+**Target package surface (for context):** `@fgv/ts-json-base` — schema-derives-T addition to whatever Direction A ends up shipping.
+
+---
+
+## Why this spike exists (Erik's review of `research.md`, 2026-06-02)
+
+The phase-1 spike recommended **Direction A** with **AJV-style consumer-supplied `T`** (`JsonSchema.toConverter<T>(schema)` — consumer asserts the type, runtime validates input against the schema, but TypeScript can't see whether `T` actually describes what the schema produces). Erik's review:
+
+> Type assertion via `.toConverter()` doesn't give us any greater protection against drift than just decoupling schema and the converter entirely — just the illusion of greater protection, which is arguably worse. Especially given that it requires extra work.
+>
+> Upon reflection (hah), relying entirely on converter→schema would fail once we hit MCP, where the tool definition will be arriving as schema (leaving aside the blast radius noted in the research document — it wouldn't be sufficient even if it were easy).
+>
+> That means we need the spike for point 1. Let's commission that now.
+
+**Two findings from the review:**
+
+1. **AJV-style assertion is worse than honest status-quo decoupling.** Same drift risk, false sense of safety, extra authoring work. Not worth shipping.
+2. **Converter → Schema (Direction B) is fundamentally insufficient for the MCP layer.** MCP tools arrive as schema descriptors; there's no Converter to generate from. Even with no blast radius, B would force a separate code path at the MCP boundary.
+
+Conclusion: the **only** alignment direction worth building is **schema-derives-T** (TypeBox-style), and it must be tractable for the LLM-tool / MCP-tool JSON Schema subset for the alignment story to be worth doing at all.
+
+---
+
+## Mission
+
+Determine feasibility, in two parts:
+
+### Part A — Is schema-derives-T tractable for the LLM-tool / MCP-tool JSON Schema subset?
+
+The LLM-tool subset (verified in phase-1 research):
+
+- `type: 'object'` with `properties`, `required`, `additionalProperties: false`
+- `type: 'string'` (plus optional `enum`, `description`)
+- `type: 'number'` / `type: 'integer'` (plus optional `enum`, `description`)
+- `type: 'boolean'`
+- `type: 'array'` with `items`
+- Nested objects and arrays
+- Property `description` strings (no impact on `T`, but consumed by providers)
+
+**Out of scope for this spike** (out-of-subset features): `$ref`, `oneOf` / `anyOf` / `allOf`, `pattern`, custom format validators, JSON Schema 2020-12 features. If schema-derives-T for the LLM subset works cleanly, those are separable extensions.
+
+**The TypeBox pattern in one line:** the schema is a TypeScript value with phantom type tags such that `Static<typeof schema>` mechanically derives the runtime type. Authoring shape:
+
+```ts
+const MemorySchema = JsonSchema.object({
+  query: JsonSchema.string(),
+  limit: JsonSchema.optional(JsonSchema.number())
+});
+type Memory = Static<typeof MemorySchema>;
+// Memory === { query: string; limit?: number }
+```
+
+Investigate:
+
+- **Type-level mechanics.** Can the LLM subset be expressed with a small set of factory functions (`object`, `string`, `number`, `boolean`, `array`, `optional`, `enum`) where each return value carries a `__type` phantom such that the conditional-type / mapped-type machinery in `Static<>` resolves cleanly? Sketch the phantom-tagging shape and the `Static<>` resolution.
+- **Compile-time error quality.** When a consumer writes a malformed schema (e.g. `JsonSchema.object({ x: 5 })`), do they get a useful TS error or "Type 'number' is not assignable to type 'never'" gibberish? TypeBox's error messages are notoriously cryptic; can the fgv version do better with a smaller surface?
+- **Optional fields.** TypeBox-style `optional(...)` is the trickiest mapped-type case. How does it interact with `required` (in the emitted JSON Schema) and `?:` (in the derived TS type)? Verify the round-trip works without TS performance issues.
+- **Inference depth.** TypeBox has known limits with deep nesting (TS `tsc --traceResolution` shows the unfold cost). The LLM subset is shallow (~2-3 levels max in practice). Confirm or refute that depth concern.
+- **Combinator surface.** TypeBox publishes ~40+ combinators because it covers full JSON Schema. The LLM subset needs ~6-8. Confirm a small surface is sufficient.
+
+### Part B — How does schema-derives-T compose with the existing fgv `Converter<T>` surface?
+
+The end goal is `JsonSchema.toConverter(schema)` returning a `Converter<Static<typeof schema>>` — schema in, Converter out, `T` derived not asserted.
+
+Investigate:
+
+- **Adapter shape.** The Converter is the fgv runtime contract; how does the TypeBox-style schema value get rendered into the runtime Converter that does the actual validation? Likely a recursive descent that switches on the phantom-tag and assembles a `Converters.object` / `Converters.string` / etc. tree. Sketch.
+- **Type-flow through the adapter.** `Static<typeof schema>` is a compile-time computation; the Converter at runtime returns `Result<T>` where `T = Static<typeof schema>`. Verify TS infers this correctly without manual `as` casts in `toConverter`'s implementation. If casts are needed, name them and verify they're correctness-preserving.
+- **Wire-format emission.** The runtime schema (used by the LLM provider) is JSON. The TypeBox-style value needs a `toJson(schema)` function that strips phantom tags and emits the wire-format JSON Schema. Sketch.
+- **Compatibility with the status-quo `IAiClientToolConfig.parametersSchema: JsonObject` shape.** Two options: (a) `parametersSchema` accepts either the typed schema value OR a `JsonObject`, with `toConverter` overloaded for both; (b) typed schema values include a `toJSON()` so they're structurally compatible with `JsonObject` consumers via implicit serialization. Pick a recommendation.
+- **`Converters.number` numeric-string acceptance** flagged in `research.md` §4: does the derived Converter need a strictness setting, or is the LLM-tool use case satisfied by the existing permissive behavior? Surface as a phase-C question for the alignment stream.
+
+### Part C — Cost + sequencing
+
+If feasibility is confirmed:
+
+- **Sketch the implementation scope.** File count, packlet location (probably `ts-json-base/json-schema` or sibling), test surface, blast radius. Compare to the phase-1 estimate (~300-500 lines impl + 300-400 tests for AJV-style Direction A).
+- **MCP fit.** Confirm that MCP-discovered schemas (which arrive as raw JSON Schema, no phantom tags) can be parsed into the typed schema value at the MCP boundary — i.e. `JsonSchema.fromJson(rawJsonObject)` reconstructs phantom tags. Sketch the parse function and its failure-mode shape (what happens if the MCP server emits an out-of-subset feature like `$ref`).
+- **Sequencing recommendation.** Erik's framing: "I'm inclined to add that now and hold the AI tool work until it's ready." Confirm or refute that ai-assist-client-tools Phase B/C should hold for this work, or propose an alternative shape (e.g. Phase B advances on contract design now; Phase C holds for alignment).
+- **Stop conditions.** Name the scenarios under which feasibility fails and the fallback shape:
+  - Phantom-type machinery has TS perf cliff at the depths the LLM subset needs.
+  - Optional / required interaction can't be expressed without consumer-visible workarounds.
+  - The combinator surface bloats past ~10 entries and starts to look like TypeBox proper.
+  - In any of these: fallback is **status quo, Direction C** with the drift-detection test pattern from `research.md` §3.3. The AJV-style assertion path is explicitly **off the table** per Erik's review.
+
+If feasibility is NOT confirmed:
+
+- **Justify the call.** Specifically which mechanism (phantom tags, mapped types, conditional inference, deep recursion, etc.) breaks and why the workaround is worse than status-quo decoupling.
+- **Confirm fallback to status-quo Direction C.** Reference `research.md` §3.3 for the recommended drift-detection test pattern.
+
+---
+
+## Reading list
+
+1. **`.ai/tasks/active/json-schema-converter-alignment/research.md`** — phase-1 spike output. §3 (Direction C / status quo), §4 (Direction A recommendation) are the most directly relevant.
+2. **`.ai/tasks/active/json-schema-converter-alignment/brief.md`** — phase-1 brief.
+3. **`.ai/tasks/active/json-schema-converter-alignment/state.md`** — phase-1 decisions log.
+4. **`.ai/tasks/active/ai-assist-client-tools/design.md`** §2.3 — where `parametersSchema: JsonObject` is currently recommended.
+5. **`libraries/ts-utils/src/packlets/conversion/`** — fgv Converter primitives (especially `Converters.object`, `Converters.string`, `Converters.optionalField`, `Converters.arrayOf`, `Converters.enumeratedValue`). The adapter sketch in Part B descends into these.
+6. **TypeBox source** (github.com/sinclairzx81/typebox) — phantom-tag pattern + `Static<>` machinery. Read enough of the type definitions to understand the mechanism; don't try to absorb the full combinator surface.
+7. **`.ai/instructions/CODING_STANDARDS.md`** § Type-Safe Validation.
+
+---
+
+## Out of scope
+
+- **Implementation.** This is a feasibility spike. Output is `derives-t-feasibility.md` with sketches + a feasibility verdict + a recommendation. The actual alignment-stream commission happens after Erik reviews this.
+- **Generalizing beyond the LLM-tool JSON Schema subset.** Future consumers can drive separate scoping.
+- **Reconciling with AJV-style Direction A.** That path is off the table per Erik's review. The spike does not need to compare schema-derives-T against AJV-style — the comparison is schema-derives-T vs status-quo Direction C.
+- **Reconciling with Direction B (Converter → Schema).** Also off the table — fails at MCP per Erik's review.
+- **No code changes.** Sketches in the doc are TypeScript pseudo-code only.
+
+---
+
+## Deliverable shape
+
+A single doc at `.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility.md` covering Parts A, B, C above. Suggested length 200–400 lines — focused feasibility verdict, not a full design.
+
+If the verdict is **feasible**: lead with the recommended implementation shape + scope estimate + sequencing. Erik's call after that.
+
+If the verdict is **infeasible**: lead with the specific blockers, then the fallback to status-quo Direction C. Erik's call after that.
+
+Either way, the doc must close with a one-paragraph recommendation: feasible / infeasible / borderline; if borderline, what would tip it.
+
+Update state.md when complete. Retract the `Out of scope (Direction A follow-on): static T-from-schema inference` decision row (it's been retracted by Erik's review) and replace with a row reflecting the new spike output.
+
+---
+
+## When the spike is ready
+
+1. Verify the doc answers Parts A, B, C.
+2. Update state.md with a phase-2 history row + retracted/replaced decision rows.
+3. Push to `chore/json-schema-derives-t-spike-prep`. Orchestrator opens or updates the PR after the agent finishes.
+4. Do NOT commission a follow-on stream yourself. Erik reviews the verdict first.
+
+---
+
+## Stop-and-surface protocol
+
+If during the spike you find an unexpected angle that materially changes the shape (e.g. "TypeBox-style schema-derives-T is feasible but the existing fgv Converter surface fundamentally can't accept a derived `T` without retrofit X"), STOP and surface to the orchestrator via a TODO at the top of `derives-t-feasibility.md` — don't paper over.
+
+If you find that schema-derives-T for the LLM subset has an obvious tractable shape (no phantom-type tricks needed, just a small set of factories with a recursive `Static<>` mapped type), say so directly and skip the deep-recursion concerns — short answers are good.
+
+**Begin.**

--- a/.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility.md
+++ b/.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility.md
@@ -1,0 +1,431 @@
+# Feasibility: `json-schema-derives-T` (TypeBox-style)
+
+**Status:** complete
+**Author:** senior-developer (phase-2 sub-spike)
+**Date:** 2026-06-02
+**Companion docs:** [derives-t-feasibility-brief.md](./derives-t-feasibility-brief.md), [state.md](./state.md), [research.md](./research.md)
+
+---
+
+## §Verdict
+
+**Feasible — tractable, no phantom-type gymnastics, implementation is straightforward.**
+
+Schema-derives-T for the LLM-tool JSON Schema subset is cleanly implementable with a small set of factory functions and a recursive `Static<S>` mapped type. The phantom-tag pattern requires no advanced TS tricks beyond what the fgv codebase already uses (branded types, mapped types). The `object` / optional-field interaction is the only non-trivial mapped-type case, and it has a well-understood solution using TS's key-remapping and conditional types. Depth concerns are not a real risk for the 2–3 level nesting the LLM subset uses in practice. The fgv `Converter<T>` surface accepts a derived `T` with no retrofit required — `Converters.object` is already generic over `T`; the adapter simply passes `Static<typeof schema>` as `T` and that resolves at the call site. The combinator surface needed is 7 factories, well within scope. Recommend commissioning the alignment stream.
+
+---
+
+## §Part A — Type-level mechanics
+
+### A.1 Phantom-tag pattern
+
+TypeBox's mechanism is straightforward: every schema node is a plain JavaScript value that also carries a phantom `static` property at the type level (not present at runtime). `Static<S>` is simply `S['static']` — a property access on the type parameter. The phantom property is never emitted to JavaScript but TypeScript sees it during type-checking.
+
+For the LLM subset, a minimal fgv variant needs these types:
+
+```typescript
+// Phantom marker — a unique symbol prevents accidental duck-typing
+declare const _phantom: unique symbol;
+
+// Base schema node. Every factory returns something extending this.
+interface ILlmSchema<T> {
+  readonly [_phantom]: T;    // phantom — exists only in the type system
+  readonly _type: string;    // discriminant for the adapter's runtime switch
+}
+
+// Static<S> — extract the phantom type from any schema node
+type Static<S extends ILlmSchema<unknown>> = S extends ILlmSchema<infer T> ? T : never;
+```
+
+Runtime objects returned by factories carry `_type` (a real string field) but no `[_phantom]` field — it is declared only in the interface so TypeScript tracks it during type-checking without emitting it.
+
+### A.2 Leaf factories
+
+Each leaf factory returns a tagged value that carries a concrete `T` in the phantom slot:
+
+```typescript
+interface ILlmStringSchema extends ILlmSchema<string> { _type: 'string'; enum?: string[] }
+interface ILlmNumberSchema extends ILlmSchema<number> { _type: 'number' | 'integer' }
+interface ILlmBooleanSchema extends ILlmSchema<boolean> { _type: 'boolean' }
+
+function string(opts?: { description?: string }): ILlmStringSchema
+function number(opts?: { description?: string }): ILlmNumberSchema
+function integer(opts?: { description?: string }): ILlmNumberSchema
+function boolean(opts?: { description?: string }): ILlmBooleanSchema
+function enumOf<T extends string>(values: readonly T[], opts?: { description?: string }):
+  ILlmSchema<T>
+```
+
+`Static<ReturnType<typeof string>>` = `string`. `Static<ReturnType<typeof enumOf<'a'|'b'>>>` = `'a' | 'b'`. These are simple property-access resolutions — no recursive unfold, no conditional-type depth penalty.
+
+### A.3 Optional wrapper
+
+TypeBox's optional handling: a property wrapped in `Optional()` gains an extra marker in the schema node's type that the `object` factory's `Static<>` reads to decide which properties get `?:`.
+
+```typescript
+declare const _optional: unique symbol;
+
+interface ILlmOptional<S extends ILlmSchema<unknown>> extends ILlmSchema<Static<S> | undefined> {
+  readonly [_optional]: true;   // phantom marker
+  readonly _type: 'optional';
+  readonly _schema: S;          // real field — adapter needs it at runtime
+}
+
+function optional<S extends ILlmSchema<unknown>>(schema: S): ILlmOptional<S>
+```
+
+The `_schema` field is a *real* runtime field (needed by the adapter to recurse). The `[_optional]` symbol is only type-level.
+
+### A.4 Object factory and the required/optional split
+
+This is the trickiest mapped-type case. The `object` factory receives a record of property schemas, some of which may be `ILlmOptional<...>`. It must produce a type where optional properties carry `?:` and required ones don't.
+
+```typescript
+type ILlmProperties = Record<string, ILlmSchema<unknown>>;
+
+// Extract keys where the schema is optional
+type OptionalKeys<P extends ILlmProperties> = {
+  [K in keyof P]: P[K] extends ILlmOptional<infer _> ? K : never
+}[keyof P];
+
+type RequiredKeys<P extends ILlmProperties> = Exclude<keyof P, OptionalKeys<P>>;
+
+// The derived object type
+type ObjectStatic<P extends ILlmProperties> =
+  { [K in RequiredKeys<P>]: Static<P[K]> } &
+  { [K in OptionalKeys<P>]?: Static<P[K]> };
+
+interface ILlmObjectSchema<P extends ILlmProperties> extends ILlmSchema<ObjectStatic<P>> {
+  _type: 'object';
+  _properties: P;                         // real field for adapter
+  additionalProperties?: false;
+  description?: string;
+}
+
+function object<P extends ILlmProperties>(
+  properties: P,
+  opts?: { additionalProperties?: false; description?: string }
+): ILlmObjectSchema<P>
+```
+
+**Round-trip verification** (the key example from the brief):
+
+```typescript
+const MemorySchema = object({
+  query: string(),
+  limit: optional(number()),
+});
+type Memory = Static<typeof MemorySchema>;
+// Memory = { query: string } & { limit?: number }
+//        = { query: string; limit?: number }       ← correct
+```
+
+The `ObjectStatic<P>` mapped type resolves in one pass — no recursion on `ObjectStatic` itself — so there is no depth-accumulation penalty. TypeScript eagerly computes the intersection when all four types (`RequiredKeys`, `OptionalKeys`, required sub-map, optional sub-map) are known, which they are since `P` is concrete at the call site.
+
+### A.5 Array factory
+
+```typescript
+interface ILlmArraySchema<S extends ILlmSchema<unknown>> extends ILlmSchema<Array<Static<S>>> {
+  _type: 'array';
+  _items: S;    // real field for adapter
+  description?: string;
+}
+
+function array<S extends ILlmSchema<unknown>>(items: S, opts?: { description?: string }):
+  ILlmArraySchema<S>
+```
+
+`Static<ILlmArraySchema<S>>` = `Array<Static<S>>` — one level of recursion, fully eager.
+
+### A.6 Nested example with full resolution
+
+```typescript
+const ToolSchema = object({
+  action: enumOf(['run', 'stop'] as const),
+  config: object({
+    timeout: optional(integer()),
+    tags: array(string()),
+  }),
+});
+
+type ToolArgs = Static<typeof ToolSchema>;
+// = { action: 'run' | 'stop';
+//     config: { timeout?: number; tags: string[] } }
+```
+
+Resolution path:
+1. `enumOf(['run','stop'] as const)` → `ILlmSchema<'run'|'stop'>`
+2. `optional(integer())` → `ILlmOptional<ILlmNumberSchema>` → carries `Static = number|undefined`
+3. `array(string())` → `ILlmArraySchema<ILlmStringSchema>` → carries `Static = string[]`
+4. Inner `object({timeout, tags})` → `ObjectStatic = { timeout?: number; tags: string[] }`
+5. Outer `object({action, config})` → `ObjectStatic = { action: 'run'|'stop'; config: { timeout?: number; tags: string[] } }`
+
+At 2 levels of nesting the resolution is 5 discrete property lookups. At 3 levels it is 7. The TypeBox performance problem (documented in issue threads) manifests at 10+ levels of nested objects with union members. The LLM tool subset rarely goes beyond 2 levels; 3 is the practical ceiling. **Depth is not a real concern for this scope.**
+
+### A.7 Compile-time error quality
+
+TypeBox's notoriously cryptic errors stem from its large combinator surface (40+ types) and heavily-distributed conditional types. The fgv variant has 7 factories with narrow, simple signatures. Passing a primitive instead of a schema:
+
+```typescript
+object({ x: 5 })  // TS error: Type 'number' is not assignable to type 'ILlmSchema<unknown>'
+```
+
+The error names the failing parameter and the expected interface — readable. Mismatched optionality (calling `optional(5)`) gives:
+```
+Argument of type 'number' is not assignable to parameter of type 'ILlmSchema<unknown>'
+```
+Also readable. The narrow surface avoids the distribution explosion that makes TypeBox errors hard to read.
+
+### A.8 `fromJson` parse path (phantom reconstruction)
+
+When a raw `JsonObject` arrives at the MCP boundary (no factory call, no phantom tags), it must be parsed into the typed schema value. `fromJson` is a runtime parse; its return type cannot carry a phantom `T` (since `T` is unknown from a raw JSON object). Two options:
+
+**Option 1 — `fromJson` returns `ILlmSchema<JsonObject>` (opaque type).** The parsed schema can be passed to `toConverter` which returns `Converter<JsonObject>`. The consumer gets runtime validation but no compile-time `T`. This is the right behavior: an MCP-discovered schema has no statically-known `T`.
+
+**Option 2 — `fromJson` is not in scope for the LLM-tool authoring use case.** MCP consumers parse raw JSON Schema into a typed schema value for validation purposes, not for type-derivation. `toConverter(rawSchema)` where `rawSchema: JsonObject` (not `ILlmObjectSchema<P>`) returns `Converter<JsonObject>`, not `Converter<Static<typeof rawSchema>>`. This is fine — there is no static type to derive.
+
+The recommendation is Option 2: `fromJson(raw: JsonObject)` returns `Result<ILlmSchema<JsonObject>>` — the phantom `T` is pinned to `JsonObject`, which is the honest type when the schema arrives at runtime. `toConverter` is overloaded to accept either a typed schema value (derives `T`) or the opaque `ILlmSchema<JsonObject>` (returns `Converter<JsonObject>`). No special `fromJson` is needed to reconstruct phantom tags — they cannot be reconstructed from a runtime value.
+
+---
+
+## §Part B — Composition with fgv `Converter<T>`
+
+### B.1 Adapter shape
+
+The adapter is a recursive descent over the schema value's `_type` discriminant. No changes to existing fgv primitives are needed — it purely composes them.
+
+```typescript
+// toConverter.ts (new packlet)
+
+function toConverter<S extends ILlmSchema<unknown>>(
+  schema: S
+): Result<Converter<Static<S>>> {
+  switch (schema._type) {
+    case 'string':
+      return succeed(Converters.string as Converter<Static<S>>);
+
+    case 'number':
+    case 'integer': {
+      const base = Converters.number;
+      const c = schema._type === 'integer'
+        ? base.withConstraint((n) => Number.isInteger(n) || fail(`${n}: not an integer`))
+        : base;
+      return succeed(c as unknown as Converter<Static<S>>);
+    }
+
+    case 'boolean':
+      return succeed(Converters.boolean as Converter<Static<S>>);
+
+    case 'enum':
+      return succeed(Converters.enumeratedValue(schema.enum) as unknown as Converter<Static<S>>);
+
+    case 'array': {
+      const arraySchema = schema as ILlmArraySchema<ILlmSchema<unknown>>;
+      return toConverter(arraySchema._items)
+        .onSuccess((inner) => succeed(Converters.arrayOf(inner) as unknown as Converter<Static<S>>));
+    }
+
+    case 'optional': {
+      const optSchema = schema as ILlmOptional<ILlmSchema<unknown>>;
+      return toConverter(optSchema._schema)
+        .onSuccess((inner) => succeed(inner.optional() as unknown as Converter<Static<S>>));
+    }
+
+    case 'object': {
+      const objSchema = schema as ILlmObjectSchema<ILlmProperties>;
+      return _buildObjectConverter(objSchema) as Result<Converter<Static<S>>>;
+    }
+
+    default:
+      return fail(`unsupported schema type: ${(schema as { _type: string })._type}`);
+  }
+}
+```
+
+**Type-flow through the adapter:** The `as unknown as Converter<Static<S>>` casts inside the switch arms are correctness-preserving. The outer function signature promises `Converter<Static<S>>`; inside each arm, `S` is narrowed to a concrete subtype (e.g. `ILlmStringSchema`) so `Static<S>` = `string`, and `Converters.string` is `Converter<string>` — the cast merely crosses the gap between the concrete arm type and the generic return type, and is structurally correct. This is the same cast pattern used throughout the existing fgv Converter factories. There are no loose `as any` casts.
+
+### B.2 Object converter construction
+
+```typescript
+function _buildObjectConverter<P extends ILlmProperties>(
+  schema: ILlmObjectSchema<P>
+): Result<Converter<ObjectStatic<P>>> {
+  const fieldResults: Record<string, Result<Converter<unknown>>> = {};
+  for (const [key, propSchema] of Object.entries(schema._properties)) {
+    fieldResults[key] = toConverter(propSchema);
+  }
+  const errors: string[] = [];
+  const fields: Record<string, Converter<unknown>> = {};
+  const optionalKeys: string[] = [];
+
+  for (const [key, result] of Object.entries(fieldResults)) {
+    if (result.isFailure()) {
+      errors.push(`property ${key}: ${result.message}`);
+    } else {
+      fields[key] = result.value;
+      if (schema._properties[key]._type === 'optional') {
+        optionalKeys.push(key);
+      }
+    }
+  }
+  if (errors.length > 0) {
+    return fail(errors.join('\n'));
+  }
+
+  const strict = schema.additionalProperties === false;
+  const converterFn = strict ? Converters.strictObject : Converters.object;
+  return succeed(
+    converterFn(fields as FieldConverters<ObjectStatic<P>>, { optionalFields: optionalKeys })
+  );
+}
+```
+
+The `fields as FieldConverters<ObjectStatic<P>>` cast is load-bearing but correct: by construction, every key in `fields` holds a `Converter<T>` where `T = Static<P[key]>`, which is exactly what `FieldConverters<ObjectStatic<P>>` requires. The type parameter `ObjectStatic<P>` was computed at compile time from the factory call; the runtime converter assembly mirrors it exactly.
+
+### B.3 Wire-format emission (`toJson`)
+
+`toJson` strips phantom fields (they don't exist at runtime anyway) and emits standard JSON Schema:
+
+```typescript
+function toJson(schema: ILlmSchema<unknown>): JsonObject {
+  switch (schema._type) {
+    case 'string':    return { type: 'string', ...(schema.description && { description: schema.description }) };
+    case 'number':    return { type: 'number', ...(schema.description && { description: schema.description }) };
+    case 'integer':   return { type: 'integer', ...(schema.description && { description: schema.description }) };
+    case 'boolean':   return { type: 'boolean', ...(schema.description && { description: schema.description }) };
+    case 'enum':      return { type: 'string', enum: schema.enum };
+    case 'optional':  return toJson(schema._schema);  // optionality is a property-level concern in JSON Schema
+    case 'array':     return { type: 'array', items: toJson(schema._items) };
+    case 'object': {
+      const properties: Record<string, JsonObject> = {};
+      const required: string[] = [];
+      for (const [key, propSchema] of Object.entries(schema._properties)) {
+        const isOpt = propSchema._type === 'optional';
+        const inner = isOpt ? (propSchema as ILlmOptional<ILlmSchema<unknown>>)._schema : propSchema;
+        properties[key] = toJson(inner);
+        if (!isOpt) required.push(key);
+      }
+      return {
+        type: 'object',
+        properties,
+        ...(required.length > 0 && { required }),
+        ...(schema.additionalProperties === false && { additionalProperties: false }),
+        ...(schema.description && { description: schema.description }),
+      };
+    }
+    default: return {};
+  }
+}
+```
+
+The key point: `optional` wrappers are invisible in the emitted JSON Schema — they appear as absent entries in `required` on the parent object, which is the correct JSON Schema representation.
+
+### B.4 Compatibility with `IAiClientToolConfig.parametersSchema: JsonObject`
+
+The `ai-assist-client-tools` design (referenced in the brief) currently uses `parametersSchema: JsonObject`. Two interop shapes are possible:
+
+**Option (a) — Overloaded `toConverter` + `toJson` for consumption at the call site.** Consumers with a typed schema value call `toJson(schema)` to get the `JsonObject` for `parametersSchema`, and `toConverter(schema)` to get the typed `Converter`. Consumers with a raw `JsonObject` (e.g. MCP-discovered) call `toConverter(raw)` which returns `Converter<JsonObject>`.
+
+**Option (b) — Schema value implements a `toJSON()` method so it is structurally serializable as `JsonObject`.** This is appealing but the schema value's `_type` and `_properties` fields would appear in the serialized form, and JSON Schema consumers would see them as unknown fields — a problem.
+
+**Recommendation: Option (a).** The `parametersSchema: JsonObject` field stays as-is in `IAiClientToolConfig`. Consumers with typed schemas call `toJson(schema)` explicitly. This is two lines (one schema construction, one `toJson` call) and is explicit. It avoids a structural mismatch between the schema value's internal representation and the wire JSON Schema. No change to `IAiClientToolConfig` is required.
+
+If Erik later wants to merge the types, an alternative is `parametersSchema: ILlmSchema<unknown> | JsonObject` with overloaded handling inside the tool infrastructure — but that is a Phase C concern, not a precondition.
+
+### B.5 `Converters.number` permissiveness
+
+As noted in `research.md` §1.5, `Converters.number` accepts numeric strings (`'42'` → `42`). The derived Converter for `number` / `integer` inherits this behavior. For the LLM-tool use case this is benign — LLMs emit JSON numbers as numbers. For other uses (REST body validation), the behavior could be surprising.
+
+This is a Phase-C design question: add a `{ strict?: boolean }` option to `toConverter` that wraps numeric converters with a `.withConstraint((n, v) => typeof v === 'number' || fail('not a number'))` guard. Deferring to the alignment stream.
+
+---
+
+## §Part C — Cost, sequencing, stop conditions
+
+### C.1 Implementation scope
+
+The implementation lives in a single new packlet in `ts-json-base`. No touch to existing exports.
+
+**Estimated file layout:**
+
+```
+libraries/ts-json-base/src/packlets/json-schema/
+├── index.ts               # re-exports (~25 lines)
+├── types.ts               # ILlmSchema, ILlmOptional, ILlmObjectSchema, etc. (~120 lines)
+├── factories.ts           # string(), number(), integer(), boolean(), enumOf(),
+│                          # optional(), array(), object() (~100 lines)
+├── toConverter.ts         # adapter recursion (~120 lines)
+├── toJson.ts              # wire-format emission (~60 lines)
+└── fromJson.ts            # parse from raw JsonObject → ILlmSchema<JsonObject> (~80 lines)
+
+Total implementation: ~505 lines
+
+libraries/ts-json-base/src/test/unit/packlets/json-schema/
+├── types.test.ts          # phantom type round-trips at the type level (~80 lines)
+├── factories.test.ts      # factory value shapes + Static<> spot-checks (~100 lines)
+├── toConverter.test.ts    # each leaf + object + optional + array + nested (~220 lines)
+├── toJson.test.ts         # wire-format correctness (~120 lines)
+└── fromJson.test.ts       # parse + reject out-of-subset features (~100 lines)
+
+Total tests: ~620 lines
+libraries/ts-json-base/src/index.ts  # one new namespace export
+```
+
+**Comparison to phase-1 AJV-style estimate (~300–500 lines impl + 300–400 lines tests):** The derives-T version is ~200 lines larger across both dimensions. The additional cost is the `types.ts` phantom-type definitions and `fromJson.ts`. Neither is complex; the delta is bookkeeping, not difficulty.
+
+**Blast radius:** `@fgv/ts-json-base` only. No touch to `ts-utils`, no new external dependencies. The new packlet is additive; existing packlets (`converters`, `validators`, `file-tree`, `json-file`) are untouched.
+
+### C.2 MCP fit
+
+MCP-discovered schemas arrive as raw `JsonObject`. The `fromJson(raw)` function:
+1. Validates the raw object is within the LLM subset (fails with a clear error if `$ref`, `oneOf`, `anyOf`, `allOf`, `pattern`, or unsupported `format` appear).
+2. Recursively reconstructs schema nodes tagged as `ILlmSchema<JsonObject>` (the opaque phantom type — `T` is `JsonObject` for all nodes since the actual type is unknown at the MCP boundary).
+3. The resulting `ILlmSchema<JsonObject>` can be passed to `toConverter` which returns `Converter<JsonObject>` — runtime validation is real, just not statically typed to a narrower `T`.
+
+This is the correct behavior for MCP: runtime validation without a derived static type. Consumers who want a stronger type must author the schema via factories (the authoring-time story).
+
+**Out-of-subset failure mode:** `fromJson` returns `fail('unsupported feature: $ref at /properties/foo')` — explicit, actionable. Consumers know exactly what to remove or rewrite.
+
+### C.3 Sequencing recommendation
+
+The brief asks whether `ai-assist-client-tools` Phase B/C should hold for this work. The answer is **hold Phase C implementation for the alignment stream, but not Phase B**.
+
+- **Phase B** (contract design, `IAiClientToolConfig` interface) does not depend on the schema type system. The recommended `parametersSchema: JsonObject` shape is correct whether or not the typed schema factories exist. Phase B should proceed as planned.
+- **Phase C** (implementation of the tool invocation pipeline) would benefit from the typed schema surface being available — specifically, `fromJson` for MCP-discovered tools and `toConverter` for runtime arg validation. If Phase C lands without it, consumers use raw `JsonObject` and hand-roll converters, which is the status-quo direction and fully valid.
+- The alignment stream (`json-schema-derives-T`) can run in parallel with Phase C or slightly ahead. It is a single-PR, contained new packlet. If it lands before Phase C closes, Phase C can adopt the typed schema factories in its testbed as a validation smoke-test. If it doesn't, Phase C proceeds with `JsonObject` and migrates later.
+
+**Erik's stated inclination:** "I'm inclined to add that now and hold the AI tool work until it's ready." This is reasonable given the scoped estimate (~500 lines impl + ~620 lines tests, single packlet). The alignment stream is a 1–2 day implementing-agent cycle. Holding Phase C for it adds ~2–3 days of schedule risk in exchange for cleaner initial consumer code. Erik's call.
+
+### C.4 Stop conditions
+
+The following scenarios would flip the verdict from feasible to infeasible or borderline:
+
+| Scenario | Likelihood | Impact | Outcome |
+|---|---|---|---|
+| `ObjectStatic<P>` mapped type causes TS perf cliff for realistic schemas | Very low — depth ≤3, no recursion on `ObjectStatic` itself | High | Fallback: Direction C with drift-detection tests per `research.md §3.3` |
+| Optional/required interaction requires workaround visible to consumers | Low — the `OptionalKeys` / `RequiredKeys` split is well-precedented in TS utility types | Medium | Simplify: `optional()` marks properties via a naming convention (`key?: ...`) rather than a phantom marker — slightly less ergonomic authoring but same runtime behavior |
+| `as unknown as Converter<Static<S>>` casts in the adapter are found to be unsound (e.g. TypeScript widens `Static<S>` in a way that breaks the cast) | Low — `Static<S>` is computed at the call site before the cast; narrowing is one-directional | High | Surface to orchestrator; would require explicit intermediate types per arm rather than a generic cast |
+| Combinator surface bloats past 10 entries to cover realistic LLM schemas | Unlikely given the subset definition; `enumOf`, `string`, `number`, `integer`, `boolean`, `array`, `optional`, `object` = 8 | Low | Accepted; 10 is still well within a manageable surface |
+| `fromJson` required for MCP cannot reliably reconstruct phantom types | Not applicable — `fromJson` intentionally pins `T = JsonObject`; no phantom reconstruction is attempted | — | By design, not a stop condition |
+
+None of these stop conditions are likely to fire for the defined scope. If one does fire during implementation, the fallback is **status-quo Direction C** with the drift-detection test pattern from `research.md §3.3`. The AJV-style path remains off the table per Erik's review.
+
+---
+
+## §Closing recommendation
+
+Schema-derives-T for the LLM-tool JSON Schema subset is **feasible**. The phantom-tag machinery is simple (7 factories, a single recursive `Static<S>` property-access type, one mapped type for optional/required splitting), the fgv `Converter<T>` surface needs no retrofit, and the blast radius is a single new packlet in `ts-json-base`. The implementation is ~500 lines with ~620 lines of tests — modestly larger than the AJV-style estimate but delivering meaningfully stronger type safety (derived, not asserted). The next step is an alignment stream commission once Erik reviews this verdict. If the verdict is accepted, recommend the orchestrator commissions `json-schema-derives-T` as an independent stream against `ts-json-base` with the phase-1 follow-on scope shape from `research.md §4.2` updated to reflect the phantom-type design described here.
+
+---
+
+## Appendix: union type approach note
+
+An alternative to the `[_phantom]: unique symbol` approach is to store the phantom in a regular (runtime) field that is structurally present but semantically meaningless, like `_phantom: undefined`. This avoids unique-symbol module-boundary issues (the TypeBox issue #679 cited in the web search) at the cost of a runtime no-op field. For the fgv use case, where schemas are constructed and immediately passed to `toConverter` within the same package, module-boundary unique-symbol issues are unlikely. The brief directs toward TypeBox-style; the unique-symbol approach is cleaner and preferred. If module-boundary friction surfaces in practice, the `_phantom: undefined` fallback is a 5-line change.
+
+---
+
+*Sources consulted for TypeBox mechanism:*
+- [TypeBox GitHub (sinclairzx81/typebox)](https://github.com/sinclairzx81/typebox)
+- [TypeBox npm package (@sinclair/typebox)](https://www.npmjs.com/package/@sinclair/typebox)
+- [TypeBox Optional/modifier discussion #835](https://github.com/sinclairzx81/typebox/discussions/835)
+- [TypeBox unique-symbol module boundary issue #679](https://github.com/sinclairzx81/typebox/issues/679)

--- a/.ai/tasks/active/json-schema-converter-alignment/research.md
+++ b/.ai/tasks/active/json-schema-converter-alignment/research.md
@@ -1,0 +1,441 @@
+# Research: `json-schema-converter-alignment`
+
+**Status:** complete — recommendation below
+**Author:** general-purpose research agent
+**Date:** 2026-06-02
+**Companion docs:** [brief.md](./brief.md), [state.md](./state.md), [`ai-assist-client-tools/design.md` §2.1](../ai-assist-client-tools/design.md)
+
+---
+
+## TL;DR
+
+**Recommendation: Direction A (Schema → Converter), bounded — but ship it as a *second-phase* additive extension, not as a Phase-C blocker for `ai-assist-client-tools`.**
+
+- The fgv Converter combinator surface is **not currently reflection-friendly enough** to drive Direction B at low cost (most combinators are opaque `BaseConverter` closures with no public fields exposing their inner converter / element converter / option set). Adding reflection would touch every basic combinator in `ts-utils/conversion` — broad blast radius on an established surface.
+- Direction A, scoped to the LLM-tool-use JSON Schema subset (`type`, `properties`, `required`, `description`, `enum`, nested object/array, `additionalProperties`), is a **small, contained, additive** new factory in `ts-json-base`. Estimated 300–500 lines of implementation + tests. No changes to existing exported surfaces.
+- Direction C (status quo) is **viable** for the LLM-tool-use case as Phase B/C of `ai-assist-client-tools` proceed; the alignment burden on a 1–3-field tool config is small and a 10-line round-trip drift test catches the realistic failure modes. The spike's recommendation does **not** block Phase C — it informs a *later* additive convenience.
+- The fgv-native answer to "consumer authors one and gets the other for free" is **author JSON Schema → derive a `Converter<JsonObject>` (or a typed `Converter<T>` if `T` is supplied by the consumer)**. This matches the asymmetry of the actual problem: the wire format is the *contract* (the LLM provider defines it), the typed runtime shape is a consumer concern.
+
+The full doc walks the reasoning. Cost comparison is in §3; recommended sequencing in §4.
+
+---
+
+## Reading-list pointers used
+
+- `libraries/ts-utils/src/packlets/conversion/{converter,baseConverter,basicConverters,objectConverter,stringConverter}.ts` — reflection surface of the Converter base classes and combinators.
+- `libraries/ts-utils/src/packlets/validation/{validator,validatorBase,object,validators}.ts` — Validators (in-place sibling).
+- `libraries/ts-json-base/src/packlets/converters/converters.ts` — JSON-shaped converters (`jsonObject`, `jsonValue`, `stringifiedJson`, etc.).
+- `libraries/ts-json-base/src/packlets/validators/validators.ts` — JSON validators.
+- `.ai/tasks/active/ai-assist-client-tools/design.md` §2.1 — the JSON-Schema-as-source-of-truth recommendation this spike pressure-tests.
+- `.ai/instructions/CODING_STANDARDS.md` (Type-Safe Validation section) — anti-pattern: manual type-checking + cast; required pattern: `Converters.object` / `Validators.object`.
+- External: Zod v4 (`z.toJSONSchema`), AJV (`ajv.compile<T>` + `JSONSchemaType<T>`), TypeBox (`Type.Static<typeof S>` over an in-memory JSON Schema), `json-schema-to-typescript` (build-time `.d.ts` emission).
+
+---
+
+## §1 Direction A — Schema → Converter
+
+### 1.1 OSS precedents
+
+| Library | What it does | Strengths | Failure modes / fit with fgv |
+|---|---|---|---|
+| **AJV** ([docs](https://ajv.js.org/guide/typescript.html)) | Compiles arbitrary JSON Schema (draft-04 → 2020-12) at runtime into a fast validator function. With `JSONSchemaType<T>` the schema is type-checked against a consumer-supplied `T`; `ajv.compile<T>(schema)` returns a type-narrowing predicate. | Mature, fast, full schema dialect coverage, code-generation under the hood. Type narrowing works as a TS guard. | Throws / returns boolean — not Result-shaped. `JSONSchemaType<T>` does not support discriminated unions / type-infers from schemas (it goes T → schema-shape, not schema → T). Heavy dep. Doesn't *produce* a `T` type from a schema; `T` is supplied. |
+| **Zod v4 native** ([Zod JSON Schema docs](https://zod.dev/json-schema)) | `z.toJSONSchema(schema)` — Zod-to-JSON-Schema is the new direction. `fromJSONSchema` is an [open feature request (#5233)](https://github.com/colinhacks/zod/issues/5233) — **not** shipped natively as of Zod 4. | Schema export is high-quality (preserves descriptions, handles enums, supports `additionalProperties`, targets draft-07 / 2020-12 / OpenAPI 3.0). | The reverse direction (Schema → Zod) is community-supplied (`json-schema-to-zod`) and lossy. Demonstrates that "schema-from-validator" is the *easier* direction in Zod's experience. |
+| **TypeBox** ([readme](https://github.com/sinclairzx81/typebox#readme)) | The schema **is** the runtime representation: `Type.Object({...})` returns a plain JSON Schema object; `Type.Static<typeof S>` derives the TS type at the type level; `TypeCompiler.Compile(S)` derives the runtime validator from the same object. | Single source of truth. Idiomatic for JSON-Schema-first authoring. Validator compiler is fast (codegen). | Authoring is not Converter-shaped (no transformation, just validation). The TS-inference is what makes it pleasant — that piece relies on heavy mapped/conditional types. Doesn't return `Result<T>`. |
+| **`json-schema-to-typescript`** | Build-time `.d.ts` emission from a JSON Schema. | Useful for *typing* the consumer's callback when the schema is wire-authored. | Build-time only; no runtime validator. Complementary, not competitive. |
+
+**Net signal from OSS:** Schema → Validator (Direction A) is a well-trodden path with multiple mature reference implementations. Validator → Schema (Direction B) is harder; the most successful instance (Zod v4) is itself author-validator-first, but native Schema → Validator (`fromJSONSchema`) is conspicuously absent from Zod 4 as of mid-2026 and is still an open feature request.
+
+### 1.2 Fit with fgv
+
+The Result-pattern constraint is the load-bearing differentiator. None of the OSS libraries return `Result<T>`; they throw or return booleans. A fgv-native `JsonSchema.toConverter<T>(schema)` must produce a `Converter<T, IJsonConverterContext>` that participates in `.onSuccess` / `.withErrorFormat` chains the same way `Converters.jsonObject` does today.
+
+The actual implementation is straightforward — walk the JSON Schema node tree, emit existing converter primitives at each node. Concretely:
+
+| JSON Schema node | Maps to existing fgv primitive |
+|---|---|
+| `{ type: 'string' }` | `Converters.string` (ts-json-base) |
+| `{ type: 'string', enum: [...] }` | `Converters.enumeratedValue([...])` |
+| `{ type: 'number' }` / `'integer'` | `Converters.number` (with integer check via `.withConstraint`) |
+| `{ type: 'boolean' }` | `Converters.boolean` |
+| `{ type: 'array', items: <sub> }` | `Converters.arrayOf(toConverter(sub))` |
+| `{ type: 'object', properties, required, additionalProperties }` | `Converters.object({...}, { optionalFields, strict })` — fields built by recursing on each property; `optionalFields` = `Object.keys(properties) \ required`; `strict: additionalProperties === false` |
+
+The conservative LLM-tool-use subset (`type`, `properties`, `required`, `description`, `enum`, nested object/array, `additionalProperties`) is fully reachable by composing the existing combinators. No new primitives required.
+
+### 1.3 Sketch: `JsonSchema.toConverter` in `ts-json-base`
+
+```typescript
+// libraries/ts-json-base/src/packlets/json-schema/toConverter.ts (new packlet)
+
+/**
+ * The conservative JSON Schema subset accepted by LLM provider function-calling
+ * APIs. Branded so consumers cannot accidentally pass arbitrary JsonObject.
+ *
+ * Out of scope (deliberately): $ref, oneOf/anyOf/allOf, pattern, custom formats,
+ * dependentRequired, conditional subschemas.
+ */
+export type LlmToolJsonSchema = Brand<JsonObject, 'LlmToolJsonSchema'>;
+
+/** Validates and brands an arbitrary JsonObject as an LlmToolJsonSchema. */
+export const llmToolJsonSchema: Converter<LlmToolJsonSchema, IJsonConverterContext>;
+
+/**
+ * Produces a runtime Converter from a JSON Schema describing an LLM tool's
+ * parameter shape.
+ *
+ * The result type defaults to JsonObject (the schema validates *shape*, not
+ * a typed domain object). Callers who want a stronger type can supply T
+ * explicitly — this is an unverified assertion at the type level (same shape
+ * as ajv's `ajv.compile<T>(schema)`); runtime validation still happens via
+ * the schema.
+ *
+ * @example
+ *   const converter = JsonSchema.toConverter(toolSchema).orThrow();
+ *   const args = converter.convert(rawArgsFromModel); // Result<JsonObject>
+ *
+ * @example
+ *   interface IWeatherArgs { city: string; units?: 'metric' | 'imperial' }
+ *   const converter = JsonSchema.toConverter<IWeatherArgs>(weatherSchema).orThrow();
+ *   const args = converter.convert(rawArgs); // Result<IWeatherArgs>
+ */
+export function toConverter<T = JsonObject>(
+  schema: LlmToolJsonSchema | JsonObject
+): Result<Converter<T, IJsonConverterContext>>;
+```
+
+**Typing story (the question from brief.md §1):** `T` is **consumer-supplied** (defaulting to `JsonObject`). Inferring `T` from the schema at the type level requires conditional-types reflection on the JsonObject contents — TypeBox does this, but it's a substantial type-system project on its own (deep recursion limits, distributive conditionals, etc.) and lives in a different design space from the rest of the Converter surface. For the LLM tool-use case, the consumer's callback already declares its parameter type; consumers either:
+
+1. Pass `JsonObject` and parse inside the callback (the current `ai-assist-client-tools` design).
+2. Supply `T` as a TypeScript hint matching what they authored in JSON Schema (the AJV pattern). Drift between `T` and the schema is a consumer-side concern — `JSONSchemaType<T>` in AJV exists to catch this *statically* in narrow cases, but at the cost of fairly involved type machinery.
+
+For the spike's scope, **option (1) + option (2) with no static cross-check** is the right pragmatic level: the runtime Converter is real and Result-shaped; the static cross-check is a future optional enhancement.
+
+**Loss-of-information concerns.** The Converter produced from a JSON Schema cannot reconstruct branded types or refined types — JSON Schema has no representation for "this string is a `UserId`". The fgv idiom for this composition already exists:
+
+```typescript
+// Consumer supplies the brand layer on top of the generated converter:
+const baseConverter = JsonSchema.toConverter<{ id: string }>(schema).orThrow();
+const brandedConverter = baseConverter.map((raw) =>
+  succeed({ id: raw.id as UserId })
+);
+```
+
+This is the same composition pattern used today when chaining `Converters.string` with `.withBrand('UserId')`. No new affordance needed.
+
+### 1.4 What this would cost to build
+
+- One new packlet under `libraries/ts-json-base/src/packlets/json-schema/` (sibling to `json-file`, `converters`, `validators`).
+- `toConverter.ts` (the dispatch / recursion) — ~150 lines.
+- A small `LlmToolJsonSchema` branded type + a Converter that validates the schema shape itself (i.e. enforces the conservative subset and rejects out-of-scope features with a clear error message) — ~100 lines. This is the key safety net: rather than silently accepting `$ref` and producing a wrong validator, the factory **rejects** schemas outside the supported subset.
+- Tests covering the LLM tool-use subset — ~300–400 lines (100% coverage target).
+- Public-API exports + TSDoc — small.
+
+Estimated total: **300–500 lines impl + 300–400 lines tests**. One packlet, one publishing surface, no touch to existing exports. Blast radius: contained.
+
+### 1.5 Failure modes specific to fgv
+
+- **`additionalProperties: false` mismatch with `Converters.object`'s `strict` option.** Today `Converters.object` defaults to `strict: false` (extra fields silently dropped). JSON Schema's default for `additionalProperties` is `true` (extra fields allowed *and preserved*). Direction A must reconcile these: when the schema sets `additionalProperties: false`, emit `Converters.strictObject`; when unset, emit `Converters.object` (silently drops extras — matches schema's "allowed" but not "preserved"). Document this as an intentional simplification of the LLM-tool subset (LLM-returned arguments shouldn't carry meaningful extra fields anyway).
+- **`description` propagation.** JSON Schema `description` annotations are LLM-visible, not validator-visible. The generated Converter cannot emit them in error messages without piping `description` through to `Converters.object`'s `description` option. This is straightforward and lossless.
+- **`enum` ordering.** `Converters.enumeratedValue` accepts a `ReadonlyArray<T>`; JSON Schema `enum` is an array. Trivial pass-through.
+
+---
+
+## §2 Direction B — Converter → Schema
+
+### 2.1 What it would take
+
+Adding `toJsonSchema()` to the `Converter<T>` surface requires every combinator to know how to describe itself. Today, the reflection surface on `Converter<T>` is:
+
+```typescript
+interface Converter<T, TC = unknown> extends ConverterTraits {
+  readonly isOptional: boolean;
+  readonly brand?: string;
+  convert(from: unknown, context?: TC): Result<T>;
+  // ... transformation methods (.map, .withBrand, .optional, .withConstraint, ...)
+}
+```
+
+`brand` and `isOptional` are the *only* introspectable state. The actual conversion logic is a closure inside `BaseConverter._converter`. `ObjectConverter` happens to additionally expose `fields: FieldConverters<T, TC>` and `options: ObjectConverterOptions<T>` — which is what makes Direction B *thinkable* — but `arrayOf`, `recordOf`, `mapOf`, `oneOf`, `enumeratedValue`, `literal`, `tuple`, `delimitedString`, `validated`, `validateWith`, `generic`, `transform`, `transformObject` all return bare `BaseConverter` instances with no public access to the data they captured.
+
+### 2.2 Coverage table
+
+| Combinator | Schema-emittable? | Lossless? | Notes |
+|---|---|---|---|
+| `Converters.string` | ✅ | ✅ | `{ type: 'string' }` |
+| `Converters.number` | ⚠️ | ⚠️ | `Converters.number` accepts numeric strings (`'42'`); JSON Schema `type: 'number'` does not. Lossy — the emitted schema would over-reject relative to the converter, or the consumer must accept that the Converter is permissive in a way the schema isn't. |
+| `Converters.boolean` | ⚠️ | ⚠️ | Same — converter accepts `'true'` / `'false'` strings; schema does not. |
+| `Converters.literal(v)` | ✅ | ✅ | `{ const: v }` (draft-06+) or `{ enum: [v] }` |
+| `Converters.enumeratedValue([...])` | ✅ | ✅ | `{ enum: [...] }` |
+| `Converters.object({...}, opts)` | ✅ | ⚠️ | Possible — fields are exposed. Lossy on `strict: false` (extras dropped silently, schema would say `additionalProperties: true` meaning "preserved"). |
+| `Converters.strictObject({...})` | ✅ | ✅ | `additionalProperties: false` |
+| `Converters.arrayOf(inner)` | ❌ | — | Inner converter not exposed. **Surface change required.** |
+| `Converters.recordOf(inner)` / `Converters.mapOf` | ❌ | — | Same. |
+| `Converters.oneOf([...])` | ❌ | — | Inner converters not exposed. Even if exposed, `oneOf` semantics in the converter are "first-match wins", not JSON Schema's "exactly-one-match". Emits as `anyOf`, not `oneOf`. |
+| `Converters.tuple([...])` | ❌ | — | Not exposed. |
+| `Converters.delimitedString` | ❌ | ❌ | Transforms string → array; no JSON Schema analog (the schema would describe one shape; the converter ingests another). |
+| `Converters.validated(c, v)` / `.withConstraint(predicate)` | ❌ | ❌ | Predicates are opaque functions. Cannot be reflected as JSON Schema constraints. |
+| `Converters.generic(fn)` | ❌ | ❌ | Arbitrary user function. By design opaque. |
+| `Converters.transform` / `Converters.transformObject` | ❌ | ❌ | Source-to-dest shape transforms — fundamentally not the same shape on both sides. JSON Schema cannot describe the transform. |
+| `.withBrand(b)` | ✅ (lossy) | ❌ | Brand is exposed; emits as `string` (drop brand) or as schema annotation `x-fgv-brand: 'UserId'` (advisory). |
+| `.optional()` | ✅ | ✅ | Flag is exposed via `isOptional`. |
+
+**Net coverage:** the *core* subset that LLM tool-use cares about (`string`, `number`, `boolean`, `enumeratedValue`, `object` with `strict`, `arrayOf`) is technically reachable **but `arrayOf`, `recordOf`, `oneOf`, `tuple` require exposing their inner converters as a public readonly field** — a surface change to four+ combinators in `ts-utils/conversion/basicConverters.ts`. Plus a new `toJsonSchema(): JsonObject` method on the `Converter<T>` interface and a default implementation that returns "I don't know how to describe myself, emit `{}` or fail" for opaque combinators.
+
+### 2.3 Loss-of-information analysis
+
+The brief asks specifically about branded types: emitting a `Converters.brandedString` (i.e. `Converters.string.withBrand('UserId')`) as JSON Schema has three options:
+
+1. **Drop the brand:** emit `{ type: 'string' }`. Schema is lossy but valid against LLM providers. Lossless inverse: not possible (the brand is gone).
+2. **Annotate:** emit `{ type: 'string', 'x-fgv-brand': 'UserId' }`. LLM providers ignore unknown annotations. Inverse: possible if the importer recognizes `x-fgv-brand`.
+3. **Format hint:** emit `{ type: 'string', format: 'uuid' }` for known formats. Doesn't generalize. Not applicable to arbitrary brands.
+
+Option 1 is the realistic choice. Option 2 is cute but adds a new dialect concern and a synchronization burden. Option 3 doesn't generalize.
+
+### 2.4 Cost to build
+
+- **Surface change on `Converter<T>` interface:** new optional `toJsonSchema(): JsonObject` method. Default implementation on `BaseConverter` returns `{}` or fails; specialized implementations on every combinator that should emit schema.
+- **Expose inner converter on `arrayOf` / `recordOf` / `oneOf` / `tuple` / `mapOf` / `delimitedString` / `validated`:** each needs a subclass of `BaseConverter` (currently they return `new BaseConverter(closure)`) that holds the inner converter as a `public readonly`. ~6 combinators × ~30–60 lines each = ~300 lines of *purely additive* surface change.
+- **`toJsonSchema()` implementations:** per-combinator, ~10–30 lines each. ~150 lines.
+- **Tests:** higher than Direction A because the coverage matrix is wider — ~600 lines.
+- **Cross-cuts:** the surface change to `arrayOf` et al. lives in `ts-utils` (an **established surface** per `ACTIVE_DEVELOPMENT.md`), so additivity is critical and well-trodden, but the surface change is *broad* (every consumer's `arrayOf(inner)` now returns a slightly more reflective object, even if the public type is unchanged).
+
+Estimated total: **~600 lines impl + 600 lines tests + cross-cutting surface change to ts-utils**. Blast radius: medium — touches `ts-utils/conversion`, which is the most-imported packlet in the monorepo.
+
+### 2.5 Why this direction is harder *for fgv specifically*
+
+Zod's path (`z.toJSONSchema`) succeeded because Zod's combinators are introspectable by design — every Zod schema node carries a discriminant tag (`_zod.def.type`) plus the captured constructor arguments. The fgv Converter combinator surface predates schema-emission as a design goal; the closures-over-data idiom is everywhere. Retrofitting reflection on every combinator is feasible but is a separate, larger workstream than Direction A.
+
+**A weaker form of Direction B** — only `ObjectConverter` and a handful of leaf converters get `toJsonSchema()`, the rest are *not* schema-emittable and the consumer authors a JSON-Schema-emittable subset of the Converter surface — is also viable, but then the consumer is back to authoring two parallel things (the schema-emittable subset *and* anything that needs `.generic` or `.transform`), just with one of them being a Converter rather than a JSON Schema.
+
+---
+
+## §3 Direction C — Status quo
+
+### 3.1 What "status quo" actually means here
+
+The `ai-assist-client-tools` Phase A design recommends: consumer authors `parametersSchema: JsonObject` (raw JSON Schema) on `IAiClientToolConfig`. If the consumer wants to validate the model-returned `args: JsonObject` in their callback before processing, they author a separate `Converter<TArgs>` for that shape.
+
+The drift risk is real: the JSON Schema describes a contract to the LLM; the Converter describes a contract to the consumer's code. If a developer adds a new optional field to the schema and forgets the converter (or vice versa), the model can send a value the callback rejects, or the callback can demand a field the model was never told to provide.
+
+### 3.2 Cost comparison
+
+For a typical LLM tool — a 1–5 field config — the actual line counts:
+
+| Item | Direction A (Schema → Converter) | Direction B (Converter → Schema) | Direction C (status quo) |
+|---|---|---|---|
+| **Per-tool authoring cost** | ~10–20 lines of JSON Schema (single source). Converter is one call: `JsonSchema.toConverter<T>(schema).orThrow()`. | ~10–20 lines of Converter code. Schema is one call: `converter.toJsonSchema()`. | ~10–20 lines of JSON Schema + ~10–20 lines of Converter = ~20–40 lines, plus a 5–10 line drift test. |
+| **Library implementation cost** | 300–500 lines impl + 300–400 lines tests, one new packlet, no surface change | ~600 lines impl + ~600 lines tests + surface change to 6+ combinators in ts-utils | 0 lines library — but every consumer ships a drift test |
+| **Drift detection cost** | None at runtime (single source); type-level `T` vs. schema is consumer's static concern | None (single source) | One round-trip test per tool: ~10 lines (sample value → `converter.convert(JSON.parse(JSON.stringify(sample))).orThrow()`) |
+| **New-tool onboarding** | Read JSON Schema, write JSON Schema, get Converter for free. Familiar to LLM-tool authors. | Read Converter API, write Converter, get Schema for free. Requires learning fgv-specific combinators first. | Write both, write drift test. Highest cognitive load per tool. |
+| **Maintenance over time** | Schema is the canonical source — refactoring the typed view requires either updating `T` (still consumer-side) or accepting `JsonObject` and parsing inline. | Converter is canonical — refactoring the schema requires re-emitting. Schema diff in PRs is harder to read than Converter diff. | Both can drift independently; tests catch most cases. |
+
+### 3.3 Recommended drift-detection test pattern (if Direction C wins)
+
+For a tool with config `{ name, description, parametersSchema, callback }` plus an internal `Converter<TArgs>`:
+
+```typescript
+// libraries/<consumer-of-ai-assist>/src/test/unit/weatherTool.test.ts
+
+import '@fgv/ts-utils-jest';
+import { weatherToolSchema, weatherArgsConverter } from '../../packlets/weather-tool';
+import { JsonSchema } from '@fgv/ts-json-base'; // *if Direction A ships*
+import { Validators } from '@fgv/ts-utils';
+
+describe('weatherTool', () => {
+  // Sample arguments that should be valid against both the schema and the converter.
+  const validSample = { city: 'Seattle', units: 'metric' as const };
+
+  test('a sample argument set valid against the schema is also accepted by the converter', () => {
+    // Round-trip through JSON to simulate the wire path.
+    const overWire = JSON.parse(JSON.stringify(validSample));
+    expect(weatherArgsConverter.convert(overWire)).toSucceedWith(validSample);
+  });
+
+  test('the schema describes the exact field set the converter accepts', () => {
+    // Static drift catch: list the required fields from the schema and the converter
+    // and assert they line up. This is the manual version of the alignment.
+    const schemaRequired = (weatherToolSchema.required as string[]).slice().sort();
+    const schemaProperties = Object.keys(weatherToolSchema.properties as object).sort();
+    expect(schemaRequired).toEqual(['city']);
+    expect(schemaProperties).toEqual(['city', 'units']);
+    // The converter exposes its fields via ObjectConverter.fields (a public readonly).
+    // If the converter is wrapped (e.g. .map / .withBrand), this assertion needs a
+    // different shape — most LLM tools won't need that.
+  });
+
+  test('the converter rejects fields the schema does not advertise', () => {
+    const sneaky = { ...validSample, hackerField: 'oops' };
+    // strictObject rejects; the model should never send this anyway.
+    expect(weatherArgsConverter.convert(sneaky)).toFailWith(/hackerField/i);
+  });
+});
+```
+
+**Key properties of this pattern:**
+
+- Doesn't require new library surface. Works today against `Converters.object` / `Converters.strictObject`.
+- The "required fields match" assertion catches the most common drift (someone adds an optional field on one side only).
+- The round-trip-through-JSON assertion catches type mismatches that escape TS (e.g. schema declares `units: { type: 'string' }`, converter declares `units: Converters.number`).
+- Recommended idiom: each tool author writes one test file with these three tests. ~30 lines per tool.
+
+**What this pattern does *not* catch:**
+
+- Description / docstring drift (the schema's `description` says "City name" but the callback's TSDoc says "ZIP code"). No automated cure for this; code review catches it.
+- Constraint drift (schema says `enum: ['metric', 'imperial']`, converter uses `Converters.string` instead of `Converters.enumeratedValue`). Catchable with a more elaborate test, but rapidly approaches the implementation cost of Direction A itself.
+
+---
+
+## §4 Recommendation and sequencing
+
+### 4.1 Recommendation: Direction A, after `ai-assist-client-tools` Phase C
+
+**The fgv-native alignment story is `JsonSchema.toConverter<T>(schema)` in `ts-json-base`. Direction B is too invasive on an established surface; Direction C is too leaky on the LLM-tool-use case as the count of tools grows.** But this is a *later* additive convenience — not a Phase-C blocker.
+
+#### Why Direction A over Direction B
+
+1. **Smaller blast radius.** Direction A is a single new packlet in `ts-json-base` with no changes to existing exports. Direction B requires reflection retrofits across the most-imported packlet in the monorepo (`ts-utils/conversion`).
+2. **Schema is the contract.** For LLM tool use, the JSON Schema is what the LLM provider receives — it *is* the source of truth in the deployment graph. The Converter exists to make the model's reply ergonomic in TypeScript. Letting the contract drive the runtime artifact aligns with how the system actually composes.
+3. **Aligns with how consumers actually write LLM tools.** A 5-tool agent ships 5 JSON Schemas the model sees and 5 typed handlers. The schema is shared with the model (and may be hand-tuned for prompt-engineering reasons — e.g. tighter `description` strings); the Converter is purely internal validation. Letting the schema author drive both keeps the prompt-tuning loop tight.
+4. **The "single declaration" win is real.** A 3-field schema becomes one declaration; today it would be one schema + one converter + one drift test. The convenience is meaningful at scale (10+ tools).
+5. **The fgv combinator surface stays as designed.** No reflection retrofit on `arrayOf` / `recordOf` / `oneOf` / `tuple`. Established-surface stability obligations honored.
+
+#### Why "after Phase C" and not "alongside Phase C"
+
+- Phase C of `ai-assist-client-tools` can ship today with the recommended `IAiClientToolConfig.parametersSchema: JsonObject` shape. The shape is *correct* whether or not `JsonSchema.toConverter` exists.
+- Direction A is a **convenience** layered on top of that surface, not a precondition for it. Consumers who want stronger runtime typing can adopt `JsonSchema.toConverter<T>` once it ships; consumers who are happy parsing `JsonObject` in their callback keep working unchanged.
+- Trying to land Direction A *alongside* Phase C pushes the spike's recommendation onto Phase C's critical path. Phase C is already a substantial stream (per the design.md §4.2 sub-phase sketch); adding a new ts-json-base packlet to its scope adds risk without unblocking anything.
+- A consumer building tools today with the status-quo pattern (schema + converter + drift test) can migrate trivially to `JsonSchema.toConverter` later: drop the hand-written converter, replace with the generated one. **No deprecation churn.**
+
+#### Sequencing
+
+| Stream | Work | Timing |
+|---|---|---|
+| `ai-assist-client-tools` Phase B / C | Ships `IAiClientToolConfig.parametersSchema: JsonObject` and the round-trip orchestrator. Consumers author JSON Schema directly + their own converter where they want runtime typing. | Per existing plan; not affected by this spike. |
+| `json-schema-converter-alignment` follow-on (if commissioned) | New packlet `libraries/ts-json-base/src/packlets/json-schema/`: `LlmToolJsonSchema` brand, `llmToolJsonSchema` schema validator, `toConverter<T>(schema)` factory. Tests. Public-API exports. | Lands after Phase C of `ai-assist-client-tools` is in `release`. Independent stream — no cross-stream dependency on `ai-assist-client-tools` once Phase C is in. |
+| Follow-on consumer adoption | Existing tools rewrite their hand-written converters as `JsonSchema.toConverter` calls. Pure simplification. | Opportunistic; not blocking. |
+
+### 4.2 Scope sketch for the follow-on stream
+
+**Package surface touched:** `@fgv/ts-json-base` only. New packlet; no edits to existing packlets.
+
+**Files (estimated):**
+
+```
+libraries/ts-json-base/src/packlets/json-schema/
+├── index.ts                              # public re-exports (~30 lines)
+├── llmToolJsonSchema.ts                  # branded type + schema-of-schemas validator (~150 lines)
+├── toConverter.ts                        # the Schema → Converter recursion (~200 lines)
+└── test/                                 # under test/unit/packlets/json-schema/ at the package root
+    ├── llmToolJsonSchema.test.ts         # ~200 lines
+    └── toConverter.test.ts               # ~250 lines
+libraries/ts-json-base/src/index.ts       # one new namespace re-export
+```
+
+**Blast radius:** contained — one new packlet, one new top-level namespace (`JsonSchema`), no edits to existing public exports.
+
+**Acceptance criteria for the follow-on:**
+
+- `JsonSchema.toConverter(schema)` succeeds for any schema in the LLM-tool-use subset and fails with a clear message for any feature outside it (`$ref`, `oneOf`/`anyOf`/`allOf`, `pattern`, custom `format`).
+- The generated Converter returns `Result<JsonObject>` by default; `<T>` overload narrows the type-level result without changing runtime behavior.
+- `LlmToolJsonSchema` brand prevents callers from accidentally passing an arbitrary `JsonObject` as a tool schema (catches "I authored a config schema not a tool schema" mistakes at the call site).
+- 100% coverage; standard rush gates pass.
+- Integration: at least one sample tool in the `ai-assist` testbed migrated to `JsonSchema.toConverter` as a smoke test.
+
+**Estimated effort:** ~1 implementing-agent stream cycle (~600–900 lines total). Single PR.
+
+### 4.3 What this does *not* deliver
+
+- It does not handle arbitrary JSON Schema (no `$ref` resolution, no compositional schemas). The brief explicitly scopes these out, and the brand prevents misuse.
+- It does not infer `T` from the schema. Consumers either accept `JsonObject` or supply `T` as a hint. `JSONSchemaType<T>`-style static cross-check is a possible future addition, separately commissioned.
+- It does not add `toJsonSchema()` to the Converter surface. Direction B is left on the table as a possible future expansion if a strong use case emerges *outside* LLM tool use (e.g. publishing fgv-Converter-described shapes to OpenAPI). For LLM tool use specifically, Direction A is sufficient.
+
+### 4.4 If Erik wants to ship Direction A alongside Phase C
+
+The spike is not blocking either way, but if shipping aligned is a goal:
+
+- The new packlet has no dependency on `ai-assist` — it can land independently in a `ts-json-base` PR before or in parallel with Phase C of `ai-assist-client-tools`.
+- Phase C of `ai-assist-client-tools` would adopt `JsonSchema.toConverter` in its testbed sample tools as documentation rather than as a hard dependency.
+- The sequencing risk is just that the follow-on stream's PR + Phase C's PR both want to land near the same alpha; the orchestrator can decide whether that risk is worth eating.
+
+---
+
+## Anti-recommendations (explicitly *not* recommending)
+
+- **Don't add `toJsonSchema()` to the `Converter<T>` interface at this time.** Direction B's coverage matrix has too many opaque combinators; the surface change is broader than the value, and consumers who currently write `.generic` or `.transform` cannot participate. Defer until a concrete use case beyond LLM-tool-use forces the question.
+- **Don't generate `T` from JSON Schema via TypeScript conditional types.** TypeBox-style `Type.Static<typeof S>` is impressive but is a large, separable type-system project. The pragmatic AJV-style "consumer supplies `T` as a hint" is sufficient for LLM-tool-use and skips a multi-week type-system spike.
+- **Don't ship a more permissive `JsonSchema.toConverter` that accepts arbitrary draft-07 / 2020-12 schemas.** The branded `LlmToolJsonSchema` input type is load-bearing: it forces the consumer to consciously declare "this is an LLM tool schema, conservative subset", and the factory rejects out-of-scope features loudly rather than silently producing a wrong validator. A "be permissive, do the best we can" implementation would be a bug farm.
+- **Don't redesign the Converter API.** Out of scope per the brief. Direction A composes existing primitives; no API change.
+
+---
+
+## Open question to surface to the orchestrator
+
+None blocking. One advisory note:
+
+- The `Converters.number` accepts numeric strings (`'42'` → `42`); `JsonSchema.toConverter` for `{ type: 'number' }` would inherit this behavior. This is technically *more* permissive than the schema strictly allows. For LLM tool use it's harmless (LLMs return numbers as numbers in JSON). For other future use cases (e.g. validating REST request bodies) it could be unexpected. Suggest a `JsonSchema.toConverter(schema, { strictTypes: true })` option in the follow-on stream's design phase if this surfaces as a concern — but defer the decision to that stream.
+
+---
+
+## Appendix: sample consumer code (illustrative, for the recommendation)
+
+What a tool author would write *today* (status quo / Phase C as designed):
+
+```typescript
+// Phase C as currently designed in ai-assist-client-tools
+const weatherSchema: JsonObject = {
+  type: 'object',
+  properties: {
+    city: { type: 'string', description: 'City name' },
+    units: { type: 'string', enum: ['metric', 'imperial'] }
+  },
+  required: ['city'],
+  additionalProperties: false
+};
+
+interface IWeatherArgs { city: string; units?: 'metric' | 'imperial' }
+
+const weatherArgsConverter = Converters.strictObject<IWeatherArgs>({
+  city: Converters.string,
+  units: Converters.enumeratedValue(['metric', 'imperial'] as const).optional()
+});
+
+const weatherTool: IAiClientTool = {
+  config: { type: 'client_tool', name: 'getWeather', description: '...', parametersSchema: weatherSchema },
+  callback: async (_name, args) => {
+    return weatherArgsConverter.convert(args)
+      .onSuccess((validated) => succeed(JSON.stringify(getForecast(validated))));
+  }
+};
+
+// + drift test (see §3.3)
+```
+
+What the same author would write *after* the Direction A follow-on ships:
+
+```typescript
+const weatherSchema = JsonSchema.llmToolJsonSchema.convert({
+  type: 'object',
+  properties: {
+    city: { type: 'string', description: 'City name' },
+    units: { type: 'string', enum: ['metric', 'imperial'] }
+  },
+  required: ['city'],
+  additionalProperties: false
+}).orThrow();
+
+interface IWeatherArgs { city: string; units?: 'metric' | 'imperial' }
+
+const weatherArgsConverter = JsonSchema.toConverter<IWeatherArgs>(weatherSchema).orThrow();
+
+const weatherTool: IAiClientTool = {
+  config: { type: 'client_tool', name: 'getWeather', description: '...', parametersSchema: weatherSchema },
+  callback: async (_name, args) => {
+    return weatherArgsConverter.convert(args)
+      .onSuccess((validated) => succeed(JSON.stringify(getForecast(validated))));
+  }
+};
+
+// No drift test needed — single source.
+```
+
+The diff is small but real: one declaration instead of two, no drift test. At 10+ tools, the cumulative savings are meaningful; at 1–2 tools, the status quo is fine.

--- a/.ai/tasks/active/json-schema-converter-alignment/state.md
+++ b/.ai/tasks/active/json-schema-converter-alignment/state.md
@@ -1,8 +1,8 @@
 # Spike state: `json-schema-converter-alignment`
 
-**Status:** 🔵 phase-2 sub-spike in flight — schema-derives-T feasibility; phase-1 Direction A recommendation retracted (AJV-style off the table)
-**Workflow shape:** parallel research spike (now with a phase-2 follow-up)
-**Last updated:** 2026-06-02 (orchestrator — phase-2 spike commissioned)
+**Status:** 🟢 phase-2 complete — verdict: **feasible**; alignment stream commission pending Erik review
+**Workflow shape:** parallel research spike (phase-2 sub-spike complete)
+**Last updated:** 2026-06-02 (senior-developer — phase-2 feasibility verdict delivered)
 
 ---
 
@@ -11,8 +11,8 @@
 | Phase | Status | Notes |
 |---|---|---|
 | Phase 1 — Research | 🟢 complete | `research.md` delivered. Initial recommendation Direction A (AJV-style) **retracted** by Erik review 2026-06-02 (assertion ≠ verification). |
-| Phase 2 — Feasibility sub-spike (schema-derives-T) | 🔵 in flight | Brief at `derives-t-feasibility-brief.md`; agent run for verdict on TypeBox-style approach in the LLM-tool subset. Output: `derives-t-feasibility.md`. |
-| Follow-on alignment stream (conditional) | ⏸ depends on phase-2 verdict | If feasible: commission alignment stream with schema-derives-T as the target. If infeasible: confirm status-quo Direction C with the drift-detection test pattern from `research.md` §3.3; no follow-on. |
+| Phase 2 — Feasibility sub-spike (schema-derives-T) | 🟢 complete | Verdict: **feasible**. Output at `derives-t-feasibility.md`. Phantom-tag pattern tractable for 7-factory LLM subset; `Converter<T>` surface needs no retrofit; ~505 lines impl + ~620 lines tests; single new packlet in `ts-json-base`. |
+| Follow-on alignment stream (conditional) | ⏸ pending Erik review | Phase-2 verdict is feasible. If Erik accepts: commission `json-schema-derives-T` alignment stream against `ts-json-base`. If rejected: confirm status-quo Direction C with the drift-detection test pattern from `research.md` §3.3. |
 
 ---
 
@@ -31,6 +31,7 @@
 | AJV-style consumer-supplied `T` is OFF THE TABLE (Erik review 2026-06-02) | "Type assertion via `.toConverter()` doesn't give us any greater protection against drift than just decoupling schema and the converter entirely — just the illusion of greater protection, which is arguably worse." Wasted authoring work + false sense of safety. The only alignment direction worth shipping is schema-derives-T (verify, not assert). |
 | Direction B (Converter → Schema) is OFF THE TABLE for an additional reason (Erik review 2026-06-02) | Beyond the blast radius (~6 combinators in ts-utils/conversion), B would fail at the MCP boundary: MCP tools arrive as schema descriptors with no Converter to generate from. The path doesn't extend. |
 | Phase-2 sub-spike commissioned: `json-schema-derives-t-feasibility` | TypeBox-style schema-derives-T is the only remaining direction. Phase-2 spike tests feasibility for the LLM-tool subset against the existing fgv Converter surface. If feasible: ai-assist-client-tools Phase B/C holds for it. If infeasible: fallback is status-quo Direction C (drift-detection test pattern per research.md §3.3). Brief at `.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility-brief.md`. |
+| Phase-2 verdict: schema-derives-T is **feasible** for the LLM-tool subset (2026-06-02) | Phantom-tag pattern (unique-symbol `[_phantom]` + `Static<S> = S['static']` property access) is tractable with 7 factories: `string`, `number`, `integer`, `boolean`, `enumOf`, `optional`, `array`, `object`. The `ObjectStatic<P>` mapped type (`OptionalKeys` + `RequiredKeys` split + intersection) resolves correctly with no depth-accumulation penalty at ≤3 nesting levels. `Converter<T>` surface needs no retrofit — the adapter composes existing `Converters.object`, `Converters.arrayOf`, etc. via a recursive switch on `_type`. Wire-format emission (`toJson`) and MCP parse (`fromJson` returning `ILlmSchema<JsonObject>`) are both straightforward. Scope: ~505 lines impl + ~620 lines tests, single new packlet in `ts-json-base`, no existing surface changes. Sequencing: Phase B of ai-assist-client-tools unblocked; Phase C can hold for or absorb the alignment stream. See `derives-t-feasibility.md` for full analysis. |
 
 ---
 
@@ -50,6 +51,7 @@ Spike runs in parallel with Phase B of `ai-assist-client-tools`; output may info
 | 2026-06-02 | Research complete | `research.md` delivered (~440 lines). Recommendation: Direction A (Schema → Converter) — small additive new packlet in `ts-json-base`, ~300–500 lines impl + ~300–400 lines tests, no surface change to existing exports. Direction B rejected (would require reflection retrofit across ts-utils combinators — broad blast radius). Direction C (status quo) viable but loses at scale (10+ tools). Sequencing: lands as **independent follow-on stream after `ai-assist-client-tools` Phase C is in `release`**, not as a Phase-C blocker. OSS verification: AJV (`ajv.compile<T>`), Zod v4 (`z.toJSONSchema` ✓, `fromJSONSchema` still open as #5233), TypeBox (schema IS the runtime rep). One advisory item surfaced: `Converters.number` accepts numeric strings — design decision deferred to follow-on stream. |
 | 2026-06-02 | Erik review of `research.md` retracted AJV-style Direction A | AJV-style consumer-supplied `T` provides illusion of safety without verification (same drift risk as decoupled schema/converter, plus wasted authoring work). Direction B also re-confirmed off the table — fails at MCP boundary where tools arrive as schema. Only remaining path is schema-derives-T (TypeBox-style). Phase-2 sub-spike commissioned to test feasibility for the LLM-tool subset. ai-assist-client-tools Phase B/C tentatively holds for the outcome. |
 | 2026-06-02 | Phase-2 sub-spike commissioned: `json-schema-derives-t-feasibility` | Substrate at `.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility-brief.md`; agent run to produce `derives-t-feasibility.md`. Erik reviews verdict; orchestrator commissions alignment stream (if feasible) or confirms status-quo Direction C (if infeasible). |
+| 2026-06-02 | Phase-2 sub-spike complete — verdict: **feasible** | `derives-t-feasibility.md` delivered. Parts A, B, C answered. Phantom-tag mechanism tractable for 7-factory LLM subset; no Converter retrofit required; scope ~505+620 lines, single new `ts-json-base` packlet. `parametersSchema: JsonObject` in `IAiClientToolConfig` unchanged — consumers call `toJson(schema)` explicitly. MCP boundary: `fromJson` returns `ILlmSchema<JsonObject>` (opaque `T`); no phantom reconstruction attempted. Sequencing: Phase B unblocked; Phase C can absorb or await alignment stream. Erik reviews verdict before follow-on commission. |
 
 ---
 

--- a/.ai/tasks/active/json-schema-converter-alignment/state.md
+++ b/.ai/tasks/active/json-schema-converter-alignment/state.md
@@ -1,8 +1,8 @@
 # Spike state: `json-schema-converter-alignment`
 
-**Status:** 🟢 research complete — recommendation Direction A (after `ai-assist-client-tools` Phase C); awaiting Erik review
-**Workflow shape:** parallel research spike
-**Last updated:** 2026-06-02 (research agent — research.md delivered)
+**Status:** 🔵 phase-2 sub-spike in flight — schema-derives-T feasibility; phase-1 Direction A recommendation retracted (AJV-style off the table)
+**Workflow shape:** parallel research spike (now with a phase-2 follow-up)
+**Last updated:** 2026-06-02 (orchestrator — phase-2 spike commissioned)
 
 ---
 
@@ -10,8 +10,9 @@
 
 | Phase | Status | Notes |
 |---|---|---|
-| Research | 🟢 complete | `research.md` delivered. Recommendation: Direction A (Schema → Converter) as a new `JsonSchema.toConverter<T>(schema)` factory in `ts-json-base`, landing **after** `ai-assist-client-tools` Phase C (not as a Phase-C blocker). |
-| Follow-on stream (conditional) | ⏸ depends on recommendation | If spike recommends building (A) or (B), commission a separate stream then. If recommendation is (C) status quo, no follow-on. |
+| Phase 1 — Research | 🟢 complete | `research.md` delivered. Initial recommendation Direction A (AJV-style) **retracted** by Erik review 2026-06-02 (assertion ≠ verification). |
+| Phase 2 — Feasibility sub-spike (schema-derives-T) | 🔵 in flight | Brief at `derives-t-feasibility-brief.md`; agent run for verdict on TypeBox-style approach in the LLM-tool subset. Output: `derives-t-feasibility.md`. |
+| Follow-on alignment stream (conditional) | ⏸ depends on phase-2 verdict | If feasible: commission alignment stream with schema-derives-T as the target. If infeasible: confirm status-quo Direction C with the drift-detection test pattern from `research.md` §3.3; no follow-on. |
 
 ---
 
@@ -26,7 +27,10 @@
 | Out of scope: generalizing beyond LLM tool-use schemas | LLM function-calling is the forcing function; the spike's scope is bounded by what those providers accept. Other use cases can drive their own rounds. |
 | Direction A over Direction B (research output) | Direction B would require reflection retrofit on every Converter combinator in `ts-utils/conversion` (closures-over-data pattern is everywhere; `arrayOf`/`recordOf`/`oneOf`/`tuple` need to expose inner converters as public fields). Direction A is a single new packlet in `ts-json-base` with no surface change. Schema is the contract (LLM provider defines it); Converter is internal validation. Schema-first authoring matches how consumers actually write LLM tools. |
 | Direction A lands *after* `ai-assist-client-tools` Phase C, not alongside | Phase C's `IAiClientToolConfig.parametersSchema: JsonObject` shape is correct whether or not `JsonSchema.toConverter` exists. Direction A is a convenience layered on top. Coupling them adds Phase-C risk without unblocking anything. Consumers building tools today (status-quo schema + converter + drift test) migrate trivially later (drop hand-written converter, replace with generated one — no deprecation churn). |
-| Out of scope (Direction A follow-on): static `T`-from-schema inference | TypeBox-style `Type.Static<typeof S>` is a separable type-system project. AJV-style consumer-supplied `T` is sufficient for LLM-tool-use. Defer until forced. |
+| ~~Out of scope (Direction A follow-on): static `T`-from-schema inference~~ **Retracted 2026-06-02 by Erik review.** Replacement row below. | ~~TypeBox-style `Type.Static<typeof S>` is a separable type-system project. AJV-style consumer-supplied `T` is sufficient for LLM-tool-use. Defer until forced.~~ |
+| AJV-style consumer-supplied `T` is OFF THE TABLE (Erik review 2026-06-02) | "Type assertion via `.toConverter()` doesn't give us any greater protection against drift than just decoupling schema and the converter entirely — just the illusion of greater protection, which is arguably worse." Wasted authoring work + false sense of safety. The only alignment direction worth shipping is schema-derives-T (verify, not assert). |
+| Direction B (Converter → Schema) is OFF THE TABLE for an additional reason (Erik review 2026-06-02) | Beyond the blast radius (~6 combinators in ts-utils/conversion), B would fail at the MCP boundary: MCP tools arrive as schema descriptors with no Converter to generate from. The path doesn't extend. |
+| Phase-2 sub-spike commissioned: `json-schema-derives-t-feasibility` | TypeBox-style schema-derives-T is the only remaining direction. Phase-2 spike tests feasibility for the LLM-tool subset against the existing fgv Converter surface. If feasible: ai-assist-client-tools Phase B/C holds for it. If infeasible: fallback is status-quo Direction C (drift-detection test pattern per research.md §3.3). Brief at `.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility-brief.md`. |
 
 ---
 
@@ -44,6 +48,8 @@ Spike runs in parallel with Phase B of `ai-assist-client-tools`; output may info
 |---|---|---|
 | 2026-06-02 | Substrate prepped + agent commissioned | brief.md + state.md + general-purpose agent run with target `research.md`. |
 | 2026-06-02 | Research complete | `research.md` delivered (~440 lines). Recommendation: Direction A (Schema → Converter) — small additive new packlet in `ts-json-base`, ~300–500 lines impl + ~300–400 lines tests, no surface change to existing exports. Direction B rejected (would require reflection retrofit across ts-utils combinators — broad blast radius). Direction C (status quo) viable but loses at scale (10+ tools). Sequencing: lands as **independent follow-on stream after `ai-assist-client-tools` Phase C is in `release`**, not as a Phase-C blocker. OSS verification: AJV (`ajv.compile<T>`), Zod v4 (`z.toJSONSchema` ✓, `fromJSONSchema` still open as #5233), TypeBox (schema IS the runtime rep). One advisory item surfaced: `Converters.number` accepts numeric strings — design decision deferred to follow-on stream. |
+| 2026-06-02 | Erik review of `research.md` retracted AJV-style Direction A | AJV-style consumer-supplied `T` provides illusion of safety without verification (same drift risk as decoupled schema/converter, plus wasted authoring work). Direction B also re-confirmed off the table — fails at MCP boundary where tools arrive as schema. Only remaining path is schema-derives-T (TypeBox-style). Phase-2 sub-spike commissioned to test feasibility for the LLM-tool subset. ai-assist-client-tools Phase B/C tentatively holds for the outcome. |
+| 2026-06-02 | Phase-2 sub-spike commissioned: `json-schema-derives-t-feasibility` | Substrate at `.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility-brief.md`; agent run to produce `derives-t-feasibility.md`. Erik reviews verdict; orchestrator commissions alignment stream (if feasible) or confirms status-quo Direction C (if infeasible). |
 
 ---
 

--- a/.ai/tasks/active/json-schema-converter-alignment/state.md
+++ b/.ai/tasks/active/json-schema-converter-alignment/state.md
@@ -1,0 +1,51 @@
+# Spike state: `json-schema-converter-alignment`
+
+**Status:** 🔵 research in flight — agent commissioned
+**Workflow shape:** parallel research spike
+**Last updated:** 2026-06-02 (orchestrator — substrate prep + commission)
+
+---
+
+## Phase status
+
+| Phase | Status | Notes |
+|---|---|---|
+| Research | 🔵 in flight | general-purpose agent commissioned; output is `research.md`. |
+| Follow-on stream (conditional) | ⏸ depends on recommendation | If spike recommends building (A) or (B), commission a separate stream then. If recommendation is (C) status quo, no follow-on. |
+
+---
+
+## Decisions log
+
+| Decision | Rationale |
+|---|---|
+| Parallel research spike, not a Phase-A of a triage cycle | This is "is there an alignment story worth building" — single-pass research, not a full design-triage-implement cycle. If the answer is "yes, build," we commission a separate stream with its own Phase A. |
+| general-purpose agent (not senior-developer) | Research-shaped: survey existing libraries, sketch fgv-native options, compare costs. senior-developer is reserved for architectural-design output; this is a design-feasibility scope. |
+| Does NOT block `ai-assist-client-tools` Phase B | The `IAiClientTool` seam is right regardless. The spike answers the authoring story for tool parameters — Phase C can adopt the spike's recommendation if it lands in time, or stick with `JsonObject`/JSON Schema as authored. |
+| Out of scope: implementation | Research only. Follow-on stream commissions if needed. |
+| Out of scope: generalizing beyond LLM tool-use schemas | LLM function-calling is the forcing function; the spike's scope is bounded by what those providers accept. Other use cases can drive their own rounds. |
+
+---
+
+## Origin
+
+2026-06-02. Erik reviewing the `ai-assist-client-tools` Phase A design surfaced authoring concern: a consumer authoring both a JSON Schema (for the wire) and a Converter/Validator (for runtime validation) over the same shape is error-prone and likely to drift. Worth investigating whether fgv can align them — either direction (Schema → Converter, Converter → Schema, or status quo with a drift-detection test pattern).
+
+Spike runs in parallel with Phase B of `ai-assist-client-tools`; output may inform Phase C's authoring story but doesn't block Phase B commission.
+
+---
+
+## History
+
+| Date | Event | Notes |
+|---|---|---|
+| 2026-06-02 | Substrate prepped + agent commissioned | brief.md + state.md + general-purpose agent run with target `research.md`. |
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep + research | (this PR) | open → release; research.md added once complete |
+| Follow-on stream | TBD | not yet commissioned |

--- a/.ai/tasks/active/json-schema-converter-alignment/state.md
+++ b/.ai/tasks/active/json-schema-converter-alignment/state.md
@@ -1,8 +1,8 @@
 # Spike state: `json-schema-converter-alignment`
 
-**Status:** 🔵 research in flight — agent commissioned
+**Status:** 🟢 research complete — recommendation Direction A (after `ai-assist-client-tools` Phase C); awaiting Erik review
 **Workflow shape:** parallel research spike
-**Last updated:** 2026-06-02 (orchestrator — substrate prep + commission)
+**Last updated:** 2026-06-02 (research agent — research.md delivered)
 
 ---
 
@@ -10,7 +10,7 @@
 
 | Phase | Status | Notes |
 |---|---|---|
-| Research | 🔵 in flight | general-purpose agent commissioned; output is `research.md`. |
+| Research | 🟢 complete | `research.md` delivered. Recommendation: Direction A (Schema → Converter) as a new `JsonSchema.toConverter<T>(schema)` factory in `ts-json-base`, landing **after** `ai-assist-client-tools` Phase C (not as a Phase-C blocker). |
 | Follow-on stream (conditional) | ⏸ depends on recommendation | If spike recommends building (A) or (B), commission a separate stream then. If recommendation is (C) status quo, no follow-on. |
 
 ---
@@ -24,6 +24,9 @@
 | Does NOT block `ai-assist-client-tools` Phase B | The `IAiClientTool` seam is right regardless. The spike answers the authoring story for tool parameters — Phase C can adopt the spike's recommendation if it lands in time, or stick with `JsonObject`/JSON Schema as authored. |
 | Out of scope: implementation | Research only. Follow-on stream commissions if needed. |
 | Out of scope: generalizing beyond LLM tool-use schemas | LLM function-calling is the forcing function; the spike's scope is bounded by what those providers accept. Other use cases can drive their own rounds. |
+| Direction A over Direction B (research output) | Direction B would require reflection retrofit on every Converter combinator in `ts-utils/conversion` (closures-over-data pattern is everywhere; `arrayOf`/`recordOf`/`oneOf`/`tuple` need to expose inner converters as public fields). Direction A is a single new packlet in `ts-json-base` with no surface change. Schema is the contract (LLM provider defines it); Converter is internal validation. Schema-first authoring matches how consumers actually write LLM tools. |
+| Direction A lands *after* `ai-assist-client-tools` Phase C, not alongside | Phase C's `IAiClientToolConfig.parametersSchema: JsonObject` shape is correct whether or not `JsonSchema.toConverter` exists. Direction A is a convenience layered on top. Coupling them adds Phase-C risk without unblocking anything. Consumers building tools today (status-quo schema + converter + drift test) migrate trivially later (drop hand-written converter, replace with generated one — no deprecation churn). |
+| Out of scope (Direction A follow-on): static `T`-from-schema inference | TypeBox-style `Type.Static<typeof S>` is a separable type-system project. AJV-style consumer-supplied `T` is sufficient for LLM-tool-use. Defer until forced. |
 
 ---
 
@@ -40,6 +43,7 @@ Spike runs in parallel with Phase B of `ai-assist-client-tools`; output may info
 | Date | Event | Notes |
 |---|---|---|
 | 2026-06-02 | Substrate prepped + agent commissioned | brief.md + state.md + general-purpose agent run with target `research.md`. |
+| 2026-06-02 | Research complete | `research.md` delivered (~440 lines). Recommendation: Direction A (Schema → Converter) — small additive new packlet in `ts-json-base`, ~300–500 lines impl + ~300–400 lines tests, no surface change to existing exports. Direction B rejected (would require reflection retrofit across ts-utils combinators — broad blast radius). Direction C (status quo) viable but loses at scale (10+ tools). Sequencing: lands as **independent follow-on stream after `ai-assist-client-tools` Phase C is in `release`**, not as a Phase-C blocker. OSS verification: AJV (`ajv.compile<T>`), Zod v4 (`z.toJSONSchema` ✓, `fromJSONSchema` still open as #5233), TypeBox (schema IS the runtime rep). One advisory item surfaced: `Converters.number` accepts numeric strings — design decision deferred to follow-on stream. |
 
 ---
 
@@ -47,5 +51,5 @@ Spike runs in parallel with Phase B of `ai-assist-client-tools`; output may info
 
 | Phase | PR | Status |
 |---|---|---|
-| Substrate prep + research | (this PR) | open → release; research.md added once complete |
-| Follow-on stream | TBD | not yet commissioned |
+| Substrate prep + research | open draft PR `research(json-schema-converter-alignment): spike output` → release | research.md added; awaiting Erik review |
+| Follow-on stream (Direction A) | TBD | not yet commissioned — orchestrator's call after Erik reviews the recommendation |

--- a/.ai/tasks/active/json-schema-derives-t/brief.md
+++ b/.ai/tasks/active/json-schema-derives-t/brief.md
@@ -1,0 +1,175 @@
+# Stream brief: `json-schema-derives-t`
+
+**Status:** 🟢 ready to commission
+**Integration branch:** `json-schema-derives-t` (off `release`, currently sitting on top of `chore/json-schema-derives-t-spike-prep` so the spike substrate + feasibility verdict ride into release in the same squash) → squash to `release` at close
+**Workflow shape:** single implementation PR onto integration branch
+**Package surface:** new packlet `@fgv/ts-json-base/json-schema-builder` (or similar — exact packlet name is a small Phase-B-equivalent choice in this brief). No surface change to any existing exports. New types/factories/adapters/serializers live in the new packlet; tests likewise.
+
+---
+
+## Mission
+
+Ship the **schema-derives-T** alignment capability in `@fgv/ts-json-base`: a small set of factory functions that build a typed JSON Schema value, plus a `Static<S>` type-level extractor, plus a runtime adapter that materializes the schema into a fgv `Converter<Static<S>>`, plus a JSON-format emitter and a parse-from-raw-JSON-Schema entry point for the MCP boundary.
+
+The feasibility spike already produced concrete sketches. **This stream's job is to land those sketches as production code**, not to redesign them. Open design questions (small, all named below in §Phase-B-equivalent decisions) are bounded; the implementing agent makes calls and documents them in state.md.
+
+**Hard sequencing:** `ai-assist-client-tools` Phase B/C is **held** for this stream. The `IAiClientToolConfig.parametersSchema: JsonObject` shape adopts the new typed schema authoring as part of Phase C; consumers (personaility) get verify-not-assert end-to-end from day one of layer-1 tool-use.
+
+---
+
+## Design source-of-truth (read in full before any coding)
+
+The two artifacts that already live on the integration branch and constitute the design specification for this stream:
+
+1. **`.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility.md`** — the phase-2 spike's verdict + sketches for Parts A (type-level mechanics, 7-factory surface, optional/required split, `Static<S> = S['static']`), B (adapter shape, `toJson`, `fromJson`, MCP boundary), and C (cost/sequencing).
+2. **`.ai/tasks/active/json-schema-converter-alignment/research.md`** — phase-1 spike. §3.3 has the drift-detection test pattern (not adopted as the shipping path, but worth keeping in test coverage so the alignment story is end-to-end demonstrable).
+
+These two docs are the **specification**. The brief below stakes out the shipping contract; the design docs explain the mechanics.
+
+---
+
+## Locked design (from the feasibility spike — reproduced for the agent's convenience)
+
+### The 7 factories (LLM-tool subset)
+
+```ts
+JsonSchema.string()
+JsonSchema.number()
+JsonSchema.integer()
+JsonSchema.boolean()
+JsonSchema.enumOf(<literal-array>)
+JsonSchema.array(<inner>)
+JsonSchema.object({ key: <inner>, ... })
+JsonSchema.optional(<inner>)
+```
+
+Each factory returns a schema value carrying a phantom `static` property; the schema value also carries the JSON Schema runtime data. `Static<S>` extracts the type via `S['static']`.
+
+### Public API (this is the stream's exported surface)
+
+```ts
+export namespace JsonSchema {
+  export function string(opts?: { description?: string; enum?: readonly string[] }): IStringSchema;
+  export function number(opts?: { description?: string }): INumberSchema;
+  export function integer(opts?: { description?: string }): IIntegerSchema;
+  export function boolean(opts?: { description?: string }): IBooleanSchema;
+  export function enumOf<const T extends readonly (string | number)[]>(values: T, opts?: { description?: string }): IEnumSchema<T>;
+  export function array<S extends ILlmSchema>(items: S, opts?: { description?: string }): IArraySchema<S>;
+  export function object<P extends Record<string, ILlmSchema>>(properties: P, opts?: { description?: string; additionalProperties?: boolean }): IObjectSchema<P>;
+  export function optional<S extends ILlmSchema>(inner: S): IOptionalSchema<S>;
+
+  // Runtime → Converter adapter
+  export function toConverter<S extends ILlmSchema>(schema: S): Converter<Static<S>>;
+
+  // Wire-format emission
+  export function toJson(schema: ILlmSchema): JsonObject;
+
+  // MCP boundary parse (returns opaque-phantom schema for unknown-T MCP descriptors)
+  export function fromJson(json: JsonObject): Result<ILlmSchema<JsonObject>>;
+}
+
+export type Static<S extends ILlmSchema> = S['static'];
+```
+
+The exact factory shapes, opt-bag fields, and `_type` discriminant names are open to the agent's discretion as long as the contract above is preserved.
+
+### Adapter — recursive switch on `_type`
+
+`toConverter` walks the schema tree and composes existing `Converters.*` (no new combinators). For each `_type`:
+
+- `'string'` / `'number'` / `'integer'` / `'boolean'` → `Converters.string` / `Converters.number` / etc.
+- `'enum'` → `Converters.enumeratedValue(values)`.
+- `'array'` → `Converters.arrayOf(toConverter(items))`.
+- `'object'` → `Converters.object({ key: toConverter(inner) | Converters.optionalField(toConverter(inner.inner)), ... })`.
+- `'optional'` → wrapped inline by the parent `object` factory; not a freestanding adapter case (or handled if appearing freestanding).
+
+The `as unknown as Converter<Static<S>>` cast at each arm is correctness-preserving because the phantom-type and the runtime data are constructed together by the factories — the cast bridges a compile-time fact the type system can't see directly.
+
+### `toJson` — strip phantoms, emit JSON Schema
+
+Walks the schema tree and emits standard JSON Schema (`{ type: 'object', properties, required, additionalProperties }`, `{ type: 'string', enum, description }`, etc.). Phantom properties don't exist at runtime so no stripping is necessary at JS level; the function just constructs the JSON Schema object from the schema value's runtime data.
+
+### `fromJson` — MCP boundary parse
+
+Validates that the input JSON is in the LLM-tool subset. On success returns `Result<ILlmSchema<JsonObject>>` — the phantom-`T` is opaquely `JsonObject` because the actual type is unknown at the MCP boundary. On out-of-subset features (`$ref`, `oneOf`, etc.) returns `fail(...)`.
+
+This is the **honest** behavior; the MCP boundary doesn't get type-derivation magic, just runtime validation against the wire-format schema. Consumers who want typed access to MCP-discovered tools assert `as ILlmSchema<MyType>` at their own risk (and a follow-up stream can add a `fromJsonWithT<T>(json, schema)` that takes a TypeBox-style schema-pair as evidence — out of scope here).
+
+---
+
+## Phase-B-equivalent decisions for the implementing agent
+
+The feasibility spike left these small calls open. Resolve in implementation, document in state.md decisions log:
+
+1. **Packlet name.** `json-schema-builder`? `llm-schema`? `schema-builder`? Default: `json-schema-builder` (descriptive, matches the consumer-facing nature). Pick one; name it in state.md.
+2. **Strict numeric mode.** `Converters.number` accepts numeric strings (e.g. `'42'`). Feasibility doc flags this as a phase-C question. Recommended default: strict (reject numeric strings). Provide a `{ strict: false }` opt-out on `JsonSchema.number()` for consumers who want the existing permissive behavior. Document the decision either way.
+3. **`additionalProperties` default.** JSON Schema default is `true`; LLM-tool common convention is `false`. Recommended: default to `false` (most LLM providers reject objects with extras anyway), with an opt-in `{ additionalProperties: true }` on `JsonSchema.object`. Document.
+4. **Error message strategy.** When `toConverter`-generated Converter fails, the error message should name which schema field failed. The feasibility doc didn't sketch this. Use the existing `Converters.object` field-name-aware error reporting; verify it works through the adapter; don't invent a parallel error reporter.
+5. **`fromJson` strictness on out-of-subset features.** Recommended: return `fail()` with a clear "feature X is out of the LLM-tool subset" message. Some MCP servers may emit `description`-only fields that are technically out of subset but harmless; recommend pass-through for ignorable fields, `fail()` for structural out-of-subset (`$ref`, `oneOf`, etc.). Document the cutoff.
+
+These are five small choices, not a Phase B triage cycle. Agent decides + documents.
+
+---
+
+## Acceptance criteria
+
+- [ ] New packlet `@fgv/ts-json-base/<packlet-name>` exports the 7 factories + `Static<S>` + `toConverter` + `toJson` + `fromJson` + supporting types.
+- [ ] Static type inference works as the feasibility doc sketches: `Static<typeof Schema> === { ...derived shape... }` for every factory combination including nested object/array/optional. Tests assert this via `expectTypeOf` or equivalent.
+- [ ] Runtime adapter composes existing `Converters.*` primitives; no new combinators in `ts-utils/conversion`; no retrofit anywhere.
+- [ ] `toJson` round-trips: every schema value emits the JSON Schema it semantically represents; tested against fixture schemas covering all factory combinations.
+- [ ] `fromJson` round-trips for in-subset schemas: `toJson(fromJson(rawJson).orThrow())` is structurally equal to `rawJson`. Out-of-subset features `fail()` cleanly.
+- [ ] `Result` pattern throughout. No `any`. No `Result<void>`.
+- [ ] Result-pattern compliance: factories are infallible (no Result wrapping); `fromJson` and `toConverter`-generated converters return `Result<T>` per fgv convention.
+- [ ] 100% statements/branches/functions/lines on the new packlet.
+- [ ] `rush build` passes monorepo-wide (no consumer breakage anywhere — new packlet is additive).
+- [ ] `rushx lint` passes in `libraries/ts-json-base`.
+- [ ] `rushx fixlint` was run before final commit.
+- [ ] api-extractor report regenerated (`libraries/ts-json-base/etc/ts-json-base.api.md`); committed.
+- [ ] `minor` rush change file for `@fgv/ts-json-base` describing the additive new packlet.
+- [ ] `LIBRARY_CAPABILITIES.md` entry added under `@fgv/ts-json-base` describing the new packlet, naming the canonical `Static<>` extraction pattern, and pointing at the LLM-tool-use motivating consumer (`@fgv/ts-extras/ai-assist`). Cross-link `Decision shortcuts (start here)` with a "Need typed JSON Schema for LLM tool authoring? → ..." entry.
+- [ ] `code-reviewer` agent run on the final diff per L32; findings resolved or dispositioned; summary in the PR description.
+- [ ] Copilot review loop driven per L33; stopped on diminishing returns or 10-round cap; status in PR description.
+
+---
+
+## Out of scope
+
+- **`ai-assist-client-tools` Phase B/C** — separate stream, holding for this one to land. Do **not** touch `ai-assist-client-tools` substrate or the design.md. The next stream after this lands will commission Phase B against an updated design with the typed-schema authoring.
+- **JSON Schema features beyond the LLM-tool subset** — no `$ref`, no `oneOf`/`anyOf`/`allOf`, no `pattern`, no custom formats, no JSON Schema 2020-12. If a consumer needs them later, separate scoping round.
+- **TypeBox-style full combinator parity** — the 7-factory surface is deliberate. Don't pre-emptively add factories for unscoped use cases.
+- **A typed `fromJsonWithT<T>(json, schema)`** that takes a schema-pair as evidence and produces `ILlmSchema<T>` for MCP-discovered tools — explicitly deferred per feasibility doc Part B closing.
+- **A consumer-facing tutorial / README rewrite for `ts-json-base`** — `LIBRARY_CAPABILITIES.md` entry is sufficient; consumer-side docs land when ai-assist-client-tools Phase C ships the consuming surface.
+- **Performance benchmarking** — out of scope at the implementation level; surface as a follow-up only if a real perf concern materializes during testbed integration.
+
+---
+
+## Reading list (start here)
+
+**Design specification (required):**
+
+1. `.ai/tasks/active/json-schema-converter-alignment/derives-t-feasibility.md` — Parts A, B, C with all the sketches.
+2. `.ai/tasks/active/json-schema-converter-alignment/research.md` — §3.3 for the drift-detection test pattern (useful as a test case showing the new approach replaces the manual pattern).
+
+**Existing surfaces this stream composes against (required):**
+
+3. `libraries/ts-utils/src/packlets/conversion/` — `Converters.string`, `Converters.number`, `Converters.boolean`, `Converters.enumeratedValue`, `Converters.object`, `Converters.optionalField`, `Converters.arrayOf`. The adapter descends into these.
+4. `libraries/ts-json-base/src/packlets/converters/` — existing JSON-shaped converters (`Converters.jsonObject`, `Converters.jsonValue`). The new packlet should fit alongside without overlap.
+5. `libraries/ts-json-base/src/packlets/` — packlet layout convention.
+6. `libraries/ts-json-base/etc/ts-json-base.api.md` — api-extractor baseline.
+7. `.ai/instructions/CODING_STANDARDS.md` — Result pattern, Type-Safe Validation, Pre-PR Validation Checklist, Review-loop discipline (L32 + L33).
+8. `.ai/instructions/LIBRARY_CAPABILITIES.md` — the existing `@fgv/ts-json-base` entry that this stream extends.
+
+**Reference (light skim):**
+
+9. TypeBox source (github.com/sinclairzx81/typebox) — for prior-art on the phantom-tag pattern; do **not** mirror the API or combinator surface.
+10. `.ai/tasks/active/ai-assist-client-tools/design.md` §2.3 — the consumer surface that adopts this stream's output in the next stream.
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep | (this PR) | open → integration branch |
+| Implementation | TBD | not yet commissioned |
+| Cluster close (integration → release) | TBD | after implementation merges to integration |

--- a/.ai/tasks/active/json-schema-derives-t/state.md
+++ b/.ai/tasks/active/json-schema-derives-t/state.md
@@ -1,0 +1,53 @@
+# Stream state: `json-schema-derives-t`
+
+**Status:** 🟢 ready to commission — substrate prep in flight
+**Integration branch:** `json-schema-derives-t` (off `release`, sitting on top of `chore/json-schema-derives-t-spike-prep` so the spike substrate + feasibility verdict ride into release in the same squash)
+**Last updated:** 2026-06-02 (orchestrator — substrate prep)
+
+---
+
+## Phase status
+
+| Phase | Status | Notes |
+|---|---|---|
+| Implementation | 🟢 ready | Single-PR feature implementing the feasibility-spike-validated design. ~505 lines impl + ~620 lines tests estimated. |
+| Cluster close (integration → release) | ⏸ after implementation | Standard integration→release squash. |
+
+---
+
+## Decisions log
+
+| Decision | Rationale |
+|---|---|
+| Commission implementation stream now; hold ai-assist-client-tools Phase B/C for it (Erik 2026-06-02) | Per Erik's runway assessment: enough time before the personaility sprint hits ai-assist-client-tools Phase C to land the alignment work first. Verify-not-assert end-to-end from day one of layer-1 tool-use is the prize. |
+| Integration branch sits on top of `chore/json-schema-derives-t-spike-prep` | Lets the spike substrate (brief.md, state.md, research.md, derives-t-feasibility-brief.md, derives-t-feasibility.md) ride into release as part of the implementation stream's squash. Eliminates the dependency on landing PR #439 separately; both spike docs and the implementation land together. |
+| Single implementation PR, no Phase B triage | Feasibility spike doc has concrete sketches for every shape; remaining open questions are 5 small calls (packlet name, strict numeric mode, additionalProperties default, error message strategy, fromJson out-of-subset cutoff) that the implementing agent resolves in-flight and documents in state.md. A full Phase B triage cycle would be overkill. |
+| Spike substrate stays at `.ai/tasks/active/json-schema-converter-alignment/` for the stream's lifetime | The spike's docs are the design specification; keeping them under their original directory preserves the design lineage. On stream completion, both substrates move to `.ai/tasks/completed/2026-06/` (spike dir + stream dir as separate sub-directories). |
+| `code-reviewer` (L32) + agent-driven Copilot loop (L33) required for the implementation PR | This is exactly the focused-diff shape where the pre-PR `code-reviewer` gate shines (recent precedent: `capture-async-result-upgrade` PR #433). |
+| Hold ai-assist-client-tools Phase B/C — handled in that stream's substrate | The hold is recorded in `.ai/tasks/active/ai-assist-client-tools/state.md`. PR #436 (Phase A design) can still land; Phase B commission waits until this stream squashes. |
+
+---
+
+## Origin
+
+2026-06-02. Phase-2 sub-spike `json-schema-derives-t-feasibility` returned a clean **feasible** verdict (~505 lines impl + ~620 lines tests, single new packlet in `ts-json-base`, no surface change anywhere). Erik picked Option 1 from the verdict's sequencing options: commission the alignment stream now, hold ai-assist-client-tools Phase B/C for it.
+
+The motivating chain: Erik review of phase-1 research retracted AJV-style consumer-supplied `T` (assertion ≠ verification, false sense of safety). Direction B retracted earlier (blast radius + fails at MCP boundary). Schema-derives-T (TypeBox-style) is the only direction with verify-not-assert end-to-end; phase-2 spike confirmed it's tractable for the LLM-tool subset.
+
+---
+
+## History
+
+| Date | Event | Notes |
+|---|---|---|
+| 2026-06-02 | Stream commissioned + substrate prepped | brief.md + state.md + integration branch off `chore/json-schema-derives-t-spike-prep`. Implementation agent commission pending merge of this substrate-prep PR. |
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep | (this PR) | open → integration branch |
+| Implementation | TBD | not yet commissioned |
+| Cluster close (integration → release) | TBD | after implementation merges to integration |

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -128,6 +128,30 @@ substrate. Don't queue streams against them here.
 
 ## Active workstreams
 
+### `json-schema-derives-t` 🟢
+
+**Status:** 🟢 ready to commission — substrate prep in flight
+**Integration branch:** `json-schema-derives-t` (off `release`, sitting on top of `chore/json-schema-derives-t-spike-prep` so the phase-1 + phase-2 spike substrate rides into release in the same squash) → squash to `release` at close
+**Workflow shape:** single implementation PR onto integration branch
+**Substrate:** `.ai/tasks/active/json-schema-derives-t/{brief.md, state.md}`; design source-of-truth at `.ai/tasks/active/json-schema-converter-alignment/{research.md, derives-t-feasibility.md}`
+**Package surface:** new packlet in `@fgv/ts-json-base` (`json-schema-builder` working name; agent picks final). No surface change to existing exports.
+**Out-of-scope:** `ai-assist-client-tools` Phase B/C (held for this stream to land); JSON Schema features beyond the LLM-tool subset (`$ref`, `oneOf`/`anyOf`/`allOf`, `pattern`, custom formats); TypeBox-style full combinator parity; a typed `fromJsonWithT<T>` for MCP-discovered schemas (deferred per feasibility doc).
+
+**Mission.** Ship the **schema-derives-T** alignment capability in `@fgv/ts-json-base`: 7 factory functions that build a typed JSON Schema value (`string` / `number` / `integer` / `boolean` / `enumOf` / `array` / `optional` / `object`), a `Static<S>` type-level extractor, a runtime adapter (`toConverter`) that materializes the schema into a fgv `Converter<Static<S>>`, a JSON-format emitter (`toJson`), and an MCP-boundary parse entry point (`fromJson` returning `Result<ILlmSchema<JsonObject>>`). Consumer authors a single typed schema value; `T` is mechanically derived (`type X = Static<typeof Schema>`) — no place for the consumer to assert. ~505 lines impl + ~620 lines tests per the phase-2 feasibility spike; no retrofit anywhere — adapter composes existing `Converters.*` primitives.
+
+**Origin.** Two spike phases under `json-schema-converter-alignment` retired AJV-style consumer-supplied `T` (assertion ≠ verification; false sense of safety) and Direction B (Converter → Schema; fails at MCP boundary). Phase-2 sub-spike confirmed schema-derives-T tractable for the LLM-tool subset. Erik picked the sequencing option that lands the alignment work first, then ai-assist-client-tools Phase B/C adopts it for verify-not-assert end-to-end. Sprint window holds for this.
+
+### `ai-assist-client-tools` 🟡 (held)
+
+**Status:** 🟡 Phase A complete (PR #436); **Phase B/C held** pending `json-schema-derives-t` stream landing
+**Workflow shape:** design-triage-implement
+**Substrate:** `.ai/tasks/active/ai-assist-client-tools/{brief.md, state.md, design.md}`
+**Package surface:** `@fgv/ts-extras/ai-assist` (model types, converters, registry, apiClient, streaming adapters, toolFormats) + `LIBRARY_CAPABILITIES.md`; layer 2 (MCP) is sprint+1 in a separate `@fgv/ts-extras-mcp` Result-integration-boundary package.
+
+**Mission.** Add client-defined tool support (function calling) to `@fgv/ts-extras/ai-assist` in two sequenced layers: layer 1 harness-supplied tools, layer 2 MCP (later). Phase A design landed; Phase B (triage) is held for `json-schema-derives-t` to ship so Phase C adopts the typed-schema authoring from day one (consumer gets verify-not-assert end-to-end; no two-step migration).
+
+**Origin.** 2026-05-30 conversation — personaility roadmap moves into agentic territory; client-tool support is "one sprint out." Phase A spike confirmed `IAiClientTool` as the seam that admits both layer-1 (harness) and layer-2 (MCP). Erik's review of the spike triggered the JSON-Schema / Converter alignment spike, which produced the `json-schema-derives-t` stream that this stream now holds for.
+
 ### `private-key-storage` ✅
 
 **Status:** ✅ implemented + reviewed (PR #427, gates green) — ready for squash to `release`


### PR DESCRIPTION
## Summary

Substrate prep for the `json-schema-derives-t` implementation stream. Erik picked Option 1 from the phase-2 feasibility verdict: commission alignment work now, hold `ai-assist-client-tools` Phase B/C for it. Goal: verify-not-assert end-to-end from day one of layer-1 LLM tool use.

## Substrate added

- `.ai/tasks/active/json-schema-derives-t/brief.md` — implementation contract; references the phase-2 feasibility doc as the design specification; locks the 7-factory surface + `Static<S>` + `toConverter` + `toJson` + `fromJson`.
- `.ai/tasks/active/json-schema-derives-t/state.md` — decisions log + history.
- `docs/WORKSTREAMS.md` — new entry for this stream; new (held) entry for `ai-assist-client-tools`.

## Integration branch posture

Integration branch `json-schema-derives-t` sits on top of `chore/json-schema-derives-t-spike-prep` so the spike substrate (phase-1 + phase-2 briefs, `research.md`, `derives-t-feasibility.md`, state-log progression) rides into `release` as part of this stream's eventual squash. Avoids a separate spike-merge step; spike docs land as design-context alongside the implementation.

## What's in the implementation contract (brief.md)

- 7 factories: `string`, `number`, `integer`, `boolean`, `enumOf`, `array`, `optional`, `object`.
- `Static<S> = S['static']` type-level extractor.
- `toConverter(schema): Converter<Static<S>>` — recursive switch composing existing `Converters.*` primitives; no retrofit anywhere.
- `toJson(schema): JsonObject` — wire-format emission.
- `fromJson(json): Result<ILlmSchema<JsonObject>>` — MCP-boundary parse; opaque `T = JsonObject` for unknown-source schemas (honest behavior).
- ~505 lines impl + ~620 lines tests per phase-2 estimate; new packlet in `ts-json-base`; no surface change to existing exports.

Five small in-flight calls left to the implementing agent (packlet name, strict numeric mode, `additionalProperties` default, error message strategy, `fromJson` out-of-subset cutoff). All bounded; agent decides + documents in state.md.

## Acceptance criteria (full list in brief.md)

Standard build/lint/test gates, plus L32 (`code-reviewer` agent on final diff before opening PR) and L33 (agent-driven Copilot loop with cap). 100% coverage on the new packlet. api-extractor report regenerated. `minor` rush change file. `LIBRARY_CAPABILITIES.md` entry under `@fgv/ts-json-base`.

## Test plan

- [ ] Substrate-prep PR (this one) — no code; merge to integration branch `json-schema-derives-t`.
- [ ] After merge, orchestrator commissions the implementation agent off the integration branch.
- [ ] When implementation PR merges to integration, orchestrator opens cluster-close PR (integration → release); Erik squashes.

https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_