### PR TITLE
fix(ts-utils): Converters.discriminatedObject threads self to per-arm converters

### DIFF
--- a/.ai/tasks/active/discriminated-object-self-fix/brief.md
+++ b/.ai/tasks/active/discriminated-object-self-fix/brief.md
@@ -1,0 +1,139 @@
+# Stream brief: `discriminated-object-self-fix`
+
+**Status:** 🟢 ready to commission
+**Workflow shape:** single implementation PR direct to `release` (small focused fix on established surface; no integration branch overhead)
+**Package surface:** `@fgv/ts-utils` — `conversion/basicConverters.ts` (`discriminatedObject`) + supporting test surface. Possibly `conversion/baseConverter.ts` if a public `convert(from, context?, self?)` overload is needed; the agent decides.
+
+---
+
+## Mission
+
+Fix `Converters.discriminatedObject` so the per-arm converter invocation threads `self` correctly. Today (`basicConverters.ts:911`) the body does `return converter.convert(from)` — dropping `self` and `context`. Every other `Converter` combinator in `baseConverter.ts` correctly threads `self` through to its body. `discriminatedObject` is the outlier; the omission breaks recursive discriminated-union parsers because arms can't reach the outer dispatcher for recursion.
+
+**The forcing function**: `json-schema-derives-t` (PR #441) revision needs to express the JSON-Schema-spec parser as `Converters.discriminatedObject('type', { array: ..., object: ..., ... })` where the `array` and `object` arms recurse to the outer parser for nested schemas. With `self` not threaded, the arms have no way to reach the outer; the workaround would be a lazy-thunk closure (`let outerConverter; const recurse = (json) => outerConverter.convert(json); outerConverter = Converters.discriminatedObject(...)`) — a real idiom but a workaround. Fixing the primitive removes the workaround.
+
+Erik's call (2026-06-03): "that's just a bug in the discriminatedObject. Let's just fix it (in a separate PR) instead of creating debt, carrying debt and then clearing debt."
+
+---
+
+## Locked design
+
+### The fix
+
+`Converters.discriminatedObject` body, currently:
+
+```ts
+return new BaseConverter((from: unknown) => {
+  // ... validation ...
+  return converter.convert(from);
+});
+```
+
+After:
+
+```ts
+return new BaseConverter<T, TC>((from: unknown, self, context?: TC) => {
+  // ... validation as before ...
+  const arm = converters[discriminatorValue];
+  // Pass the outer self through to the arm so recursive discriminated-union
+  // parsers can reach the dispatcher via self.
+  return arm.convert(from, context, self);
+});
+```
+
+This requires the per-arm `Converter` / `Validator` to accept a `self` override on its `convert` / `validate` method. **Check the existing surface**: `BaseConverter.convert(from, context)` may not take a `self` parameter today. If so, add an optional third parameter:
+
+```ts
+public convert(from: unknown, context?: TC, selfOverride?: Converter<T, TC>): Result<T> {
+  return this._converter(from, selfOverride ?? this, context);
+}
+```
+
+Mirror on `Validator` (`validatorBase.ts`) if its public `validate` similarly drops `self`.
+
+**Both changes are strictly additive at every call site**: existing call sites that don't pass `selfOverride` are unaffected (defaults to `this` as today). New call sites in `discriminatedObject` opt in.
+
+### Test surface
+
+Add a focused test in `basicConverters.test.ts` that demonstrates recursive parsing through `discriminatedObject`. Minimal shape — a tree:
+
+```ts
+interface ITreeNode {
+  type: 'leaf' | 'branch';
+  value?: number;       // on leaf
+  left?: ITreeNode;     // on branch
+  right?: ITreeNode;
+}
+
+// Build a recursive tree-parser with the now-self-aware discriminatedObject
+let treeConverter: Converter<ITreeNode>;
+treeConverter = Converters.discriminatedObject<ITreeNode>('type', {
+  leaf: Converters.object<ITreeNode>({
+    type: Converters.enumeratedValue(['leaf']),
+    value: Converters.number
+  }),
+  branch: Converters.generic<ITreeNode>((from, self) =>
+    // `self` here is the outer `treeConverter` passed by the fix
+    /* parse { type:'branch', left, right } using self.convert(...) for children */
+  )
+});
+
+// Verify nested input round-trips
+expect(treeConverter.convert(nestedInput)).toSucceedWith(expected);
+```
+
+The test must exercise: (a) self is non-undefined inside the arm, (b) self is the outer `discriminatedObject` Converter (not the arm), (c) recursive `self.convert(...)` from inside an arm resolves nested inputs correctly.
+
+### Documentation
+
+Update `discriminatedObject`'s TSDoc to note that `self` is threaded to arms, enabling recursive parsers. Brief, one-sentence addition.
+
+---
+
+## Acceptance criteria
+
+- [ ] `Converters.discriminatedObject` threads `self` and `context` to per-arm `convert` / `validate` invocations.
+- [ ] `BaseConverter.convert` (and `ValidatorBase.validate` if needed) accepts an optional `selfOverride` parameter; default behavior unchanged.
+- [ ] Recursive-discriminated-union test added; passes.
+- [ ] Existing `discriminatedObject` test suite continues to pass; coverage stays at 100%.
+- [ ] `rush build` passes monorepo-wide (additive — no caller breaks).
+- [ ] `rushx lint` + `rushx fixlint` in `libraries/ts-utils`.
+- [ ] `rushx test` passes monorepo-wide with full coverage.
+- [ ] api-extractor report regenerated (`libraries/ts-utils/etc/ts-utils.api.md`).
+- [ ] `minor` rush change file for `@fgv/ts-utils` (additive surface).
+- [ ] No `any` types. No `Result<void>`.
+- [ ] **`code-reviewer` agent run on the final diff** per L32; findings resolved / dispositioned in PR description.
+- [ ] **Copilot review loop driven** per L33; stopped on diminishing returns or 10-round cap; status in PR description.
+
+---
+
+## Out of scope
+
+- **`json-schema-derives-t` revision** — PR #441 revision waits for this stream to land, then resumes. Do NOT touch `libraries/ts-json-base/src/packlets/json-schema-builder/` or `.ai/tasks/active/json-schema-derives-t/` in this stream.
+- **`discriminatedObject` API redesign** — this is a small fix to the existing signature, not a rethink. If a redesign is warranted (e.g. typed discriminator inference per arm), surface as separate scoping.
+- **Other Converter combinators** — `arrayOf`, `objectOf`, etc. already thread `self` correctly (verified). Only `discriminatedObject` is the outlier; don't sweep others.
+- **Lazy-thunk closure pattern documentation** — once this lands, the lazy-thunk pattern is no longer needed for `discriminatedObject` recursion. No doc update needed.
+
+---
+
+## Reading list (start here)
+
+1. `libraries/ts-utils/src/packlets/conversion/basicConverters.ts:880-925` — current `discriminatedObject` implementation; lines 906–925 are the body to fix.
+2. `libraries/ts-utils/src/packlets/conversion/baseConverter.ts:80-100` — `ConverterFunc<T, TC>` signature; confirms `self` is part of the contract.
+3. `libraries/ts-utils/src/packlets/validation/validatorBase.ts` — symmetric Validator surface; check if `validate()` needs the same `selfOverride` overload.
+4. `libraries/ts-utils/src/test/unit/conversion/basicConverters.test.ts` — existing `discriminatedObject` tests; add the recursive case alongside.
+5. `.ai/instructions/CODING_STANDARDS.md` — Result pattern, lint gates, review-loop discipline (L32 + L33).
+6. `.ai/instructions/ACTIVE_DEVELOPMENT.md` — `ts-utils` is established surface; additive-only; "extend the primitive, don't work around it" is the doctrine driving this stream.
+
+## Reference for design context
+
+- PR #441 (current `json-schema-derives-t` implementation) — the `_parseNode` switch is exactly the procedural inspection pattern this fix retires for the next stream's revision.
+- 2026-06-03 conversation (Erik flagged the procedural matching in PR #441; this stream is the upstream primitive fix).
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep + implementation | (this PR) | open → release |

--- a/.ai/tasks/active/discriminated-object-self-fix/state.md
+++ b/.ai/tasks/active/discriminated-object-self-fix/state.md
@@ -1,7 +1,7 @@
 # Stream state: `discriminated-object-self-fix`
 
-**Status:** 🟢 ready to commission
-**Last updated:** 2026-06-03 (orchestrator — substrate prep)
+**Status:** 🟢 implementation complete
+**Last updated:** 2026-06-03 (implementation agent)
 
 ---
 
@@ -22,6 +22,10 @@
 | Additive overload on `BaseConverter.convert` (and `Validator.validate` if needed) | Lets `discriminatedObject` pass the outer `self` to arms without changing existing call-site behavior. Default `selfOverride ?? this` preserves current semantics for callers that don't opt in. |
 | `json-schema-derives-t` (PR #441) revision waits for this | Out of scope for this stream. Once this lands on release, the integration branch `json-schema-derives-t` merges release, and the revision agent picks up the fixed primitive. |
 | `code-reviewer` + agent-driven Copilot review loop required | Per L32 + L33; small-focused-diff is the canonical case. |
+| `ValidatorBase.validate` did NOT need a `selfOverride` parameter (implementation finding) | `ValidatorBase.validate` already passes `self` correctly via the `GenericValidator._validator(from, context, this)` call pattern — the `self` is always the validator itself. `Validator.validate` is not called from `discriminatedObject` (only `.convert()` is). The `Validator.convert` method does not need `selfOverride` either: in `discriminatedObject`, when an arm is a `Validator`, we call `arm.convert(from, context)` without `self` (since validators are in-place and don't support the outer-converter recursion pattern). Converter arms — the recursive case — use `arm.convert(from, context, self)` via the new `BaseConverter.convert` overload. |
+| `BaseConverter.convert` exact signature: `convert(from: unknown, context?: TC, selfOverride?: Converter<T, TC>): Result<T>` | Third parameter defaults to `undefined`; implementation uses `selfOverride ?? this` as the `self` passed to `_converter`. Strictly additive — existing two-parameter call sites are unaffected. |
+| `Converter` interface `convert` updated to include `selfOverride?: Converter<T, TC>` | Required for TypeScript to allow three-argument calls to `arm.convert(from, context, self)` when `arm` is typed as `Converter<T, TC>`. Since the third parameter is optional, all existing call sites remain valid. |
+| `discriminatedObject` body: discriminate between Converter and Validator arms | `isValidator(arm)` check at call site: validators get `arm.convert(from, context)` (no self); converters get `arm.convert(from, context, self)`. This is type-safe and avoids needing to change the `Validator.convert` interface. The recursive-via-self pattern is a converter-arm pattern; validator arms have no need to recurse through the outer dispatcher. |
 
 ---
 
@@ -36,6 +40,7 @@ PR #441 review (2026-06-03) surfaced the procedural `_parseNode` switch inside `
 | Date | Event | Notes |
 |---|---|---|
 | 2026-06-03 | Stream commissioned + substrate prepped | brief.md + state.md; implementation agent to follow. |
+| 2026-06-03 | Implementation complete | Three-part fix: `Converter` interface + `BaseConverter.convert` gain optional `selfOverride`; `discriminatedObject` body rewritten to thread `self` and `context` to per-arm calls; validator/converter arms discriminated at call site. Recursive-tree test added; all existing tests pass; `basicConverters.ts` + `baseConverter.ts` + `converter.ts` at 100% coverage. `minor` change file created. PR pending. |
 
 ---
 

--- a/.ai/tasks/active/discriminated-object-self-fix/state.md
+++ b/.ai/tasks/active/discriminated-object-self-fix/state.md
@@ -1,0 +1,46 @@
+# Stream state: `discriminated-object-self-fix`
+
+**Status:** 🟢 ready to commission
+**Last updated:** 2026-06-03 (orchestrator — substrate prep)
+
+---
+
+## Phase status
+
+| Phase | Status | Notes |
+|---|---|---|
+| Implementation | 🟢 ready | Small focused fix on `Converters.discriminatedObject` + supporting overloads on `BaseConverter.convert` (and `ValidatorBase.validate` if symmetric). Single PR direct to `release`. |
+
+---
+
+## Decisions log
+
+| Decision | Rationale |
+|---|---|
+| Fix the primitive instead of working around in `json-schema-derives-t` (Erik 2026-06-03) | "That's just a bug in the discriminatedObject. Let's just fix it (in a separate PR) instead of creating debt, carrying debt and then clearing debt." Lazy-thunk closure works as a workaround but accumulates a known-recurring-idiom debt. Fixing the primitive once removes the workaround everywhere. |
+| Direct to release, no integration branch | Small focused change on established surface. Same posture as other small ts-utils fixes; integration branch adds overhead without value. |
+| Additive overload on `BaseConverter.convert` (and `Validator.validate` if needed) | Lets `discriminatedObject` pass the outer `self` to arms without changing existing call-site behavior. Default `selfOverride ?? this` preserves current semantics for callers that don't opt in. |
+| `json-schema-derives-t` (PR #441) revision waits for this | Out of scope for this stream. Once this lands on release, the integration branch `json-schema-derives-t` merges release, and the revision agent picks up the fixed primitive. |
+| `code-reviewer` + agent-driven Copilot review loop required | Per L32 + L33; small-focused-diff is the canonical case. |
+
+---
+
+## Origin
+
+PR #441 review (2026-06-03) surfaced the procedural `_parseNode` switch inside `fromJson` as exactly the manual-type-check anti-pattern fgv forbids. Discussion converged on building `fromJson` via `Converters.discriminatedObject` instead — but recursion into nested schemas needs the per-arm body to reach the outer dispatcher. Inspection of `discriminatedObject`'s implementation showed it drops `self` (and `context`) at the per-arm dispatch (`return converter.convert(from)`). Every other Converter combinator threads `self` correctly. Erik called the omission a bug and asked for a focused fix here so the json-schema-derives-t revision builds on the corrected primitive.
+
+---
+
+## History
+
+| Date | Event | Notes |
+|---|---|---|
+| 2026-06-03 | Stream commissioned + substrate prepped | brief.md + state.md; implementation agent to follow. |
+
+---
+
+## PRs
+
+| Phase | PR | Status |
+|---|---|---|
+| Substrate prep + implementation | (this PR) | open → release |

--- a/common/changes/@fgv/ts-utils/discriminated-object-self-fix_2026-06-03.json
+++ b/common/changes/@fgv/ts-utils/discriminated-object-self-fix_2026-06-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Converters.discriminatedObject now threads self (and context) to per-arm converter invocations, enabling recursive discriminated-union parsers; BaseConverter.convert gains optional selfOverride parameter (additive; existing call sites unaffected).",
+      "type": "minor",
+      "packageName": "@fgv/ts-utils"
+    }
+  ],
+  "packageName": "@fgv/ts-utils",
+  "email": "noreply@anthropic.com"
+}

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -128,6 +128,18 @@ substrate. Don't queue streams against them here.
 
 ## Active workstreams
 
+### `discriminated-object-self-fix` 🟢
+
+**Status:** 🟢 ready to commission — substrate prepped
+**Workflow shape:** single implementation PR direct to `release` (small focused fix on established surface)
+**Substrate:** `.ai/tasks/active/discriminated-object-self-fix/{brief.md, state.md}`
+**Package surface:** `@fgv/ts-utils` — `conversion/basicConverters.ts` (`discriminatedObject`), possibly `conversion/baseConverter.ts` + `validation/validatorBase.ts` for the matching additive overloads
+**Out-of-scope:** `json-schema-derives-t` revision (PR #441 — waits for this to land); other Converter combinators (already thread `self` correctly); `discriminatedObject` API redesign.
+
+**Mission.** `Converters.discriminatedObject` drops `self` (and `context`) at per-arm dispatch — every other Converter combinator threads `self` correctly, this is the outlier. The omission breaks recursive discriminated-union parsers because arms can't reach the outer dispatcher. Fix: per-arm `convert` invocation passes the outer `self` (additive overload on `BaseConverter.convert` and symmetric `Validator.validate`). Existing callers unaffected; new recursive-parser cases opt in.
+
+**Origin.** Surfaced during `json-schema-derives-t` (PR #441) review — the `_parseNode` switch in `fromJson` is exactly the procedural-inspection anti-pattern fgv forbids; correct shape is `Converters.discriminatedObject('type', { array: ..., object: ..., ... })` where arms recurse to the outer for nested schemas. Erik's call (2026-06-03): "that's just a bug in the discriminatedObject. Let's just fix it (in a separate PR) instead of creating debt, carrying debt and then clearing debt." Lands before the json-schema-derives-t revision resumes.
+
 ### `private-key-storage` ✅
 
 **Status:** ✅ implemented + reviewed (PR #427, gates green) — ready for squash to `release`

--- a/libraries/ts-utils/etc/ts-utils.api.md
+++ b/libraries/ts-utils/etc/ts-utils.api.md
@@ -208,7 +208,7 @@ class BaseConverter<T, TC = unknown> implements Converter<T, TC> {
     protected _brand?: string;
     // @internal (undocumented)
     protected _context(supplied?: TC): TC | undefined;
-    convert(from: unknown, context?: TC): Result<T>;
+    convert(from: unknown, context?: TC, selfOverride?: Converter<T, TC>): Result<T>;
     convertOptional(from: unknown, context?: TC, onError?: OnError): Result<T | undefined>;
     // @internal (undocumented)
     protected readonly _defaultContext?: TC;
@@ -705,7 +705,7 @@ type ConvertedToType<TCONV> = Infer<TCONV>;
 // @public
 export interface Converter<T, TC = unknown> extends ConverterTraits {
     readonly brand?: string;
-    convert(from: unknown, context?: TC): Result<T>;
+    convert(from: unknown, context?: TC, selfOverride?: Converter<T, TC>): Result<T>;
     convertOptional(from: unknown, context?: TC, onError?: OnError): Result<T | undefined>;
     readonly isOptional: boolean;
     map<T2>(mapper: (from: T, context?: TC) => Result<T2>): Converter<T2, TC>;

--- a/libraries/ts-utils/src/packlets/conversion/baseConverter.ts
+++ b/libraries/ts-utils/src/packlets/conversion/baseConverter.ts
@@ -133,11 +133,14 @@ export class BaseConverter<T, TC = unknown> implements Converter<T, TC> {
    * @param from - The `unknown` to be converted
    * @param context - An optional conversion context of type `<TC>` to be used in
    * the conversion.
+   * @param selfOverride - An optional override for the `self` reference passed to the
+   * converter function, enabling outer converters (e.g. discriminated-object) to thread
+   * themselves through to per-arm converters for recursive parsing.
    * @returns A {@link Result} with a {@link Success} and a value on success or an
    * {@link Failure} with a a message on failure.
    */
-  public convert(from: unknown, context?: TC): Result<T> {
-    return this._converter(from, this, context ?? this._defaultContext);
+  public convert(from: unknown, context?: TC, selfOverride?: Converter<T, TC>): Result<T> {
+    return this._converter(from, selfOverride ?? this, context ?? this._defaultContext);
   }
 
   /**

--- a/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
+++ b/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
@@ -897,6 +897,9 @@ export type DiscriminatedObjectConverters<T, TD extends string = string, TC = un
  *
  * If the source is not an object, the discriminator property is missing, or the discriminator has
  * a value not present in the converters, conversion fails and returns {@link Failure | Failure} with more information.
+ *
+ * The `self` reference of the outer converter is threaded through to per-arm converter invocations,
+ * enabling recursive discriminated-union parsers where arms recurse via `self`.
  * @param discriminatorProp - Name of the property used to discriminate types.
  * @param converters - {@link Converters.DiscriminatedObjectConverters | String-keyed record of converters and validators}
  * to invoke, where each key corresponds to a value of the discriminator property.
@@ -907,7 +910,7 @@ export function discriminatedObject<T, TD extends string = string, TC = unknown>
   discriminatorProp: string,
   converters: DiscriminatedObjectConverters<T, TD>
 ): Converter<T, TC> {
-  return new BaseConverter((from: unknown) => {
+  return new BaseConverter<T, TC>((from: unknown, self: Converter<T, TC>, context?: TC) => {
     if (typeof from !== 'object' || Array.isArray(from) || from === null) {
       return fail(`Not a discriminated object: "${JSON.stringify(from)}"`);
     }
@@ -916,10 +919,15 @@ export function discriminatedObject<T, TD extends string = string, TC = unknown>
     }
 
     const discriminatorValue = from[discriminatorProp] as TD;
-    const converter = converters[discriminatorValue];
-    if (converter === undefined) {
+    const arm = converters[discriminatorValue];
+    if (arm === undefined) {
       return fail(`No converter for discriminator ${discriminatorProp}="${discriminatorValue}"`);
     }
-    return converter.convert(from);
+    // Thread the outer self and context through to the arm so that recursive
+    // discriminated-union parsers can reach the outer dispatcher via self.
+    if (isValidator(arm)) {
+      return arm.convert(from, context);
+    }
+    return arm.convert(from, context, self);
   });
 }

--- a/libraries/ts-utils/src/packlets/conversion/converter.ts
+++ b/libraries/ts-utils/src/packlets/conversion/converter.ts
@@ -85,10 +85,13 @@ export interface Converter<T, TC = unknown> extends ConverterTraits {
    * @param from - The `unknown` to be converted
    * @param context - An optional conversion context of type `<TC>` to be used in
    * the conversion.
+   * @param selfOverride - An optional override for the `self` reference passed to the
+   * converter function, enabling outer converters (e.g. discriminated-object) to thread
+   * themselves through to per-arm converters for recursive parsing.
    * @returns A {@link Result} with a {@link Success} and a value on success or an
    * {@link Failure} with a a message on failure.
    */
-  convert(from: unknown, context?: TC): Result<T>;
+  convert(from: unknown, context?: TC, selfOverride?: Converter<T, TC>): Result<T>;
 
   /**
    * Converts from `unknown` to `<T>` or `undefined`, as appropriate.

--- a/libraries/ts-utils/src/test/unit/converters.basic.test.ts
+++ b/libraries/ts-utils/src/test/unit/converters.basic.test.ts
@@ -23,7 +23,7 @@
 import '../helpers/jest';
 
 import { Validation } from '../../index';
-import { omit, Result, succeed } from '../../packlets/base';
+import { fail, omit, Result, succeed } from '../../packlets/base';
 import { Converters, FieldConverters } from '../../packlets/conversion';
 
 describe('Basic converters', () => {
@@ -1378,6 +1378,106 @@ describe('Basic converters', () => {
         /not a discriminated object/i
       );
       expect(thing.convert(null)).toFailWith(/not a discriminated object/i);
+    });
+
+    test('invokes a validator arm via its convert method', () => {
+      const stValidator = Validation.Validators.object<IStringThing>({
+        which: Validation.Validators.isA(
+          'string thing',
+          (v: unknown): v is 'string thing' => v === 'string thing'
+        ),
+        property: Validation.Validators.string
+      });
+      const thingWithValidator = Converters.discriminatedObject<IStringThing, 'string thing'>('which', {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'string thing': stValidator
+      });
+      const st: IStringThing = { which: 'string thing', property: 'hello' };
+      expect(thingWithValidator.convert(st)).toSucceedWith(st);
+    });
+
+    describe('recursive discriminated-union via self', () => {
+      interface ITreeNode {
+        type: 'leaf' | 'branch';
+        value?: number;
+        left?: ITreeNode;
+        right?: ITreeNode;
+      }
+
+      const leafConverter = Converters.object<ITreeNode>({
+        type: Converters.enumeratedValue<'leaf'>(['leaf']),
+        value: Converters.number
+      });
+
+      // Branch arm uses self to recurse into children via the outer discriminatedObject converter.
+      const treeConverter = Converters.discriminatedObject<ITreeNode>('type', {
+        leaf: leafConverter,
+        branch: Converters.generic<ITreeNode>((from, self) => {
+          if (typeof from !== 'object' || Array.isArray(from) || from === null) {
+            return fail('not an object');
+          }
+          const obj = from as Record<string, unknown>;
+          return self
+            .convert(obj.left)
+            .onSuccess((left) =>
+              self
+                .convert(obj.right)
+                .onSuccess((right) => succeed<ITreeNode>({ type: 'branch', left, right }))
+            );
+        })
+      });
+
+      test('self is defined and is the outer discriminatedObject converter', () => {
+        let capturedSelf: unknown;
+        const capturingConverter = Converters.discriminatedObject<ITreeNode>('type', {
+          leaf: leafConverter,
+          branch: Converters.generic<ITreeNode>((from, self) => {
+            capturedSelf = self;
+            return succeed({ type: 'branch' as const });
+          })
+        });
+        capturingConverter.convert({ type: 'branch' });
+        expect(capturedSelf).toBe(capturingConverter);
+      });
+
+      test('recursive converter resolves leaf nodes', () => {
+        expect(treeConverter.convert({ type: 'leaf', value: 42 })).toSucceedWith({
+          type: 'leaf',
+          value: 42
+        });
+      });
+
+      test('recursive converter resolves nested branch nodes', () => {
+        const tree = {
+          type: 'branch',
+          left: { type: 'leaf', value: 1 },
+          right: { type: 'leaf', value: 2 }
+        };
+        expect(treeConverter.convert(tree)).toSucceedAndSatisfy((node) => {
+          expect(node.type).toBe('branch');
+          expect(node.left).toEqual({ type: 'leaf', value: 1 });
+          expect(node.right).toEqual({ type: 'leaf', value: 2 });
+        });
+      });
+
+      test('recursive converter resolves deeply nested branch nodes', () => {
+        const tree = {
+          type: 'branch',
+          left: {
+            type: 'branch',
+            left: { type: 'leaf', value: 10 },
+            right: { type: 'leaf', value: 20 }
+          },
+          right: { type: 'leaf', value: 30 }
+        };
+        expect(treeConverter.convert(tree)).toSucceedAndSatisfy((node) => {
+          expect(node.type).toBe('branch');
+          expect(node.left?.type).toBe('branch');
+          expect(node.left?.left).toEqual({ type: 'leaf', value: 10 });
+          expect(node.left?.right).toEqual({ type: 'leaf', value: 20 });
+          expect(node.right).toEqual({ type: 'leaf', value: 30 });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes a missing-self-propagation bug in `Converters.discriminatedObject`. Today the body invokes `converter.convert(from)` — dropping `self` and `context` at the per-arm dispatch — while every other Converter combinator in `baseConverter.ts` correctly threads `self` through its body. The omission blocks recursive discriminated-union parsers because arms can't reach the outer dispatcher for recursion.

Surfaced during `json-schema-derives-t` (PR #441) review: the procedural `_parseNode` switch inside `fromJson` is the manual-type-check anti-pattern fgv forbids. Correct shape is `Converters.discriminatedObject('type', { array: ..., object: ..., ... })` with arms recursing through `self` for nested schemas. This PR fixes the primitive so that shape works; the json-schema-derives-t revision builds on top.

## The fix in three parts

**1. `Converter` interface (`converter.ts`)** — `convert()` gains optional third parameter `selfOverride?: Converter<T, TC>`. Strictly additive; existing two-parameter call sites unaffected.

**2. `BaseConverter.convert` (`baseConverter.ts`)**:

```ts
public convert(from: unknown, context?: TC, selfOverride?: Converter<T, TC>): Result<T> {
  return this._converter(from, selfOverride ?? this, context ?? this._defaultContext);
}
```

When `selfOverride` is absent (i.e. all existing callers), behaviour is identical to before.

**3. `Converters.discriminatedObject` (`basicConverters.ts`)** — body now wraps a `ConverterFunc` and threads `self`/`context` to arms:

```ts
return new BaseConverter<T, TC>((from, self, context) => {
  // ... discriminator validation ...
  const arm = converters[discriminatorValue];
  return isValidator(arm)
    ? arm.convert(from, context)              // validator arms: in-place, no recursion semantics
    : arm.convert(from, context, self);        // converter arms: pass outer self for recursion
});
```

Validator arms can't participate in the recursion-via-self pattern (validators are for in-place type checking, not outer-dispatcher recursion); the `isValidator` discriminator keeps the call site type-safe without requiring a `selfOverride` parameter on `Validator`.

## `ValidatorBase.validate` — no change needed

Implementation inspection confirmed `ValidatorBase.validate` already threads `self` correctly via `this._validator(from, context, this)`. The validator-arm case in `discriminatedObject` doesn't need to recurse to the outer dispatcher, so no `selfOverride` analogue is needed on `Validator.convert`. Documented in `.ai/tasks/active/discriminated-object-self-fix/state.md` decisions log.

## Tests added (`converters.basic.test.ts`)

Five new tests covering the recursive-union case end-to-end:

1. **Validator arm test** — exercises the new `isValidator(arm)` branch in the dispatch body.
2. **`self` identity test** — captures `self` from inside an arm; asserts `capturedSelf === outerDiscriminatedObjectConverter` (not the arm itself).
3. **Leaf parsing** — recursive converter resolves leaf nodes correctly.
4. **Shallow nesting** — branch with two leaf children round-trips.
5. **Deep nesting** — 3-level deep branch round-trips, proving unbounded recursion works.

## Gates

| Gate | Status |
|---|---|
| `rush build` monorepo-wide | Clean |
| `rushx build` in `libraries/ts-utils` | Clean, no warnings |
| `rushx lint` in `libraries/ts-utils` | Exit 0 |
| `rushx fixlint` | Run before final commit |
| `rushx test` in `libraries/ts-utils` | 158 tests pass; `basicConverters.ts` / `baseConverter.ts` / `converter.ts` all 100% |
| api-extractor report regenerated | `etc/ts-utils.api.md` shows new `selfOverride` parameter |
| `minor` rush change file | `common/changes/@fgv/ts-utils/discriminated-object-self-fix_2026-06-03.json` |
| No `any` types; no `Result<void>` | Confirmed |
| Existing tests unchanged | All pass; no behaviour change for non-opting callers |

`code-reviewer` agent gate (L32): run on final diff; no P1 findings; minor P2/P3 observations addressed in the implementation (TSDoc on the new parameter; isValidator discriminator chosen over a parallel `selfOverride` on Validator).

Copilot review loop (L33): pending PR open; loop driven by implementer after first push.

## Substrate

- `.ai/tasks/active/discriminated-object-self-fix/brief.md` (added)
- `.ai/tasks/active/discriminated-object-self-fix/state.md` (added; updated with implementation-complete decisions + history rows)
- `docs/WORKSTREAMS.md` — entry above `private-key-storage`

## Sequencing downstream

Once this lands on `release`:
1. Integration branch `json-schema-derives-t` merges `release` to pick up the fix.
2. Revision agent resumes on PR #441 with the corrected target shape: schema factories return Validators, `jsonSchemaConverter` built via `Converters.discriminatedObject` with arms recursing through the now-self-aware dispatch.

## Test plan

- [ ] Reviewer confirms the three-part fix is additive at every existing call site.
- [ ] Reviewer confirms the recursive-tree test covers the `self` propagation evidence.
- [ ] Merge to `release`.
- [ ] Orchestrator merges `release` → `json-schema-derives-t` integration branch; commissions revision agent on PR #441.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_