### PR TITLE
fix(ts-json-base): add JsonSchema to browser barrel export

### DIFF
--- a/libraries/ts-json-base/src/index.browser.ts
+++ b/libraries/ts-json-base/src/index.browser.ts
@@ -26,7 +26,8 @@ import * as FileTree from './packlets/file-tree/index.browser';
 import * as JsonCompatible from './packlets/json-compatible';
 // eslint-disable-next-line @rushstack/packlets/mechanics
 import * as JsonFile from './packlets/json-file/index.browser';
+import * as JsonSchema from './packlets/json-schema-builder';
 import * as Validators from './packlets/validators';
 
 export * from './packlets/json';
-export { Converters, FileTree, JsonCompatible, JsonFile, Validators };
+export { Converters, FileTree, JsonCompatible, JsonFile, JsonSchema, Validators };


### PR DESCRIPTION
## Summary

Fix the missing `JsonSchema` namespace export in `@fgv/ts-json-base`'s **browser** barrel. The `json-schema-derives-t` stream (PR #444, 2026-06-03) added it to the Node barrel (`src/index.ts`) but missed `src/index.browser.ts`. Browser bundles resolving via the package.json `exports` map (e.g. `samples/testbed`'s webpack bundle) get an undefined `JsonSchema` and crash on first use:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'object')
    at anthropicClientTools/index.ts:83 — JsonSchema.object({...})
```

## Root cause

```ts
// src/index.ts (Node) — correct
import * as JsonSchema from './packlets/json-schema-builder';
export { Converters, FileTree, JsonCompatible, JsonFile, JsonSchema, Validators };

// src/index.browser.ts — missing JsonSchema
export { Converters, FileTree, JsonCompatible, JsonFile, Validators };
```

## Fix

One-line additive change to `src/index.browser.ts`: add the `JsonSchema` namespace import and include it in the export list.

The `json-schema-builder` packlet has no node-only dependencies (pure schema types + factories + `fromJson` parser), so it is safe to expose in the browser barrel without further refactoring.

## Verification

- `rushx build` in `@fgv/ts-json-base` passes; `lib/index.browser.js` now contains 3 references to `JsonSchema` (matching the Node barrel).
- The `anthropicClientTools` testbed scenario (which surfaced the bug) should now load.

## Note

This bug is on `release` as well (since `json-schema-derives-t` shipped there via PR #444). Targeting `ai-assist-client-tools` integration so the live-testbed verification can proceed; the fix will flow to release as part of the cluster-close promotion.

https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_