### PR TITLE
fix(ai-assist): Anthropic thinking wire shape — use thinking.budget_tokens

### DIFF
--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -1690,6 +1690,7 @@ interface IResolvedImageOptions {
 
 // @public
 interface IResolvedThinkingConfig {
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "anthropicEffortToBudgetTokens"
     readonly anthropicEffort?: IAnthropicThinkingConfig['effort'];
     readonly geminiThinkingBudget?: number;
     readonly openAiEffort?: IOpenAiThinkingConfig['effort'];

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -54,6 +54,7 @@ import {
   resolveModel
 } from './model';
 import {
+  anthropicEffortToBudgetTokens,
   checkTemperatureConflict,
   mergeThinkingConfig,
   providerDiscriminatorForId,
@@ -625,8 +626,10 @@ async function callAnthropicCompletion(
   };
 
   if (resolvedThinking?.anthropicEffort !== undefined) {
-    body.thinking = { type: 'enabled' };
-    body.output_config = { effort: resolvedThinking.anthropicEffort };
+    body.thinking = {
+      type: 'enabled',
+      budget_tokens: anthropicEffortToBudgetTokens(resolvedThinking.anthropicEffort)
+    };
   }
   if (resolvedThinking?.otherParams !== undefined) {
     Object.assign(body, resolvedThinking.otherParams);

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -1136,7 +1136,9 @@ export type XAiThinkingModelNames = 'grok-3-mini' | 'grok-4.3' | 'grok-4';
  */
 export interface IAnthropicThinkingConfig {
   /**
-   * Anthropic effort level. Maps 1:1 to `output_config.effort` on the wire.
+   * Anthropic effort level. The emit-site converts to `thinking.budget_tokens`
+   * (the integer budget the Anthropic API requires). Mapping policy: low = 2048,
+   * medium = 8192, high = 24000, max = 32000.
    * - 'low' | 'medium' | 'high': all thinking-capable models
    * - 'max': Opus 4.6 only
    */

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/anthropic.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/anthropic.ts
@@ -38,7 +38,7 @@ import { buildAnthropicMessages } from '../chatRequestBuilders';
 import { AiPrompt, type AiToolConfig, type IAiStreamEvent, type IChatMessage } from '../model';
 import { parseSseEventJson, readSseEvents } from '../sseParser';
 import { toAnthropicTools } from '../toolFormats';
-import { type IResolvedThinkingConfig } from '../thinkingOptionsResolver';
+import { anthropicEffortToBudgetTokens, type IResolvedThinkingConfig } from '../thinkingOptionsResolver';
 import { IStreamApiConfig, openSseConnection, validateEventPayload } from './common';
 
 // ============================================================================
@@ -437,8 +437,10 @@ export async function callAnthropicStream(
     stream: true
   };
   if (resolvedThinking?.anthropicEffort !== undefined) {
-    body.thinking = { type: 'enabled' };
-    body.output_config = { effort: resolvedThinking.anthropicEffort };
+    body.thinking = {
+      type: 'enabled',
+      budget_tokens: anthropicEffortToBudgetTokens(resolvedThinking.anthropicEffort)
+    };
   }
   if (resolvedThinking?.otherParams !== undefined) {
     Object.assign(body, resolvedThinking.otherParams);

--- a/libraries/ts-extras/src/packlets/ai-assist/thinkingOptionsResolver.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/thinkingOptionsResolver.ts
@@ -79,7 +79,7 @@ export function providerDiscriminatorForId(providerId: string): ThinkingProvider
  * @public
  */
 export interface IResolvedThinkingConfig {
-  /** Anthropic: output_config.effort value */
+  /** Anthropic: effort level; emit-site converts to `thinking.budget_tokens` via {@link anthropicEffortToBudgetTokens}. */
   readonly anthropicEffort?: IAnthropicThinkingConfig['effort'];
   /** OpenAI Chat: reasoning_effort value; OpenAI Responses: reasoning.effort */
   readonly openAiEffort?: IOpenAiThinkingConfig['effort'];
@@ -100,6 +100,32 @@ export interface IResolvedThinkingConfig {
  */
 function genericEffortToAnthropic(effort: 'low' | 'medium' | 'high'): IAnthropicThinkingConfig['effort'] {
   return effort; // 1:1 mapping for the common subset
+}
+
+/**
+ * Maps Anthropic effort level to the `thinking.budget_tokens` integer that the
+ * Anthropic API requires when `thinking.type === 'enabled'`.
+ *
+ * Policy: low = 2048, medium = 8192, high = 24000, max = 32000. The lower three
+ * align with the Anthropic-published minimum-meaningful budget, a mid-range
+ * default, and a "deep thinking" allotment respectively. `max` targets Opus 4.6's
+ * deepest budget and stays within typical model limits.
+ *
+ * @public
+ */
+export function anthropicEffortToBudgetTokens(
+  effort: NonNullable<IAnthropicThinkingConfig['effort']>
+): number {
+  switch (effort) {
+    case 'low':
+      return 2048;
+    case 'medium':
+      return 8192;
+    case 'high':
+      return 24000;
+    case 'max':
+      return 32000;
+  }
 }
 
 /**

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
@@ -1246,8 +1246,8 @@ describe('thinking-config wire encoding (non-streaming)', () => {
         thinking: { effort: 'high' }
       });
       const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-      expect(body.thinking).toEqual({ type: 'enabled' });
-      expect(body.output_config).toEqual({ effort: 'high' });
+      expect(body.thinking).toEqual({ type: 'enabled', budget_tokens: 24000 });
+      expect(body.output_config).toBeUndefined();
       expect(body.temperature).toBeUndefined();
     });
 

--- a/libraries/ts-extras/src/test/unit/ai-assist/streamingClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/streamingClient.test.ts
@@ -866,8 +866,8 @@ describe('callProviderCompletionStream', () => {
         thinking: { effort: 'high' }
       });
       const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-      expect(body.thinking).toEqual({ type: 'enabled' });
-      expect(body.output_config).toEqual({ effort: 'high' });
+      expect(body.thinking).toEqual({ type: 'enabled', budget_tokens: 24000 });
+      expect(body.output_config).toBeUndefined();
       expect(body.temperature).toBeUndefined();
     });
 

--- a/libraries/ts-extras/src/test/unit/ai-assist/thinkingOptionsResolver.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/thinkingOptionsResolver.test.ts
@@ -22,6 +22,7 @@ import '@fgv/ts-utils-jest';
 
 // eslint-disable-next-line @rushstack/packlets/mechanics
 import {
+  anthropicEffortToBudgetTokens,
   checkTemperatureConflict,
   mergeThinkingConfig,
   providerDiscriminatorForId
@@ -700,6 +701,21 @@ describe('checkTemperatureConflict', () => {
     test('xAI error message mentions provider xai', () => {
       const result = checkTemperatureConflict({ xaiEffort: 'high' }, 'xai', 0.7);
       expect(result).toFailWith(/provider xai/i);
+    });
+  });
+
+  describe('anthropicEffortToBudgetTokens', () => {
+    test('low effort maps to 2048', () => {
+      expect(anthropicEffortToBudgetTokens('low')).toBe(2048);
+    });
+    test('medium effort maps to 8192', () => {
+      expect(anthropicEffortToBudgetTokens('medium')).toBe(8192);
+    });
+    test('high effort maps to 24000', () => {
+      expect(anthropicEffortToBudgetTokens('high')).toBe(24000);
+    });
+    test('max effort maps to 32000', () => {
+      expect(anthropicEffortToBudgetTokens('max')).toBe(32000);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fix the Anthropic thinking-config wire shape that's been wrong since the thinking-config stream landed. Surfaced by the `anthropicClientTools` live testbed scenario returning HTTP 400:

```
thinking.enabled.budget_tokens: Field required
```

## Root cause

`fgv/ts-extras/ai-assist` was emitting:

```js
body.thinking = { type: 'enabled' };
body.output_config = { effort: 'low' | 'medium' | 'high' | 'max' };
```

Anthropic's API actually requires:

```js
body.thinking = { type: 'enabled', budget_tokens: <integer> };
```

`output_config.effort` is **not** an Anthropic API field — it was an internal assumption from the thinking-config stream that never matched the real wire format. Unit tests passed because they asserted the body matched what fgv emits, not what Anthropic accepts. **Same L37 failure mode that bit `ai-assist-client-tools` P1-1**: 100% coverage on test architecture that mocked the response side and never validated the request body against the live API.

## Fix

- New exported helper `anthropicEffortToBudgetTokens(effort)` in `thinkingOptionsResolver.ts` mapping:
  - `low` → 2048
  - `medium` → 8192
  - `high` → 24000
  - `max` → 32000
- Both emit sites (`apiClient.ts` non-streaming + `streamingAdapters/anthropic.ts` streaming) now emit `body.thinking = { type: 'enabled', budget_tokens: <n> }` and no longer set `body.output_config`.
- TSDoc on `IAnthropicThinkingConfig.effort` and `IResolvedThinkingConfig.anthropicEffort` walked back to describe the budget_tokens mapping (was incorrectly claiming `1:1 to output_config.effort`).
- Two existing tests that locked in the broken shape (`apiClient.test.ts:1249-1250`, `streamingClient.test.ts:869-870`) updated to assert `{ type: 'enabled', budget_tokens: 24000 }` and `body.output_config` is undefined.
- Added 4 tests covering all four `anthropicEffortToBudgetTokens` cases.

## Mapping policy

low=2048, medium=8192, high=24000, max=32000 (Erik 2026-06-04). The lower three give Anthropic enough budget to produce meaningful thinking output at each tier; max targets Opus 4.6's deepest budget while staying within typical model limits.

## Verification

- ✅ `rushx build` in `@fgv/ts-extras`
- ✅ `rushx lint` in `@fgv/ts-extras`
- ✅ `rushx test` in `@fgv/ts-extras` (100% coverage)
- ⏸ **Live testbed re-run** — needs `ANTHROPIC_API_KEY` in env. The `anthropicClientTools` scenario should now succeed end-to-end with thinking + memory client tool + web_search server tool.

## Substrate impact

This is the **third** consecutive bug in this cluster where unit tests passed because they mocked the response side and never validated the request body against the live API:

1. `ai-assist-client-tools` P1-1: client tools never reached the provider.
2. PR #448: `JsonSchema` missing from `@fgv/ts-json-base`'s browser barrel (similar pattern — surface visible only when actually consumed).
3. This PR: thinking-config wire shape wrong; tests asserted the broken shape.

L37 is doing its job by codifying the discipline; the pattern of evidence accumulates each time we exercise the live path. Worth a follow-up substrate update once this lands: any stream that adds wire-format emission to a live provider needs at least one test that validates the emitted shape against the provider's documented contract, not just against the emitter's own implementation.

## Note on branch

Targeting `ai-assist-client-tools` integration so the live-testbed verification for the cluster can proceed. The bug also exists on `release` (`json-schema-derives-t`-era code); this fix will flow there via the cluster-close promotion.

Also depends on **PR #448** (missing `JsonSchema` browser export) being merged so the browser-bundled testbed loads in the first place. CLI-only testing can proceed against this PR independently.

https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpzNpoTrqYgNGUBGrF3ZKE)_