### PR TITLE
Extend client-tool continuation wire-forwarding to OpenAI/Gemini/xAI

### DIFF
--- a/.ai/tasks/active/ai-assist-cross-provider-continuation/result.md
+++ b/.ai/tasks/active/ai-assist-cross-provider-continuation/result.md
@@ -1,0 +1,82 @@
+# `ai-assist-cross-provider-continuation` — result
+
+**Completed:** 2026-06-04
+**Work branch:** `claude/ai-assist-continuation-impl-ZlQ7C` (forked off the
+`per-provider-testbed-scenarios` integration branch)
+**Final commit:** `ef761b61`
+
+---
+
+## What shipped
+
+Client-tool continuation wire-forwarding extended from Anthropic-only to **all
+four providers**. `executeClientToolTurn`'s `continuationMessages` (the prior
+turn's reconstructed assistant turn + tool outputs) now flow through to every
+provider's request builder as `rawTail`, so the follow-up request body carries
+the reconstructed items. xAI inherits the fix via `apiFormat: 'openai'`.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `chatRequestBuilders.ts` | `buildMessages` (OpenAI/xAI Responses) and `buildGeminiContents` (Gemini) now consume `IBuildMessagesOptions.rawTail`. Added two `@internal` converters: `openAiRawTailItemConverter` (verbatim passthrough with `isJsonObject` guard) and `geminiRawTailMessageConverter` (projects to `{ role: 'user'\|'model', parts: unknown[] }`). `buildMessages` return type widened to `Array<Record<string, unknown>>`; `buildGeminiContents` `parts` widened to `unknown[]`. `IBuildMessagesOptions.rawTail` TSDoc generalized to per-builder behavior. |
+| `streamingAdapters/openaiResponses.ts` | `callOpenAiResponsesStream` gains a trailing optional `continuationMessages?: ReadonlyArray<JsonObject>`, threaded to `buildMessages` as `rawTail`. |
+| `streamingAdapters/gemini.ts` | `callGeminiStream` gains a trailing optional `continuationMessages?: ReadonlyArray<JsonObject>`, threaded to `buildGeminiContents` as `rawTail`. |
+| `streamingAdapters/clientToolContinuationBuilder.ts` | `executeClientToolTurn`'s `openai` and `gemini` switch arms now forward `continuationMessages` (mirroring the `anthropic` arm). `IExecuteClientToolTurnParams.continuationMessages` TSDoc rewritten to per-provider behavior. |
+| `test/unit/ai-assist/streamingAdapters.test.ts` | +7 tests: OpenAI request-body shape, OpenAI malformed-skip, Gemini request-body shape, Gemini malformed-skip, xAI inheritance (end-to-end via `executeClientToolTurn`), and two no-options builder tests covering the `options?.rawTail` short-circuit. |
+
+### Verified, not assumed
+
+- **xAI routing:** `registry.ts` `xai-grok` descriptor (line 229) declares
+  `apiFormat: 'openai'`, so `executeClientToolTurn`'s `case 'openai'` handles it
+  and forwards `continuationMessages` to `callOpenAiResponsesStream`. The xAI
+  test drives this end-to-end through `executeClientToolTurn`.
+- **Anthropic untouched:** no behavior change to `callAnthropicStream`,
+  `buildAnthropicMessages`, or the `anthropic` switch arm. Existing Anthropic
+  tests pass unmodified.
+- **Public API unchanged:** all new parameters/converters are `@internal`;
+  re-running API Extractor produced no diff to `etc/ts-extras.api.md`.
+
+---
+
+## code-reviewer pass (run BEFORE coverage closure, per L37)
+
+Run on the post-implementation / pre-coverage-closure diff. Findings:
+
+| Pri | Finding | Disposition |
+|-----|---------|-------------|
+| P1 | `continuationMessages` TSDoc described stale Anthropic-only `{ role, content }` projection | **Fixed** — rewritten to per-provider shape handling. |
+| P2 | `geminiRawTailMessageConverter` `parts` guard was a type lie (`Array.isArray` asserting `Record<string,unknown>[]`) | **Fixed** — narrowed to sound `unknown[]`; widened `buildGeminiContents` return type to match. |
+| P2 | `openAiRawTailItemConverter` is a runtime guard on a typed path | **Kept + documented** — preserves the Anthropic "malformed better omitted than transmitted" posture; continuation messages can round-trip through untyped JSON. Rationale added to TSDoc. |
+| P2 | Imperative `toSucceed()` + `isSuccess()` guard in new tests | **Dispositioned** — parallels the established Anthropic continuation test; the post-success step is an async stream consumption that doesn't fit a sync `toSucceedAndSatisfy` callback. Sibling consistency + brief's "parallel the Anthropic pattern" directive. |
+| P3 | Pre-existing Anthropic test could adopt the new body-capture helper | **Dispositioned** — left to minimize blast radius (Anthropic is out of this stream's behavior scope). |
+| P3 | `buildMessages` TSDoc gap on `rawTail` + return widening | **Fixed** — TSDoc added. |
+
+No new `c8 ignore` directives. The one coverage gap surfaced after the review
+(the `options === undefined` short-circuit of `options?.rawTail`) was closed
+with a real functional test (no-options builder calls), not a directive.
+
+---
+
+## Gates
+
+- ✅ `rushx build` — PASS (`@fgv/ts-extras`)
+- ✅ `rushx lint` — PASS, no warnings
+- ✅ `rushx test` — PASS, 100% coverage (all four modified source files at
+  100% statements/branches/functions/lines; global gate green)
+- ✅ `rushx fixlint` — run before final commit
+- ✅ Anthropic regression check — existing Anthropic continuation tests pass unmodified
+
+---
+
+## Branch/PR note
+
+The harness rule for this session is "do not open a PR unless explicitly
+asked," so the agent pushed the work branch but did **not** open the PR. When
+opened, the PR targets the **`per-provider-testbed-scenarios`** integration
+branch (NOT `release`), per the brief. After it merges onto integration, the
+paused testbed PR #453 can rebase onto the new integration HEAD and resume —
+the scenarios were intentionally left in final form and should light up on the
+next live run with no scenario edits.
+
+The Copilot review loop (layer 2) runs once the PR is open.

--- a/.ai/tasks/active/ai-assist-cross-provider-continuation/state.md
+++ b/.ai/tasks/active/ai-assist-cross-provider-continuation/state.md
@@ -3,7 +3,7 @@
 **Stream:** `ai-assist-cross-provider-continuation`
 **Parent cluster:** `per-provider-testbed-scenarios`
 **Integration branch (shared with cluster):** `per-provider-testbed-scenarios`
-**Status:** commissioned 2026-06-04 — awaiting agent kickoff
+**Status:** implementation complete 2026-06-04 — all gates green, awaiting PR open against integration branch
 
 ---
 
@@ -18,49 +18,65 @@ Full diagnosis: `.ai/tasks/active/per-provider-testbed-scenarios/findings/inbox/
 ## Phases
 
 ### Phase 1 — Read surface
-- [ ] Read the finding doc + prior-cluster continuation-wire-position finding
-- [ ] Read Anthropic reference (`callAnthropicStream` + `buildAnthropicMessages` + `executeClientToolTurn`'s `anthropic` arm)
-- [ ] Read OpenAI Responses + Gemini adapters
-- [ ] Confirm `IBuildMessagesOptions.rawTail` declared but unused outside Anthropic
-- [ ] Confirm xAI routes through OpenAI via `apiFormat: 'openai'`
+- [x] Read the finding doc + prior-cluster continuation-wire-position finding
+- [x] Read Anthropic reference (`callAnthropicStream` + `buildAnthropicMessages` + `executeClientToolTurn`'s `anthropic` arm)
+- [x] Read OpenAI Responses + Gemini adapters
+- [x] Confirm `IBuildMessagesOptions.rawTail` declared but unused outside Anthropic
+- [x] Confirm xAI routes through OpenAI via `apiFormat: 'openai'` (registry.ts `xai-grok` descriptor line 229–233)
 
 ### Phase 2 — OpenAI path
-- [ ] `callOpenAiResponsesStream` signature widening (add `continuationMessages?`)
-- [ ] `buildMessages` consumes `rawTail`, emits `function_call` + `function_call_output` tail items
-- [ ] Unit test: request body carries the reconstructed wire items
+- [x] `callOpenAiResponsesStream` signature widening (add `continuationMessages?`)
+- [x] `buildMessages` consumes `rawTail`, emits `function_call` + `function_call_output` tail items (verbatim)
+- [x] Unit test: request body carries the reconstructed wire items
 
 ### Phase 3 — Gemini path
-- [ ] `callGeminiStream` signature widening (add `continuationMessages?`)
-- [ ] `buildGeminiContents` consumes `rawTail`, emits model `functionCall` parts + user `functionResponse` parts at the tail
-- [ ] Unit test: request body carries the reconstructed wire items
+- [x] `callGeminiStream` signature widening (add `continuationMessages?`)
+- [x] `buildGeminiContents` consumes `rawTail`, emits model `functionCall` parts + user `functionResponse` parts at the tail
+- [x] Unit test: request body carries the reconstructed wire items
 
 ### Phase 4 — Switch wiring
-- [ ] `executeClientToolTurn`'s `openai` arm forwards `continuationMessages`
-- [ ] `executeClientToolTurn`'s `gemini` arm forwards `continuationMessages`
-- [ ] Unit test confirms xAI inherits the fix via OpenAI routing
+- [x] `executeClientToolTurn`'s `openai` arm forwards `continuationMessages`
+- [x] `executeClientToolTurn`'s `gemini` arm forwards `continuationMessages`
+- [x] Unit test confirms xAI inherits the fix via OpenAI routing (end-to-end through `executeClientToolTurn`)
 
 ### Phase 5 — Code review + coverage closure
-- [ ] `code-reviewer` agent run on the diff BEFORE chasing 100% coverage (L37)
-- [ ] Findings resolved or dispositioned
-- [ ] 100% coverage closed
-- [ ] `rushx fixlint` run
+- [x] `code-reviewer` agent run on the diff BEFORE chasing 100% coverage (L37)
+- [x] Findings resolved or dispositioned (1 P1 + 3 P2 + 2 P3 — see result.md)
+- [x] 100% coverage closed (no new `c8 ignore` directives)
+- [x] `rushx fixlint` run
 
 ### Phase 6 — Final gates + PR
-- [ ] `rushx build` PASS
-- [ ] `rushx lint` PASS (no warnings)
-- [ ] `rushx test` PASS with 100% coverage
-- [ ] `etc/ts-extras.api.md` regenerated and committed
-- [ ] PR opens against `per-provider-testbed-scenarios` integration branch
-- [ ] Copilot loop driven; stopped on diminishing returns or 10-round cap
+- [x] `rushx build` PASS
+- [x] `rushx lint` PASS (no warnings)
+- [x] `rushx test` PASS with 100% coverage
+- [x] `etc/ts-extras.api.md` — re-run API Extractor produced no diff (all changes `@internal`; public surface unchanged)
+- [ ] PR opens against `per-provider-testbed-scenarios` integration branch (not opened by agent — see result.md "Branch/PR note")
+- [ ] Copilot loop driven; stopped on diminishing returns or 10-round cap (pending PR)
 
 ---
 
 ## Decisions made
 
-(empty — agent records architectural decisions here)
+- **OpenAI rawTail items appended verbatim, not projected.** OpenAI Responses
+  continuation items (`function_call` / `function_call_output`) are a `type`-keyed
+  discriminated union whose fields differ per item; projecting to `{ role, content }`
+  (the Anthropic shape) would drop the distinguishing fields. The `openAiRawTailItemConverter`
+  guards only that each entry is a JSON object and preserves it whole.
+- **Gemini rawTail items projected to `{ role, parts }`.** Gemini turns carry all
+  payload in `parts`; the converter narrows `role` to `'user' | 'model'` and validates
+  `parts` is an array (typed `unknown[]` — `Array.isArray` cannot soundly assert a
+  richer element type, and the array is serialized verbatim anyway).
+- **`buildMessages` return type widened to `Array<Record<string, unknown>>`** to hold
+  both `{ role, content }` messages and the heterogeneous OpenAI input items. Verified
+  safe: no caller indexes `.role`/`.content` on the result (all spread it into the body).
+- **Kept the imperative `expect(...).toSucceed(); if (!isSuccess) return; await collect(...)`
+  test shape** (P2 disposition) — parallels the established Anthropic continuation test
+  (`streamingAdapters.test.ts`), whose post-success step is an async stream consumption
+  that does not fit a sync `toSucceedAndSatisfy` callback. Sibling consistency + the
+  brief's "parallel the Anthropic test pattern" directive.
 
 ---
 
 ## Follow-up findings filed
 
-(empty — agent files findings in `findings/inbox/<YYYY-MM-DD>-<topic>.md`)
+(none — the change matched the brief's sketched shape exactly; no ambiguity surfaced.)

--- a/libraries/ts-extras/src/packlets/ai-assist/chatRequestBuilders.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/chatRequestBuilders.ts
@@ -55,9 +55,15 @@ const rawTailMessageConverter: Converter<{ role: 'user' | 'assistant'; content: 
  * Converter for an OpenAI / xAI Responses API `rawTail` item. These are
  * provider-native input items (`function_call`, `function_call_output`) whose
  * fields differ per item type, so — unlike the Anthropic `{ role, content }`
- * projection — the whole object is preserved verbatim. The converter only
- * guards that each entry is a JSON object; malformed (non-object) entries fail
- * conversion and are skipped by the caller.
+ * projection — the whole object is preserved verbatim.
+ *
+ * The static input is already typed `JsonObject`, so the `isJsonObject` guard
+ * is a runtime backstop, not a compile-time narrowing: continuation messages
+ * originate from a prior turn's `IAiClientToolContinuation.messages` and a
+ * consumer may persist and reload them through untyped JSON before passing them
+ * back. The guard preserves the same "a malformed continuation message is
+ * better omitted than transmitted verbatim" posture as the Anthropic path —
+ * non-object entries fail conversion and are skipped by the caller.
  * @internal
  */
 const openAiRawTailItemConverter: Converter<JsonObject> = Converters.isA<JsonObject>(
@@ -75,11 +81,14 @@ const openAiRawTailItemConverter: Converter<JsonObject> = Converters.isA<JsonObj
  */
 const geminiRawTailMessageConverter: Converter<{
   role: 'user' | 'model';
-  parts: Array<Record<string, unknown>>;
-}> = Converters.object<{ role: 'user' | 'model'; parts: Array<Record<string, unknown>> }>(
+  parts: unknown[];
+}> = Converters.object<{ role: 'user' | 'model'; parts: unknown[] }>(
   {
     role: Converters.enumeratedValue<'user' | 'model'>(['user', 'model']),
-    parts: Converters.isA('array', (v): v is Array<Record<string, unknown>> => Array.isArray(v))
+    // `parts` is preserved verbatim and serialized into the request body, so the
+    // element shape is not narrowed here — `Array.isArray` soundly guarantees
+    // `unknown[]` (narrowing to `Record<string, unknown>[]` would be an unchecked cast).
+    parts: Converters.isA('array', (v): v is unknown[] => Array.isArray(v))
   },
   { strict: false }
 );
@@ -125,6 +134,13 @@ export interface IBuildMessagesOptions {
  * Builds the messages array from prompt + optional head/tail messages.
  * The caller supplies the user content (string for text-only, parts array
  * for vision prompts) since the parts shape differs by format.
+ *
+ * `rawTail` items (OpenAI / xAI Responses `function_call` /
+ * `function_call_output` continuation items) are appended verbatim after the
+ * user message — their fields differ per item `type`, so they are preserved
+ * rather than projected. The return type is `Array<Record<string, unknown>>`
+ * to accommodate both `{ role, content }` messages and these heterogeneous
+ * input items.
  *
  * @internal
  */
@@ -293,8 +309,8 @@ export function buildAnthropicMessages(
 export function buildGeminiContents(
   prompt: AiPrompt,
   options?: IBuildMessagesOptions
-): Array<{ role: string; parts: Array<Record<string, unknown>> }> {
-  const contents: Array<{ role: string; parts: Array<Record<string, unknown>> }> = [];
+): Array<{ role: string; parts: unknown[] }> {
+  const contents: Array<{ role: string; parts: unknown[] }> = [];
   /* c8 ignore next 7 - head branch: options?.head short-circuit not reached from current call sites */
   if (options?.head) {
     for (const msg of options.head) {

--- a/libraries/ts-extras/src/packlets/ai-assist/chatRequestBuilders.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/chatRequestBuilders.ts
@@ -26,7 +26,7 @@
  * @packageDocumentation
  */
 
-import type { JsonObject } from '@fgv/ts-json-base';
+import { isJsonObject, type JsonObject } from '@fgv/ts-json-base';
 import { type Converter, Converters } from '@fgv/ts-utils';
 
 import { AiPrompt, type IAiImageAttachment, type IChatMessage, toDataUrl } from './model';
@@ -52,6 +52,39 @@ const rawTailMessageConverter: Converter<{ role: 'user' | 'assistant'; content: 
   );
 
 /**
+ * Converter for an OpenAI / xAI Responses API `rawTail` item. These are
+ * provider-native input items (`function_call`, `function_call_output`) whose
+ * fields differ per item type, so — unlike the Anthropic `{ role, content }`
+ * projection — the whole object is preserved verbatim. The converter only
+ * guards that each entry is a JSON object; malformed (non-object) entries fail
+ * conversion and are skipped by the caller.
+ * @internal
+ */
+const openAiRawTailItemConverter: Converter<JsonObject> = Converters.isA<JsonObject>(
+  'JsonObject',
+  (v): v is JsonObject => isJsonObject(v)
+);
+
+/**
+ * Converter for a Gemini `rawTail` item. Gemini continuation messages are
+ * `{ role, parts }` turns (a model turn with `functionCall` parts followed by a
+ * user turn with `functionResponse` parts). Narrows a `JsonObject` to
+ * `{ role: 'user' | 'model'; parts: Array<Record<string, unknown>> }`; entries
+ * that fail validation are skipped by the caller.
+ * @internal
+ */
+const geminiRawTailMessageConverter: Converter<{
+  role: 'user' | 'model';
+  parts: Array<Record<string, unknown>>;
+}> = Converters.object<{ role: 'user' | 'model'; parts: Array<Record<string, unknown>> }>(
+  {
+    role: Converters.enumeratedValue<'user' | 'model'>(['user', 'model']),
+    parts: Converters.isA('array', (v): v is Array<Record<string, unknown>> => Array.isArray(v))
+  },
+  { strict: false }
+);
+
+/**
  * Optional head/tail messages to weave around the prompt's user message.
  *
  * @internal
@@ -70,12 +103,18 @@ export interface IBuildMessagesOptions {
   /**
    * Raw JSON objects appended after the prompt's user message. Used to
    * inject provider-specific continuation messages (e.g. Anthropic assistant
-   * turns with thinking blocks) that cannot be expressed as plain
-   * {@link IChatMessage} objects.
+   * turns with thinking blocks, OpenAI Responses `function_call` /
+   * `function_call_output` items, Gemini `functionCall` / `functionResponse`
+   * turns) that cannot be expressed as plain {@link IChatMessage} objects.
    *
-   * Each element is validated against a `{ role: string, content: string | unknown[] }`
-   * shape and projected to those two fields; any additional fields on the input
-   * are dropped. Entries that fail the shape check are silently skipped (the
+   * Each builder applies its own provider-specific shape guard:
+   * - {@link buildAnthropicMessages} projects each entry to `{ role, content }`.
+   * - {@link buildMessages} (OpenAI / xAI Responses) preserves each item
+   *   verbatim (item fields differ per `type`), guarding only that it is a
+   *   JSON object.
+   * - {@link buildGeminiContents} projects each entry to `{ role, parts }`.
+   *
+   * Entries that fail their builder's shape check are silently skipped (the
    * caller is responsible for supplying well-formed continuation messages).
    * Takes precedence over (and is appended after) `tail`.
    */
@@ -93,10 +132,8 @@ export function buildMessages(
   systemPrompt: string,
   userContent: string | unknown[],
   options?: IBuildMessagesOptions
-): Array<{ role: string; content: string | unknown[] }> {
-  const messages: Array<{ role: string; content: string | unknown[] }> = [
-    { role: 'system', content: systemPrompt }
-  ];
+): Array<Record<string, unknown>> {
+  const messages: Array<Record<string, unknown>> = [{ role: 'system', content: systemPrompt }];
   /* c8 ignore next 4 - head branch: options?.head short-circuit not reached from current call sites */
   if (options?.head) {
     for (const msg of options.head) {
@@ -108,6 +145,17 @@ export function buildMessages(
   if (options?.tail) {
     for (const msg of options.tail) {
       messages.push({ role: msg.role, content: msg.content });
+    }
+  }
+  // OpenAI / xAI Responses continuation items (function_call /
+  // function_call_output) are appended verbatim — their field set differs per
+  // item type, so the whole object is preserved rather than projected.
+  if (options?.rawTail) {
+    for (const item of options.rawTail) {
+      const converted = openAiRawTailItemConverter.convert(item);
+      if (converted.isSuccess()) {
+        messages.push(converted.value);
+      }
     }
   }
   return messages;
@@ -267,6 +315,16 @@ export function buildGeminiContents(
           role: msg.role === 'assistant' ? 'model' : msg.role,
           parts: [{ text: msg.content }]
         });
+      }
+    }
+  }
+  // Gemini continuation turns (model `functionCall` parts + user
+  // `functionResponse` parts) are projected to `{ role, parts }`.
+  if (options?.rawTail) {
+    for (const item of options.rawTail) {
+      const converted = geminiRawTailMessageConverter.convert(item);
+      if (converted.isSuccess()) {
+        contents.push(converted.value);
       }
     }
   }

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
@@ -312,10 +312,15 @@ export interface IExecuteClientToolTurnParams {
    * message. Used to supply the output of {@link AiAssist.IAiClientToolContinuation}'s
    * `messages` field from a prior turn back to the provider in the follow-up request.
    *
-   * Each message is projected to `{ role, content }` — fields beyond `role` and
-   * `content` are dropped, and entries missing either field are skipped. This is
-   * sufficient for Anthropic thinking blocks and `tool_result` arrays, which
-   * carry all meaningful content in those two fields.
+   * Each provider applies its own shape guard to the supplied wire objects:
+   * - Anthropic: projects each entry to `{ role, content }` (sufficient for
+   *   thinking blocks and `tool_result` arrays).
+   * - OpenAI / xAI Responses: passes each item verbatim (`function_call` /
+   *   `function_call_output` items carry distinct fields per `type`); only guards
+   *   that each entry is a JSON object.
+   * - Gemini: projects each entry to `{ role, parts }`.
+   *
+   * Entries that fail their provider's shape check are silently skipped.
    */
   readonly continuationMessages?: ReadonlyArray<JsonObject>;
   /** Temperature (default: 0.7). */

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
@@ -456,7 +456,8 @@ export function executeClientToolTurn(
           logger,
           signal,
           resolvedThinking,
-          openAiCallMap
+          openAiCallMap,
+          continuationMessages
         );
       case 'gemini':
         return callGeminiStream(
@@ -468,7 +469,8 @@ export function executeClientToolTurn(
           logger,
           signal,
           resolvedThinking,
-          geminiCalls
+          geminiCalls,
+          continuationMessages
         );
       /* c8 ignore next 4 - defensive coding: exhaustive switch guaranteed by TypeScript */
       default: {

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/gemini.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/gemini.ts
@@ -213,10 +213,14 @@ export async function callGeminiStream(
   logger?: Logging.ILogger,
   signal?: AbortSignal,
   resolvedThinking?: IResolvedThinkingConfig,
-  functionCalls?: IAccumulatedGeminiFunctionCall[]
+  functionCalls?: IAccumulatedGeminiFunctionCall[],
+  continuationMessages?: ReadonlyArray<JsonObject>
 ): Promise<Result<AsyncIterable<IAiStreamEvent>>> {
   const url = `${config.baseUrl}/models/${config.model}:streamGenerateContent?alt=sse`;
-  const contents = buildGeminiContents(prompt, { head: messagesBefore });
+  const contents = buildGeminiContents(prompt, {
+    head: messagesBefore,
+    rawTail: continuationMessages
+  });
   const generationConfig: Record<string, unknown> = { temperature };
   if (resolvedThinking?.geminiThinkingBudget !== undefined) {
     generationConfig.thinkingConfig = { thinkingBudget: resolvedThinking.geminiThinkingBudget };

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/openaiResponses.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/openaiResponses.ts
@@ -320,11 +320,13 @@ export async function callOpenAiResponsesStream(
   logger?: Logging.ILogger,
   signal?: AbortSignal,
   resolvedThinking?: IResolvedThinkingConfig,
-  functionCallMap?: Map<string, IAccumulatedFunctionCall>
+  functionCallMap?: Map<string, IAccumulatedFunctionCall>,
+  continuationMessages?: ReadonlyArray<JsonObject>
 ): Promise<Result<AsyncIterable<IAiStreamEvent>>> {
   const url = `${config.baseUrl}/responses`;
   const input = buildMessages(prompt.system, buildOpenAiResponsesUserContent(prompt), {
-    head: messagesBefore
+    head: messagesBefore,
+    rawTail: continuationMessages
   });
   const effort = resolvedThinking?.openAiEffort ?? resolvedThinking?.xaiEffort;
   const supportsReasoning = config.model !== 'grok-4';

--- a/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
@@ -76,6 +76,29 @@ async function collect(iter: AsyncIterable<AiAssist.IAiStreamEvent>): Promise<Ai
   return out;
 }
 
+/**
+ * Mocks `global.fetch` to serve the supplied SSE chunks while capturing the
+ * request body of the outbound call. Returns an accessor for the parsed body
+ * so tests can assert on the constructed request shape.
+ */
+function mockSseResponseCapturingBody(chunks: ReadonlyArray<string>): {
+  getBody: () => Record<string, unknown> | undefined;
+} {
+  let capturedBody: Record<string, unknown> | undefined;
+  (global.fetch as jest.Mock).mockImplementation((...args: unknown[]) => {
+    const init = args[1] as RequestInit;
+    capturedBody = JSON.parse(init.body as string) as Record<string, unknown>;
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      body: makeReadable(chunks),
+      text: jest.fn().mockResolvedValue(''),
+      headers: new Map([['content-type', 'text/event-stream']])
+    });
+  });
+  return { getBody: () => capturedBody };
+}
+
 // ============================================================================
 // SSE body builders
 // ============================================================================
@@ -1235,5 +1258,278 @@ describe('Gemini streaming adapter — C2 client tool extensions', () => {
     expect(functionCalls).toHaveLength(1);
     expect(functionCalls[0].name).toBe('do_thing');
     expect(functionCalls[0].args).toEqual({ param: 'value' });
+  });
+});
+
+// ============================================================================
+// Tests — cross-provider client-tool continuation wire forwarding
+//
+// Verifies that `continuationMessages` (the prior turn's reconstructed
+// assistant turn + tool outputs) reach the request body for OpenAI Responses,
+// Gemini, and (by `apiFormat: 'openai'` routing) xAI — paralleling the
+// Anthropic C4 coverage above. The load-bearing assertions check the actual
+// request body shape, not just that the call succeeds.
+// ============================================================================
+
+describe('cross-provider client-tool continuation wire forwarding', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // OpenAI Responses input completion stream: a text delta + completed event.
+  const openAiDoneSse: ReadonlyArray<string> = [
+    `event: response.output_text.delta\ndata: ${JSON.stringify({ delta: 'ok' })}\n\n`,
+    `event: response.completed\ndata: ${JSON.stringify({ response: { status: 'completed' } })}\n\n`
+  ];
+
+  test('OpenAI Responses: appends function_call + function_call_output items after the user message', async () => {
+    const continuationMessages: ReadonlyArray<JsonObject> = [
+      {
+        type: 'function_call',
+        id: 'fc_1',
+        name: 'recall_memory',
+        arguments: '{"key":"display-mode"}'
+      },
+      { type: 'function_call_output', call_id: 'fc_1', output: 'dark mode' }
+    ];
+
+    const bodyCapture = mockSseResponseCapturingBody(openAiDoneSse);
+    const { callOpenAiResponsesStream } = await import(
+      '../../../packlets/ai-assist/streamingAdapters/openaiResponses'
+    );
+
+    const streamConfig = {
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiKey: 'sk-test'
+    };
+
+    const streamResult = await callOpenAiResponsesStream(
+      streamConfig,
+      TEST_PROMPT,
+      [{ type: 'web_search' }],
+      undefined,
+      0.5,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      continuationMessages
+    );
+
+    expect(streamResult).toSucceed();
+    if (!streamResult.isSuccess()) return;
+    await collect(streamResult.value);
+
+    const input = bodyCapture.getBody()?.input as Array<Record<string, unknown>>;
+    expect(input).toBeDefined();
+    // input: [{ role: 'system' }, { role: 'user' }, function_call, function_call_output]
+    expect(input).toHaveLength(4);
+    expect(input[1].role).toBe('user');
+    expect(input[2]).toEqual({
+      type: 'function_call',
+      id: 'fc_1',
+      name: 'recall_memory',
+      arguments: '{"key":"display-mode"}'
+    });
+    expect(input[3]).toEqual({
+      type: 'function_call_output',
+      call_id: 'fc_1',
+      output: 'dark mode'
+    });
+  });
+
+  test('OpenAI Responses: skips malformed (non-object) continuation items', async () => {
+    const continuationMessages: ReadonlyArray<JsonObject> = [
+      { type: 'function_call', id: 'fc_ok', name: 't', arguments: '{}' },
+      // Malformed: not a JSON object — must be skipped, not transmitted.
+      'not-an-object' as unknown as JsonObject
+    ];
+
+    const bodyCapture = mockSseResponseCapturingBody(openAiDoneSse);
+    const { callOpenAiResponsesStream } = await import(
+      '../../../packlets/ai-assist/streamingAdapters/openaiResponses'
+    );
+
+    const streamResult = await callOpenAiResponsesStream(
+      { baseUrl: 'https://api.openai.com/v1', model: 'gpt-4o', apiKey: 'sk-test' },
+      TEST_PROMPT,
+      [{ type: 'web_search' }],
+      undefined,
+      0.5,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      continuationMessages
+    );
+
+    expect(streamResult).toSucceed();
+    if (!streamResult.isSuccess()) return;
+    await collect(streamResult.value);
+
+    const input = bodyCapture.getBody()?.input as Array<Record<string, unknown>>;
+    // [system, user, fc_ok] — the malformed entry is dropped.
+    expect(input).toHaveLength(3);
+    expect(input[2].id).toBe('fc_ok');
+  });
+
+  test('Gemini: appends model functionCall + user functionResponse turns after the user message', async () => {
+    const continuationMessages: ReadonlyArray<JsonObject> = [
+      {
+        role: 'model',
+        parts: [{ functionCall: { name: 'recall_memory', args: { key: 'display-mode' } } }] as JsonArray
+      },
+      {
+        role: 'user',
+        parts: [
+          { functionResponse: { name: 'recall_memory', response: { content: 'dark mode' } } }
+        ] as JsonArray
+      }
+    ];
+
+    const bodyCapture = mockSseResponseCapturingBody(
+      geminiFunctionCallSse({ calls: [], textDeltas: ['ok'] })
+    );
+    const { callGeminiStream } = await import('../../../packlets/ai-assist/streamingAdapters/gemini');
+
+    const streamResult = await callGeminiStream(
+      {
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+        model: 'gemini-1.5-pro',
+        apiKey: 'sk-test'
+      },
+      TEST_PROMPT,
+      undefined,
+      0.5,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      continuationMessages
+    );
+
+    expect(streamResult).toSucceed();
+    if (!streamResult.isSuccess()) return;
+    await collect(streamResult.value);
+
+    const contents = bodyCapture.getBody()?.contents as Array<Record<string, unknown>>;
+    expect(contents).toBeDefined();
+    // contents: [{ role: 'user' }, model functionCall turn, user functionResponse turn]
+    expect(contents).toHaveLength(3);
+    expect(contents[0].role).toBe('user');
+    expect(contents[1].role).toBe('model');
+    expect(contents[1].parts).toEqual([
+      { functionCall: { name: 'recall_memory', args: { key: 'display-mode' } } }
+    ]);
+    expect(contents[2].role).toBe('user');
+    expect(contents[2].parts).toEqual([
+      { functionResponse: { name: 'recall_memory', response: { content: 'dark mode' } } }
+    ]);
+  });
+
+  test('Gemini: skips malformed continuation items (invalid role)', async () => {
+    const continuationMessages: ReadonlyArray<JsonObject> = [
+      {
+        role: 'model',
+        parts: [{ functionCall: { name: 't', args: {} } }] as JsonArray
+      },
+      // Malformed: 'assistant' is not a valid Gemini role (only 'user' / 'model').
+      { role: 'assistant', parts: [] as JsonArray } as unknown as JsonObject
+    ];
+
+    const bodyCapture = mockSseResponseCapturingBody(
+      geminiFunctionCallSse({ calls: [], textDeltas: ['ok'] })
+    );
+    const { callGeminiStream } = await import('../../../packlets/ai-assist/streamingAdapters/gemini');
+
+    const streamResult = await callGeminiStream(
+      {
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+        model: 'gemini-1.5-pro',
+        apiKey: 'sk-test'
+      },
+      TEST_PROMPT,
+      undefined,
+      0.5,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      continuationMessages
+    );
+
+    expect(streamResult).toSucceed();
+    if (!streamResult.isSuccess()) return;
+    await collect(streamResult.value);
+
+    const contents = bodyCapture.getBody()?.contents as Array<Record<string, unknown>>;
+    // [user, model] — the invalid-role entry is dropped.
+    expect(contents).toHaveLength(2);
+    expect(contents[1].role).toBe('model');
+  });
+
+  test('xAI (apiFormat openai) forwards continuationMessages through executeClientToolTurn into the request body', async () => {
+    // xAI routes through the OpenAI Responses adapter via apiFormat: 'openai',
+    // so it inherits the continuation forwarding once executeClientToolTurn's
+    // openai switch arm passes continuationMessages through. This test verifies
+    // that inheritance end-to-end (not just that the adapter accepts the param).
+    const continuationMessages: ReadonlyArray<JsonObject> = [
+      { type: 'function_call', id: 'fc_x', name: 'recall_memory', arguments: '{"key":"k"}' },
+      { type: 'function_call_output', call_id: 'fc_x', output: 'v' }
+    ];
+
+    const bodyCapture = mockSseResponseCapturingBody(openAiDoneSse);
+
+    const xaiDescriptor: IAiProviderDescriptor = {
+      id: 'xai-grok',
+      label: 'xAI',
+      buttonLabel: 'AI Assist | xAI',
+      needsSecret: true,
+      apiFormat: 'openai',
+      baseUrl: 'https://api.x.ai/v1',
+      defaultModel: 'grok-3',
+      supportedTools: ['web_search'],
+      corsRestricted: false,
+      streamingCorsRestricted: false,
+      acceptsImageInput: true,
+      thinkingMode: 'optional'
+    };
+
+    const turnResult = AiAssist.executeClientToolTurn({
+      descriptor: xaiDescriptor,
+      apiKey: 'sk-test',
+      prompt: TEST_PROMPT,
+      tools: [{ type: 'web_search' }],
+      clientTools: [],
+      continuationMessages
+    });
+
+    expect(turnResult).toSucceed();
+    if (!turnResult.isSuccess()) return;
+    await collect(turnResult.value.events);
+    await turnResult.value.nextTurn;
+
+    const input = bodyCapture.getBody()?.input as Array<Record<string, unknown>>;
+    expect(input).toBeDefined();
+    expect(input[input.length - 2]).toEqual({
+      type: 'function_call',
+      id: 'fc_x',
+      name: 'recall_memory',
+      arguments: '{"key":"k"}'
+    });
+    expect(input[input.length - 1]).toEqual({
+      type: 'function_call_output',
+      call_id: 'fc_x',
+      output: 'v'
+    });
   });
 });

--- a/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
@@ -1533,3 +1533,28 @@ describe('cross-provider client-tool continuation wire forwarding', () => {
     });
   });
 });
+
+// ============================================================================
+// Tests — chatRequestBuilders rawTail short-circuit (no options supplied)
+//
+// Exercises the `options === undefined` branch of the `options?.rawTail`
+// optional chain in buildMessages / buildGeminiContents — the path where no
+// continuation messages (and no head/tail) are woven around the user message.
+// ============================================================================
+
+describe('chatRequestBuilders — builders called without options', () => {
+  test('buildMessages emits only system + user when no options are supplied', async () => {
+    const { buildMessages } = await import('../../../packlets/ai-assist/chatRequestBuilders');
+    const messages = buildMessages('system prompt', 'user text');
+    expect(messages).toEqual([
+      { role: 'system', content: 'system prompt' },
+      { role: 'user', content: 'user text' }
+    ]);
+  });
+
+  test('buildGeminiContents emits only the user turn when no options are supplied', async () => {
+    const { buildGeminiContents } = await import('../../../packlets/ai-assist/chatRequestBuilders');
+    const contents = buildGeminiContents(TEST_PROMPT);
+    expect(contents).toEqual([{ role: 'user', parts: [{ text: 'hello' }] }]);
+  });
+});


### PR DESCRIPTION
## Mission

Extends client-tool **continuation wire-forwarding** in `@fgv/ts-extras/ai-assist` from Anthropic-only to **all four providers** (OpenAI Responses, Gemini, and xAI by `apiFormat: 'openai'` routing). This is the load-bearing prerequisite that paused PR #453 — once this merges onto the integration branch, the testbed scenarios light up on the next live run with no scenario edits.

Stream: `ai-assist-cross-provider-continuation` (cluster: `per-provider-testbed-scenarios`). Brief: `.ai/tasks/active/ai-assist-cross-provider-continuation/brief.md`.

## What changed

`executeClientToolTurn`'s `continuationMessages` (the prior turn's reconstructed assistant turn + tool outputs) now flow through to every provider's request builder as `rawTail`, so the follow-up request body carries the reconstructed wire items.

| Switch arm | Behavior |
|---|---|
| `anthropic` | unchanged (reference; already correct) |
| `openai` | forwards `continuationMessages` → `callOpenAiResponsesStream` → `buildMessages` `rawTail` → `function_call` / `function_call_output` items appended verbatim after the user message |
| `gemini` | forwards → `callGeminiStream` → `buildGeminiContents` `rawTail` → model `functionCall` turn + user `functionResponse` turn appended |
| xAI | inherits via routing — `registry.ts` `xai-grok` declares `apiFormat: 'openai'` (verified, not assumed); test drives it end-to-end through `executeClientToolTurn` |

**Minimum-additive, parallel to the existing Anthropic pattern.** No behavior change for Anthropic. All new params/converters are `@internal` — API Extractor produced no `ts-extras.api.md` diff.

### Files
- `chatRequestBuilders.ts` — `buildMessages` (OpenAI/xAI) and `buildGeminiContents` (Gemini) consume `IBuildMessagesOptions.rawTail` (field was pre-declared, previously only honored by `buildAnthropicMessages`). Two `@internal` converters added: `openAiRawTailItemConverter` (verbatim passthrough, `isJsonObject` guard — OpenAI items are a `type`-keyed union whose fields differ per item, so projection would drop data) and `geminiRawTailMessageConverter` (projects to `{ role: 'user'|'model', parts: unknown[] }`). `buildMessages` return widened to `Array<Record<string, unknown>>`; `buildGeminiContents` `parts` to `unknown[]`.
- `streamingAdapters/openaiResponses.ts`, `streamingAdapters/gemini.ts` — trailing optional `continuationMessages?: ReadonlyArray<JsonObject>`, threaded to the builder as `rawTail`.
- `streamingAdapters/clientToolContinuationBuilder.ts` — `openai` and `gemini` switch arms forward `continuationMessages`; `continuationMessages` TSDoc rewritten to per-provider behavior.
- `test/unit/ai-assist/streamingAdapters.test.ts` — +7 tests.

### Tests (+7)
Request-body verification (asserts the reconstructed wire items at the correct array positions — not just call success): OpenAI shape, Gemini shape, OpenAI malformed-skip, Gemini malformed-skip, xAI inheritance via `executeClientToolTurn`, plus two no-options builder tests covering the `options?.rawTail` short-circuit branch.

## code-reviewer pass (run BEFORE coverage closure, per L37)

1 P1 + 3 P2 + 2 P3:
- **P1** — stale `continuationMessages` TSDoc (Anthropic-only `{ role, content }` projection) → **fixed** (per-provider).
- **P2** — `geminiRawTailMessageConverter` `parts` type-lie (`Array.isArray` asserting `Record<string,unknown>[]`) → **fixed** to sound `unknown[]`; return type widened to match.
- **P2** — `openAiRawTailItemConverter` runtime guard on a typed path → **kept + documented** (preserves the Anthropic "malformed better omitted than transmitted" posture; continuation messages can round-trip through untyped JSON).
- **P2** — imperative `toSucceed()` + `isSuccess()` test shape → **dispositioned** (parallels the established Anthropic continuation test; post-success step is async stream consumption that doesn't fit a sync `toSucceedAndSatisfy`).
- **P3** — Anthropic test could adopt the new body-capture helper → **dispositioned** (out of this stream's behavior scope).
- **P3** — `buildMessages` TSDoc gap → **fixed**.

No new `c8 ignore` directives. The post-review coverage gap (the `options === undefined` short-circuit) was closed with a real functional test, not a directive.

## Gates (`@fgv/ts-extras`)
- ✅ `rushx build` · ✅ `rushx lint` (no warnings) · ✅ `rushx test` 100% coverage (all four modified source files at 100%) · ✅ `rushx fixlint` run · ✅ Anthropic tests pass unmodified · ✅ API Extractor — no public-surface diff.

Copilot review loop driven by implementer; will stop on diminishing returns or the 10-round cap.

https://claude.ai/code/session_012Z5LiCtVuE4VoeY8fx36rP

---
_Generated by [Claude Code](https://claude.ai/code/session_012Z5LiCtVuE4VoeY8fx36rP)_