### PR TITLE
fix(ts-extras/ai-assist): sanitize Gemini tool schema + surface incomplete reason

### DIFF
--- a/.ai/tasks/active/ai-assist-cross-provider-fixes/result.md
+++ b/.ai/tasks/active/ai-assist-cross-provider-fixes/result.md
@@ -1,0 +1,107 @@
+# `ai-assist-cross-provider-fixes` — result
+
+**Stream:** `ai-assist-cross-provider-fixes`
+**Parent cluster:** `per-provider-testbed-scenarios`
+**Work branch:** `chore/ai-assist-cross-provider-fixes-impl`
+**PR target:** `per-provider-testbed-scenarios` (integration — NOT `release`)
+
+---
+
+## What shipped
+
+Two additive `@fgv/ts-extras/ai-assist` fixes, both in one PR.
+
+### Fix 1 — Gemini function-declaration schema sanitization
+
+`JsonSchema.object(...).toJson()` is strict-by-default and emits `additionalProperties: false` on every object node. Gemini's `function_declarations[].parameters` is an OpenAPI 3.0 Schema Object subset that **rejects** (does not ignore) `additionalProperties`, so every `JsonSchema`-authored client tool 400'd on Gemini.
+
+- New `@internal` helper `toGeminiParameterSchema(schema: JsonValue): JsonValue` — recursively strips `additionalProperties` (the confirmed P1 trigger) and `$schema` (defensive). Recurses through arrays and object values, so nested object schemas are sanitized at every level. Infallible → returns a plain value, no `Result`.
+- Applied at the `case 'client_tool':` arm of `toGeminiTools`.
+- Exported from the module (not the packlet barrel) so it stays out of `.api.md` while remaining unit-testable.
+
+**Files:**
+- `libraries/ts-extras/src/packlets/ai-assist/toolFormats.ts:26` — added `JsonValue` import.
+- `libraries/ts-extras/src/packlets/ai-assist/toolFormats.ts:205-237` — new `toGeminiParameterSchema` helper.
+- `libraries/ts-extras/src/packlets/ai-assist/toolFormats.ts:266` — wired into the client-tool case.
+
+### Fix 2 — capture `incomplete_details.reason` on the done event
+
+The OpenAI/xAI Responses `response.completed` payload carries `incomplete_details: { reason }` when `status === 'incomplete'`. The adapter already reported `truncated` but discarded the reason, making the "completed but empty" failure mode invisible.
+
+- Extended `IResponsesCompletedPayload` + `responsesCompletedPayload` validator to optionally capture `incomplete_details.reason` (infallible — absent → undefined).
+- Threaded the captured value to the `done` event.
+- New `@public` optional field `incompleteReason?: string` on `IAiStreamDone`, documented as meaningful only when `truncated === true`.
+
+**Files:**
+- `libraries/ts-extras/src/packlets/ai-assist/model.ts:571-579` — new `incompleteReason?` field + TSDoc.
+- `libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/openaiResponses.ts:107-112` — payload interface.
+- `libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/openaiResponses.ts:165-179` — validator (`responsesIncompleteDetails` + extended `responsesCompletedPayload`).
+- `libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/openaiResponses.ts:214,292-297,310` — local capture + threading to the done event.
+
+### Public-surface diff (exactly one field)
+
+```diff
+ interface IAiStreamDone {
+     readonly fullText: string;
++    readonly incompleteReason?: string;
+     readonly truncated: boolean;
+     readonly type: 'done';
+ }
+```
+
+`etc/ts-extras.api.md` regenerated and committed.
+
+---
+
+## Tests
+
+- `toolFormats.test.ts`:
+  - 3 existing `toGeminiTools` client-tool structural tests updated to expect Gemini-sanitized params (explicit, non-circular fixtures).
+  - New `toGeminiTools` tests: strips `additionalProperties` top-level; strips at every nesting level (negative assertions + full-shape `toEqual`).
+  - New `toGeminiParameterSchema` direct tests: recursive strip through properties/items; `$schema` strip; array-nested nodes; clean-schema passthrough (deep equality); primitives unchanged.
+- `streamingAdapters.test.ts` — 3 new tests on the actual emitted done event:
+  - `status: 'incomplete'` + `incomplete_details.reason: 'max_output_tokens'` → `truncated: true`, `incompleteReason: 'max_output_tokens'`.
+  - `status: 'completed'` → `truncated: false`, `incompleteReason: undefined`.
+  - `status: 'incomplete'` without `incomplete_details` → `truncated: true`, `incompleteReason: undefined` (no throw).
+
+Per L37: Fix 1 tests inspect the **emitted Gemini function-declaration JSON**, not a call-success path.
+
+---
+
+## code-reviewer pass summary
+
+Run on the cumulative diff **before** coverage-gap closure (L37). No P1. Findings:
+
+- **P2 — nested-tool Gemini test asserted property-absence but not full shape.** Resolved: added an explicit `nestedGeminiParams` fixture + `toEqual` so an accidental drop of a non-targeted key is caught.
+- **P3 — coverage directive at `openaiResponses.ts:294`.** Reviewer offered an `if (payload)` guard refactor that collapses both `payload?.` optional-chain null branches under the single existing directive. Adopted (cleaner defensive intent; no second isolated `c8 ignore`).
+- **P3 — `incompleteReason` doc accuracy.** Reviewer confirmed accurate against the implementation; no change.
+- Other P3 (test early-return pattern, `@internal` placement) — confirmed consistent with existing file conventions; no action.
+
+Recommendation: Approved with advisory; advisories actioned.
+
+---
+
+## Gates
+
+- `rushx build` — PASS
+- `rushx lint` — PASS (no warnings)
+- `rushx test` — PASS, **100% coverage** (statements/branches/functions/lines) in `@fgv/ts-extras`
+- `rushx fixlint` — run before final commit (no changes)
+- `etc/ts-extras.api.md` — regenerated, committed
+
+---
+
+## Finding-doc disposition
+
+The two finding docs live on the testbed agent's branch `claude/magical-newton-S53ZO`, not on the integration branch this stream forks from, so they were not edited cross-branch (out of declared surface). Dispositions for the cluster-close PR / testbed agent to fold in on rebase:
+
+- **`2026-06-04-gemini-tool-schema-additionalproperties.md` → RESOLVED** by this PR. `toGeminiTools` now sanitizes the client-tool parameters schema via `toGeminiParameterSchema`, stripping `additionalProperties`/`$schema` at every nesting level. The `gemini-client-tools` scenario's previously-400 request-side round-trip is now clean; PASS/FAIL awaits the live response on PR #453's rebase + re-run. (Squash SHA TBD at cluster-close.)
+- **`2026-06-04-openai-xai-empty-completion.md` → DIAGNOSTIC GAP ADDRESSED.** The done event now surfaces `incompleteReason` so the "completed but empty" class self-explains. Root-cause confirmation (budget exhaustion vs. genuine adapter gap) still pending the testbed agent's live re-run reading `truncated` + `incompleteReason` on PR #453.
+
+---
+
+## Out of scope (per brief, untouched)
+
+- No testbed/scenario edits (PR #453 stays paused).
+- No default `max_output_tokens` for reasoning models (deferred to FUTURE.md by the brief).
+- No deeper OpenAI/xAI root-cause work (spawns a separate stream only if the re-run shows `truncated: false`).

--- a/.ai/tasks/active/ai-assist-cross-provider-fixes/result.md
+++ b/.ai/tasks/active/ai-assist-cross-provider-fixes/result.md
@@ -3,7 +3,9 @@
 **Stream:** `ai-assist-cross-provider-fixes`
 **Parent cluster:** `per-provider-testbed-scenarios`
 **Work branch:** `chore/ai-assist-cross-provider-fixes-impl`
-**PR target:** `per-provider-testbed-scenarios` (integration — NOT `release`)
+**PR:** [#457](https://github.com/ErikFortune/fgv/pull/457) → `per-provider-testbed-scenarios` (integration — NOT `release`)
+**Final commit:** `ef8e4ea2`
+**Status:** ready to merge — gates green, Copilot loop converged at 3 rounds, all threads resolved
 
 ---
 
@@ -15,7 +17,7 @@ Two additive `@fgv/ts-extras/ai-assist` fixes, both in one PR.
 
 `JsonSchema.object(...).toJson()` is strict-by-default and emits `additionalProperties: false` on every object node. Gemini's `function_declarations[].parameters` is an OpenAPI 3.0 Schema Object subset that **rejects** (does not ignore) `additionalProperties`, so every `JsonSchema`-authored client tool 400'd on Gemini.
 
-- New `@internal` helper `toGeminiParameterSchema(schema: JsonValue): JsonValue` — recursively strips `additionalProperties` (the confirmed P1 trigger) and `$schema` (defensive). Recurses through arrays and object values, so nested object schemas are sanitized at every level. Infallible → returns a plain value, no `Result`.
+- New `@internal` helper `toGeminiParameterSchema(schema: JsonValue): JsonValue` — recursively strips `additionalProperties` (the confirmed P1 trigger) and `$schema` (defensive) **only where they appear as schema keywords**. `properties` is treated as a name→subschema bag: parameter names are preserved verbatim (a parameter literally named `additionalProperties`/`$schema` survives — Copilot R1) while each subschema value is still recursively sanitized. Recurses through arrays and object values, so nested object schemas are sanitized at every level. Infallible → returns a plain value, no `Result`.
 - Applied at the `case 'client_tool':` arm of `toGeminiTools`.
 - Exported from the module (not the packlet barrel) so it stays out of `.api.md` while remaining unit-testable.
 
@@ -29,7 +31,7 @@ Two additive `@fgv/ts-extras/ai-assist` fixes, both in one PR.
 The OpenAI/xAI Responses `response.completed` payload carries `incomplete_details: { reason }` when `status === 'incomplete'`. The adapter already reported `truncated` but discarded the reason, making the "completed but empty" failure mode invisible.
 
 - Extended `IResponsesCompletedPayload` + `responsesCompletedPayload` validator to optionally capture `incomplete_details.reason` (infallible — absent → undefined).
-- Threaded the captured value to the `done` event.
+- Captured the reason in lockstep with `truncated` (`incompleteReason = truncated ? reason : undefined`) so the field never leaks on a non-incomplete payload and never goes stale under a duplicate completed event (Copilot R2/R3), then threaded it to the `done` event.
 - New `@public` optional field `incompleteReason?: string` on `IAiStreamDone`, documented as meaningful only when `truncated === true`.
 
 **Files:**
@@ -78,6 +80,20 @@ Run on the cumulative diff **before** coverage-gap closure (L37). No P1. Finding
 - Other P3 (test early-return pattern, `@internal` placement) — confirmed consistent with existing file conventions; no action.
 
 Recommendation: Approved with advisory; advisories actioned.
+
+---
+
+## Copilot review loop (layer 2)
+
+Implementer-driven; **stopped at 3 rounds on diminishing returns** (under the 10-round cap). All threads resolved.
+
+| Round | Finding | Substance | Fix |
+|---|---|---|---|
+| 1 | `toGeminiParameterSchema` stripped keyword-named keys (`additionalProperties`/`$schema`) at all depths — would corrupt a real tool schema with a parameter literally named that | Substantive (real bug) | `a73a1f5f` — keyword-aware (`properties` treated as a name→subschema bag) + regression test. (Copilot's secondary "`Object.entries` loses typing → `any`" claim was unfounded — narrowed `JsonObject` index signature is `JsonValue`; the strict `no-explicit-any` build gate proves it. Replied, no change.) |
+| 2 | `incompleteReason` not gated on `truncated` — runtime could carry a stray reason on a non-incomplete payload, mismatching the TSDoc contract | Borderline (defensive) | `62f2631b` — gated capture + regression test |
+| 3 | Stale `incompleteReason` possible if a duplicate `response.completed` event reports not-incomplete after an incomplete one | Hardening (Responses API contract precludes the stream) | `ef8e4ea2` — `truncated ? reason : undefined` lockstep assignment + regression test |
+
+**Stop rationale:** the finding profile bent down cleanly — R2 and R3 were progressively more contrived hardening of the same `incompleteReason` capture against provider streams the API contract precludes; R4 would be deeper nitpicks.
 
 ---
 

--- a/.ai/tasks/active/ai-assist-cross-provider-fixes/state.md
+++ b/.ai/tasks/active/ai-assist-cross-provider-fixes/state.md
@@ -3,54 +3,59 @@
 **Stream:** `ai-assist-cross-provider-fixes`
 **Parent cluster:** `per-provider-testbed-scenarios`
 **Integration branch (shared with cluster):** `per-provider-testbed-scenarios`
-**Status:** commissioned 2026-06-05 — awaiting agent kickoff
+**Work branch:** `chore/ai-assist-cross-provider-fixes-impl`
+**Status:** implementation complete — gates green, PR open against integration
 
 ---
 
 ## Phases
 
 ### Phase 1 — Read surface
-- [ ] Read the Gemini `additionalProperties` finding on `claude/magical-newton-S53ZO`
-- [ ] Read the OpenAI/xAI empty-completion finding on `claude/magical-newton-S53ZO`
-- [ ] Read `toGeminiTools` + `JsonSchema.object(...).toJson()` output shape
-- [ ] Read `responsesCompletedPayload` + the `done` event emit site
+- [x] Read the Gemini `additionalProperties` finding on `claude/magical-newton-S53ZO`
+- [x] Read the OpenAI/xAI empty-completion finding on `claude/magical-newton-S53ZO`
+- [x] Read `toGeminiTools` + `JsonSchema.object(...).toJson()` output shape
+- [x] Read `responsesCompletedPayload` + the `done` event emit site
 
 ### Phase 2 — Fix 1 (Gemini schema sanitization)
-- [ ] Add `toGeminiParameterSchema(schema)` recursive sanitizer
-- [ ] Wire into `toGeminiTools`'s `case 'client_tool':` arm
-- [ ] Unit test: nested-object schema → emitted Gemini declaration has no `additionalProperties` at any nesting level
-- [ ] Unit test: schema with `$schema` → stripped
-- [ ] Unit test: schema without any stripped keys → passed through unchanged
+- [x] Add `toGeminiParameterSchema(schema)` recursive sanitizer (`@internal`, exported from module not barrel)
+- [x] Wire into `toGeminiTools`'s `case 'client_tool':` arm
+- [x] Unit test: nested-object schema → emitted Gemini declaration has no `additionalProperties` at any nesting level (+ full-shape `toEqual`)
+- [x] Unit test: schema with `$schema` → stripped
+- [x] Unit test: schema without any stripped keys → passed through unchanged
+- [x] Unit test: arrays, primitives, passthrough
 
 ### Phase 3 — Fix 2 (incomplete_details.reason capture)
-- [ ] Extend `responsesCompletedPayload` to capture `incomplete_details.reason`
-- [ ] Add optional `incompleteReason?` (or chosen name) to the done event type in `model.ts`. `@public`
-- [ ] Thread captured value to done event emit site
-- [ ] Unit tests: status=incomplete + reason; status=completed (no reason); status=incomplete without details
+- [x] Extend `responsesCompletedPayload` to capture `incomplete_details.reason`
+- [x] Add optional `incompleteReason?: string` to `IAiStreamDone` in `model.ts`. `@public`
+- [x] Thread captured value to done event emit site
+- [x] Unit tests: status=incomplete + reason; status=completed (no reason); status=incomplete without details
 
 ### Phase 4 — Code review + coverage closure
-- [ ] `code-reviewer` agent run on the cumulative diff BEFORE chasing 100% coverage (L37)
-- [ ] Findings resolved or dispositioned
-- [ ] 100% coverage closed
-- [ ] `rushx fixlint` run
+- [x] `code-reviewer` agent run on the cumulative diff BEFORE chasing 100% coverage (L37)
+- [x] Findings resolved or dispositioned (P2 full-shape assertion added; P3 `if (payload)` guard refactor applied)
+- [x] 100% coverage closed
+- [x] `rushx fixlint` run (no changes)
 
 ### Phase 5 — Final gates + PR
-- [ ] `rushx build` PASS
-- [ ] `rushx lint` PASS (no warnings)
-- [ ] `rushx test` PASS with 100% coverage
-- [ ] `etc/ts-extras.api.md` regenerated and committed (expected diff: one new `incompleteReason?` field on the done event type)
-- [ ] PR opens against `per-provider-testbed-scenarios` integration branch
-- [ ] Finding docs updated with disposition
+- [x] `rushx build` PASS
+- [x] `rushx lint` PASS (no warnings)
+- [x] `rushx test` PASS with 100% coverage
+- [x] `etc/ts-extras.api.md` regenerated and committed (diff: one new `incompleteReason?` field)
+- [x] PR opens against `per-provider-testbed-scenarios` integration branch
+- [~] Finding docs updated with disposition — see Decisions: docs live on `claude/magical-newton-S53ZO`, not on integration; disposition recorded in `result.md` + PR description instead of cross-branch edit
 - [ ] Copilot loop driven; stopped on diminishing returns or 10-round cap
 
 ---
 
 ## Decisions made
 
-(empty — agent records architectural decisions here)
+- **Sanitizer exported from `toolFormats.ts` module, not the packlet barrel.** `@internal` tag keeps it out of `.api.md`; the test imports it directly from `../../../packlets/ai-assist/toolFormats`, matching the existing pattern for `toGeminiTools`/`toAnthropicTools`. This lets the `$schema`-strip + primitive/array passthrough cases be unit-tested directly while the `additionalProperties` recursion is also verified end-to-end through `toGeminiTools`.
+- **`incompleteReason?: string` chosen as the field name** (per brief's suggested name). Documented as meaningful only when `truncated === true`; populated only by the OpenAI/xAI Responses adapter.
+- **P3 coverage disposition: adopted the `if (payload)` guard refactor** (code-reviewer's design simplification) rather than a second isolated `c8 ignore`. Collapses both `payload?.` optional-chain null branches under the single existing directive; cleaner defensive intent. Result: openaiResponses.ts back to 100% with no added directive.
+- **Finding-doc disposition not written to the testbed agent's branch.** The two finding docs live on `claude/magical-newton-S53ZO` under `per-provider-testbed-scenarios/findings/inbox/` — they are not present on the integration branch this stream forks from. Editing another branch's tree is out of this stream's declared surface. Disposition is recorded in `result.md` and the PR description; the cluster-close PR (or the testbed agent on rebase) folds it into the finding docs with the squash SHA.
 
 ---
 
 ## Follow-up findings filed
 
-(empty — agent files findings in `findings/inbox/<YYYY-MM-DD>-<topic>.md`)
+(none)

--- a/.ai/tasks/active/ai-assist-cross-provider-fixes/state.md
+++ b/.ai/tasks/active/ai-assist-cross-provider-fixes/state.md
@@ -4,7 +4,8 @@
 **Parent cluster:** `per-provider-testbed-scenarios`
 **Integration branch (shared with cluster):** `per-provider-testbed-scenarios`
 **Work branch:** `chore/ai-assist-cross-provider-fixes-impl`
-**Status:** implementation complete — gates green, PR open against integration
+**Status:** complete — gates green, PR #457 open against integration, Copilot loop converged (3 rounds), ready to merge
+**Final commit:** `ef8e4ea2`
 
 ---
 
@@ -43,7 +44,7 @@
 - [x] `etc/ts-extras.api.md` regenerated and committed (diff: one new `incompleteReason?` field)
 - [x] PR opens against `per-provider-testbed-scenarios` integration branch
 - [~] Finding docs updated with disposition — see Decisions: docs live on `claude/magical-newton-S53ZO`, not on integration; disposition recorded in `result.md` + PR description instead of cross-branch edit
-- [ ] Copilot loop driven; stopped on diminishing returns or 10-round cap
+- [x] Copilot loop driven; stopped at 3 rounds on diminishing returns (under 10-round cap). All threads resolved. See `result.md` for the per-round record.
 
 ---
 

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -935,6 +935,7 @@ interface IAiProviderDescriptor {
 // @public
 interface IAiStreamDone {
     readonly fullText: string;
+    readonly incompleteReason?: string;
     readonly truncated: boolean;
     // (undocumented)
     readonly type: 'done';

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -568,6 +568,15 @@ export interface IAiStreamDone {
   readonly truncated: boolean;
   /** The full concatenated text from all `text-delta` events. */
   readonly fullText: string;
+  /**
+   * Provider-reported reason a truncated response was cut short (e.g.
+   * `'max_output_tokens'`, `'content_filter'`), when the provider supplies one.
+   * Currently populated only by the OpenAI / xAI Responses adapter, from the
+   * completed payload's `incomplete_details.reason`. Meaningful only when
+   * `truncated === true`; `undefined` otherwise (and whenever the provider
+   * reports truncation without a reason).
+   */
+  readonly incompleteReason?: string;
 }
 
 /**

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/openaiResponses.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/openaiResponses.ts
@@ -293,11 +293,10 @@ async function* translateOpenAiResponsesStream(
         if (payload) {
           truncated = payload.response.status === 'incomplete';
           // Per IAiStreamDone.incompleteReason's contract, the reason is meaningful only
-          // when the response was truncated — gate the capture on `truncated` so a stray
-          // incomplete_details on a non-incomplete payload never leaks through.
-          if (truncated) {
-            incompleteReason = payload.response.incomplete_details?.reason;
-          }
+          // when the response was truncated. Move both fields together on every completed
+          // event so a stray incomplete_details on a non-incomplete payload never leaks
+          // through, and a later (defensive) completed event can't leave a stale reason.
+          incompleteReason = truncated ? payload.response.incomplete_details?.reason : undefined;
         }
         completed = true;
         /* c8 ignore next 1 - defensive: eventName === 'error' alternative not exercised in tests */

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/openaiResponses.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/openaiResponses.ts
@@ -292,7 +292,12 @@ async function* translateOpenAiResponsesStream(
         /* c8 ignore next 1 - defensive: payload null branch unreachable after validation */
         if (payload) {
           truncated = payload.response.status === 'incomplete';
-          incompleteReason = payload.response.incomplete_details?.reason;
+          // Per IAiStreamDone.incompleteReason's contract, the reason is meaningful only
+          // when the response was truncated — gate the capture on `truncated` so a stray
+          // incomplete_details on a non-incomplete payload never leaks through.
+          if (truncated) {
+            incompleteReason = payload.response.incomplete_details?.reason;
+          }
         }
         completed = true;
         /* c8 ignore next 1 - defensive: eventName === 'error' alternative not exercised in tests */

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/openaiResponses.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/openaiResponses.ts
@@ -105,7 +105,10 @@ interface IResponsesFunctionCallArgsDonePayload {
  * @internal
  */
 interface IResponsesCompletedPayload {
-  readonly response: { readonly status?: string };
+  readonly response: {
+    readonly status?: string;
+    readonly incomplete_details?: { readonly reason?: string };
+  };
 }
 
 /**
@@ -159,11 +162,19 @@ const responsesFunctionCallArgsDonePayload: Validator<IResponsesFunctionCallArgs
     { options: { optionalFields: ['item_id', 'call_id'] } }
   );
 
+const responsesIncompleteDetails: Validator<{ reason?: string }> = Validators.object<{ reason?: string }>(
+  { reason: Validators.string.optional() },
+  { options: { optionalFields: ['reason'] } }
+);
+
 const responsesCompletedPayload: Validator<IResponsesCompletedPayload> =
   Validators.object<IResponsesCompletedPayload>({
-    response: Validators.object<{ status?: string }>(
-      { status: Validators.string.optional() },
-      { options: { optionalFields: ['status'] } }
+    response: Validators.object<{ status?: string; incomplete_details?: { reason?: string } }>(
+      {
+        status: Validators.string.optional(),
+        incomplete_details: responsesIncompleteDetails.optional()
+      },
+      { options: { optionalFields: ['status', 'incomplete_details'] } }
     )
   });
 
@@ -200,6 +211,7 @@ async function* translateOpenAiResponsesStream(
   let fullText = '';
   let truncated = false;
   let completed = false;
+  let incompleteReason: string | undefined;
 
   try {
     /* c8 ignore next - body is non-null at this point per openSseConnection */
@@ -277,8 +289,11 @@ async function* translateOpenAiResponsesStream(
         }
       } else if (eventName === 'response.completed') {
         const payload = validateEventPayload(parseSseEventJson(message.data), responsesCompletedPayload);
-        /* c8 ignore next 1 - defensive: payload?.response null branch unreachable after validation */
-        truncated = payload?.response.status === 'incomplete';
+        /* c8 ignore next 1 - defensive: payload null branch unreachable after validation */
+        if (payload) {
+          truncated = payload.response.status === 'incomplete';
+          incompleteReason = payload.response.incomplete_details?.reason;
+        }
         completed = true;
         /* c8 ignore next 1 - defensive: eventName === 'error' alternative not exercised in tests */
       } else if (eventName === 'response.failed' || eventName === 'error') {
@@ -295,7 +310,7 @@ async function* translateOpenAiResponsesStream(
   } /* c8 ignore stop */
 
   if (completed) {
-    yield { type: 'done', truncated, fullText };
+    yield { type: 'done', truncated, fullText, incompleteReason };
   } else {
     yield { type: 'error', message: 'Responses API stream ended without a completed event' };
   }

--- a/libraries/ts-extras/src/packlets/ai-assist/toolFormats.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/toolFormats.ts
@@ -23,7 +23,7 @@
  * @packageDocumentation
  */
 
-import { type JsonObject } from '@fgv/ts-json-base';
+import { type JsonObject, type JsonValue } from '@fgv/ts-json-base';
 
 import {
   type AiServerToolConfig,
@@ -203,11 +203,48 @@ export function toAnthropicTools(tools: ReadonlyArray<AiToolConfig>): ReadonlyAr
 // ============================================================================
 
 /**
+ * Sanitizes a draft-07 JSON Schema (as emitted by `JsonSchema.object(...).toJson()`)
+ * into the OpenAPI 3.0 Schema Object subset that Gemini's `function_declarations[].parameters`
+ * accepts.
+ *
+ * @remarks
+ * Gemini's function-declaration schema is **not** full JSON Schema — it is a subset of
+ * the OpenAPI 3.0 Schema Object and **rejects** (rather than ignores) draft-07-only
+ * keywords. `JsonSchema` objects are strict-by-default, so `.toJson()` emits
+ * `additionalProperties: false` on every object node, which 400s the whole request on
+ * Gemini. This helper recursively strips the unsupported keywords so any
+ * `JsonSchema`-authored client tool works on Gemini without consumer awareness of the
+ * dialect difference. Stripping is infallible, so it returns a plain value rather than a
+ * `Result`.
+ *
+ * @internal
+ */
+export function toGeminiParameterSchema(schema: JsonValue): JsonValue {
+  if (Array.isArray(schema)) {
+    return schema.map(toGeminiParameterSchema);
+  }
+  if (schema !== null && typeof schema === 'object') {
+    const out: JsonObject = {};
+    for (const [k, v] of Object.entries(schema)) {
+      if (k === 'additionalProperties' || k === '$schema') {
+        continue;
+      }
+      out[k] = toGeminiParameterSchema(v);
+    }
+    return out;
+  }
+  return schema;
+}
+
+/**
  * Formats tool configs for the Gemini generateContent API.
  *
  * @remarks
  * Gemini uses `google_search` for search grounding (no per-tool config).
  * Client-defined tools are accumulated into a single `function_declarations` entry.
+ * Each client tool's parameters schema is sanitized to Gemini's OpenAPI-subset
+ * dialect via {@link toGeminiParameterSchema} (the raw draft-07 `.toJson()` output
+ * carries `additionalProperties`, which Gemini rejects).
  *
  * @param tools - The resolved tool configs (server-side and/or client-defined)
  * @returns Provider-native tool objects for the `tools` request field
@@ -226,7 +263,7 @@ export function toGeminiTools(tools: ReadonlyArray<AiToolConfig>): ReadonlyArray
         functionDeclarations.push({
           name: t.name,
           description: t.description,
-          parameters: t.parametersSchema.toJson()
+          parameters: toGeminiParameterSchema(t.parametersSchema.toJson())
         } as JsonObject);
         break;
       /* c8 ignore next 4 - defensive coding: exhaustive switch guaranteed by TypeScript */

--- a/libraries/ts-extras/src/packlets/ai-assist/toolFormats.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/toolFormats.ts
@@ -217,6 +217,12 @@ export function toAnthropicTools(tools: ReadonlyArray<AiToolConfig>): ReadonlyAr
  * dialect difference. Stripping is infallible, so it returns a plain value rather than a
  * `Result`.
  *
+ * `additionalProperties` and `$schema` are stripped only where they appear as schema
+ * *keywords* (siblings of `type`/`properties`/etc.). Inside a `properties` map the keys
+ * are user-defined parameter names, not keywords, so they are preserved verbatim while
+ * each property's subschema value is still recursively sanitized — a tool parameter
+ * legitimately named `additionalProperties` survives.
+ *
  * @internal
  */
 export function toGeminiParameterSchema(schema: JsonValue): JsonValue {
@@ -225,11 +231,21 @@ export function toGeminiParameterSchema(schema: JsonValue): JsonValue {
   }
   if (schema !== null && typeof schema === 'object') {
     const out: JsonObject = {};
-    for (const [k, v] of Object.entries(schema)) {
-      if (k === 'additionalProperties' || k === '$schema') {
+    for (const [key, value] of Object.entries(schema)) {
+      if (key === 'additionalProperties' || key === '$schema') {
         continue;
       }
-      out[k] = toGeminiParameterSchema(v);
+      if (key === 'properties' && value !== null && typeof value === 'object' && !Array.isArray(value)) {
+        // `properties` maps user-defined parameter names to subschemas: recurse each
+        // subschema value but never treat a parameter name as a strippable keyword.
+        const properties: JsonObject = {};
+        for (const [name, propSchema] of Object.entries(value)) {
+          properties[name] = toGeminiParameterSchema(propSchema);
+        }
+        out[key] = properties;
+      } else {
+        out[key] = toGeminiParameterSchema(value);
+      }
     }
     return out;
   }

--- a/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
@@ -1149,6 +1149,79 @@ describe('OpenAI Responses API streaming adapter — C2 client tool extensions',
     expect(entry).toBeDefined();
     expect(entry?.argsBuffer).toBe('{"answer":42}');
   });
+
+  test('surfaces incompleteReason on the done event when status is incomplete', async () => {
+    const sseChunks: string[] = [
+      `event: response.output_text.delta\ndata: ${JSON.stringify({ delta: 'partial' })}\n\n`,
+      `event: response.completed\ndata: ${JSON.stringify({
+        response: { status: 'incomplete', incomplete_details: { reason: 'max_output_tokens' } }
+      })}\n\n`
+    ];
+    mockSseResponse(sseChunks);
+
+    const result = await AiAssist.callProviderCompletionStream({
+      descriptor: makeOpenAiResponsesDescriptor(),
+      apiKey: 'sk',
+      prompt: TEST_PROMPT,
+      tools
+    });
+
+    expect(result).toSucceed();
+    if (!result.isSuccess()) return;
+    const events = await collect(result.value);
+
+    const done = events[events.length - 1] as AiAssist.IAiStreamDone;
+    expect(done.type).toBe('done');
+    expect(done.truncated).toBe(true);
+    expect(done.incompleteReason).toBe('max_output_tokens');
+  });
+
+  test('leaves incompleteReason undefined on a normally completed response', async () => {
+    const sseChunks: string[] = [
+      `event: response.output_text.delta\ndata: ${JSON.stringify({ delta: 'all done' })}\n\n`,
+      `event: response.completed\ndata: ${JSON.stringify({ response: { status: 'completed' } })}\n\n`
+    ];
+    mockSseResponse(sseChunks);
+
+    const result = await AiAssist.callProviderCompletionStream({
+      descriptor: makeOpenAiResponsesDescriptor(),
+      apiKey: 'sk',
+      prompt: TEST_PROMPT,
+      tools
+    });
+
+    expect(result).toSucceed();
+    if (!result.isSuccess()) return;
+    const events = await collect(result.value);
+
+    const done = events[events.length - 1] as AiAssist.IAiStreamDone;
+    expect(done.type).toBe('done');
+    expect(done.truncated).toBe(false);
+    expect(done.incompleteReason).toBeUndefined();
+  });
+
+  test('leaves incompleteReason undefined when status is incomplete but no details are present', async () => {
+    const sseChunks: string[] = [
+      `event: response.completed\ndata: ${JSON.stringify({ response: { status: 'incomplete' } })}\n\n`
+    ];
+    mockSseResponse(sseChunks);
+
+    const result = await AiAssist.callProviderCompletionStream({
+      descriptor: makeOpenAiResponsesDescriptor(),
+      apiKey: 'sk',
+      prompt: TEST_PROMPT,
+      tools
+    });
+
+    expect(result).toSucceed();
+    if (!result.isSuccess()) return;
+    const events = await collect(result.value);
+
+    const done = events[events.length - 1] as AiAssist.IAiStreamDone;
+    expect(done.type).toBe('done');
+    expect(done.truncated).toBe(true);
+    expect(done.incompleteReason).toBeUndefined();
+  });
 });
 
 // ============================================================================

--- a/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
@@ -1227,6 +1227,35 @@ describe('OpenAI Responses API streaming adapter — C2 client tool extensions',
     expect(done.incompleteReason).toBeUndefined();
   });
 
+  test('clears a stale incompleteReason if a later completed event reports not-incomplete', async () => {
+    // Defensive: the Responses API sends exactly one completed event, but if a duplicate
+    // arrived (first incomplete, then completed), truncated and incompleteReason must move
+    // together so the done event never reports truncated:false with a stale reason.
+    const sseChunks: string[] = [
+      `event: response.completed\ndata: ${JSON.stringify({
+        response: { status: 'incomplete', incomplete_details: { reason: 'max_output_tokens' } }
+      })}\n\n`,
+      `event: response.completed\ndata: ${JSON.stringify({ response: { status: 'completed' } })}\n\n`
+    ];
+    mockSseResponse(sseChunks);
+
+    const result = await AiAssist.callProviderCompletionStream({
+      descriptor: makeOpenAiResponsesDescriptor(),
+      apiKey: 'sk',
+      prompt: TEST_PROMPT,
+      tools
+    });
+
+    expect(result).toSucceed();
+    if (!result.isSuccess()) return;
+    const events = await collect(result.value);
+
+    const done = events[events.length - 1] as AiAssist.IAiStreamDone;
+    expect(done.type).toBe('done');
+    expect(done.truncated).toBe(false);
+    expect(done.incompleteReason).toBeUndefined();
+  });
+
   test('leaves incompleteReason undefined when status is incomplete but no details are present', async () => {
     const sseChunks: string[] = [
       `event: response.completed\ndata: ${JSON.stringify({ response: { status: 'incomplete' } })}\n\n`

--- a/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
@@ -1200,6 +1200,33 @@ describe('OpenAI Responses API streaming adapter — C2 client tool extensions',
     expect(done.incompleteReason).toBeUndefined();
   });
 
+  test('does not leak incompleteReason when status is not incomplete but details are present', async () => {
+    // Defensive: a provider should never send incomplete_details on a completed payload,
+    // but if it does, the reason must not leak through (contract: meaningful only when truncated).
+    const sseChunks: string[] = [
+      `event: response.completed\ndata: ${JSON.stringify({
+        response: { status: 'completed', incomplete_details: { reason: 'max_output_tokens' } }
+      })}\n\n`
+    ];
+    mockSseResponse(sseChunks);
+
+    const result = await AiAssist.callProviderCompletionStream({
+      descriptor: makeOpenAiResponsesDescriptor(),
+      apiKey: 'sk',
+      prompt: TEST_PROMPT,
+      tools
+    });
+
+    expect(result).toSucceed();
+    if (!result.isSuccess()) return;
+    const events = await collect(result.value);
+
+    const done = events[events.length - 1] as AiAssist.IAiStreamDone;
+    expect(done.type).toBe('done');
+    expect(done.truncated).toBe(false);
+    expect(done.incompleteReason).toBeUndefined();
+  });
+
   test('leaves incompleteReason undefined when status is incomplete but no details are present', async () => {
     const sseChunks: string[] = [
       `event: response.completed\ndata: ${JSON.stringify({ response: { status: 'incomplete' } })}\n\n`

--- a/libraries/ts-extras/src/test/unit/ai-assist/toolFormats.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/toolFormats.test.ts
@@ -517,6 +517,30 @@ describe('toGeminiParameterSchema', () => {
     });
   });
 
+  test('preserves a parameter literally named additionalProperties or $schema', () => {
+    // Inside a `properties` map the keys are user-defined parameter names, not schema
+    // keywords — they must survive even when they collide with a stripped keyword.
+    const input: JsonValue = {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        additionalProperties: { type: 'string', description: 'a real param' },
+        $schema: { type: 'string' },
+        nested: { type: 'object', additionalProperties: false, properties: {} }
+      },
+      required: ['additionalProperties']
+    };
+    expect(toGeminiParameterSchema(input)).toEqual({
+      type: 'object',
+      properties: {
+        additionalProperties: { type: 'string', description: 'a real param' },
+        $schema: { type: 'string' },
+        nested: { type: 'object', properties: {} }
+      },
+      required: ['additionalProperties']
+    });
+  });
+
   test('passes through a schema with none of the stripped keys unchanged', () => {
     const clean: JsonValue = {
       type: 'object',

--- a/libraries/ts-extras/src/test/unit/ai-assist/toolFormats.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/toolFormats.test.ts
@@ -20,7 +20,7 @@
 
 import '@fgv/ts-utils-jest';
 
-import { JsonSchema } from '@fgv/ts-json-base';
+import { JsonSchema, type JsonValue } from '@fgv/ts-json-base';
 
 // eslint-disable-next-line @rushstack/packlets/mechanics
 import type {
@@ -34,6 +34,7 @@ import type {
 import {
   resolveEffectiveTools,
   toAnthropicTools,
+  toGeminiParameterSchema,
   toGeminiTools,
   toResponsesApiTools
 } from '../../../packlets/ai-assist/toolFormats';
@@ -93,6 +94,48 @@ const weatherTool: IAiClientToolConfig = {
 const memoryWireSchema = memorySchema.toJson();
 // The expected wire schema from the weather tool's parametersSchema.toJson()
 const weatherWireSchema = weatherSchema.toJson();
+
+// A client tool whose parameters schema nests an object property, so the recursive
+// Gemini sanitizer must strip `additionalProperties` at more than the top level.
+const nestedSchema = JsonSchema.object({
+  filter: JsonSchema.object({
+    field: JsonSchema.string({ description: 'Field to match' })
+  })
+});
+
+const nestedTool: IAiClientToolConfig = {
+  type: 'client_tool',
+  name: 'search',
+  description: 'Search with a nested filter',
+  parametersSchema: nestedSchema
+};
+
+// Expected Gemini-sanitized parameters (draft-07 `additionalProperties` stripped at
+// every nesting level). Authored explicitly — not derived from the function under test.
+const memoryGeminiParams = {
+  type: 'object',
+  properties: { query: { type: 'string', description: 'What to recall' } },
+  required: ['query']
+};
+const weatherGeminiParams = {
+  type: 'object',
+  properties: {
+    location: { type: 'string', description: 'City name' },
+    units: { type: 'string', enum: ['celsius', 'fahrenheit'], description: 'Temperature units' }
+  },
+  required: ['location']
+};
+const nestedGeminiParams = {
+  type: 'object',
+  properties: {
+    filter: {
+      type: 'object',
+      properties: { field: { type: 'string', description: 'Field to match' } },
+      required: ['field']
+    }
+  },
+  required: ['filter']
+};
 
 function makeDescriptor(overrides: Partial<IAiProviderDescriptor> = {}): IAiProviderDescriptor {
   return {
@@ -355,7 +398,7 @@ describe('toGeminiTools', () => {
           {
             name: 'recall_memory',
             description: 'Recall stored user context',
-            parameters: memoryWireSchema
+            parameters: memoryGeminiParams
           }
         ]
       }
@@ -369,12 +412,12 @@ describe('toGeminiTools', () => {
           {
             name: 'recall_memory',
             description: 'Recall stored user context',
-            parameters: memoryWireSchema
+            parameters: memoryGeminiParams
           },
           {
             name: 'get_weather',
             description: 'Get current weather for a location',
-            parameters: weatherWireSchema
+            parameters: weatherGeminiParams
           }
         ]
       }
@@ -391,9 +434,102 @@ describe('toGeminiTools', () => {
         {
           name: 'recall_memory',
           description: 'Recall stored user context',
-          parameters: memoryWireSchema
+          parameters: memoryGeminiParams
         }
       ]
     });
+  });
+
+  test('strips additionalProperties from a client tool parameters schema (top level)', () => {
+    // The raw draft-07 schema carries `additionalProperties: false`, which Gemini rejects.
+    expect(memoryWireSchema).toHaveProperty('additionalProperties', false);
+
+    const result = toGeminiTools([memoryTool]);
+    const declarations = (result[0] as { function_declarations: Array<{ parameters: object }> })
+      .function_declarations;
+    const params = declarations[0].parameters as Record<string, unknown>;
+    expect(params).not.toHaveProperty('additionalProperties');
+  });
+
+  test('strips additionalProperties at every nesting level', () => {
+    // Sanity-check the fixture: the raw schema carries additionalProperties on both the
+    // outer object and the nested `filter` object.
+    const rawParams = nestedSchema.toJson() as {
+      additionalProperties?: unknown;
+      properties: { filter: { additionalProperties?: unknown } };
+    };
+    expect(rawParams).toHaveProperty('additionalProperties', false);
+    expect(rawParams.properties.filter).toHaveProperty('additionalProperties', false);
+
+    const result = toGeminiTools([nestedTool]);
+    const declarations = (result[0] as { function_declarations: Array<{ parameters: object }> })
+      .function_declarations;
+    const params = declarations[0].parameters as {
+      additionalProperties?: unknown;
+      properties: { filter: { additionalProperties?: unknown } };
+    };
+    expect(params).not.toHaveProperty('additionalProperties');
+    expect(params.properties.filter).not.toHaveProperty('additionalProperties');
+    // Full-shape check: only the stripped keys are removed; nothing else drops.
+    expect(params).toEqual(nestedGeminiParams);
+  });
+});
+
+// ============================================================================
+// toGeminiParameterSchema (Gemini schema sanitizer)
+// ============================================================================
+
+describe('toGeminiParameterSchema', () => {
+  test('strips additionalProperties recursively through properties and items', () => {
+    const input: JsonValue = {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        nested: { type: 'object', additionalProperties: false, properties: {} }
+      },
+      items: { type: 'object', additionalProperties: false, properties: {} }
+    };
+    expect(toGeminiParameterSchema(input)).toEqual({
+      type: 'object',
+      properties: { nested: { type: 'object', properties: {} } },
+      items: { type: 'object', properties: {} }
+    });
+  });
+
+  test('strips $schema (defensive — draft-07 emitters may include it)', () => {
+    const input: JsonValue = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { nested: { $schema: 'x', type: 'string' } }
+    };
+    expect(toGeminiParameterSchema(input)).toEqual({
+      type: 'object',
+      properties: { nested: { type: 'string' } }
+    });
+  });
+
+  test('sanitizes schema nodes nested inside arrays', () => {
+    const input: JsonValue = {
+      anyOf: [{ type: 'object', additionalProperties: false, properties: {} }, { type: 'string' }]
+    };
+    expect(toGeminiParameterSchema(input)).toEqual({
+      anyOf: [{ type: 'object', properties: {} }, { type: 'string' }]
+    });
+  });
+
+  test('passes through a schema with none of the stripped keys unchanged', () => {
+    const clean: JsonValue = {
+      type: 'object',
+      properties: { name: { type: 'string', description: 'A name' } },
+      required: ['name']
+    };
+    expect(toGeminiParameterSchema(clean)).toEqual(clean);
+  });
+
+  test('returns primitive values unchanged', () => {
+    expect(toGeminiParameterSchema('hello')).toBe('hello');
+    expect(toGeminiParameterSchema(42)).toBe(42);
+    expect(toGeminiParameterSchema(true)).toBe(true);
+    expect(toGeminiParameterSchema(null)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Two additive `@fgv/ts-extras/ai-assist` fixes surfaced by the `per-provider-testbed-scenarios` cluster's live runs (beyond the continuation-forwarding gap PR #454 already fixed). **Targets the `per-provider-testbed-scenarios` integration branch, not `release`.**

### Fix 1 — Gemini function-declaration schema sanitization

`JsonSchema.object(...).toJson()` is strict-by-default and emits `additionalProperties: false` on every object node. Gemini's `function_declarations[].parameters` is an OpenAPI 3.0 Schema Object subset that **rejects** (does not ignore) `additionalProperties` — so every `JsonSchema`-authored client tool 400'd on Gemini with `INVALID_ARGUMENT`.

- New `@internal` `toGeminiParameterSchema(schema: JsonValue): JsonValue` recursively strips `additionalProperties` (confirmed P1 trigger) and `$schema` (defensive) **only where they appear as schema keywords** — inside a `properties` map the keys are user-defined parameter names and are preserved verbatim while each subschema value is still sanitized.
- Applied at the `case 'client_tool':` arm of `toGeminiTools`.
- Exported from the module (not the packlet barrel), so it stays out of `.api.md` while remaining unit-testable.

### Fix 2 — capture `incomplete_details.reason` on the done event

The OpenAI/xAI Responses `response.completed` payload carries `incomplete_details: { reason }` when `status === 'incomplete'`. The adapter already reported `truncated` but discarded the reason, making the "completed but empty" failure mode invisible without source inspection.

- Extended `responsesCompletedPayload` validator to optionally capture `incomplete_details.reason`.
- New `@public` optional field `incompleteReason?: string` on `IAiStreamDone`, documented as meaningful only when `truncated === true`. The capture moves in lockstep with `truncated` (`truncated ? reason : undefined`) so the field never leaks or goes stale under unexpected provider streams.

### Public-surface diff (exactly one field)

```diff
 interface IAiStreamDone {
     readonly fullText: string;
+    readonly incompleteReason?: string;
     readonly truncated: boolean;
     readonly type: 'done';
 }
```

`etc/ts-extras.api.md` regenerated and committed.

## Tests (verify actual emitted JSON, per L37)

- `toolFormats.test.ts` — Fix 1 tests walk the **emitted Gemini function-declaration JSON** and assert `additionalProperties`/`$schema` absent at every nesting level (top-level + nested), plus full-shape `toEqual`, plus a keyword-collision regression (a parameter literally named `additionalProperties`/`$schema` survives). Direct `toGeminiParameterSchema` tests cover recursion through properties/items, `$schema` strip, array-nested nodes, clean-schema passthrough, primitives.
- `streamingAdapters.test.ts` — tests on the actual emitted done event: incomplete + reason; completed (both unset); incomplete without details; completed-with-stray-details (gated out); duplicate-completed (stale reason cleared).

## Review-loop discipline

**Layer 1 — `code-reviewer` run on the cumulative diff BEFORE coverage closure (L37).** No P1. P2 (nested-tool full-shape assertion) resolved; P3 (`if (payload)` guard refactor; doc accuracy) addressed.

**Layer 2 — Copilot loop driven by implementer; stopped at 3 rounds on diminishing returns** (under the 10-round cap):
- R1 — schema sanitizer stripped keyword-named params at all depths (real structural bug) → fixed `a73a1f5f`.
- R2 — `incompleteReason` not gated on `truncated` (contract mismatch) → fixed `62f2631b`.
- R3 — stale `incompleteReason` possible under a duplicate completed event (doubly-defensive) → fixed `ef8e4ea2`.
- Stopped: R2/R3 were progressively more contrived hardening of the same capture against streams the Responses API contract precludes; R4 would be deeper nitpicks. All threads resolved.

## Gates

- `rushx build` ✅ · `rushx lint` ✅ (no warnings) · `rushx test` ✅ **100% coverage** · `rushx fixlint` run · `api.md` regenerated

## Finding-doc disposition

The two finding docs live on `claude/magical-newton-S53ZO` (not on integration), so they were not edited cross-branch. Dispositions for cluster-close / testbed-agent rebase:
- `2026-06-04-gemini-tool-schema-additionalproperties.md` → **RESOLVED** by this PR; the previously-400 request-side round-trip is now clean (live PASS awaits PR #453 re-run).
- `2026-06-04-openai-xai-empty-completion.md` → **diagnostic gap addressed** via `incompleteReason`; root-cause confirmation still pending the testbed agent's live re-run.

## Out of scope (untouched)

No testbed/scenario edits (PR #453 stays paused); no default `max_output_tokens`; no deeper OpenAI/xAI root-cause work.

https://claude.ai/code/session_01BnYGJHogjE9VAHesFB7kM9