### PR TITLE
fix(ai-assist): honor endpoint override in executeClientToolTurn

### DIFF
--- a/common/changes/@fgv/ts-extras/fix-endpoint-override-tool-turn_2026-06-06-00-00.json
+++ b/common/changes/@fgv/ts-extras/fix-endpoint-override-tool-turn_2026-06-06-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "ai-assist: executeClientToolTurn now honors the endpoint override (new optional IExecuteClientToolTurnParams.endpoint), routed through resolveEffectiveBaseUrl — client-tool turns can target a local Ollama / LAN OpenAI-compatible server, matching callProviderCompletion / callProviderCompletionStream",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "ErikFortune@outlook.com"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -1205,6 +1205,7 @@ interface IExecuteClientToolTurnParams {
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     readonly continuationMessages?: ReadonlyArray<JsonObject>;
     readonly descriptor: IAiProviderDescriptor;
+    readonly endpoint?: string;
     readonly logger?: Logging.ILogger;
     readonly messagesBefore?: ReadonlyArray<IChatMessage>;
     readonly model?: string;

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
@@ -52,6 +52,7 @@ import {
   resolveModel
 } from '../model';
 import { type IResolvedThinkingConfig } from '../thinkingOptionsResolver';
+import { resolveEffectiveBaseUrl } from '../endpoint';
 import { type IAccumulatedBlock } from './anthropic';
 import { type IAccumulatedFunctionCall } from './openaiResponses';
 import { type IAccumulatedGeminiFunctionCall } from './gemini';
@@ -335,6 +336,16 @@ export interface IExecuteClientToolTurnParams {
   readonly clientTools: ReadonlyArray<IAiClientTool>;
   /** Optional abort signal. */
   readonly signal?: AbortSignal;
+  /**
+   * Optional override of the descriptor's default base URL. Same semantics as
+   * the non-streaming completion path and `callProviderCompletionStream`: a
+   * well-formed `http`/`https` URL is substituted for `descriptor.baseUrl`
+   * when composing the per-format request, with the per-format suffix appended
+   * unchanged. Validated at the dispatcher; auth shape is unaffected. Use this
+   * to point a client-tool turn at a local / LAN OpenAI-compatible server
+   * (Ollama, LM Studio, llama.cpp).
+   */
+  readonly endpoint?: string;
   /** Optional logger for diagnostics. */
   readonly logger?: Logging.ILogger;
   /** Optional resolved thinking config (pre-resolved by the caller). */
@@ -402,7 +413,8 @@ export function executeClientToolTurn(
     signal,
     logger,
     resolvedThinking,
-    model
+    model,
+    endpoint
   } = params;
 
   // Build a lookup map of client tools by name for fast access.
@@ -424,8 +436,12 @@ export function executeClientToolTurn(
 
   const effectiveTemperature = temperature ?? 0.7;
   const resolvedModel = model ?? resolveModel(descriptor.defaultModel);
+  const baseUrlResult = resolveEffectiveBaseUrl(descriptor, endpoint);
+  if (baseUrlResult.isFailure()) {
+    return fail(baseUrlResult.message);
+  }
   const config: IStreamApiConfig = {
-    baseUrl: descriptor.baseUrl,
+    baseUrl: baseUrlResult.value,
     apiKey,
     model: resolvedModel
   };

--- a/libraries/ts-extras/src/test/unit/ai-assist/clientToolContinuationBuilder.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/clientToolContinuationBuilder.test.ts
@@ -878,6 +878,84 @@ describe('executeClientToolTurn', () => {
     });
   });
 
+  describe('endpoint override', () => {
+    test('substitutes endpoint for descriptor.baseUrl on the tool-turn request', async () => {
+      mockSseResponse(anthropicDoneSse());
+
+      const result = executeClientToolTurn({
+        descriptor: makeAnthropicDescriptor(),
+        apiKey: 'test-key',
+        prompt: testPrompt,
+        clientTools: [makeMemoryTool(async () => 'unused')] as IAiClientTool[],
+        model: 'claude-sonnet-4-6',
+        endpoint: 'http://localhost:11434/v1'
+      });
+      expect(result).toSucceed();
+      if (result.isFailure()) return;
+
+      await collect(result.value.events);
+      await result.value.nextTurn;
+
+      const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0];
+      expect(fetchUrl).toBe('http://localhost:11434/v1/messages');
+    });
+
+    test('falls back to descriptor.baseUrl when no endpoint is supplied', async () => {
+      mockSseResponse(anthropicDoneSse());
+
+      const result = executeClientToolTurn({
+        descriptor: makeAnthropicDescriptor(),
+        apiKey: 'test-key',
+        prompt: testPrompt,
+        clientTools: [makeMemoryTool(async () => 'unused')] as IAiClientTool[],
+        model: 'claude-sonnet-4-6'
+      });
+      expect(result).toSucceed();
+      if (result.isFailure()) return;
+
+      await collect(result.value.events);
+      await result.value.nextTurn;
+
+      const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0];
+      expect(fetchUrl).toBe('https://api.anthropic.com/v1/messages');
+    });
+
+    test('honors endpoint when descriptor.baseUrl is empty (local / openai-compat server)', async () => {
+      mockSseResponse(anthropicDoneSse());
+
+      const result = executeClientToolTurn({
+        descriptor: { ...makeAnthropicDescriptor(), baseUrl: '' },
+        apiKey: 'test-key',
+        prompt: testPrompt,
+        clientTools: [makeMemoryTool(async () => 'unused')] as IAiClientTool[],
+        model: 'claude-sonnet-4-6',
+        endpoint: 'http://192.168.1.42:1234/v1'
+      });
+      expect(result).toSucceed();
+      if (result.isFailure()) return;
+
+      await collect(result.value.events);
+      await result.value.nextTurn;
+
+      const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0];
+      expect(fetchUrl).toBe('http://192.168.1.42:1234/v1/messages');
+    });
+
+    test('rejects a malformed endpoint up front, before opening the stream', () => {
+      const result = executeClientToolTurn({
+        descriptor: makeAnthropicDescriptor(),
+        apiKey: 'test-key',
+        prompt: testPrompt,
+        clientTools: [makeMemoryTool(async () => 'unused')] as IAiClientTool[],
+        model: 'claude-sonnet-4-6',
+        endpoint: 'not a url'
+      });
+
+      expect(result).toFailWith(/endpoint is not a valid URL/i);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
   describe('model optional — falls back to descriptor.defaultModel when omitted', () => {
     test('uses descriptor.defaultModel when model is not supplied', async () => {
       // P2-5: model is optional; when absent, resolveModel(descriptor.defaultModel) is used.


### PR DESCRIPTION
## Summary

Fixes a downstream-reported bug (personaility project): **`AiAssist.executeClientToolTurn` did not honor the `endpoint` override.**

`IAiAssistProviderConfig.endpoint` (used to point a descriptor at a local Ollama / LAN OpenAI-compatible server) was honored by `callProviderCompletion` and `callProviderCompletionStream`, but the client-tools turn path hardcoded `baseUrl: descriptor.baseUrl` — so local-endpoint **tool** calls were impossible.

## Fix

- Add optional `endpoint?: string` to `IExecuteClientToolTurnParams`.
- Route the base-URL build through the existing `resolveEffectiveBaseUrl(descriptor, endpoint)` helper — **symmetric with `callProviderCompletionStream`** (`streamingClient.ts:107`). Validation (http(s)-only; no query/fragment/userinfo; trailing-slash normalization) and fail-fast-before-stream-open come for free from the shared helper.

~10 lines of logic; no new behavior beyond extending the already-shipped override mechanism to the tools path. This is the additive upstream extension the reporter recommended (vs. a local workaround).

## Tests

New `endpoint override` block in `clientToolContinuationBuilder.test.ts` (4 tests):
- override substitutes for `descriptor.baseUrl` → request hits the local URL
- omitted → falls back to `descriptor.baseUrl` (regression guard)
- **empty `descriptor.baseUrl` + override** → the openai-compat / local-server case (the reporter's primary scenario)
- malformed endpoint → fails fast, stream never opens

100% coverage maintained (`clientToolContinuationBuilder.ts` and `endpoint.ts` both 100%). `etc/ts-extras.api.md` regenerated (additive public-surface change).

## Validation

- `rushx build` ✅ · `rushx lint` ✅ · `rushx test` ✅ (full suite, 100% coverage)
- **`code-reviewer`**: no P1. One P2 (test symmetry vs. the sibling streaming block) — addressed by adding the empty-`baseUrl` test. Query-string-rejection symmetry dispositioned as redundant (already covered by `apiClient.endpoint.test.ts` + the malformed-endpoint test at the same integration branch). P3s cosmetic (TSDoc intentionally mirrors the sibling's wording).

Targets `release` — this surface (ai-assist client tools) is release-only active development; it does not exist on `main`.

https://claude.ai/code/session_01CbUfvtALfVNHjXeSZKRSXZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbUfvtALfVNHjXeSZKRSXZ)_