### PR TITLE
test(ts-extras-mcp): end-to-end constraint verification against a real in-memory MCP server

### DIFF
--- a/common/changes/@fgv/ts-extras-mcp/ts-extras-mcp-e2e-verify_2026-06-06-01-00.json
+++ b/common/changes/@fgv/ts-extras-mcp/ts-extras-mcp-e2e-verify_2026-06-06-01-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Test-only: add an end-to-end verification suite exercising the two load-bearing constraints (graceful + NOISY schema-bearing degradation; the probe report) against a REAL in-memory MCP server (SDK `Server` + `InMemoryTransport`), advertising one tool per `JsonSchema.fromJson`-rejected feature ($ref, oneOf, anyOf, pattern, union type[]). Hardens the `sdk.ts` projection casts that line-coverage of a mocked seam cannot reach. No production code change.",
+      "type": "none",
+      "packageName": "@fgv/ts-extras-mcp"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-mcp",
+  "email": "ErikFortune@outlook.com"
+}

--- a/libraries/ts-extras-mcp/src/test/unit/endToEnd.test.ts
+++ b/libraries/ts-extras-mcp/src/test/unit/endToEnd.test.ts
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * End-to-end verification against a REAL in-memory MCP server (the SDK's `Server` +
+ * `InMemoryTransport.createLinkedPair()`) — NOT a mocked SDK. This is the durable proof that the
+ * brief's two load-bearing constraints actually flow through the full stack: the real SDK `Client`,
+ * the real initialize handshake, the real `listTools`/`callTool` round-trips, the `sdk.ts`
+ * projection casts, and `adaptMcpTools`' `JsonSchema.fromJson` gate. It is the class of gap that
+ * 100%-line-coverage of a mocked seam cannot catch (e.g. a projection-shape mismatch in `sdk.ts`).
+ *
+ * The fixture server advertises a MIX of tools: two adaptable, and one for each JSON Schema feature
+ * `JsonSchema.fromJson` rejects ($ref, oneOf, anyOf, pattern, union `type[]`).
+ */
+
+import '@fgv/ts-utils-jest';
+import { Logging } from '@fgv/ts-utils';
+
+// Real MCP SDK server side — exercised over an in-process linked transport pair. Subpath imports
+// resolve via the tsconfig `paths` mapping (the same seam the package's sdk.ts uses).
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+import {
+  type IMcpSession,
+  adaptMcpTools,
+  callMcpTool,
+  closeMcpSession,
+  connectMcpSession,
+  listMcpTools
+} from '../../packlets/mcp';
+// Internal: the opaque-handle class. The package exposes only stdio/http transport factories, so a
+// real in-process e2e (which must inject the SDK's InMemoryTransport) wraps it here. Tests may
+// import internal modules directly (TESTING_GUIDELINES § Testing Internal Code).
+// eslint-disable-next-line @rushstack/packlets/mechanics
+import { McpTransport } from '../../packlets/mcp/transports';
+
+// ---------------------------------------------------------------------------
+// Fixture server — a real SDK Server advertising a mix of adaptable + un-adaptable tools.
+// ---------------------------------------------------------------------------
+
+/** The two adaptable tools (in the supported JSON Schema subset). */
+const ADAPTABLE_TOOLS = [
+  {
+    name: 'echo',
+    description: 'Echoes the supplied message back.',
+    inputSchema: {
+      type: 'object',
+      properties: { msg: { type: 'string', description: 'message to echo' } },
+      required: ['msg']
+    }
+  },
+  {
+    name: 'ping',
+    description: 'Health check with no required args.',
+    inputSchema: { type: 'object', properties: {} }
+  }
+];
+
+/**
+ * One tool per JSON Schema feature `JsonSchema.fromJson` rejects. Each carries the forbidden
+ * keyword NESTED inside a property (the real-world shape: the top-level inputSchema is a valid
+ * `type: 'object'`, so the MCP SDK's own result validation lets it through, and the rejection
+ * happens in `adaptMcpTools` exactly as a real server would surface it).
+ */
+const UNADAPTABLE_TOOLS = [
+  {
+    name: 'ref_tool',
+    inputSchema: { type: 'object', properties: { x: { $ref: '#/$defs/Foo' } } }
+  },
+  {
+    name: 'oneof_tool',
+    inputSchema: { type: 'object', properties: { x: { oneOf: [{ type: 'string' }, { type: 'number' }] } } }
+  },
+  {
+    name: 'anyof_tool',
+    inputSchema: { type: 'object', properties: { x: { anyOf: [{ type: 'string' }, { type: 'number' }] } } }
+  },
+  {
+    name: 'pattern_tool',
+    inputSchema: { type: 'object', properties: { code: { type: 'string', pattern: '^[A-Z]+$' } } }
+  },
+  {
+    name: 'union_tool',
+    inputSchema: { type: 'object', properties: { x: { type: ['string', 'null'] } } }
+  }
+];
+
+const ALL_TOOLS = [...ADAPTABLE_TOOLS, ...UNADAPTABLE_TOOLS];
+
+/** Builds and connects a real in-memory MCP server; returns its server-side handle for teardown. */
+async function startFixtureServer(): Promise<{ server: Server; clientTransport: InMemoryTransport }> {
+  const server = new Server(
+    { name: 'fixture-mcp-server', version: '0.0.1' },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: ALL_TOOLS }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    if (name === 'echo') {
+      return { content: [{ type: 'text', text: `echo: ${JSON.stringify(args)}` }] };
+    }
+    if (name === 'ping') {
+      return { content: [{ type: 'text', text: 'pong' }] };
+    }
+    return { content: [{ type: 'text', text: `unknown tool: ${name}` }], isError: true };
+  });
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  return { server, clientTransport };
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end suite
+// ---------------------------------------------------------------------------
+
+describe('@fgv/ts-extras-mcp end-to-end against a real in-memory MCP server', () => {
+  let server: Server;
+  let session: IMcpSession;
+
+  beforeEach(async () => {
+    const fixture = await startFixtureServer();
+    server = fixture.server;
+    // Wrap the SDK in-memory client transport in the package's opaque handle, then connect through
+    // the PUBLIC connectMcpSession (real Client + real initialize handshake).
+    const transport = new McpTransport('http', fixture.clientTransport);
+    session = (await connectMcpSession({ transport, clientName: 'e2e', clientVersion: '0.0.0' })).orThrow();
+  });
+
+  afterEach(async () => {
+    await closeMcpSession(session);
+    await server.close();
+  });
+
+  test('the initialize handshake reports the real server identity', () => {
+    expect(session.serverInfo).toEqual({ name: 'fixture-mcp-server', version: '0.0.1' });
+  });
+
+  test('listMcpTools returns the full catalog over the real transport', async () => {
+    expect(await listMcpTools(session)).toSucceedAndSatisfy((tools) => {
+      expect(tools.map((t) => t.name).sort()).toEqual(
+        ['anyof_tool', 'echo', 'oneof_tool', 'pattern_tool', 'ping', 'ref_tool', 'union_tool'].sort()
+      );
+    });
+  });
+
+  test('callMcpTool round-trips a real tool result, and maps isError to Failure', async () => {
+    expect(await callMcpTool(session, 'echo', { msg: 'hi' })).toSucceedWith({
+      content: 'echo: {"msg":"hi"}'
+    });
+    expect(await callMcpTool(session, 'nope', {})).toFailWith(/unknown tool: nope/);
+  });
+
+  // =========================================================================
+  // CONSTRAINT 1 — graceful degradation with NOISY, schema-bearing warnings.
+  // =========================================================================
+  describe('Constraint 1 — adaptMcpTools graceful + NOISY degradation', () => {
+    test('excludes EVERY un-adaptable tool from `tools`, surfaces each on `skipped`, warns with the raw schema', async () => {
+      const logger = new Logging.InMemoryLogger('all');
+      const expectedReasonFragment: Record<string, RegExp> = {
+        ref_tool: /\$ref/,
+        oneof_tool: /oneOf/,
+        anyof_tool: /anyOf/,
+        pattern_tool: /pattern/,
+        union_tool: /union 'type'/
+      };
+
+      expect(await adaptMcpTools(session, { logger })).toSucceedAndSatisfy((result) => {
+        // (a) Only the adaptable tools are offered to the model; none of the rejected ones leak.
+        expect(result.tools.map((t) => t.config.name).sort()).toEqual(['echo', 'ping']);
+        const offeredNames = new Set(result.tools.map((t) => t.config.name));
+        for (const t of UNADAPTABLE_TOOLS) {
+          expect(offeredNames.has(t.name)).toBe(false);
+        }
+
+        // (b) Each un-adaptable tool is surfaced structurally with name + JSON-pointer reason + the
+        //     RAW failing schema (verbatim, so the subset can be widened later).
+        expect(result.skipped).toHaveLength(UNADAPTABLE_TOOLS.length);
+        const skippedByName = new Map(result.skipped.map((s) => [s.name, s]));
+        for (const tool of UNADAPTABLE_TOOLS) {
+          const skipped = skippedByName.get(tool.name);
+          expect(skipped).toBeDefined();
+          // JSON-pointer path into the offending node.
+          expect(skipped?.reason).toMatch(/#\/properties\//);
+          expect(skipped?.reason).toMatch(expectedReasonFragment[tool.name]);
+          // The RAW failing schema, verbatim.
+          expect(skipped?.schema).toEqual(tool.inputSchema);
+        }
+      });
+
+      // (c) A NOISY warning per skip that INCLUDES the raw failing schema text + the reason. The
+      //     schema-in-the-warning is the whole "so we can extend fromJson later" requirement — a
+      //     warn WITHOUT the schema would fail this assertion.
+      const warned = logger.logged.join('\n');
+      for (const tool of UNADAPTABLE_TOOLS) {
+        expect(warned).toContain(`skipping tool '${tool.name}'`);
+        // The raw schema, serialized exactly as adaptMcpTools emits it, must appear in the warn.
+        expect(warned).toContain(JSON.stringify(tool.inputSchema));
+      }
+      // And the reason fragments are present in the warnings too.
+      expect(warned).toMatch(/\$ref/);
+      expect(warned).toMatch(/union 'type'/);
+    });
+
+    test('an adapted tool executes end-to-end against the real server', async () => {
+      const result = (await adaptMcpTools(session)).orThrow();
+      const echo = result.tools.find((t) => t.config.name === 'echo');
+      if (echo === undefined) {
+        throw new Error('expected the `echo` tool to be adapted');
+      }
+      // The adapted execute callback round-trips through callMcpTool → the real server.
+      expect(await echo.execute({ msg: 'roundtrip' })).toSucceedWith('echo: {"msg":"roundtrip"}');
+    });
+  });
+});

--- a/libraries/ts-extras-mcp/src/test/unit/endToEnd.test.ts
+++ b/libraries/ts-extras-mcp/src/test/unit/endToEnd.test.ts
@@ -33,7 +33,7 @@
  */
 
 import '@fgv/ts-utils-jest';
-import { Logging } from '@fgv/ts-utils';
+import { Logging, type Result } from '@fgv/ts-utils';
 
 // Real MCP SDK server side — exercised over an in-process linked transport pair. Subpath imports
 // resolve via the tsconfig `paths` mapping (the same seam the package's sdk.ts uses).
@@ -145,16 +145,26 @@ describe('@fgv/ts-extras-mcp end-to-end against a real in-memory MCP server', ()
     const fixture = await startFixtureServer();
     server = fixture.server;
     // Wrap the SDK in-memory client transport in the package's opaque handle, then connect through
-    // the PUBLIC connectMcpSession (real Client + real initialize handshake).
+    // the PUBLIC connectMcpSession (real Client + real initialize handshake). On a connect failure,
+    // tear the fixture server down before throwing so a failed handshake can't leak open handles.
     const transport = new McpTransport('http', fixture.clientTransport);
-    session = (await connectMcpSession({ transport, clientName: 'e2e', clientVersion: '0.0.0' })).orThrow();
+    const connectResult = await connectMcpSession({ transport, clientName: 'e2e', clientVersion: '0.0.0' });
+    if (connectResult.isFailure()) {
+      await server.close();
+      throw new Error(`fixture connect failed: ${connectResult.message}`);
+    }
+    session = connectResult.value;
   });
 
   afterEach(async () => {
-    // Assert teardown succeeds — a regression in close/transport would otherwise pass silently
-    // (and could leak handles).
-    expect(await closeMcpSession(session)).toSucceedWith(true);
-    await server.close();
+    // Assert teardown succeeds — a regression in close/transport would otherwise pass silently.
+    // `server.close()` runs in `finally` so the fixture is always torn down even if the assertion
+    // throws (otherwise a failed close would leak handles and make later tests flaky).
+    try {
+      expect(await closeMcpSession(session)).toSucceedWith(true);
+    } finally {
+      await server.close();
+    }
   });
 
   test('the initialize handshake reports the real server identity', () => {
@@ -228,13 +238,17 @@ describe('@fgv/ts-extras-mcp end-to-end against a real in-memory MCP server', ()
     });
 
     test('an adapted tool executes end-to-end against the real server', async () => {
-      const result = (await adaptMcpTools(session)).orThrow();
-      const echo = result.tools.find((t) => t.config.name === 'echo');
-      if (echo === undefined) {
-        throw new Error('expected the `echo` tool to be adapted');
-      }
-      // The adapted execute callback round-trips through callMcpTool → the real server.
-      expect(await echo.execute({ msg: 'roundtrip' })).toSucceedWith('echo: {"msg":"roundtrip"}');
+      // Result-matcher-driven: extract the adapted `echo` tool inside the success satisfier (where
+      // its presence is asserted), then drive its execute callback — which round-trips through
+      // callMcpTool to the real server — with another matcher.
+      let echoExecute: ((args: unknown) => Promise<Result<unknown>>) | undefined;
+      expect(await adaptMcpTools(session)).toSucceedAndSatisfy((result) => {
+        const echo = result.tools.find((t) => t.config.name === 'echo');
+        expect(echo).toBeDefined();
+        echoExecute = echo?.execute;
+      });
+      expect(echoExecute).toBeDefined();
+      expect(await echoExecute?.({ msg: 'roundtrip' })).toSucceedWith('echo: {"msg":"roundtrip"}');
     });
   });
 });

--- a/libraries/ts-extras-mcp/src/test/unit/endToEnd.test.ts
+++ b/libraries/ts-extras-mcp/src/test/unit/endToEnd.test.ts
@@ -151,7 +151,9 @@ describe('@fgv/ts-extras-mcp end-to-end against a real in-memory MCP server', ()
   });
 
   afterEach(async () => {
-    await closeMcpSession(session);
+    // Assert teardown succeeds — a regression in close/transport would otherwise pass silently
+    // (and could leak handles).
+    expect(await closeMcpSession(session)).toSucceedWith(true);
     await server.close();
   });
 

--- a/samples/testbed/src/test/unit/scenarios/mcpProbe.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/mcpProbe.test.ts
@@ -22,6 +22,7 @@
 
 import '@fgv/ts-utils-jest';
 import { Logging, type Result, fail, succeed } from '@fgv/ts-utils';
+import { JsonSchema } from '@fgv/ts-json-base';
 import type { IAdaptMcpToolsResult, IMcpSession } from '@fgv/ts-extras-mcp';
 
 import {
@@ -34,11 +35,16 @@ import {
 import { mcpProbeScenario } from '../../../scenarios/mcpProbe';
 import type { IScenarioContext } from '../../../shell';
 
-/** Builds a minimal adapted-tool entry for report-formatting tests (intentionally partial). */
+/**
+ * Builds a structurally valid adapted-tool entry for report-formatting tests — a real
+ * `JsonSchema` validator + a no-op `execute`, so the type is checked for real (no `as unknown as`
+ * that could mask an `IAiClientTool` / `IAdaptMcpToolsResult` shape regression).
+ */
 function adaptedTool(name: string): IAdaptMcpToolsResult['tools'][number] {
   return {
-    config: { type: 'client_tool', name, description: name, parametersSchema: {} }
-  } as unknown as IAdaptMcpToolsResult['tools'][number];
+    config: { type: 'client_tool', name, description: name, parametersSchema: JsonSchema.object({}) },
+    execute: async () => succeed(undefined)
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/samples/testbed/src/test/unit/scenarios/mcpProbe.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/mcpProbe.test.ts
@@ -34,6 +34,13 @@ import {
 import { mcpProbeScenario } from '../../../scenarios/mcpProbe';
 import type { IScenarioContext } from '../../../shell';
 
+/** Builds a minimal adapted-tool entry for report-formatting tests (intentionally partial). */
+function adaptedTool(name: string): IAdaptMcpToolsResult['tools'][number] {
+  return {
+    config: { type: 'client_tool', name, description: name, parametersSchema: {} }
+  } as unknown as IAdaptMcpToolsResult['tools'][number];
+}
+
 // ---------------------------------------------------------------------------
 // parseMcpProbeSpecFromEnv
 // ---------------------------------------------------------------------------
@@ -113,14 +120,9 @@ describe('parseMcpProbeSpecFromEnv', () => {
 // ---------------------------------------------------------------------------
 
 describe('formatMcpProbeReport', () => {
-  const adapted = (name: string): IAdaptMcpToolsResult['tools'][number] =>
-    ({
-      config: { type: 'client_tool', name, description: name, parametersSchema: {} }
-    } as unknown as IAdaptMcpToolsResult['tools'][number]);
-
   test('reports a mixed catalog with identity', () => {
     const result: IAdaptMcpToolsResult = {
-      tools: [adapted('alpha')],
+      tools: [adaptedTool('alpha')],
       skipped: [{ name: 'beta', reason: '#/properties/x: pattern', schema: { type: 'object' } }]
     };
     const report = formatMcpProbeReport('HTTP http://h/mcp', { name: 'srv', version: '2.0' }, result);
@@ -135,7 +137,7 @@ describe('formatMcpProbeReport', () => {
   });
 
   test('reports an all-clean catalog with no identity', () => {
-    const result: IAdaptMcpToolsResult = { tools: [adapted('only')], skipped: [] };
+    const result: IAdaptMcpToolsResult = { tools: [adaptedTool('only')], skipped: [] };
     const report = formatMcpProbeReport('stdio "x"', undefined, result);
     expect(report).toMatch(/Identity: \(not reported\)/);
     expect(report).toMatch(/Skipped[^\n]*\(0\):\n {2}\(none\)/);
@@ -168,24 +170,62 @@ describe('runMcpProbe', () => {
     return { deps, close };
   }
 
-  test('connects, adapts, formats the report (ALL skips), and closes the session', async () => {
-    // Two skips: Constraint 2 requires the report enumerate EVERY adaptation error, not just one.
+  test('connects, adapts, and prints the per-tool adapt/skip report for EVERY rejection class', async () => {
+    // Constraint 2: the probe must enumerate ALL adaptation errors, with the raw schema + reason
+    // per skip. The mixed result below mirrors the exact `IAdaptMcpToolsResult` shape that the real
+    // `adaptMcpTools` emits from a real server — proven against an in-memory MCP server in
+    // `@fgv/ts-extras-mcp`'s endToEnd.test.ts (one skip per fromJson-rejected feature). Composed,
+    // those two tests are an end-to-end proof: real server → real adapter output → real probe report.
     const adaptResult: IAdaptMcpToolsResult = {
-      tools: [],
+      tools: [adaptedTool('echo'), adaptedTool('ping')],
       skipped: [
-        { name: 'beta', reason: 'pattern', schema: { type: 'object' } },
-        { name: 'gamma', reason: 'oneOf', schema: { type: 'object', oneOf: [] } }
+        {
+          name: 'ref_tool',
+          reason: "#/properties/x: unsupported JSON Schema keyword '$ref'",
+          schema: { type: 'object', properties: { x: { $ref: '#/$defs/Foo' } } }
+        },
+        {
+          name: 'oneof_tool',
+          reason: "#/properties/x: unsupported JSON Schema keyword 'oneOf'",
+          schema: { type: 'object', properties: { x: { oneOf: [] } } }
+        },
+        {
+          name: 'anyof_tool',
+          reason: "#/properties/x: unsupported JSON Schema keyword 'anyOf'",
+          schema: { type: 'object', properties: { x: { anyOf: [] } } }
+        },
+        {
+          name: 'pattern_tool',
+          reason: "#/properties/code: unsupported JSON Schema keyword 'pattern'",
+          schema: { type: 'object', properties: { code: { type: 'string', pattern: '^[A-Z]+$' } } }
+        },
+        {
+          name: 'union_tool',
+          reason: "#/properties/x: union 'type' arrays are not supported",
+          schema: { type: 'object', properties: { x: { type: ['string', 'null'] } } }
+        }
       ]
     };
     const { deps, close } = makeDeps({ adapt: jest.fn(async () => succeed(adaptResult)) });
-    const logger = new Logging.InMemoryLogger('all');
 
-    expect(await runMcpProbe(stdioSpec, deps, logger)).toSucceedAndSatisfy((report: string) => {
-      expect(report).toMatch(/stdio "cmd --flag"/);
-      expect(report).toMatch(/Identity: srv@1.0/);
-      expect(report).toMatch(/✗ beta/);
-      expect(report).toMatch(/✗ gamma/);
-    });
+    expect(await runMcpProbe(stdioSpec, deps, new Logging.InMemoryLogger())).toSucceedAndSatisfy(
+      (report: string) => {
+        expect(report).toMatch(/stdio "cmd --flag"/);
+        expect(report).toMatch(/Identity: srv@1.0/);
+        expect(report).toMatch(/Tools discovered: 7 — 2 adapted, 5 skipped/);
+        // Adapted tools listed.
+        expect(report).toMatch(/✓ echo/);
+        expect(report).toMatch(/✓ ping/);
+        // EVERY skipped tool surfaced with its name, JSON-pointer reason, AND raw schema verbatim.
+        for (const skipped of adaptResult.skipped) {
+          expect(report).toContain(`✗ ${skipped.name}`);
+          expect(report).toContain(`reason: ${skipped.reason}`);
+          expect(report).toContain(`schema: ${JSON.stringify(skipped.schema)}`);
+        }
+        // The "so we can extend fromJson later" framing is present.
+        expect(report).toMatch(/additively widened in @fgv\/ts-json-base/);
+      }
+    );
     expect(close).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
Follow-up to #469. Verifies — **end-to-end, not via coverage %** — that the brief's two load-bearing constraints actually flow, and adds the durable proof. Targets the `ts-extras-mcp` integration branch.

## TL;DR — both constraints PASS

No production bug found; the constraints hold. The gap this closes is **fidelity**: slice 1's adapter tests mocked the SDK seam, so they couldn't catch a projection-shape mismatch in `sdk.ts` (the one file with `as unknown as` casts) and only exercised two rejection classes. This PR adds a **real in-memory MCP server** test (real SDK `Server` + `InMemoryTransport.createLinkedPair()`, real `Client`, real initialize handshake, real `listTools`/`callTool` wire round-trips) covering **all five** `JsonSchema.fromJson`-rejected classes.

## Constraint 1 — graceful + NOISY degradation: **PASS**

`libraries/ts-extras-mcp/src/test/unit/endToEnd.test.ts` (new). A real fixture server advertises 2 adaptable tools + one tool per rejected feature: `$ref`, `oneOf`, `anyOf`, `pattern`, union `type[]` (each nested in a property — the real-world shape that passes the SDK's own result validation and is rejected only by `adaptMcpTools`). Driven through the **public** API (`connectMcpSession`/`listMcpTools`/`adaptMcpTools`/`callMcpTool`/`closeMcpSession`); the in-memory client transport is wrapped in the package-internal `McpTransport` (test-only import — the package intentionally exposes only stdio/http factories). Proven explicitly:

- every un-adaptable tool is **excluded** from `tools` (asserted by name — none leak to the model);
- each is on `skipped[]` with **name + JSON-pointer reason + the raw failing schema** (`schema` deep-equals the server's verbatim `inputSchema`);
- the injected `ILogger` warn **contains the raw schema text + the reason** for each skip — a warn that omitted the schema would fail the assertion (`expect(warned).toContain(JSON.stringify(tool.inputSchema))`). This is the load-bearing "so we can extend `fromJson` later" requirement.
- bonus: an adapted tool's `execute` round-trips through `callMcpTool` to the real server; `callMcpTool` maps a real `isError` result to `Result.fail`.

## Constraint 2 — the probe: **PASS**

`samples/testbed/src/test/unit/scenarios/mcpProbe.test.ts` strengthened: drives the real probe code (`runMcpProbe` → `formatMcpProbeReport`) over a mixed result covering **all five** rejection classes, asserting the report lists the adapted tools and surfaces **every** skipped tool with its raw schema + reason + the "additively widened in @fgv/ts-json-base" framing. Composed with the package e2e (which proves the real adapter emits exactly that `IAdaptMcpToolsResult` shape from a real server), this is an end-to-end proof: real server → real adapter output → real probe report. (Node's `exports` map blocks deep-importing the package internals into the testbed, so an in-process probe-against-server with an injected in-memory transport isn't reachable from an external consumer — the composition is the faithful in-process proof.)

## Validation

- `@fgv/ts-extras-mcp`: build + lint + test **100% coverage** (46 tests; the e2e exercises the real SDK round-trip — nothing mocked at the SDK/transport layer).
- `@fgv/testbed`: build + lint + test **100% coverage** (159 tests).
- `rushx fixlint` run before commit. `code-reviewer` run on the diff: approved, no P1; P2/P3 (orThrow-in-body → `toSucceedAndSatisfy`, dropped `echo!` non-null assertion, unified duplicated test helper) resolved.

## Note / observation (no change made)

The package has no public seam to inject a custom transport (only stdio/http factories), so external consumers cannot drive it in-process against an in-memory MCP server for their own tests — they'd use a real stdio/http server. Not a defect for production use; noting it as a possible future testability affordance. Test-only change; no production code touched.

https://claude.ai/code/session_01QWUgR4DGA3xQzg7qX8dyFE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWUgR4DGA3xQzg7qX8dyFE)_