### PR TITLE
ts-extras-ollama O-2: model management primitives

### DIFF
--- a/common/changes/@fgv/ts-extras-ollama/claude-ollama-o2-model-management.json
+++ b/common/changes/@fgv/ts-extras-ollama/claude-ollama-o2-model-management.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add model-management primitives to @fgv/ts-extras-ollama (O-2): listModels, listRunning, showModel, deleteModel, with fgv-owned normalized model types.",
+      "type": "none",
+      "packageName": "@fgv/ts-extras-ollama"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-ollama",
+  "email": "ErikFortune@outlook.com"
+}

--- a/libraries/ts-extras-ollama/etc/ts-extras-ollama.api.md
+++ b/libraries/ts-extras-ollama/etc/ts-extras-ollama.api.md
@@ -4,11 +4,15 @@
 
 ```ts
 
+import { JsonValue } from '@fgv/ts-json-base';
 import { Ollama } from 'ollama';
 import { Result } from '@fgv/ts-utils';
 
 // @public
 export function createOllamaClient(params?: ICreateOllamaClientParams): Result<IOllamaClient>;
+
+// @public
+export function deleteModel(client: IOllamaClient, model: string): Promise<Result<IOllamaDeleteResult>>;
 
 // @public
 export interface ICreateOllamaClientParams {
@@ -19,5 +23,62 @@ export interface ICreateOllamaClientParams {
 
 // @public
 export type IOllamaClient = Ollama;
+
+// @public
+export interface IOllamaDeleteResult {
+    readonly deleted: true;
+    readonly model: string;
+}
+
+// @public
+export interface IOllamaModel extends IOllamaModelBase {
+    readonly modifiedAt: Date;
+}
+
+// @public
+export interface IOllamaModelBase {
+    readonly details: IOllamaModelDetail;
+    readonly digest: string;
+    readonly model: string;
+    readonly name: string;
+    readonly size: number;
+}
+
+// @public
+export interface IOllamaModelDetail {
+    readonly families?: ReadonlyArray<string>;
+    readonly family?: string;
+    readonly format?: string;
+    readonly parameterSize?: string;
+    readonly parentModel?: string;
+    readonly quantizationLevel?: string;
+}
+
+// @public
+export interface IOllamaModelInfo {
+    readonly capabilities?: ReadonlyArray<string>;
+    readonly details: IOllamaModelDetail;
+    readonly modelfile?: string;
+    readonly modelInfo?: Readonly<Record<string, JsonValue>>;
+    readonly parameters?: string;
+    readonly template?: string;
+}
+
+// @public
+export interface IOllamaRunningModel extends IOllamaModelBase {
+    readonly expiresAt: Date;
+    readonly sizeVram: number;
+}
+
+// @public
+export function listModels(client: IOllamaClient): Promise<Result<ReadonlyArray<IOllamaModel>>>;
+
+// @public
+export function listRunning(client: IOllamaClient): Promise<Result<ReadonlyArray<IOllamaRunningModel>>>;
+
+// @public
+export function showModel(client: IOllamaClient, model: string, options?: {
+    readonly verbose?: boolean;
+}): Promise<Result<IOllamaModelInfo>>;
 
 ```

--- a/libraries/ts-extras-ollama/src/index.ts
+++ b/libraries/ts-extras-ollama/src/index.ts
@@ -29,8 +29,9 @@
  * @packageDocumentation
  */
 
-import { Ollama } from 'ollama';
-import { captureResult, type Result } from '@fgv/ts-utils';
+import { Ollama, type ListResponse, type ModelResponse, type ModelDetails, type ShowResponse } from 'ollama';
+import { captureAsyncResult, captureResult, type Result } from '@fgv/ts-utils';
+import { type JsonValue } from '@fgv/ts-json-base';
 
 /**
  * Construction parameters for an Ollama client. All optional; defaults match the `ollama` JS
@@ -70,4 +71,259 @@ export function createOllamaClient(params?: ICreateOllamaClientParams): Result<I
   // The upstream `Ollama` constructor reads each config field with `?? <default>`, so omitted or
   // `undefined` fields fall back to the library defaults — no per-field guarding needed.
   return captureResult(() => new Ollama(params ?? {}));
+}
+
+// ─── Shared normalized model types (§3.2) ───────────────────────────────────────
+
+/**
+ * GGUF / model detail block, common to `/api/tags`, `/api/ps`, and `/api/show`. All fields
+ * optional — Ollama omits any it cannot determine.
+ * @public
+ */
+export interface IOllamaModelDetail {
+  /** Storage format, e.g. `'gguf'`. */
+  readonly format?: string;
+  /** Primary architecture family, e.g. `'llama'`. */
+  readonly family?: string;
+  /** All architecture families this model belongs to. */
+  readonly families?: ReadonlyArray<string>;
+  /** Human-readable parameter count, e.g. `'8.0B'`. */
+  readonly parameterSize?: string;
+  /** Quantization level, e.g. `'Q4_0'`. */
+  readonly quantizationLevel?: string;
+  /** Parent model for fine-tunes / derived models. */
+  readonly parentModel?: string;
+}
+
+/**
+ * Fields common to a locally-stored model and a running model.
+ * @public
+ */
+export interface IOllamaModelBase {
+  /** Tagged name, e.g. `'llama3.1:8b'`. */
+  readonly name: string;
+  /** Underlying model id (often equal to `name`). */
+  readonly model: string;
+  /** On-disk size in bytes. */
+  readonly size: number;
+  /** SHA-256 manifest digest. */
+  readonly digest: string;
+  /** GGUF / architecture detail. */
+  readonly details: IOllamaModelDetail;
+}
+
+/**
+ * A model present in the local store (`/api/tags`).
+ * @public
+ */
+export interface IOllamaModel extends IOllamaModelBase {
+  /** Last-modified timestamp, parsed from the RFC3339 wire value. */
+  readonly modifiedAt: Date;
+}
+
+/**
+ * A model currently loaded into memory (`/api/ps`). Note `/api/ps` does NOT return
+ * `modified_at`, so this does not extend {@link IOllamaModel}.
+ * @public
+ */
+export interface IOllamaRunningModel extends IOllamaModelBase {
+  /** When the model will be unloaded, parsed from the RFC3339 wire value. */
+  readonly expiresAt: Date;
+  /** Bytes resident in VRAM (0 when fully on CPU). */
+  readonly sizeVram: number;
+}
+
+/**
+ * Full model detail, capabilities, parameters, and template (`POST /api/show`).
+ * @public
+ */
+export interface IOllamaModelInfo {
+  /** The Modelfile source, when returned. */
+  readonly modelfile?: string;
+  /** Default parameters string. */
+  readonly parameters?: string;
+  /** The prompt template. */
+  readonly template?: string;
+  /** GGUF / architecture detail. */
+  readonly details: IOllamaModelDetail;
+  /** Low-level model metadata key-value map (`model_info`). */
+  readonly modelInfo?: Readonly<Record<string, JsonValue>>;
+  /** Declared capabilities, e.g. `['completion', 'tools', 'vision', 'thinking']`. */
+  readonly capabilities?: ReadonlyArray<string>;
+}
+
+/**
+ * Result of a delete. Returns a meaningful value rather than `Result<void>` (per repo standards —
+ * `Result<void>` is an anti-pattern).
+ * @public
+ */
+export interface IOllamaDeleteResult {
+  /** The model that was deleted. */
+  readonly model: string;
+  /** Always `true` — a failed delete surfaces as `Result.fail`, never `deleted: false`. */
+  readonly deleted: true;
+}
+
+// ─── Wire → fgv normalization (§6.3, Appendix) ──────────────────────────────────
+
+/**
+ * Maps the upstream snake_case `ModelDetails` to the normalized camelCase {@link IOllamaModelDetail}.
+ * Upstream types every field as a required `string`, but Ollama omits fields it cannot determine,
+ * so individual values may be `undefined` at runtime — the normalized type reflects that by making
+ * every field optional.
+ */
+function normalizeModelDetail(d: ModelDetails): IOllamaModelDetail {
+  return {
+    format: d.format,
+    family: d.family,
+    families: d.families,
+    parameterSize: d.parameter_size,
+    quantizationLevel: d.quantization_level,
+    parentModel: d.parent_model
+  };
+}
+
+/**
+ * Maps a `/api/tags` `ModelResponse` to {@link IOllamaModel}. `modified_at` is normalized to a
+ * `Date` via the `Date` constructor, which accepts both the RFC3339 string the wire actually
+ * delivers and the `Date` the upstream type (inaccurately) claims.
+ */
+function normalizeModel(m: ModelResponse): IOllamaModel {
+  return {
+    name: m.name,
+    model: m.model,
+    size: m.size,
+    digest: m.digest,
+    details: normalizeModelDetail(m.details),
+    modifiedAt: new Date(m.modified_at)
+  };
+}
+
+/**
+ * Maps a `/api/ps` `ModelResponse` to {@link IOllamaRunningModel}. `/api/ps` returns `expires_at`
+ * and `size_vram` in place of `modified_at`.
+ */
+function normalizeRunningModel(m: ModelResponse): IOllamaRunningModel {
+  return {
+    name: m.name,
+    model: m.model,
+    size: m.size,
+    digest: m.digest,
+    details: normalizeModelDetail(m.details),
+    expiresAt: new Date(m.expires_at),
+    sizeVram: m.size_vram
+  };
+}
+
+/**
+ * Normalizes the `model_info` metadata bag. The upstream type annotates it as `Map<string, any>`,
+ * but the lib returns `response.json()` verbatim, so the wire delivers a plain JSON object (or
+ * omits the field). The single `as unknown as` bridge reconciles the inaccurate upstream annotation
+ * with the actual JSON shape — there is no untyped input to validate here.
+ */
+function normalizeModelInfo(
+  raw: ShowResponse['model_info']
+): Readonly<Record<string, JsonValue>> | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  return raw as unknown as Readonly<Record<string, JsonValue>>;
+}
+
+/**
+ * Maps a `/api/show` `ShowResponse` to {@link IOllamaModelInfo}. The remaining `ShowResponse`
+ * fields (`license`, `system`, `messages`, `modified_at`, `projector_info`) are intentionally not
+ * carried through — they are out of scope for the v0.1 surface.
+ */
+function normalizeShowResponse(r: ShowResponse): IOllamaModelInfo {
+  return {
+    modelfile: r.modelfile,
+    parameters: r.parameters,
+    template: r.template,
+    details: normalizeModelDetail(r.details),
+    modelInfo: normalizeModelInfo(r.model_info),
+    capabilities: r.capabilities
+  };
+}
+
+// ─── Model management primitives (§3.3) ─────────────────────────────────────────
+
+/**
+ * Lists models in the local store (`GET /api/tags`). Each entry is normalized to
+ * {@link IOllamaModel} (camelCase, `modifiedAt` as a `Date`).
+ *
+ * @param client - A client from {@link createOllamaClient}.
+ * @returns `Promise<Result<ReadonlyArray<IOllamaModel>>>`; upstream / transport errors are captured
+ *   as `Failure`.
+ * @public
+ */
+export async function listModels(client: IOllamaClient): Promise<Result<ReadonlyArray<IOllamaModel>>> {
+  return captureAsyncResult(async () => {
+    const response: ListResponse = await client.list();
+    return response.models.map(normalizeModel);
+  });
+}
+
+/**
+ * Lists models currently loaded into memory (`GET /api/ps`). Each entry is normalized to
+ * {@link IOllamaRunningModel} (camelCase, `expiresAt` as a `Date`, `sizeVram` in bytes).
+ *
+ * @param client - A client from {@link createOllamaClient}.
+ * @returns `Promise<Result<ReadonlyArray<IOllamaRunningModel>>>`; upstream / transport errors are
+ *   captured as `Failure`.
+ * @public
+ */
+export async function listRunning(
+  client: IOllamaClient
+): Promise<Result<ReadonlyArray<IOllamaRunningModel>>> {
+  return captureAsyncResult(async () => {
+    const response: ListResponse = await client.ps();
+    return response.models.map(normalizeRunningModel);
+  });
+}
+
+/**
+ * Full model detail, capabilities, parameters, and template (`POST /api/show`), normalized to
+ * {@link IOllamaModelInfo}.
+ *
+ * @param client - A client from {@link createOllamaClient}.
+ * @param model - The model name to inspect, e.g. `'llama3.1:8b'`.
+ * @param options - Optional flags. `verbose: true` requests the full low-level `model_info` block.
+ * @returns `Promise<Result<IOllamaModelInfo>>`; upstream / transport errors (e.g. unknown model)
+ *   are captured as `Failure`.
+ * @public
+ */
+export async function showModel(
+  client: IOllamaClient,
+  model: string,
+  options?: { readonly verbose?: boolean }
+): Promise<Result<IOllamaModelInfo>> {
+  return captureAsyncResult(async () => {
+    // `verbose` is a valid `/api/show` body field that the lib forwards verbatim, but the upstream
+    // `ShowRequest` type omits it; building it as a non-literal object passes it through without a
+    // cast (and omits the key entirely when no flag was supplied).
+    const request = { model, ...(options?.verbose !== undefined && { verbose: options.verbose }) };
+    const response: ShowResponse = await client.show(request);
+    return normalizeShowResponse(response);
+  });
+}
+
+/**
+ * Deletes a model from the local store (`DELETE /api/delete`). Returns a meaningful
+ * {@link IOllamaDeleteResult} rather than `Result<void>`.
+ *
+ * @param client - A client from {@link createOllamaClient}.
+ * @param model - The model name to delete.
+ * @returns `Promise<Result<IOllamaDeleteResult>>`; a missing model or transport error surfaces as
+ *   `Failure`.
+ * @public
+ */
+export async function deleteModel(
+  client: IOllamaClient,
+  model: string
+): Promise<Result<IOllamaDeleteResult>> {
+  return captureAsyncResult(async () => {
+    await client.delete({ model });
+    return { model, deleted: true };
+  });
 }

--- a/libraries/ts-extras-ollama/src/test/unit/fixtures/wireFixtures.ts
+++ b/libraries/ts-extras-ollama/src/test/unit/fixtures/wireFixtures.ts
@@ -1,0 +1,95 @@
+import { type ListResponse, type ShowResponse } from 'ollama';
+
+/**
+ * Canned wire-shape fixtures for the layer-1 structural-client-mock tests.
+ *
+ * These mirror the actual JSON the Ollama daemon returns — snake_case keys and **string**
+ * timestamps. The upstream `ollama` types annotate `modified_at` / `expires_at` as `Date`, but the
+ * library returns `response.json()` verbatim so the wire delivers RFC3339 strings; each fixture is
+ * cast once (`as unknown as <Response>`) to reconcile the inaccurate upstream annotation with the
+ * real shape, so the normalization layer is exercised against the data it actually sees.
+ */
+
+/** `GET /api/tags` — one fully-detailed model plus one with sparse `details` (missing fields). */
+export const tagsResponse: ListResponse = {
+  models: [
+    {
+      name: 'llama3.1:8b',
+      model: 'llama3.1:8b',
+      modified_at: '2024-08-01T12:34:56.789Z',
+      size: 4661226402,
+      digest: 'sha256:abc123',
+      details: {
+        parent_model: '',
+        format: 'gguf',
+        family: 'llama',
+        families: ['llama'],
+        parameter_size: '8.0B',
+        quantization_level: 'Q4_0'
+      }
+    },
+    {
+      name: 'custom:latest',
+      model: 'custom:latest',
+      modified_at: '2024-09-15T08:00:00.000Z',
+      size: 1234567,
+      digest: 'sha256:def456',
+      // Sparse details — Ollama omits fields it cannot determine; exercises the optional-field path.
+      details: {
+        format: 'gguf',
+        family: 'llama'
+      }
+    }
+  ]
+} as unknown as ListResponse;
+
+/** `GET /api/ps` — a running model with `expires_at` + `size_vram` (no `modified_at`). */
+export const psResponse: ListResponse = {
+  models: [
+    {
+      name: 'llama3.1:8b',
+      model: 'llama3.1:8b',
+      size: 4661226402,
+      digest: 'sha256:abc123',
+      details: {
+        parent_model: '',
+        format: 'gguf',
+        family: 'llama',
+        families: ['llama'],
+        parameter_size: '8.0B',
+        quantization_level: 'Q4_0'
+      },
+      expires_at: '2024-08-01T13:00:00.000Z',
+      size_vram: 4661226402
+    }
+  ]
+} as unknown as ListResponse;
+
+/** `POST /api/show` — full response including the low-level `model_info` metadata bag. */
+export const showResponse: ShowResponse = {
+  modelfile: 'FROM llama3.1:8b',
+  parameters: 'stop "<|eot_id|>"',
+  template: '{{ .Prompt }}',
+  details: {
+    parent_model: '',
+    format: 'gguf',
+    family: 'llama',
+    families: ['llama'],
+    parameter_size: '8.0B',
+    quantization_level: 'Q4_0'
+  },
+  model_info: {
+    'general.architecture': 'llama',
+    'llama.context_length': 131072,
+    'llama.embedding_length': 4096
+  },
+  capabilities: ['completion', 'tools']
+} as unknown as ShowResponse;
+
+/** `POST /api/show` — a minimal response with `model_info` and `capabilities` omitted. */
+export const showResponseMinimal: ShowResponse = {
+  details: {
+    format: 'gguf',
+    family: 'llama'
+  }
+} as unknown as ShowResponse;

--- a/libraries/ts-extras-ollama/src/test/unit/modelManagement.test.ts
+++ b/libraries/ts-extras-ollama/src/test/unit/modelManagement.test.ts
@@ -1,0 +1,128 @@
+import '@fgv/ts-utils-jest';
+import { type IOllamaClient, listModels, listRunning, showModel, deleteModel } from '../../index';
+import { psResponse, showResponse, showResponseMinimal, tagsResponse } from './fixtures/wireFixtures';
+
+/**
+ * Builds a structural client mock exposing only the methods under test, typed back to
+ * {@link IOllamaClient}. This is the layer-1 seam from the design (§7) — it verifies the wire→fgv
+ * mapping and Result success/failure paths without HTTP or the `ollama` lib internals.
+ */
+function mockClient(methods: Partial<Record<'list' | 'ps' | 'show' | 'delete', unknown>>): IOllamaClient {
+  return methods as unknown as IOllamaClient;
+}
+
+describe('listModels', () => {
+  test('normalizes /api/tags entries to camelCase with a parsed modifiedAt Date', async () => {
+    const client = mockClient({ list: jest.fn().mockResolvedValue(tagsResponse) });
+    expect(await listModels(client)).toSucceedAndSatisfy((models) => {
+      expect(models).toHaveLength(2);
+      const [full, sparse] = models;
+      expect(full.name).toBe('llama3.1:8b');
+      expect(full.size).toBe(4661226402);
+      expect(full.digest).toBe('sha256:abc123');
+      expect(full.modifiedAt).toBeInstanceOf(Date);
+      expect(full.modifiedAt.toISOString()).toBe('2024-08-01T12:34:56.789Z');
+      expect(full.details).toEqual({
+        parentModel: '',
+        format: 'gguf',
+        family: 'llama',
+        families: ['llama'],
+        parameterSize: '8.0B',
+        quantizationLevel: 'Q4_0'
+      });
+      // An empty `parent_model` is preserved as '' (present-and-empty, distinct from undefined).
+      expect(full.details.parentModel).toBe('');
+      // Sparse details: omitted wire fields normalize to undefined.
+      expect(sparse.details.format).toBe('gguf');
+      expect(sparse.details.parameterSize).toBeUndefined();
+      expect(sparse.details.quantizationLevel).toBeUndefined();
+      expect(sparse.details.parentModel).toBeUndefined();
+      expect(sparse.details.families).toBeUndefined();
+    });
+  });
+
+  test('fails when the client throws', async () => {
+    const client = mockClient({ list: jest.fn().mockRejectedValue(new Error('connection refused')) });
+    expect(await listModels(client)).toFailWith(/connection refused/);
+  });
+});
+
+describe('listRunning', () => {
+  test('normalizes /api/ps entries with expiresAt Date and sizeVram', async () => {
+    const client = mockClient({ ps: jest.fn().mockResolvedValue(psResponse) });
+    expect(await listRunning(client)).toSucceedAndSatisfy((running) => {
+      expect(running).toHaveLength(1);
+      const [model] = running;
+      expect(model.name).toBe('llama3.1:8b');
+      expect(model.sizeVram).toBe(4661226402);
+      expect(model.expiresAt).toBeInstanceOf(Date);
+      expect(model.expiresAt.toISOString()).toBe('2024-08-01T13:00:00.000Z');
+      expect(model.details.family).toBe('llama');
+    });
+  });
+
+  test('fails when the client throws', async () => {
+    const client = mockClient({ ps: jest.fn().mockRejectedValue(new Error('daemon down')) });
+    expect(await listRunning(client)).toFailWith(/daemon down/);
+  });
+});
+
+describe('showModel', () => {
+  test('normalizes /api/show including the model_info metadata bag', async () => {
+    const show = jest.fn().mockResolvedValue(showResponse);
+    const client = mockClient({ show });
+    expect(await showModel(client, 'llama3.1:8b')).toSucceedAndSatisfy((info) => {
+      expect(info.modelfile).toBe('FROM llama3.1:8b');
+      expect(info.parameters).toBe('stop "<|eot_id|>"');
+      expect(info.template).toBe('{{ .Prompt }}');
+      expect(info.capabilities).toEqual(['completion', 'tools']);
+      expect(info.modelInfo).toEqual({
+        'general.architecture': 'llama',
+        'llama.context_length': 131072,
+        'llama.embedding_length': 4096
+      });
+      expect(info.details.parameterSize).toBe('8.0B');
+    });
+    // No verbose flag was requested, so only `model` is on the request body.
+    expect(show).toHaveBeenCalledWith({ model: 'llama3.1:8b' });
+  });
+
+  test('maps an absent model_info to undefined', async () => {
+    const client = mockClient({ show: jest.fn().mockResolvedValue(showResponseMinimal) });
+    expect(await showModel(client, 'custom:latest')).toSucceedAndSatisfy((info) => {
+      expect(info.modelInfo).toBeUndefined();
+      expect(info.capabilities).toBeUndefined();
+      expect(info.modelfile).toBeUndefined();
+      expect(info.details.family).toBe('llama');
+    });
+  });
+
+  test('forwards verbose: true on the /api/show request body', async () => {
+    const show = jest.fn().mockResolvedValue(showResponse);
+    const client = mockClient({ show });
+    expect(await showModel(client, 'llama3.1:8b', { verbose: true })).toSucceed();
+    expect(show).toHaveBeenCalledWith({ model: 'llama3.1:8b', verbose: true });
+  });
+
+  test('fails when the client throws (unknown model)', async () => {
+    const client = mockClient({ show: jest.fn().mockRejectedValue(new Error('model not found')) });
+    expect(await showModel(client, 'nope:latest')).toFailWith(/model not found/);
+  });
+});
+
+describe('deleteModel', () => {
+  test('succeeds with a meaningful result and forwards the model name', async () => {
+    const del = jest.fn().mockResolvedValue({ status: 'success' });
+    const client = mockClient({ delete: del });
+    expect(await deleteModel(client, 'llama3.1:8b')).toSucceedWith({
+      model: 'llama3.1:8b',
+      deleted: true
+    });
+    expect(del).toHaveBeenCalledWith({ model: 'llama3.1:8b' });
+  });
+
+  test('fails when the client throws (missing model)', async () => {
+    const client = mockClient({ delete: jest.fn().mockRejectedValue(new Error('model not found')) });
+    expect(await deleteModel(client, 'nope:latest')).toFailWith(/model not found/);
+  });
+});


### PR DESCRIPTION
## O-2 — Model management (read/delete half) (`ollama-native` stream, design §10)

Builds on O-1 (#472). Adds the native model-management surface that the `/v1` compat layer cannot express.

### What shipped
Four primitives + the fgv-owned normalized model types (design §3.2/§3.3, Appendix mapping):
- `listModels(client)` → `Result<ReadonlyArray<IOllamaModel>>` (`/api/tags`)
- `listRunning(client)` → `Result<ReadonlyArray<IOllamaRunningModel>>` (`/api/ps`)
- `showModel(client, model, { verbose? })` → `Result<IOllamaModelInfo>` (`/api/show`)
- `deleteModel(client, model)` → `Result<IOllamaDeleteResult>` (`/api/delete`)
- Types: `IOllamaModelDetail`, `IOllamaModelBase`, `IOllamaModel`, `IOllamaRunningModel`, `IOllamaModelInfo`, `IOllamaDeleteResult`.

### Normalization notes (design §6.3)
- Each primitive wraps the upstream call in `captureAsyncResult` and maps snake_case wire → camelCase readonly types.
- **Dates:** the `ollama` lib returns `response.json()` verbatim with **no** date parsing, so `modified_at`/`expires_at` arrive as ISO **strings** despite the upstream `Date` typing. `new Date(...)` normalizes both — exactly the upstream-churn insulation §6.3 calls for.
- **`model_info`:** typed `Map<string,any>` upstream but a plain JSON object at runtime; a single documented `as unknown as Record<string, JsonValue>` bridge reconciles the inaccurate annotation (no untyped input to validate). This import makes `@fgv/ts-json-base` a *used* hard dependency already at O-2.
- **`verbose`:** a valid `/api/show` body field omitted from the upstream `ShowRequest` type; forwarded via a non-literal request object (no cast).
- `deleteModel` returns a meaningful `IOllamaDeleteResult`, not `Result<void>`.

### Gates
- `rushx build` ✅ · `rushx lint` clean ✅ · `rushx test` 14/14 at **100%** coverage ✅ · `rushx fixlint` applied ✅

### Review loop (layer 1)
`code-reviewer` on the diff: **no P1 findings.** P2/P3 items applied — single-declaration `showModel` request (removed post-construction mutation), a dropped-`ShowResponse`-fields note in `normalizeShowResponse`, and explicit `parentModel === ''` / `families === undefined` test assertions for the present-empty-vs-omitted paths.

### Test strategy (design §7, layer 1)
Structural client-mock tests against checked-in wire fixtures (`src/test/unit/fixtures/wireFixtures.ts`) with realistic string-date / snake_case shapes. No live daemon. The layer-2 fetch-level integration tests land with the streaming/format work in O-3/O-4.

Targets `ollama-native`, not `release`/`main`.

https://claude.ai/code/session_01P93MSi9D9DFT5Z4R33nNUH

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93MSi9D9DFT5Z4R33nNUH)_