### PR TITLE
ts-extras-ollama O-3: pullModel with streamed progress

### DIFF
--- a/common/changes/@fgv/ts-extras-ollama/claude-ollama-o3-pull.json
+++ b/common/changes/@fgv/ts-extras-ollama/claude-ollama-o3-pull.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add pullModel to @fgv/ts-extras-ollama (O-3): streamed /api/pull progress via a terminal Result + onProgress callback, with AbortSignal support.",
+      "type": "none",
+      "packageName": "@fgv/ts-extras-ollama"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-ollama",
+  "email": "ErikFortune@outlook.com"
+}

--- a/libraries/ts-extras-ollama/etc/ts-extras-ollama.api.md
+++ b/libraries/ts-extras-ollama/etc/ts-extras-ollama.api.md
@@ -65,9 +65,32 @@ export interface IOllamaModelInfo {
 }
 
 // @public
+export interface IOllamaPullProgress {
+    readonly completed?: number;
+    readonly digest?: string;
+    readonly status: string;
+    readonly total?: number;
+}
+
+// @public
+export interface IOllamaPullResult {
+    readonly chunkCount: number;
+    readonly finalStatus: string;
+    readonly model: string;
+}
+
+// @public
 export interface IOllamaRunningModel extends IOllamaModelBase {
     readonly expiresAt: Date;
     readonly sizeVram: number;
+}
+
+// @public
+export interface IPullModelParams {
+    readonly insecure?: boolean;
+    readonly model: string;
+    readonly onProgress?: (progress: IOllamaPullProgress) => void;
+    readonly signal?: AbortSignal;
 }
 
 // @public
@@ -75,6 +98,9 @@ export function listModels(client: IOllamaClient): Promise<Result<ReadonlyArray<
 
 // @public
 export function listRunning(client: IOllamaClient): Promise<Result<ReadonlyArray<IOllamaRunningModel>>>;
+
+// @public
+export function pullModel(client: IOllamaClient, params: IPullModelParams): Promise<Result<IOllamaPullResult>>;
 
 // @public
 export function showModel(client: IOllamaClient, model: string, options?: {

--- a/libraries/ts-extras-ollama/src/index.ts
+++ b/libraries/ts-extras-ollama/src/index.ts
@@ -29,7 +29,14 @@
  * @packageDocumentation
  */
 
-import { Ollama, type ListResponse, type ModelResponse, type ModelDetails, type ShowResponse } from 'ollama';
+import {
+  Ollama,
+  type ListResponse,
+  type ModelResponse,
+  type ModelDetails,
+  type ProgressResponse,
+  type ShowResponse
+} from 'ollama';
 import { captureAsyncResult, captureResult, type Result } from '@fgv/ts-utils';
 import { type JsonValue } from '@fgv/ts-json-base';
 
@@ -325,5 +332,129 @@ export async function deleteModel(
   return captureAsyncResult(async () => {
     await client.delete({ model });
     return { model, deleted: true };
+  });
+}
+
+// ─── Pull with streamed progress (§3.4, §5) ─────────────────────────────────────
+
+/**
+ * A single progress chunk from a streamed pull (`/api/pull`). Ollama emits a JSON-lines stream;
+ * each line is one of these. Fields map 1:1 from the upstream `ProgressResponse`; the layer fields
+ * (`digest`/`total`/`completed`) are `undefined` on the manifest / verify / write phases.
+ * @public
+ */
+export interface IOllamaPullProgress {
+  /**
+   * Phase string, e.g. `'pulling manifest'`, `'pulling <digest>'`, `'verifying sha256 digest'`,
+   * `'writing manifest'`, `'success'`.
+   */
+  readonly status: string;
+  /** Layer digest being transferred (present during `'pulling <digest>'` phases). */
+  readonly digest?: string;
+  /** Total bytes for the current layer, when known. */
+  readonly total?: number;
+  /** Bytes transferred so far for the current layer, when known. */
+  readonly completed?: number;
+}
+
+/**
+ * Terminal result of a completed pull. Returns a meaningful value (not `Result<void>`): the final
+ * status plus a count of progress chunks observed.
+ * @public
+ */
+export interface IOllamaPullResult {
+  /** The model that was pulled. */
+  readonly model: string;
+  /** The `status` of the final chunk, normally `'success'`. */
+  readonly finalStatus: string;
+  /** Number of progress chunks observed (useful for tests and diagnostics). */
+  readonly chunkCount: number;
+}
+
+/**
+ * Parameters for {@link pullModel}.
+ * @public
+ */
+export interface IPullModelParams {
+  /** Model to pull, e.g. `'llama3.1:8b'`. */
+  readonly model: string;
+  /** Allow pulling from insecure (non-TLS) registries. */
+  readonly insecure?: boolean;
+  /**
+   * Progress callback, invoked once per JSON-lines chunk as it arrives. The `Result` returned by
+   * {@link pullModel} resolves only after the stream terminates; progress is surfaced here in the
+   * interim. A throw from this callback fails the whole pull (it runs inside the captured loop).
+   */
+  readonly onProgress?: (progress: IOllamaPullProgress) => void;
+  /**
+   * Abort signal. Cancels the in-flight pull; the upstream stream throws an `AbortError`, which
+   * surfaces as `Result.fail`. An already-aborted signal cancels immediately.
+   */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Maps an upstream `ProgressResponse` chunk to {@link IOllamaPullProgress}. The upstream type marks
+ * every field required, but the layer fields are omitted (and thus `undefined` at runtime) on the
+ * non-transfer phases — a direct structural copy preserves that, matching the optional fields.
+ */
+function normalizePullProgress(c: ProgressResponse): IOllamaPullProgress {
+  return {
+    status: c.status,
+    digest: c.digest,
+    total: c.total,
+    completed: c.completed
+  };
+}
+
+/**
+ * Pulls a model with streamed progress (`POST /api/pull`). Drives the upstream JSON-lines stream
+ * internally, invoking `params.onProgress` once per chunk, and resolves the `Result` once the
+ * stream terminates. Any upstream error — connection drop, registry 404, abort, or a throwing
+ * `onProgress` — becomes a single `Failure`; success returns a meaningful {@link IOllamaPullResult}
+ * rather than `Result<void>`.
+ *
+ * @param client - A client from {@link createOllamaClient}.
+ * @param params - {@link IPullModelParams} — the model, optional `insecure` flag, optional
+ *   `onProgress` callback, and optional `AbortSignal`.
+ * @returns `Promise<Result<IOllamaPullResult>>`.
+ * @public
+ */
+export async function pullModel(
+  client: IOllamaClient,
+  params: IPullModelParams
+): Promise<Result<IOllamaPullResult>> {
+  return captureAsyncResult(async () => {
+    const request = {
+      model: params.model,
+      stream: true as const,
+      ...(params.insecure !== undefined && { insecure: params.insecure })
+    };
+    const iterator = await client.pull(request);
+
+    // Wire the abort signal to the upstream iterator's abort path. An already-aborted signal
+    // cancels immediately; otherwise abort on first fire (and clean the listener up in `finally`).
+    const abortListener = (): void => iterator.abort();
+    if (params.signal !== undefined) {
+      if (params.signal.aborted) {
+        iterator.abort();
+      } else {
+        params.signal.addEventListener('abort', abortListener, { once: true });
+      }
+    }
+
+    let chunkCount = 0;
+    let finalStatus = '';
+    try {
+      for await (const chunk of iterator) {
+        params.onProgress?.(normalizePullProgress(chunk));
+        chunkCount += 1;
+        finalStatus = chunk.status;
+      }
+    } finally {
+      params.signal?.removeEventListener('abort', abortListener);
+    }
+
+    return { model: params.model, finalStatus, chunkCount };
   });
 }

--- a/libraries/ts-extras-ollama/src/test/unit/pullModel.test.ts
+++ b/libraries/ts-extras-ollama/src/test/unit/pullModel.test.ts
@@ -1,0 +1,220 @@
+import '@fgv/ts-utils-jest';
+import { type IOllamaClient, type IOllamaPullProgress, createOllamaClient, pullModel } from '../../index';
+
+/** The actual `/api/pull` wire chunk shape — layer fields absent on non-transfer phases. */
+interface IPullChunk {
+  status: string;
+  digest?: string;
+  total?: number;
+  completed?: number;
+}
+
+/**
+ * Builds a structural mock of the upstream `AbortableAsyncIterator` returned by `client.pull`.
+ * `abort()` flips an internal flag that the generator checks before each chunk — so an abort
+ * triggered mid-stream surfaces as a throw on the next iteration, matching the real lib.
+ */
+function makePullIterator(
+  chunks: ReadonlyArray<IPullChunk>,
+  opts?: { readonly throwMidStream?: boolean }
+): { abort: jest.Mock } & AsyncIterable<IPullChunk> {
+  let aborted = false;
+  return {
+    abort: jest.fn(() => {
+      aborted = true;
+    }),
+    async *[Symbol.asyncIterator](): AsyncGenerator<IPullChunk> {
+      for (const chunk of chunks) {
+        if (aborted) {
+          throw new Error('The operation was aborted');
+        }
+        yield chunk;
+        if (opts?.throwMidStream) {
+          throw new Error('stream broke mid-pull');
+        }
+      }
+    }
+  };
+}
+
+function mockPullClient(pull: unknown): IOllamaClient {
+  return { pull } as unknown as IOllamaClient;
+}
+
+const happyChunks: ReadonlyArray<IPullChunk> = [
+  { status: 'pulling manifest' },
+  { status: 'pulling sha256:abc', digest: 'sha256:abc', total: 1000, completed: 1000 },
+  { status: 'success' }
+];
+
+describe('pullModel (layer 1 — structural client mock)', () => {
+  test('drives the stream, maps each chunk, and resolves with finalStatus + chunkCount', async () => {
+    const pull = jest.fn().mockResolvedValue(makePullIterator(happyChunks));
+    const client = mockPullClient(pull);
+    const seen: IOllamaPullProgress[] = [];
+
+    expect(await pullModel(client, { model: 'llama3.1:8b', onProgress: (p) => seen.push(p) })).toSucceedWith({
+      model: 'llama3.1:8b',
+      finalStatus: 'success',
+      chunkCount: 3
+    });
+    expect(pull).toHaveBeenCalledWith({ model: 'llama3.1:8b', stream: true });
+    expect(seen).toHaveLength(3);
+    // Manifest phase: no layer fields.
+    expect(seen[0]).toEqual({
+      status: 'pulling manifest',
+      digest: undefined,
+      total: undefined,
+      completed: undefined
+    });
+    // Transfer phase: layer fields present and mapped 1:1.
+    expect(seen[1]).toEqual({
+      status: 'pulling sha256:abc',
+      digest: 'sha256:abc',
+      total: 1000,
+      completed: 1000
+    });
+    expect(seen[2].status).toBe('success');
+  });
+
+  test('forwards insecure and works without an onProgress callback', async () => {
+    const pull = jest.fn().mockResolvedValue(makePullIterator(happyChunks));
+    const client = mockPullClient(pull);
+
+    expect(await pullModel(client, { model: 'llama3.1:8b', insecure: true })).toSucceedWith({
+      model: 'llama3.1:8b',
+      finalStatus: 'success',
+      chunkCount: 3
+    });
+    expect(pull).toHaveBeenCalledWith({ model: 'llama3.1:8b', stream: true, insecure: true });
+  });
+
+  test('fails when the stream errors mid-pull', async () => {
+    const pull = jest.fn().mockResolvedValue(makePullIterator(happyChunks, { throwMidStream: true }));
+    const client = mockPullClient(pull);
+
+    expect(await pullModel(client, { model: 'llama3.1:8b' })).toFailWith(/stream broke mid-pull/);
+  });
+
+  test('fails when onProgress throws', async () => {
+    const pull = jest.fn().mockResolvedValue(makePullIterator(happyChunks));
+    const client = mockPullClient(pull);
+
+    expect(
+      await pullModel(client, {
+        model: 'llama3.1:8b',
+        onProgress: () => {
+          throw new Error('consumer blew up');
+        }
+      })
+    ).toFailWith(/consumer blew up/);
+  });
+
+  test('an already-aborted signal cancels the pull on the first iteration', async () => {
+    // The signal is aborted before the loop begins, so the iterator's abort fires up front; the
+    // throw surfaces on the first iteration attempt (the mock checks the flag before the first yield).
+    const iterator = makePullIterator(happyChunks);
+    const pull = jest.fn().mockResolvedValue(iterator);
+    const client = mockPullClient(pull);
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(await pullModel(client, { model: 'llama3.1:8b', signal: controller.signal })).toFailWith(/abort/i);
+    expect(iterator.abort).toHaveBeenCalledTimes(1);
+  });
+
+  test('a mid-stream abort cancels the pull, removes the listener, and surfaces as failure', async () => {
+    const iterator = makePullIterator(happyChunks);
+    const pull = jest.fn().mockResolvedValue(iterator);
+    const client = mockPullClient(pull);
+    const controller = new AbortController();
+    const removeSpy = jest.spyOn(controller.signal, 'removeEventListener');
+    const seen: IOllamaPullProgress[] = [];
+
+    const result = await pullModel(client, {
+      model: 'llama3.1:8b',
+      signal: controller.signal,
+      onProgress: (p) => {
+        seen.push(p);
+        if (seen.length === 1) {
+          controller.abort();
+        }
+      }
+    });
+    expect(result).toFailWith(/abort/i);
+    expect(iterator.abort).toHaveBeenCalled();
+    expect(seen).toHaveLength(1);
+    // The `finally` cleanup runs on the failure path too — no listener leak after an abort.
+    expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+  });
+
+  test('removes the abort listener after a normal completion', async () => {
+    const pull = jest.fn().mockResolvedValue(makePullIterator(happyChunks));
+    const client = mockPullClient(pull);
+    const controller = new AbortController();
+    const removeSpy = jest.spyOn(controller.signal, 'removeEventListener');
+
+    expect(await pullModel(client, { model: 'llama3.1:8b', signal: controller.signal })).toSucceed();
+    expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+  });
+});
+
+/**
+ * Layer 2 — a real client built with a mock `fetch` whose body is a `ReadableStream` of
+ * newline-delimited JSON. This exercises the `ollama` lib's actual JSON-lines stream parsing
+ * flowing through `pullModel`'s loop — the framing that layer 1 stubs over.
+ */
+function ndjsonResponse(lines: ReadonlyArray<string>): Response {
+  const bytes = new TextEncoder().encode(lines.join('\n') + '\n');
+  // Split the payload mid-stream (likely mid-line) into two reads to exercise buffer reassembly.
+  const mid = Math.floor(bytes.length / 2);
+  const parts = [bytes.slice(0, mid), bytes.slice(mid)];
+  let i = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller: ReadableStreamDefaultController<Uint8Array>): void {
+      if (i < parts.length) {
+        controller.enqueue(parts[i++]);
+      } else {
+        controller.close();
+      }
+    }
+  });
+  return new Response(stream, { status: 200 });
+}
+
+describe('pullModel (layer 2 — fetch-level JSON-lines integration)', () => {
+  test('parses a real newline-delimited /api/pull stream through the ollama lib', async () => {
+    const lines = [
+      JSON.stringify({ status: 'pulling manifest' }),
+      JSON.stringify({ status: 'pulling sha256:abc', digest: 'sha256:abc', total: 1000, completed: 1000 }),
+      JSON.stringify({ status: 'verifying sha256 digest' }),
+      JSON.stringify({ status: 'writing manifest' }),
+      JSON.stringify({ status: 'success' })
+    ];
+    const fetchMock = jest.fn().mockResolvedValue(ndjsonResponse(lines));
+    const client = createOllamaClient({ fetch: fetchMock as unknown as typeof fetch }).orThrow();
+    const seen: IOllamaPullProgress[] = [];
+
+    expect(
+      await pullModel(client, { model: 'llama3.1:8b', onProgress: (p) => seen.push(p) })
+    ).toSucceedAndSatisfy((r) => {
+      expect(r.finalStatus).toBe('success');
+      expect(r.chunkCount).toBe(5);
+    });
+    expect(seen.map((s) => s.status)).toEqual([
+      'pulling manifest',
+      'pulling sha256:abc',
+      'verifying sha256 digest',
+      'writing manifest',
+      'success'
+    ]);
+    expect(seen[1]).toEqual({
+      status: 'pulling sha256:abc',
+      digest: 'sha256:abc',
+      total: 1000,
+      completed: 1000
+    });
+    expect(seen[0].digest).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toEqual(expect.stringContaining('/api/pull'));
+  });
+});


### PR DESCRIPTION
## O-3 — Pull with streamed progress (`ollama-native` stream, design §10)

Builds on O-2 (#473). The trickiest phase: streamed model download with progress.

### What shipped
- `pullModel(client, params)` → `Result<IOllamaPullResult>` (`/api/pull`), plus `IOllamaPullProgress`, `IOllamaPullResult`, `IPullModelParams`, and `normalizePullProgress`.
- **Shape (design §5):** terminal `Result` + per-chunk `onProgress` callback — **not** a returned async-iterable. The function drives the upstream JSON-lines stream internally; the whole consume-loop sits inside `captureAsyncResult`, so a mid-stream error, registry failure, abort, or a throwing `onProgress` all collapse to a single `Failure`. Success returns a meaningful `{ model, finalStatus, chunkCount }`, not `Result<void>`.
- **AbortSignal:** wired to the upstream `AbortableAsyncIterator.abort()`. Already-aborted signals cancel up front; mid-stream aborts cancel the in-flight fetch; the listener is `{ once: true }` and removed in `finally` on every exit path (no leak).

### Test strategy (design §7 — both layers)
- **Layer 1** (structural client mock): happy path + per-chunk mapping, `insecure` forwarding, no-`onProgress`, mid-stream error, throwing `onProgress`, already-aborted signal, mid-stream-abort-with-listener-cleanup, normal-completion cleanup.
- **Layer 2** (fetch-level): a real client over a mock `fetch` whose body is a `ReadableStream` of newline-delimited JSON **split mid-payload** — exercises the `ollama` lib's actual stream-framing/buffer-reassembly flowing through `pullModel`'s loop (what layer 1 stubs over). No live daemon.

### Gates
- `rushx build` ✅ · `rushx lint` clean ✅ · `rushx test` 22/22 at **100%** coverage ✅ · `rushx fixlint` applied ✅

### Review loop (layer 1)
`code-reviewer` on the diff: **no P1 findings.** P2s applied — added an explicit `removeEventListener` assertion on the abort (failure) exit path to close the listener-leak coverage gap, and corrected the already-aborted-signal test's timing wording. P3 TSDoc wording (`undefined` vs "absent" layer fields) tightened.

Targets `ollama-native`, not `release`/`main`.

https://claude.ai/code/session_01P93MSi9D9DFT5Z4R33nNUH

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93MSi9D9DFT5Z4R33nNUH)_