### PR TITLE
docs(ollama-native): record O-1…O-4 implementation in state.md

### DIFF
--- a/.ai/tasks/active/ollama-native/state.md
+++ b/.ai/tasks/active/ollama-native/state.md
@@ -8,10 +8,24 @@
 - (A speculative `followup.md` the implementing agent added — written without this brief — was stripped before merge; the authoritative artifacts are `brief.md` + `design.md` here.)
 
 ## Task B — `@fgv/ts-extras-ollama` native-API boundary
-**📐 Designed + amended; implementation NOT started.** See `design.md` (and its 2026-06-06 orchestrator-review amendment note).
-Implementation (phases O-1…O-4) is gated on:
-- Task A landed ✅
-- MCP slice (`ts-extras-mcp`) lands
-- **For the O-4 `embed` sub-task only:** the `ai-assist-embeddings` design concludes whether a cross-provider embedding primitive makes native Ollama `embed` redundant (resolves OQ-1).
+**🛠️ IMPLEMENTED (phases O-1…O-4) into the `ollama-native` integration branch.** Native `embed` remains HELD.
 
-Amendments locked: `chatStructured` gets `AbortSignal` (OQ-3); draft-07 `format` sanitizer budgeted into O-4 (Gemini precedent); `embed` HELD pending the embedding verdict.
+| Phase | Scope | PR (→ `ollama-native`) | Status |
+|---|---|---|---|
+| O-1 | Scaffold + `createOllamaClient` factory (mirrors the ts-extras-transformers Node scaffold; `ollama` dev+peer, `@fgv/ts-json-base` hard dep). | #472 | ✅ merged |
+| O-2 | Model management: `listModels`/`listRunning`/`showModel`/`deleteModel` + normalized fgv-owned camelCase types. | #473 | ✅ merged |
+| O-3 | `pullModel` — streamed `/api/pull` progress (terminal `Result` + `onProgress` callback, NOT a returned iterable) + `AbortSignal`; layer-2 JSON-lines fetch test. | #474 | ✅ merged |
+| O-4 | `chatStructured<T>` (grammar-constrained `/api/chat` `format`, one-declaration `JsonSchema` no-drift + draft-07 sanitizer + `AbortSignal`) + README/LIBRARY_CAPABILITIES docs. | #475 | ✅ merged |
+
+Per-phase gates met: `rushx build` + `rushx lint` (clean) + `rushx test` (100% coverage), `rushx fixlint`, and a `code-reviewer` pass before coverage-chasing. Each phase carries a `rush change` file (`type: none`, new package).
+
+**Decision needing ratification (O-4):** `chatStructured` is implemented over the **streaming** chat path (`stream:true` + `AbortableAsyncIterator.abort()`), not the design §4 sketch's `stream:false`. Rationale: the `ollama` lib threads an `AbortSignal` only on the streaming path (non-streaming chat is uncancellable), so streaming is the only way to honor the locked OQ-3 `AbortSignal` amendment — and matches "the mechanism already exists for `pullModel`". The document is still assembled and validated whole after the stream completes. The `code-reviewer` agent vetted and approved the deviation.
+
+**Still HELD / out of scope:**
+- Native `embed` (OQ-1) — gated on the `ai-assist-embeddings` design verdict; build it here only if that design concludes native Ollama `embed` adds something `/v1`-through-ai-assist can't.
+- Browser sibling `@fgv/ts-web-extras-ollama` (O-5, future) — `docs/FUTURE.md` candidate.
+
+**Integration note:** the O-4 `LIBRARY_CAPABILITIES.md` cross-link to Task A's ai-assist Ollama `/v1` recipe is conceptual on this branch — Task A (PR #468 → `release`) isn't on the `ollama-native` base, so the literal link reconciles when this stream promotes to `release`.
+
+### Original gating (now resolved for O-1…O-4 except the embed sub-task)
+Amendments locked: `chatStructured` gets `AbortSignal` (OQ-3) ✅; draft-07 `format` sanitizer budgeted into O-4 ✅; `embed` HELD pending the embedding verdict.


### PR DESCRIPTION
Updates the `ollama-native` task `state.md` to record that Task B phases O-1…O-4 are implemented and merged into the `ollama-native` integration branch (PRs #472–#475), with the per-phase table, the O-4 `stream:true` ratification note, and what remains HELD (native `embed`, the browser sibling).

Docs-only.

https://claude.ai/code/session_01P93MSi9D9DFT5Z4R33nNUH

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93MSi9D9DFT5Z4R33nNUH)_