### PR TITLE
feat(ai-assist): embedding modality foundation (Phase 1)

### DIFF
--- a/common/changes/@fgv/ts-extras/ai-assist-embeddings-phase1_2026-06-07-00-00.json
+++ b/common/changes/@fgv/ts-extras/ai-assist-embeddings-phase1_2026-06-07-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "ai-assist: add the embedding modality foundation (Phase 1) — new AiEmbeddingApiFormat, AiEmbeddingTaskType, IAiEmbeddingParams/IAiEmbeddingResult/IAiEmbeddingUsage, IAiEmbeddingModelCapability types; additive embedding? field on IAiProviderDescriptor; 'embedding' added to ModelSpecKey/allModelSpecKeys and AiModelCapability (+ new allModelCapabilities single-source-of-truth constant); registry embedding capabilities for openai/google-gemini/ollama/openai-compat/mistral; supportsEmbedding/resolveEmbeddingCapability helpers; DEFAULT_MODEL_CAPABILITY_CONFIG embedding rules. Additive only — no wire calls yet (dispatcher + adapters land in Phase 2/3).",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -27,6 +27,7 @@ declare namespace AiAssist {
     export {
         AiPrompt,
         AiModelCapability,
+        allModelCapabilities,
         AiProviderId,
         AiServerToolType,
         AiServerToolConfig,
@@ -43,6 +44,12 @@ declare namespace AiAssist {
         IChatRequest,
         AiApiFormat,
         AiImageApiFormat,
+        AiEmbeddingApiFormat,
+        AiEmbeddingTaskType,
+        IAiEmbeddingModelCapability,
+        IAiEmbeddingParams,
+        IAiEmbeddingUsage,
+        IAiEmbeddingResult,
         IAiImageModelCapability,
         IAiProviderDescriptor,
         IAiAssistProviderConfig,
@@ -121,6 +128,8 @@ declare namespace AiAssist {
         getProviderDescriptor,
         resolveImageCapability,
         supportsImageGeneration,
+        resolveEmbeddingCapability,
+        supportsEmbedding,
         DEFAULT_MODEL_CAPABILITY_CONFIG,
         callProviderCompletion,
         callProxiedCompletion,
@@ -179,6 +188,15 @@ const aiAssistSettings: Converter<IAiAssistSettings>;
 // @public
 const aiClientToolConfig: Converter<IAiClientToolConfig>;
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "AiApiFormat"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "AiImageApiFormat"
+//
+// @public
+type AiEmbeddingApiFormat = 'openai-embeddings' | 'gemini-embeddings';
+
+// @public
+type AiEmbeddingTaskType = 'retrieval-query' | 'retrieval-document' | 'semantic-similarity' | 'classification' | 'clustering' | 'code-retrieval-query' | 'question-answering' | 'fact-verification' | (string & {});
+
 // @public
 type AiImageApiFormat = 'openai-images' | 'gemini-imagen' | 'xai-images' | 'xai-images-edits' | 'gemini-image-out';
 
@@ -191,7 +209,7 @@ type AiImageSize = DallE2Size | DallE3Size | GptImageSize;
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-type AiModelCapability = 'chat' | 'tools' | 'vision' | 'image-generation' | 'thinking';
+type AiModelCapability = 'chat' | 'tools' | 'vision' | 'image-generation' | 'thinking' | 'embedding';
 
 // @public
 class AiPrompt {
@@ -256,6 +274,11 @@ const allKeyStoreSecretTypes: ReadonlyArray<KeyStoreSecretType>;
 
 // @public
 const allKeyStoreSymmetricSecretTypes: ReadonlyArray<KeyStoreSymmetricSecretType>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "AiModelCapability"
+//
+// @public
+const allModelCapabilities: ReadonlyArray<AiModelCapability>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "ModelSpecKey"
 //
@@ -832,6 +855,40 @@ interface IAiCompletionResponse {
     readonly truncated: boolean;
 }
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiProviderDescriptor"
+//
+// @public
+interface IAiEmbeddingModelCapability {
+    readonly defaultDimensions?: number;
+    readonly format: AiEmbeddingApiFormat;
+    readonly maxBatchSize?: number;
+    readonly modelPrefix: string;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly supportsDimensions?: boolean;
+    readonly supportsTaskType?: boolean;
+}
+
+// @public
+interface IAiEmbeddingParams {
+    readonly dimensions?: number;
+    readonly input: string | ReadonlyArray<string>;
+    readonly taskType?: AiEmbeddingTaskType;
+}
+
+// @public
+interface IAiEmbeddingResult {
+    readonly dimensions: number;
+    readonly model: string;
+    readonly usage?: IAiEmbeddingUsage;
+    readonly vectors: ReadonlyArray<ReadonlyArray<number>>;
+}
+
+// @public
+interface IAiEmbeddingUsage {
+    readonly promptTokens?: number;
+    readonly totalTokens?: number;
+}
+
 // @public
 interface IAiGeneratedImage extends IAiImageData {
     readonly revisedPrompt?: string;
@@ -923,6 +980,9 @@ interface IAiProviderDescriptor {
     readonly buttonLabel: string;
     readonly corsRestricted: boolean;
     readonly defaultModel: ModelSpec;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "ModelSpecKey"
+    readonly embedding?: ReadonlyArray<IAiEmbeddingModelCapability>;
     readonly id: AiProviderId;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "ModelSpecKey"
@@ -2043,7 +2103,7 @@ type ModelSpec = string | IModelSpecMap;
 const modelSpec: Converter<ModelSpec>;
 
 // @public
-type ModelSpecKey = 'base' | 'tools' | 'image' | 'thinking';
+type ModelSpecKey = 'base' | 'tools' | 'image' | 'thinking' | 'embedding';
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "ModelSpecKey"
 //
@@ -2235,6 +2295,11 @@ function resolveEffectiveTools(descriptor: IAiProviderDescriptor, settingsTools?
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiProviderDescriptor"
 //
 // @public
+function resolveEmbeddingCapability(descriptor: IAiProviderDescriptor, modelId: string): IAiEmbeddingModelCapability | undefined;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiProviderDescriptor"
+//
+// @public
 function resolveImageCapability(descriptor: IAiProviderDescriptor, modelId: string): IAiImageModelCapability | undefined;
 
 // @public
@@ -2253,6 +2318,11 @@ type SecretProvider = (secretName: string) => Promise<Result<Uint8Array>>;
 //
 // @public
 const SMART_JSON_PROMPT_HINT: string;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiProviderDescriptor"
+//
+// @public
+function supportsEmbedding(descriptor: IAiProviderDescriptor): boolean;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiProviderDescriptor"
 //

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -34,6 +34,7 @@ import { fail, type Logging, mapResults, Result, succeed, type Validator, Valida
 import {
   AiPrompt,
   type AiModelCapability,
+  allModelCapabilities,
   type AiServerToolConfig,
   type IAiCompletionResponse,
   type IAiGeneratedImage,
@@ -1022,15 +1023,7 @@ interface IProxiedListModelsBody {
 const proxiedListModelsEntry: Validator<IProxiedListModelsEntry> = Validators.object<IProxiedListModelsEntry>(
   {
     id: Validators.string,
-    capabilities: Validators.arrayOf(
-      Validators.enumeratedValue<AiModelCapability>([
-        'chat',
-        'tools',
-        'vision',
-        'image-generation',
-        'thinking'
-      ])
-    ),
+    capabilities: Validators.arrayOf(Validators.enumeratedValue<AiModelCapability>(allModelCapabilities)),
     displayName: Validators.string.optional()
   }
 );

--- a/libraries/ts-extras/src/packlets/ai-assist/index.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/index.ts
@@ -6,6 +6,7 @@
 export {
   AiPrompt,
   type AiModelCapability,
+  allModelCapabilities,
   type AiProviderId,
   type AiServerToolType,
   type AiServerToolConfig,
@@ -22,6 +23,12 @@ export {
   type IChatRequest,
   type AiApiFormat,
   type AiImageApiFormat,
+  type AiEmbeddingApiFormat,
+  type AiEmbeddingTaskType,
+  type IAiEmbeddingModelCapability,
+  type IAiEmbeddingParams,
+  type IAiEmbeddingUsage,
+  type IAiEmbeddingResult,
   type IAiImageModelCapability,
   type IAiProviderDescriptor,
   type IAiAssistProviderConfig,
@@ -106,6 +113,8 @@ export {
   getProviderDescriptor,
   resolveImageCapability,
   supportsImageGeneration,
+  resolveEmbeddingCapability,
+  supportsEmbedding,
   DEFAULT_MODEL_CAPABILITY_CONFIG
 } from './registry';
 

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -436,13 +436,19 @@ export interface IAiClientToolTurnResult {
  * Known context keys for model specification maps.
  * @public
  */
-export type ModelSpecKey = 'base' | 'tools' | 'image' | 'thinking';
+export type ModelSpecKey = 'base' | 'tools' | 'image' | 'thinking' | 'embedding';
 
 /**
  * All valid {@link ModelSpecKey} values.
  * @public
  */
-export const allModelSpecKeys: ReadonlyArray<ModelSpecKey> = ['base', 'tools', 'image', 'thinking'];
+export const allModelSpecKeys: ReadonlyArray<ModelSpecKey> = [
+  'base',
+  'tools',
+  'image',
+  'thinking',
+  'embedding'
+];
 
 /**
  * Default context key used as fallback when resolving a {@link ModelSpec}.
@@ -567,6 +573,25 @@ export type AiImageApiFormat =
   | 'xai-images'
   | 'xai-images-edits'
   | 'gemini-image-out';
+
+/**
+ * API format categories for embedding provider routing.
+ *
+ * @remarks
+ * - `'openai-embeddings'` — OpenAI `/v1/embeddings` shape. Serves OpenAI,
+ *   Ollama (via `/v1`), openai-compat self-hosted servers (vLLM, LM Studio,
+ *   llama.cpp's openai-server), and Mistral (`mistral-embed`) — all of which
+ *   speak the same request/response shape.
+ * - `'gemini-embeddings'` — Google Gemini `:batchEmbedContents` endpoint. A
+ *   genuinely divergent shape (different route, auth header, request body, and
+ *   the `taskType` retrieval-asymmetry knob that has no OpenAI analog).
+ *
+ * Named with the `ApiFormat` suffix for symmetry with {@link AiApiFormat} and
+ * {@link AiImageApiFormat}.
+ *
+ * @public
+ */
+export type AiEmbeddingApiFormat = 'openai-embeddings' | 'gemini-embeddings';
 
 // ============================================================================
 // Completion Response
@@ -750,6 +775,23 @@ export interface IAiProviderDescriptor {
    * `defaultModel.image`, e.g. `{ base: 'gpt-4o', image: 'dall-e-3' }`.
    */
   readonly imageGeneration?: ReadonlyArray<IAiImageModelCapability>;
+  /**
+   * Embedding capabilities, scoped to model id prefixes. Empty or undefined
+   * means the provider does not support embeddings.
+   *
+   * @remarks
+   * The dispatcher matches the resolved embedding model id against each rule's
+   * `modelPrefix` and selects the longest match (see
+   * {@link AiAssist.resolveEmbeddingCapability}). An empty `modelPrefix` is the
+   * catch-all and matches every model id.
+   *
+   * Embedding-model selection uses the `embedding` {@link ModelSpecKey}.
+   * Providers that declare `embedding` should declare a model in
+   * `defaultModel.embedding`, e.g. `{ base: 'gpt-4o', embedding: 'text-embedding-3-small' }`.
+   * Self-hosted providers (`ollama`, `openai-compat`) leave it unset — the
+   * caller supplies the embedding model via `modelOverride`.
+   */
+  readonly embedding?: ReadonlyArray<IAiEmbeddingModelCapability>;
 }
 
 /**
@@ -791,6 +833,132 @@ export interface IAiImageModelCapability {
   readonly outputParamStyle?: 'response-format' | 'output-format' | 'none';
   /** Default MIME type for response images. */
   readonly defaultOutputMimeType?: string;
+}
+
+// ============================================================================
+// Embedding — capability + request/result types
+// ============================================================================
+
+/**
+ * Embedding capability for a model family within a provider. Used as an entry
+ * in {@link IAiProviderDescriptor.embedding}.
+ *
+ * @public
+ */
+export interface IAiEmbeddingModelCapability {
+  /**
+   * Prefix matched against the resolved embedding model id. The empty string is
+   * the catch-all and matches every model. When multiple rules' prefixes match
+   * a model id, the longest prefix wins; ties are broken by first-encountered.
+   */
+  readonly modelPrefix: string;
+  /** API format used to dispatch requests for matching models. */
+  readonly format: AiEmbeddingApiFormat;
+  /**
+   * Whether matching models honor a requested output `dimensions`
+   * (OpenAI `text-embedding-3-*`, Gemini `gemini-embedding-001` via MRL
+   * truncation). When false/undefined, a caller-supplied `dimensions` is a
+   * no-op (logged, not failed — see {@link AiAssist.IAiEmbeddingParams}).
+   */
+  readonly supportsDimensions?: boolean;
+  /**
+   * Whether matching models honor a `taskType` hint (Gemini only today). When
+   * false/undefined, a caller-supplied `taskType` is a no-op (logged, not
+   * failed).
+   */
+  readonly supportsTaskType?: boolean;
+  /** Native fixed output dimension, when the model has one (metadata only). */
+  readonly defaultDimensions?: number;
+  /**
+   * Maximum number of inputs accepted per request. When present, the dispatcher
+   * rejects batches larger than this up front (no auto-chunking in v1).
+   */
+  readonly maxBatchSize?: number;
+}
+
+/**
+ * A single embedding task-type hint (Gemini-style). Cross-provider; providers
+ * that don't support task typing ignore it (logged, not failed). Open string
+ * union so new Gemini task types don't force a churn, with the known set
+ * enumerated for ergonomics.
+ *
+ * @remarks
+ * Values are the kebab-case cross-provider form; the Gemini adapter maps them to
+ * `SCREAMING_SNAKE_CASE` on the wire (e.g. `'retrieval-document'` →
+ * `RETRIEVAL_DOCUMENT`).
+ *
+ * @public
+ */
+export type AiEmbeddingTaskType =
+  | 'retrieval-query'
+  | 'retrieval-document'
+  | 'semantic-similarity'
+  | 'classification'
+  | 'clustering'
+  | 'code-retrieval-query'
+  | 'question-answering'
+  | 'fact-verification'
+  | (string & {});
+
+/**
+ * Parameters for an embedding request. Batch is the norm: `input` accepts a
+ * single string or an array; the result always exposes a vector array aligned
+ * by index to the input.
+ *
+ * @public
+ */
+export interface IAiEmbeddingParams {
+  /** One or more input strings. A bare string is treated as a single-element batch. */
+  readonly input: string | ReadonlyArray<string>;
+  /**
+   * Requested output dimensionality. Honored only by models whose capability
+   * declares `supportsDimensions` (OpenAI `text-embedding-3-*`, Gemini
+   * `gemini-embedding-001` via MRL truncation). Ignored — with a `logger.info`
+   * note — by models that don't.
+   */
+  readonly dimensions?: number;
+  /**
+   * Task-type hint. Mapped to Gemini `taskType`; a no-op (with a `logger.info`
+   * note) on OpenAI/Ollama/compat/Mistral. Preserves Gemini's
+   * query-vs-document retrieval asymmetry.
+   */
+  readonly taskType?: AiEmbeddingTaskType;
+}
+
+/**
+ * Token-usage accounting for an embedding call, when the provider reports it.
+ * @public
+ */
+export interface IAiEmbeddingUsage {
+  /** Tokens consumed by the input(s). */
+  readonly promptTokens?: number;
+  /** Total tokens billed. */
+  readonly totalTokens?: number;
+}
+
+/**
+ * Result of an embedding call. `vectors[i]` is the embedding for `input[i]`,
+ * in request order.
+ *
+ * @remarks
+ * Vectors are plain `number[]` (not `Float32Array`) for JSON-wire fidelity and
+ * validator-friendliness — consumers who want a typed array call
+ * `Float32Array.from(vector)` at the vector-store / WebGPU boundary. The
+ * library does not L2-normalize; Gemini's MRL truncation (when
+ * `dimensions < native`) returns un-normalized vectors that the consumer should
+ * normalize if their similarity metric requires it.
+ *
+ * @public
+ */
+export interface IAiEmbeddingResult {
+  /** One vector per input, aligned by index to the request order. */
+  readonly vectors: ReadonlyArray<ReadonlyArray<number>>;
+  /** The resolved provider-native model id that produced the vectors. */
+  readonly model: string;
+  /** Dimensionality of each returned vector (`vectors[0].length`; `0` for empty input). */
+  readonly dimensions: number;
+  /** Token usage, when the provider reports it (OpenAI-format; absent for Gemini). */
+  readonly usage?: IAiEmbeddingUsage;
 }
 
 // ============================================================================
@@ -1109,7 +1277,21 @@ export interface IAiGeneratedImage extends IAiImageData {
  *
  * @public
  */
-export type AiModelCapability = 'chat' | 'tools' | 'vision' | 'image-generation' | 'thinking';
+export type AiModelCapability = 'chat' | 'tools' | 'vision' | 'image-generation' | 'thinking' | 'embedding';
+
+/**
+ * All valid {@link AiModelCapability} values — the single source of truth for
+ * the capability vocabulary (used by validators and capability filters).
+ * @public
+ */
+export const allModelCapabilities: ReadonlyArray<AiModelCapability> = [
+  'chat',
+  'tools',
+  'vision',
+  'image-generation',
+  'thinking',
+  'embedding'
+];
 
 /**
  * Information about a single model returned by a provider's list endpoint,

--- a/libraries/ts-extras/src/packlets/ai-assist/registry.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/registry.ts
@@ -195,8 +195,7 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
       },
       {
         modelPrefix: '',
-        format: 'openai-embeddings',
-        maxBatchSize: 2048
+        format: 'openai-embeddings'
       }
     ],
     imageGeneration: [

--- a/libraries/ts-extras/src/packlets/ai-assist/registry.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/registry.ts
@@ -27,6 +27,7 @@ import { fail, Result, succeed } from '@fgv/ts-utils';
 
 import {
   type AiProviderId,
+  type IAiEmbeddingModelCapability,
   type IAiImageModelCapability,
   type IAiModelCapabilityConfig,
   type IAiProviderDescriptor
@@ -76,12 +77,25 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     needsSecret: true,
     apiFormat: 'gemini',
     baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
-    defaultModel: { base: 'gemini-2.5-flash', image: 'gemini-2.5-flash-image' },
+    defaultModel: {
+      base: 'gemini-2.5-flash',
+      image: 'gemini-2.5-flash-image',
+      embedding: 'gemini-embedding-001'
+    },
     supportedTools: ['web_search'],
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: true,
     thinkingMode: 'optional',
+    embedding: [
+      {
+        modelPrefix: '',
+        format: 'gemini-embeddings',
+        supportsDimensions: true,
+        supportsTaskType: true,
+        defaultDimensions: 3072
+      }
+    ],
     imageGeneration: [
       {
         // Imagen 4 Ultra: max 1 image
@@ -136,12 +150,13 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     needsSecret: true,
     apiFormat: 'openai',
     baseUrl: 'https://api.mistral.ai/v1',
-    defaultModel: 'mistral-large-latest',
+    defaultModel: { base: 'mistral-large-latest', embedding: 'mistral-embed' },
     supportedTools: [],
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: false,
-    thinkingMode: 'unsupported'
+    thinkingMode: 'unsupported',
+    embedding: [{ modelPrefix: '', format: 'openai-embeddings' }]
   },
   {
     id: 'ollama',
@@ -155,7 +170,8 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: false,
-    thinkingMode: 'unsupported'
+    thinkingMode: 'unsupported',
+    embedding: [{ modelPrefix: '', format: 'openai-embeddings' }]
   },
   {
     id: 'openai',
@@ -164,12 +180,25 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     needsSecret: true,
     apiFormat: 'openai',
     baseUrl: 'https://api.openai.com/v1',
-    defaultModel: { base: 'gpt-4o', image: 'dall-e-3' },
+    defaultModel: { base: 'gpt-4o', image: 'dall-e-3', embedding: 'text-embedding-3-small' },
     supportedTools: ['web_search'],
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: true,
     thinkingMode: 'optional',
+    embedding: [
+      {
+        modelPrefix: 'text-embedding-3',
+        format: 'openai-embeddings',
+        supportsDimensions: true,
+        maxBatchSize: 2048
+      },
+      {
+        modelPrefix: '',
+        format: 'openai-embeddings',
+        maxBatchSize: 2048
+      }
+    ],
     imageGeneration: [
       {
         modelPrefix: 'gpt-image-',
@@ -223,7 +252,8 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     corsRestricted: false,
     streamingCorsRestricted: false,
     acceptsImageInput: false,
-    thinkingMode: 'unsupported'
+    thinkingMode: 'unsupported',
+    embedding: [{ modelPrefix: '', format: 'openai-embeddings' }]
   },
   {
     id: 'xai-grok',
@@ -347,6 +377,42 @@ export function resolveImageCapability(
     );
 }
 
+/**
+ * Whether a provider declares any embedding capability at all.
+ *
+ * @param descriptor - The provider descriptor
+ * @returns `true` when {@link IAiProviderDescriptor.embedding} has at least one
+ *   entry; `false` otherwise.
+ * @public
+ */
+export function supportsEmbedding(descriptor: IAiProviderDescriptor): boolean {
+  return (descriptor.embedding?.length ?? 0) > 0;
+}
+
+/**
+ * Resolve the embedding capability that applies to a given model id for a
+ * provider. Returns the entry from {@link IAiProviderDescriptor.embedding} whose
+ * `modelPrefix` is the longest prefix of `modelId`. Ties are broken by
+ * first-encountered.
+ *
+ * @param descriptor - The provider descriptor
+ * @param modelId - The resolved embedding model id
+ * @returns The matching capability, or `undefined` when no rule matches or the
+ *   provider declares no embedding capabilities.
+ * @public
+ */
+export function resolveEmbeddingCapability(
+  descriptor: IAiProviderDescriptor,
+  modelId: string
+): IAiEmbeddingModelCapability | undefined {
+  return (descriptor.embedding ?? [])
+    .filter((cap) => modelId.startsWith(cap.modelPrefix))
+    .reduce<IAiEmbeddingModelCapability | undefined>(
+      (best, cap) => (best && best.modelPrefix.length >= cap.modelPrefix.length ? best : cap),
+      undefined
+    );
+}
+
 // ============================================================================
 // Default model capability config
 // ============================================================================
@@ -364,6 +430,7 @@ export const DEFAULT_MODEL_CAPABILITY_CONFIG: IAiModelCapabilityConfig = {
     openai: [
       { idPattern: /^dall-e/, capabilities: ['image-generation'] },
       { idPattern: /^gpt-image/, capabilities: ['image-generation'] },
+      { idPattern: /^text-embedding/, capabilities: ['embedding'] },
       { idPattern: /^gpt-5/, capabilities: ['chat', 'tools', 'vision', 'thinking'] },
       { idPattern: /^gpt-4/, capabilities: ['chat', 'tools', 'vision'] },
       { idPattern: /^gpt-3\.5/, capabilities: ['chat'] },
@@ -381,6 +448,7 @@ export const DEFAULT_MODEL_CAPABILITY_CONFIG: IAiModelCapabilityConfig = {
     'google-gemini': [
       { idPattern: /^imagen/, capabilities: ['image-generation'] },
       { idPattern: /^gemini-.*-image/, capabilities: ['image-generation'] },
+      { idPattern: /embedding/, capabilities: ['embedding'] },
       { idPattern: /^gemini-2\.5/, capabilities: ['chat', 'tools', 'vision', 'thinking'] },
       { idPattern: /^gemini-/, capabilities: ['chat', 'tools', 'vision'] }
     ],
@@ -390,7 +458,10 @@ export const DEFAULT_MODEL_CAPABILITY_CONFIG: IAiModelCapabilityConfig = {
       { idPattern: /^claude-/, capabilities: ['chat', 'tools', 'vision'] }
     ],
     groq: [{ idPattern: /./, capabilities: ['chat'] }],
-    mistral: [{ idPattern: /./, capabilities: ['chat'] }],
+    mistral: [
+      { idPattern: /embed/, capabilities: ['embedding'] },
+      { idPattern: /./, capabilities: ['chat'] }
+    ],
     // Self-hosted OpenAI-compatible servers (Ollama, LM Studio, llama.cpp) serve
     // arbitrary, caller-chosen models whose ids we can't enumerate ahead of time.
     // The catch-all `/./` intentionally departs from the "narrow patterns" rule

--- a/libraries/ts-extras/src/test/unit/ai-assist/model.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/model.test.ts
@@ -107,6 +107,21 @@ describe('resolveModel', () => {
     const spec: AiAssist.ModelSpec = { tools: 'grok-reasoning', image: 'grok-vision' };
     expect(AiAssist.resolveModel(spec)).toBe('grok-reasoning');
   });
+
+  test('resolves the embedding context key from an object spec', () => {
+    const spec: AiAssist.ModelSpec = { base: 'gpt-4o', embedding: 'text-embedding-3-small' };
+    expect(AiAssist.resolveModel(spec, 'embedding')).toBe('text-embedding-3-small');
+  });
+});
+
+describe('capability + spec-key vocabularies', () => {
+  test('allModelSpecKeys includes the embedding key', () => {
+    expect(AiAssist.allModelSpecKeys).toContain('embedding');
+  });
+
+  test('allModelCapabilities includes the embedding capability', () => {
+    expect(AiAssist.allModelCapabilities).toContain('embedding');
+  });
 });
 
 describe('modelSpec converter', () => {

--- a/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
@@ -259,6 +259,12 @@ describe('AiAssist.registry', () => {
     test('openai declares a text-embedding-3 default and a dimensions-capable prefix', () => {
       expect(AiAssist.getProviderDescriptor('openai')).toSucceedAndSatisfy((desc) => {
         expect(AiAssist.resolveModel(desc.defaultModel, 'embedding')).toBe('text-embedding-3-small');
+        expect(AiAssist.resolveEmbeddingCapability(desc, 'text-embedding-3-small')).toMatchObject({
+          modelPrefix: 'text-embedding-3',
+          format: 'openai-embeddings',
+          supportsDimensions: true,
+          maxBatchSize: 2048
+        });
       });
     });
 
@@ -313,6 +319,10 @@ describe('AiAssist.registry', () => {
       });
       expect(
         AiAssist.resolveEmbeddingCapability(descriptor, 'text-embedding-ada-002')?.supportsDimensions
+      ).toBeUndefined();
+      // Catch-all carries no batch-size guard (matches design §5.1).
+      expect(
+        AiAssist.resolveEmbeddingCapability(descriptor, 'text-embedding-ada-002')?.maxBatchSize
       ).toBeUndefined();
     });
 

--- a/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
@@ -236,6 +236,92 @@ describe('AiAssist.registry', () => {
     });
   });
 
+  describe('supportsEmbedding', () => {
+    test('is true for providers that declare an embedding capability', () => {
+      for (const id of ['openai', 'google-gemini', 'ollama', 'openai-compat', 'mistral'] as const) {
+        expect(AiAssist.getProviderDescriptor(id)).toSucceedAndSatisfy((desc) => {
+          expect(AiAssist.supportsEmbedding(desc)).toBe(true);
+        });
+      }
+    });
+
+    test('is false for providers without an embedding endpoint', () => {
+      for (const id of ['xai-grok', 'anthropic', 'groq', 'copy-paste'] as const) {
+        expect(AiAssist.getProviderDescriptor(id)).toSucceedAndSatisfy((desc) => {
+          expect(desc.embedding).toBeUndefined();
+          expect(AiAssist.supportsEmbedding(desc)).toBe(false);
+        });
+      }
+    });
+  });
+
+  describe('embedding registry entries', () => {
+    test('openai declares a text-embedding-3 default and a dimensions-capable prefix', () => {
+      expect(AiAssist.getProviderDescriptor('openai')).toSucceedAndSatisfy((desc) => {
+        expect(AiAssist.resolveModel(desc.defaultModel, 'embedding')).toBe('text-embedding-3-small');
+      });
+    });
+
+    test('gemini declares a gemini-embedding-001 default with taskType + dimensions', () => {
+      expect(AiAssist.getProviderDescriptor('google-gemini')).toSucceedAndSatisfy((desc) => {
+        expect(AiAssist.resolveModel(desc.defaultModel, 'embedding')).toBe('gemini-embedding-001');
+        const cap = AiAssist.resolveEmbeddingCapability(desc, 'gemini-embedding-001');
+        expect(cap).toMatchObject({
+          format: 'gemini-embeddings',
+          supportsTaskType: true,
+          supportsDimensions: true
+        });
+      });
+    });
+
+    test('mistral declares a mistral-embed default via the openai-embeddings format', () => {
+      expect(AiAssist.getProviderDescriptor('mistral')).toSucceedAndSatisfy((desc) => {
+        expect(AiAssist.resolveModel(desc.defaultModel, 'embedding')).toBe('mistral-embed');
+        expect(AiAssist.resolveEmbeddingCapability(desc, 'mistral-embed')).toMatchObject({
+          format: 'openai-embeddings'
+        });
+      });
+    });
+
+    test('self-hosted providers declare a catch-all capability and no default embedding model', () => {
+      for (const id of ['ollama', 'openai-compat'] as const) {
+        expect(AiAssist.getProviderDescriptor(id)).toSucceedAndSatisfy((desc) => {
+          expect(AiAssist.resolveModel(desc.defaultModel, 'embedding')).toBe('');
+          expect(AiAssist.resolveEmbeddingCapability(desc, 'nomic-embed-text')).toMatchObject({
+            modelPrefix: '',
+            format: 'openai-embeddings'
+          });
+        });
+      }
+    });
+  });
+
+  describe('resolveEmbeddingCapability', () => {
+    test('selects the most specific (longest) prefix even when listed after the catch-all', () => {
+      const descriptor = AiAssist.getProviderDescriptor('openai').orThrow();
+      // text-embedding-3-large hits the specific prefix (dimensions-capable, batched).
+      expect(AiAssist.resolveEmbeddingCapability(descriptor, 'text-embedding-3-large')).toMatchObject({
+        modelPrefix: 'text-embedding-3',
+        format: 'openai-embeddings',
+        supportsDimensions: true,
+        maxBatchSize: 2048
+      });
+      // text-embedding-ada-002 falls back to the catch-all (no dimensions support).
+      expect(AiAssist.resolveEmbeddingCapability(descriptor, 'text-embedding-ada-002')).toMatchObject({
+        modelPrefix: '',
+        format: 'openai-embeddings'
+      });
+      expect(
+        AiAssist.resolveEmbeddingCapability(descriptor, 'text-embedding-ada-002')?.supportsDimensions
+      ).toBeUndefined();
+    });
+
+    test('returns undefined when the provider declares no embedding capabilities', () => {
+      const descriptor = AiAssist.getProviderDescriptor('anthropic').orThrow();
+      expect(AiAssist.resolveEmbeddingCapability(descriptor, 'claude-3-opus')).toBeUndefined();
+    });
+  });
+
   describe('allProviderIds', () => {
     test('contains all provider ids in same order as descriptors', () => {
       const descriptors = AiAssist.getProviderDescriptors();
@@ -268,5 +354,20 @@ describe('DEFAULT_MODEL_CAPABILITY_CONFIG', () => {
       }
     }
     expect(caps.has('chat')).toBe(true);
+  });
+
+  test.each([
+    ['openai', 'text-embedding-3-large'],
+    ['google-gemini', 'gemini-embedding-001'],
+    ['mistral', 'mistral-embed']
+  ] as const)('%s tags %s with the embedding capability', (provider, modelId) => {
+    const rules = config.perProvider?.[provider] ?? [];
+    const caps = new Set<string>();
+    for (const rule of rules) {
+      if (rule.idPattern.test(modelId)) {
+        rule.capabilities.forEach((c) => caps.add(c));
+      }
+    }
+    expect(caps.has('embedding')).toBe(true);
   });
 });


### PR DESCRIPTION
## Phase 1 of the cross-provider embedding primitive

Implements **Phase 1** of `.ai/tasks/active/ai-assist-embeddings/design.md` (§13): the **types + capability declaration + registry foundation**, mirroring the image-generation primitive. **No wire calls yet** — the dispatcher and HTTP adapters land in Phase 2 (OpenAI-format) and Phase 3 (Gemini + proxy). Additive only; no existing export changes.

Targets `ai-assist-embeddings` (not `main`).

### What shipped

**`model.ts`**
- New types: `AiEmbeddingApiFormat` (`'openai-embeddings' | 'gemini-embeddings'`), `AiEmbeddingTaskType` (open kebab-case union), `IAiEmbeddingParams` (`input`/`dimensions`/`taskType`), `IAiEmbeddingUsage`, `IAiEmbeddingResult` (`number[][]` vectors), `IAiEmbeddingModelCapability`.
- `'embedding'` added to `ModelSpecKey` + `allModelSpecKeys` and to `AiModelCapability`.
- New `allModelCapabilities` single-source-of-truth constant (mirrors `allModelSpecKeys`).
- Additive `embedding?: ReadonlyArray<IAiEmbeddingModelCapability>` field on `IAiProviderDescriptor`.

**`registry.ts`**
- Embedding capabilities for `openai` (`text-embedding-3` prefix w/ `supportsDimensions` + `maxBatchSize: 2048`, plus catch-all), `google-gemini` (`taskType` + `dimensions`, `defaultDimensions: 3072`), `ollama`/`openai-compat` (catch-all, no default model — caller supplies), `mistral` (`mistral-embed`). `xai-grok`/`anthropic`/`groq`/`copy-paste` correctly omit embeddings (no endpoint).
- `supportsEmbedding` / `resolveEmbeddingCapability` helpers (longest-prefix match, exact copy of the image-gen algorithm).
- `DEFAULT_MODEL_CAPABILITY_CONFIG` embedding rules for openai/gemini/mistral.

**`apiClient.ts`** — `proxiedListModelsEntry` validator now uses the `allModelCapabilities` constant (DRY; behavior-preserving; now accepts `'embedding'`). This also keeps the file under the 2000-line lint ceiling.

**`index.ts`** — exports the new symbols. **`etc/ts-extras.api.md`** regenerated.

### §14 amendments honored
- Naming is `AiEmbeddingApiFormat` (not `AiEmbeddingFormat`). ✅
- `maxBatchSize` present on the `text-embedding-3` capability for Phase 2 fail-fast. ✅
- Self-hosted `listModels` caveat (catch-all tags everything `chat`, embedding models won't auto-surface) — to be documented in Phase 4 docs.

### Gates
- `rushx build` ✅ · `rushx lint` ✅ (0 problems) · `rushx test` ✅ **100% coverage**
- `rushx fixlint` run before final commit ✅
- No `any`; additive-only.

### Review loop
- **`code-reviewer` run on the diff before this PR.** No P1s. Two P2s resolved: (P2-1) test name/body alignment — strengthened the openai registry test to verify the dimensions-capable prefix; (P2-2) the OpenAI catch-all carried an undocumented `maxBatchSize` deviating from design §5.1 — removed it (only the `text-embedding-3` prefix carries the batch guard) and added a test asserting its absence. P3-3 (cheap) also applied: `allModelSpecKeys`/`allModelCapabilities` membership tests. P3-1/P3-2 dispositioned as pre-existing/advisory.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XXKssj1G7jYcs8hFUWjqbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXKssj1G7jYcs8hFUWjqbZ)_