### PR TITLE
feat(ai-assist): callProviderEmbedding + OpenAI-format adapter (Phase 2)

### DIFF
--- a/common/changes/@fgv/ts-extras/ai-assist-embeddings-phase2_2026-06-07-01-00.json
+++ b/common/changes/@fgv/ts-extras/ai-assist-embeddings-phase2_2026-06-07-01-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "ai-assist: add callProviderEmbedding (Phase 2) — the cross-provider embedding dispatcher + OpenAI-format adapter (serves OpenAI, Ollama via /v1, openai-compat self-hosted, and Mistral). Batch in, number[][] out; empty-input short-circuits with no wire call; batch over capability.maxBatchSize fails fast; encoding_format:'float'; caller dimensions/taskType honored where the model supports them and a logged no-op otherwise (preserving the cross-provider call site). Extracts the shared fetchJson + IAiApiConfig HTTP helpers into an internal http.ts module reused by apiClient.ts and embeddingClient.ts. Gemini adapter + callProxiedEmbedding land in Phase 3.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -140,6 +140,8 @@ declare namespace AiAssist {
         IProviderCompletionParams,
         IProviderImageGenerationParams,
         IProviderListModelsParams,
+        callProviderEmbedding,
+        IProviderEmbeddingParams,
         callProviderCompletionStream,
         callProxiedCompletionStream,
         IProviderCompletionStreamParams,
@@ -317,6 +319,11 @@ function callProviderCompletion(params: IProviderCompletionParams): Promise<Resu
 //
 // @public
 function callProviderCompletionStream(params: IProviderCompletionStreamParams): Promise<Result<AsyncIterable<IAiStreamEvent>>>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+function callProviderEmbedding(params: IProviderEmbeddingParams): Promise<Result<IAiEmbeddingResult>>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiImageModelCapability"
 //
@@ -1694,6 +1701,19 @@ interface IProviderCompletionStreamParams extends IChatRequest {
     readonly temperature?: number;
     readonly thinking?: IThinkingConfig;
     readonly tools?: ReadonlyArray<AiServerToolConfig>;
+}
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+interface IProviderEmbeddingParams {
+    readonly apiKey: string;
+    readonly descriptor: IAiProviderDescriptor;
+    readonly endpoint?: string;
+    readonly logger?: Logging.ILogger;
+    readonly modelOverride?: ModelSpec;
+    readonly params: IAiEmbeddingParams;
+    readonly signal?: AbortSignal;
 }
 
 // @public

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -69,6 +69,7 @@ import {
   splitChatRequest
 } from './chatRequestBuilders';
 import { bearerAuthHeader, resolveEffectiveBaseUrl } from './endpoint';
+import { type IAiApiConfig, fetchJson } from './http';
 import { DEFAULT_MODEL_CAPABILITY_CONFIG, resolveImageCapability, supportsImageGeneration } from './registry';
 import {
   resolveImageOptions,
@@ -80,16 +81,6 @@ import { toAnthropicTools, toGeminiTools, toResponsesApiTools } from './toolForm
 // ============================================================================
 // Types
 // ============================================================================
-
-/**
- * Internal API configuration built from a provider descriptor.
- * @internal
- */
-interface IAiApiConfig {
-  readonly baseUrl: string;
-  readonly apiKey: string;
-  readonly model: string;
-}
 
 /**
  * Parameters for a provider completion request. Carries the unified
@@ -134,61 +125,6 @@ export interface IProviderCompletionParams extends IChatRequest {
  * Makes an HTTP request and returns the parsed JSON, or a failure.
  * @internal
  */
-async function fetchJson(
-  url: string,
-  headers: Record<string, string>,
-  body: unknown,
-  logger?: Logging.ILogger,
-  signal?: AbortSignal
-): Promise<Result<JsonObject>> {
-  /* c8 ignore next 1 - optional logger */
-  logger?.detail(`AI API request: POST ${url}`);
-
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...headers
-      },
-      body: JSON.stringify(body),
-      signal
-    });
-  } catch (err: unknown) {
-    const detail = err instanceof Error ? err.message : String(err);
-    /* c8 ignore next 1 - optional logger */
-    logger?.error(`AI API request failed: ${detail}`);
-    return fail(`AI API request failed: ${detail}`);
-  }
-
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => 'unknown error');
-    /* c8 ignore next 1 - optional logger */
-    logger?.error(`AI API returned ${response.status}: ${errorText}`);
-    return fail(`AI API returned ${response.status}: ${errorText}`);
-  }
-
-  /* c8 ignore next 1 - optional logger */
-  logger?.detail(`AI API response: ${response.status}`);
-
-  let json: unknown;
-  try {
-    json = await response.json();
-  } catch {
-    /* c8 ignore next 1 - optional logger */
-    logger?.error('AI API returned invalid JSON response');
-    return fail('AI API returned invalid JSON response');
-  }
-
-  if (!isJsonObject(json)) {
-    /* c8 ignore next 1 - optional logger */
-    logger?.error('AI API returned non-object JSON response');
-    return fail('AI API returned non-object JSON response');
-  }
-  return succeed(json);
-}
-
 /**
  * Makes a multipart/form-data POST request and returns the parsed JSON, or a
  * failure. The Content-Type header (with boundary) is set automatically by

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -122,10 +122,6 @@ export interface IProviderCompletionParams extends IChatRequest {
 // ============================================================================
 
 /**
- * Makes an HTTP request and returns the parsed JSON, or a failure.
- * @internal
- */
-/**
  * Makes a multipart/form-data POST request and returns the parsed JSON, or a
  * failure. The Content-Type header (with boundary) is set automatically by
  * `fetch` from the `FormData` body — callers must NOT pass it explicitly.

--- a/libraries/ts-extras/src/packlets/ai-assist/embeddingClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/embeddingClient.ts
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * Cross-provider embedding client for AI assist. Mirrors the completion and
+ * image-generation primitives in `apiClient.ts`: a single dispatcher
+ * ({@link AiAssist.callProviderEmbedding}) resolves the provider descriptor's
+ * embedding capability and routes to the per-format adapter. `text -> vector`,
+ * batch in, `number[][]` out.
+ *
+ * @packageDocumentation
+ */
+
+import { fail, type Logging, Result, succeed, type Validator, Validators } from '@fgv/ts-utils';
+
+import {
+  type AiEmbeddingApiFormat,
+  type IAiEmbeddingModelCapability,
+  type IAiEmbeddingParams,
+  type IAiEmbeddingResult,
+  type IAiEmbeddingUsage,
+  type IAiProviderDescriptor,
+  type ModelSpec,
+  resolveModel
+} from './model';
+import { bearerAuthHeader, resolveEffectiveBaseUrl } from './endpoint';
+import { resolveEmbeddingCapability, supportsEmbedding } from './registry';
+import { type IAiApiConfig, fetchJson } from './http';
+
+// ============================================================================
+// Request types
+// ============================================================================
+
+/**
+ * Parameters for a provider embedding request. Mirrors
+ * {@link AiAssist.IProviderImageGenerationParams}.
+ * @public
+ */
+export interface IProviderEmbeddingParams {
+  /** The provider descriptor. */
+  readonly descriptor: IAiProviderDescriptor;
+  /** API key for authentication (empty string for keyless self-hosted providers). */
+  readonly apiKey: string;
+  /** The embedding request (input + optional knobs). */
+  readonly params: IAiEmbeddingParams;
+  /**
+   * Optional model override — string or context-aware map. Uses
+   * `descriptor.defaultModel.embedding` otherwise. Self-hosted providers
+   * (`ollama`, `openai-compat`) have no default and require this.
+   */
+  readonly modelOverride?: ModelSpec;
+  /** Optional logger for request/response observability. */
+  readonly logger?: Logging.ILogger;
+  /** Optional abort signal for cancelling the in-flight request. */
+  readonly signal?: AbortSignal;
+  /** Optional override of the descriptor's base URL; the `/embeddings` suffix is appended unchanged. */
+  readonly endpoint?: string;
+}
+
+// ============================================================================
+// OpenAI-format (`/v1/embeddings`) response validators
+// ============================================================================
+
+/** @internal */
+interface IOpenAiEmbeddingItem {
+  index: number;
+  embedding: number[];
+}
+/** @internal */
+interface IOpenAiEmbeddingUsage {
+  prompt_tokens?: number;
+  total_tokens?: number;
+}
+/** @internal */
+interface IOpenAiEmbeddingResponse {
+  data: IOpenAiEmbeddingItem[];
+  model?: string;
+  usage?: IOpenAiEmbeddingUsage;
+}
+
+const openAiEmbeddingItem: Validator<IOpenAiEmbeddingItem> = Validators.object<IOpenAiEmbeddingItem>({
+  index: Validators.number,
+  embedding: Validators.arrayOf(Validators.number)
+});
+const openAiEmbeddingUsage: Validator<IOpenAiEmbeddingUsage> = Validators.object<IOpenAiEmbeddingUsage>({
+  prompt_tokens: Validators.number.optional(),
+  total_tokens: Validators.number.optional()
+});
+const openAiEmbeddingResponse: Validator<IOpenAiEmbeddingResponse> =
+  Validators.object<IOpenAiEmbeddingResponse>({
+    data: Validators.arrayOf(openAiEmbeddingItem).withConstraint((arr) => arr.length > 0),
+    model: Validators.string.optional(),
+    usage: openAiEmbeddingUsage.optional()
+  });
+
+// ============================================================================
+// Shared helpers
+// ============================================================================
+
+/**
+ * Normalizes the `input` field (string | string[]) into a concrete string array.
+ * @internal
+ */
+function toInputArray(input: string | ReadonlyArray<string>): ReadonlyArray<string> {
+  return typeof input === 'string' ? [input] : input;
+}
+
+/**
+ * Builds an {@link IAiEmbeddingUsage} from OpenAI-format usage, or `undefined`
+ * when no token counts are reported.
+ * @internal
+ */
+function toEmbeddingUsage(usage: IOpenAiEmbeddingUsage | undefined): IAiEmbeddingUsage | undefined {
+  if (usage === undefined || (usage.prompt_tokens === undefined && usage.total_tokens === undefined)) {
+    return undefined;
+  }
+  return {
+    ...(usage.prompt_tokens !== undefined ? { promptTokens: usage.prompt_tokens } : {}),
+    ...(usage.total_tokens !== undefined ? { totalTokens: usage.total_tokens } : {})
+  };
+}
+
+// ============================================================================
+// OpenAI-format adapter
+// ============================================================================
+
+/**
+ * Calls the OpenAI `/v1/embeddings` endpoint. Serves OpenAI, Ollama (via `/v1`),
+ * openai-compat self-hosted servers, and Mistral. Sends `dimensions` only when
+ * the capability declares `supportsDimensions`; always requests
+ * `encoding_format: 'float'`.
+ *
+ * @remarks
+ * `encoding_format: 'float'` is a known assumption (design §14 #5): a strict
+ * openai-compat server could in principle reject the field, but mainstream
+ * servers accept it and it keeps us off the base64 decode path. Low risk.
+ *
+ * @internal
+ */
+async function callOpenAiEmbeddings(
+  config: IAiApiConfig,
+  inputs: ReadonlyArray<string>,
+  request: IAiEmbeddingParams,
+  capability: IAiEmbeddingModelCapability,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<IAiEmbeddingResult>> {
+  const body: Record<string, unknown> = {
+    model: config.model,
+    input: inputs,
+    encoding_format: 'float'
+  };
+  if (capability.supportsDimensions && request.dimensions !== undefined) {
+    body.dimensions = request.dimensions;
+  }
+  const headers: Record<string, string> = bearerAuthHeader(config.apiKey);
+
+  /* c8 ignore next 1 - optional logger */
+  logger?.info(`AI embedding: format=openai-embeddings, model=${config.model}, inputs=${inputs.length}`);
+
+  const jsonResult = await fetchJson(`${config.baseUrl}/embeddings`, headers, body, logger, signal);
+  if (jsonResult.isFailure()) {
+    return fail(jsonResult.message);
+  }
+  return openAiEmbeddingResponse
+    .validate(jsonResult.value)
+    .withErrorFormat((msg) => `OpenAI embeddings API response: ${msg}`)
+    .onSuccess((response) => {
+      // The spec allows `data` in any order; align to request order by `index`.
+      const ordered = [...response.data].sort((a, b) => a.index - b.index);
+      const vectors = ordered.map((item) => item.embedding);
+      const usage = toEmbeddingUsage(response.usage);
+      // `vectors` is guaranteed non-empty: the validator constrains `data` to
+      // length > 0 and the empty-input case short-circuits before the wire call.
+      return succeed({
+        vectors,
+        model: response.model ?? config.model,
+        dimensions: vectors[0].length,
+        ...(usage !== undefined ? { usage } : {})
+      });
+    });
+}
+
+// ============================================================================
+// Dispatcher
+// ============================================================================
+
+/**
+ * Notes any caller-supplied embedding knobs that the resolved capability does
+ * not honor. Per design §7 these are a no-op (logged, never a failure) so a
+ * cross-provider call site can pass `taskType`/`dimensions` once and have them
+ * apply only where supported.
+ * @internal
+ */
+function noteUnsupportedKnobs(
+  model: string,
+  request: IAiEmbeddingParams,
+  capability: IAiEmbeddingModelCapability,
+  logger?: Logging.ILogger
+): void {
+  if (logger === undefined) {
+    return;
+  }
+  if (request.taskType !== undefined && !capability.supportsTaskType) {
+    logger.info(`AI embedding: model "${model}" ignores taskType (not supported); proceeding without it`);
+  }
+  if (request.dimensions !== undefined && !capability.supportsDimensions) {
+    logger.info(`AI embedding: model "${model}" ignores dimensions (not supported); proceeding without it`);
+  }
+}
+
+/**
+ * Calls the appropriate embedding API for a given provider. Routes by the
+ * `format` of the resolved {@link AiAssist.IAiEmbeddingModelCapability}:
+ * `'openai-embeddings'` or `'gemini-embeddings'`.
+ *
+ * @remarks
+ * - Rejects up front when the provider declares no embedding capability, when no
+ *   embedding model resolves, or when the batch exceeds the capability's
+ *   `maxBatchSize` (no auto-chunking).
+ * - An empty `input` array short-circuits to an empty result with no wire call
+ *   (most providers HTTP-400 on empty input).
+ * - Caller-supplied `dimensions`/`taskType` that the model doesn't support are a
+ *   no-op (logged), not a failure (design §7).
+ *
+ * @param params - Request parameters including descriptor, API key, and input.
+ * @returns The embedding vectors aligned to input order, or a failure.
+ * @public
+ */
+export async function callProviderEmbedding(
+  params: IProviderEmbeddingParams
+): Promise<Result<IAiEmbeddingResult>> {
+  const { descriptor, apiKey, params: request, modelOverride, logger, signal, endpoint } = params;
+
+  if (!supportsEmbedding(descriptor)) {
+    return fail(`provider "${descriptor.id}" does not support embeddings`);
+  }
+
+  const model = resolveModel(modelOverride ?? descriptor.defaultModel, 'embedding');
+  if (model.length === 0) {
+    return fail(
+      `provider "${descriptor.id}": no embedding model resolved; ` +
+        `pass modelOverride or set descriptor.defaultModel ` +
+        `(a plain string, or an object with an "embedding" entry)`
+    );
+  }
+
+  const capability = resolveEmbeddingCapability(descriptor, model);
+  if (capability === undefined) {
+    return fail(`provider "${descriptor.id}" does not support embeddings for model "${model}"`);
+  }
+
+  const inputs = toInputArray(request.input);
+  if (inputs.length === 0) {
+    // Short-circuit: empty batch never hits the wire (design §14 #2).
+    return succeed({ vectors: [], model, dimensions: 0 });
+  }
+  if (capability.maxBatchSize !== undefined && inputs.length > capability.maxBatchSize) {
+    return fail(
+      `provider "${descriptor.id}": embedding batch of ${inputs.length} exceeds ` +
+        `model "${model}" maximum of ${capability.maxBatchSize}`
+    );
+  }
+
+  const baseUrlResult = resolveEffectiveBaseUrl(descriptor, endpoint);
+  if (baseUrlResult.isFailure()) {
+    return fail(baseUrlResult.message);
+  }
+
+  noteUnsupportedKnobs(model, request, capability, logger);
+
+  const config: IAiApiConfig = { baseUrl: baseUrlResult.value, apiKey, model };
+
+  return dispatchEmbedding(capability.format, config, inputs, request, capability, logger, signal);
+}
+
+/**
+ * Routes a resolved embedding request to the per-format adapter.
+ * @internal
+ */
+function dispatchEmbedding(
+  format: AiEmbeddingApiFormat,
+  config: IAiApiConfig,
+  inputs: ReadonlyArray<string>,
+  request: IAiEmbeddingParams,
+  capability: IAiEmbeddingModelCapability,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<IAiEmbeddingResult>> {
+  switch (format) {
+    case 'openai-embeddings':
+      return callOpenAiEmbeddings(config, inputs, request, capability, logger, signal);
+    case 'gemini-embeddings':
+      // Wired in Phase 3 (batchEmbedContents adapter).
+      return Promise.resolve(fail('gemini embeddings adapter not yet implemented'));
+    /* c8 ignore next 4 - defensive: exhaustive switch guaranteed by TypeScript */
+    default: {
+      const _exhaustive: never = format;
+      return Promise.resolve(fail(`unsupported embedding API format: ${String(_exhaustive)}`));
+    }
+  }
+}

--- a/libraries/ts-extras/src/packlets/ai-assist/embeddingClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/embeddingClient.ts
@@ -185,14 +185,41 @@ async function callOpenAiEmbeddings(
     .onSuccess((response) => {
       // The spec allows `data` in any order; align to request order by `index`.
       const ordered = [...response.data].sort((a, b) => a.index - b.index);
+      // Validate the response is well-formed against the request before trusting
+      // the alignment: a compat server could return an incomplete batch, gapped
+      // or duplicate indices, or ragged dimensions — all of which would silently
+      // yield misaligned/partial vectors. (inputs is non-empty here; the
+      // empty-input case short-circuits before the wire call.)
+      if (ordered.length !== inputs.length) {
+        return fail(
+          `OpenAI embeddings API response: expected ${inputs.length} embedding(s), got ${ordered.length}`
+        );
+      }
+      // After sorting, a perfect 0..n-1 sequence has item.index === position at
+      // every slot. Any gap OR duplicate shifts a later element off its position
+      // (the second copy of value k, or the element after a missing k, lands at
+      // position > its index), so this single walk catches both.
+      const misindexed = ordered.findIndex((item, i) => item.index !== i);
+      if (misindexed !== -1) {
+        return fail(
+          `OpenAI embeddings API response: malformed embedding indices ` +
+            `(expected 0..${inputs.length - 1}; gap or duplicate at position ${misindexed})`
+        );
+      }
       const vectors = ordered.map((item) => item.embedding);
+      const dimensions = vectors[0].length;
+      const ragged = vectors.findIndex((v) => v.length !== dimensions);
+      if (ragged !== -1) {
+        return fail(
+          `OpenAI embeddings API response: inconsistent vector dimensionality ` +
+            `(vector ${ragged} has length ${vectors[ragged].length}, expected ${dimensions})`
+        );
+      }
       const usage = toEmbeddingUsage(response.usage);
-      // `vectors` is guaranteed non-empty: the validator constrains `data` to
-      // length > 0 and the empty-input case short-circuits before the wire call.
       return succeed({
         vectors,
         model: response.model ?? config.model,
-        dimensions: vectors[0].length,
+        dimensions,
         ...(usage !== undefined ? { usage } : {})
       });
     });

--- a/libraries/ts-extras/src/packlets/ai-assist/http.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/http.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * Shared low-level HTTP helpers for the AI-assist provider clients (completion,
+ * image generation, embedding). Internal to the packlet.
+ * @packageDocumentation
+ */
+
+import { isJsonObject, type JsonObject } from '@fgv/ts-json-base';
+import { fail, type Logging, Result, succeed } from '@fgv/ts-utils';
+
+/**
+ * Internal API configuration built from a provider descriptor.
+ * @internal
+ */
+export interface IAiApiConfig {
+  readonly baseUrl: string;
+  readonly apiKey: string;
+  readonly model: string;
+}
+
+/**
+ * Makes a JSON POST request and returns the parsed object body, or a failure.
+ * Non-2xx responses, network errors, invalid JSON, and non-object JSON bodies
+ * are all surfaced as `Result.fail`.
+ * @internal
+ */
+export async function fetchJson(
+  url: string,
+  headers: Record<string, string>,
+  body: unknown,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<JsonObject>> {
+  /* c8 ignore next 1 - optional logger */
+  logger?.detail(`AI API request: POST ${url}`);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers
+      },
+      body: JSON.stringify(body),
+      signal
+    });
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    /* c8 ignore next 1 - optional logger */
+    logger?.error(`AI API request failed: ${detail}`);
+    return fail(`AI API request failed: ${detail}`);
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'unknown error');
+    /* c8 ignore next 1 - optional logger */
+    logger?.error(`AI API returned ${response.status}: ${errorText}`);
+    return fail(`AI API returned ${response.status}: ${errorText}`);
+  }
+
+  /* c8 ignore next 1 - optional logger */
+  logger?.detail(`AI API response: ${response.status}`);
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    /* c8 ignore next 1 - optional logger */
+    logger?.error('AI API returned invalid JSON response');
+    return fail('AI API returned invalid JSON response');
+  }
+
+  if (!isJsonObject(json)) {
+    /* c8 ignore next 1 - optional logger */
+    logger?.error('AI API returned non-object JSON response');
+    return fail('AI API returned non-object JSON response');
+  }
+  return succeed(json);
+}

--- a/libraries/ts-extras/src/packlets/ai-assist/index.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/index.ts
@@ -130,6 +130,8 @@ export {
   type IProviderListModelsParams
 } from './apiClient';
 
+export { callProviderEmbedding, type IProviderEmbeddingParams } from './embeddingClient';
+
 export {
   callProviderCompletionStream,
   callProxiedCompletionStream,

--- a/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
@@ -251,6 +251,8 @@ describe('callProviderEmbedding', () => {
       });
 
       expect(lastRequestBody().dimensions).toBe(256);
+      // taskType is never part of the OpenAI wire shape.
+      expect(lastRequestBody().taskType).toBeUndefined();
     });
 
     test('omits dimensions (no-op) and logs a note for a model that does not support it', async () => {

--- a/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
@@ -445,6 +445,50 @@ describe('callProviderEmbedding', () => {
       });
       expect(result).toFailWith(/OpenAI embeddings API response/i);
     });
+
+    test('fails when the embedding count does not match the input count', async () => {
+      // Two inputs, but the server returns only one embedding.
+      mockFetchResponse(openAiEmbeddingBody([[0.1]]));
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: ['a', 'b'] }
+      });
+      expect(result).toFailWith(/expected 2 embedding\(s\), got 1/i);
+    });
+
+    test('fails when the response indices have a gap or duplicate', async () => {
+      // Two inputs, two embeddings, but indices are {0, 2} — index 1 is missing.
+      mockFetchResponse({
+        object: 'list',
+        data: [
+          { object: 'embedding', index: 0, embedding: [0.1] },
+          { object: 'embedding', index: 2, embedding: [0.2] }
+        ]
+      });
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: ['a', 'b'] }
+      });
+      expect(result).toFailWith(/malformed embedding indices .*position 1/i);
+    });
+
+    test('fails when vectors have inconsistent dimensionality', async () => {
+      mockFetchResponse({
+        object: 'list',
+        data: [
+          { object: 'embedding', index: 0, embedding: [0.1, 0.2] },
+          { object: 'embedding', index: 1, embedding: [0.3] }
+        ]
+      });
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: ['a', 'b'] }
+      });
+      expect(result).toFailWith(/inconsistent vector dimensionality .*vector 1 has length 1, expected 2/i);
+    });
   });
 
   describe('gemini-embeddings format (Phase 2 — not yet implemented)', () => {

--- a/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
@@ -1,0 +1,458 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * Tests for callProviderEmbedding (Phase 2 — OpenAI-format adapter + dispatcher).
+ * Mock fetch, per-format fixtures, no live calls.
+ */
+
+import '@fgv/ts-utils-jest';
+
+import { Logging } from '@fgv/ts-utils';
+import { AiAssist } from '../../..';
+// eslint-disable-next-line @rushstack/packlets/mechanics
+import type { IAiProviderDescriptor } from '../../../packlets/ai-assist/model';
+
+// ============================================================================
+// Mock helpers
+// ============================================================================
+
+function mockFetchResponse(body: unknown, status: number = 200): void {
+  const response = {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(JSON.stringify(body))
+  };
+  (global.fetch as jest.Mock).mockResolvedValue(response);
+}
+
+function mockFetchError(error: Error): void {
+  (global.fetch as jest.Mock).mockRejectedValue(error);
+}
+
+function mockFetchHttpError(status: number, errorText: string): void {
+  const response = {
+    ok: false,
+    status,
+    text: jest.fn().mockResolvedValue(errorText)
+  };
+  (global.fetch as jest.Mock).mockResolvedValue(response);
+}
+
+function lastRequestBody(): Record<string, unknown> {
+  return JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+}
+
+function lastRequestUrl(): string {
+  return (global.fetch as jest.Mock).mock.calls[0][0];
+}
+
+function lastRequestHeaders(): Record<string, string> {
+  return (global.fetch as jest.Mock).mock.calls[0][1].headers;
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+/** OpenAI `/v1/embeddings` response body. */
+function openAiEmbeddingBody(
+  vectors: number[][],
+  opts: { model?: string; usage?: { prompt_tokens?: number; total_tokens?: number }; shuffle?: boolean } = {}
+): unknown {
+  const data = vectors.map((embedding, index) => ({ object: 'embedding', index, embedding }));
+  if (opts.shuffle) {
+    data.reverse();
+  }
+  return {
+    object: 'list',
+    data,
+    ...(opts.model !== undefined ? { model: opts.model } : {}),
+    ...(opts.usage !== undefined ? { usage: opts.usage } : {})
+  };
+}
+
+function openAiDescriptor(): IAiProviderDescriptor {
+  return AiAssist.getProviderDescriptor('openai').orThrow();
+}
+
+// ============================================================================
+// callProviderEmbedding — OpenAI format
+// ============================================================================
+
+describe('callProviderEmbedding', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  describe('OpenAI-format adapter', () => {
+    test('embeds a single string input', async () => {
+      mockFetchResponse(
+        openAiEmbeddingBody([[0.1, 0.2, 0.3]], { usage: { prompt_tokens: 4, total_tokens: 4 } })
+      );
+
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'hello world' }
+      });
+
+      expect(result).toSucceedAndSatisfy((embedding) => {
+        expect(embedding.vectors).toEqual([[0.1, 0.2, 0.3]]);
+        expect(embedding.model).toBe('text-embedding-3-small');
+        expect(embedding.dimensions).toBe(3);
+        expect(embedding.usage).toEqual({ promptTokens: 4, totalTokens: 4 });
+      });
+
+      // Single string is sent as a one-element batch.
+      expect(lastRequestUrl()).toBe('https://api.openai.com/v1/embeddings');
+      expect(lastRequestBody().input).toEqual(['hello world']);
+      expect(lastRequestHeaders().Authorization).toBe('Bearer sk-test');
+    });
+
+    test('embeds a batch, aligning vectors to request order even when data is out of order', async () => {
+      // shuffle reverses the data array; the adapter must re-sort by `index`.
+      // The response also reports its own model id, which the result echoes.
+      mockFetchResponse(
+        openAiEmbeddingBody(
+          [
+            [1, 1],
+            [2, 2],
+            [3, 3]
+          ],
+          { shuffle: true, model: 'text-embedding-3-small' }
+        )
+      );
+
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: ['a', 'b', 'c'] }
+      });
+
+      expect(result).toSucceedAndSatisfy((embedding) => {
+        expect(embedding.vectors).toEqual([
+          [1, 1],
+          [2, 2],
+          [3, 3]
+        ]);
+        expect(embedding.dimensions).toBe(2);
+        expect(embedding.model).toBe('text-embedding-3-small');
+        // No usage reported → omitted.
+        expect(embedding.usage).toBeUndefined();
+      });
+      expect(lastRequestBody().input).toEqual(['a', 'b', 'c']);
+    });
+
+    test('falls back to the resolved model id when the response omits model', async () => {
+      mockFetchResponse(openAiEmbeddingBody([[0.5]]));
+
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        modelOverride: 'text-embedding-3-large',
+        params: { input: 'x' }
+      });
+
+      expect(result).toSucceedAndSatisfy((embedding) => {
+        expect(embedding.model).toBe('text-embedding-3-large');
+      });
+    });
+
+    test('always sends encoding_format=float', async () => {
+      mockFetchResponse(openAiEmbeddingBody([[0.1]]));
+
+      await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+
+      expect(lastRequestBody().encoding_format).toBe('float');
+    });
+
+    test('reports partial usage when only total_tokens is present', async () => {
+      mockFetchResponse(openAiEmbeddingBody([[0.1]], { usage: { total_tokens: 7 } }));
+
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+
+      expect(result).toSucceedAndSatisfy((embedding) => {
+        expect(embedding.usage).toEqual({ totalTokens: 7 });
+      });
+    });
+
+    test('reports partial usage when only prompt_tokens is present', async () => {
+      mockFetchResponse(openAiEmbeddingBody([[0.1]], { usage: { prompt_tokens: 5 } }));
+
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+
+      expect(result).toSucceedAndSatisfy((embedding) => {
+        expect(embedding.usage).toEqual({ promptTokens: 5 });
+      });
+    });
+
+    test('omits usage when the usage object carries no token counts', async () => {
+      mockFetchResponse(openAiEmbeddingBody([[0.1]], { usage: {} }));
+
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+
+      expect(result).toSucceedAndSatisfy((embedding) => {
+        expect(embedding.usage).toBeUndefined();
+      });
+    });
+  });
+
+  describe('dimensions knob (request-body assertions)', () => {
+    test('sends dimensions on the wire for a dimensions-capable model', async () => {
+      mockFetchResponse(openAiEmbeddingBody([[0.1, 0.2]]));
+
+      await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        modelOverride: 'text-embedding-3-small',
+        params: { input: 'x', dimensions: 256 }
+      });
+
+      expect(lastRequestBody().dimensions).toBe(256);
+    });
+
+    test('omits dimensions (no-op) and logs a note for a model that does not support it', async () => {
+      mockFetchResponse(openAiEmbeddingBody([[0.1]]));
+      const logger = new Logging.InMemoryLogger('all');
+
+      await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        // ada-002 hits the catch-all capability (no supportsDimensions).
+        modelOverride: 'text-embedding-ada-002',
+        params: { input: 'x', dimensions: 256 },
+        logger
+      });
+
+      expect(lastRequestBody().dimensions).toBeUndefined();
+      expect(logger.logged.some((m) => /ignores dimensions/.test(m))).toBe(true);
+    });
+  });
+
+  describe('taskType knob (request-body assertions)', () => {
+    test('never sends taskType on the OpenAI wire and logs a no-op note', async () => {
+      mockFetchResponse(openAiEmbeddingBody([[0.1]]));
+      const logger = new Logging.InMemoryLogger('all');
+
+      await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x', taskType: 'retrieval-query' },
+        logger
+      });
+
+      expect(lastRequestBody().taskType).toBeUndefined();
+      expect(lastRequestBody().task_type).toBeUndefined();
+      expect(logger.logged.some((m) => /ignores taskType/.test(m))).toBe(true);
+    });
+
+    test('does not log a no-op note when no unsupported knobs are supplied', async () => {
+      mockFetchResponse(openAiEmbeddingBody([[0.1]]));
+      const logger = new Logging.InMemoryLogger('all');
+
+      await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' },
+        logger
+      });
+
+      expect(logger.logged.some((m) => /ignores/.test(m))).toBe(false);
+    });
+  });
+
+  describe('self-hosted (endpoint override, keyless)', () => {
+    test('routes ollama through the resolved endpoint with no auth header', async () => {
+      mockFetchResponse(openAiEmbeddingBody([[0.1, 0.2]]));
+
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: AiAssist.getProviderDescriptor('ollama').orThrow(),
+        apiKey: '',
+        modelOverride: 'nomic-embed-text',
+        params: { input: 'x' },
+        endpoint: 'http://localhost:11434/v1'
+      });
+
+      expect(result).toSucceed();
+      expect(lastRequestUrl()).toBe('http://localhost:11434/v1/embeddings');
+      expect(lastRequestHeaders().Authorization).toBeUndefined();
+    });
+  });
+
+  describe('up-front rejections', () => {
+    test('fails when the provider declares no embedding capability', async () => {
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: AiAssist.getProviderDescriptor('xai-grok').orThrow(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/does not support embeddings/i);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('fails when no embedding model resolves (self-hosted with no override)', async () => {
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: AiAssist.getProviderDescriptor('openai-compat').orThrow(),
+        apiKey: '',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/no embedding model resolved/i);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('fails fast when the batch exceeds the model maximum (no auto-chunking)', async () => {
+      const inputs: string[] = [];
+      for (let i = 0; i < 2049; i++) {
+        inputs.push(`item-${i}`);
+      }
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        modelOverride: 'text-embedding-3-small',
+        params: { input: inputs }
+      });
+      expect(result).toFailWith(/batch of 2049 exceeds .* maximum of 2048/i);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('fails when no capability matches the resolved model', async () => {
+      // Declares an embedding capability, but only for a specific prefix that
+      // the resolved model does not match (no catch-all entry).
+      const descriptor: IAiProviderDescriptor = {
+        ...openAiDescriptor(),
+        defaultModel: { base: 'gpt-4o', embedding: 'some-unlisted-model' },
+        embedding: [{ modelPrefix: 'text-embedding-3', format: 'openai-embeddings' }]
+      };
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor,
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/does not support embeddings for model "some-unlisted-model"/i);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('fails when the endpoint override is malformed', async () => {
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' },
+        endpoint: 'not a url'
+      });
+      expect(result).toFail();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('empty input short-circuit', () => {
+    test('returns an empty result with no wire call', async () => {
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: [] }
+      });
+
+      expect(result).toSucceedAndSatisfy((embedding) => {
+        expect(embedding.vectors).toEqual([]);
+        expect(embedding.dimensions).toBe(0);
+        expect(embedding.model).toBe('text-embedding-3-small');
+      });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error paths', () => {
+    test('surfaces an HTTP error', async () => {
+      mockFetchHttpError(429, 'rate limited');
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/429.*rate limited/i);
+    });
+
+    test('surfaces a network error', async () => {
+      mockFetchError(new Error('boom'));
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/boom/i);
+    });
+
+    test('fails when the response is missing the data array', async () => {
+      mockFetchResponse({ object: 'list', model: 'text-embedding-3-small' });
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/OpenAI embeddings API response/i);
+    });
+
+    test('fails when the response data array is empty', async () => {
+      mockFetchResponse({ object: 'list', data: [] });
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/OpenAI embeddings API response/i);
+    });
+  });
+
+  describe('gemini-embeddings format (Phase 2 — not yet implemented)', () => {
+    test('the gemini adapter is pending until Phase 3', async () => {
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: AiAssist.getProviderDescriptor('google-gemini').orThrow(),
+        apiKey: 'gk-test',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/gemini embeddings adapter not yet implemented/i);
+    });
+  });
+});


### PR DESCRIPTION
## Phase 2 — the dispatcher + OpenAI-format adapter

Implements **Phase 2** of `.ai/tasks/active/ai-assist-embeddings/design.md` (§13): `callProviderEmbedding` + the OpenAI-format adapter. **This phase alone delivers embeddings for OpenAI, Ollama (via `/v1`), openai-compat self-hosted servers, and Mistral** — i.e. it resolves the Ollama-redundancy verdict (OQ-1) in practice. Gemini's `batchEmbedContents` adapter and `callProxiedEmbedding` are deferred to Phase 3.

> **Stacked on [#481](https://github.com/ErikFortune/fgv/pull/481) (Phase 1).** Until Phase 1 merges, this PR's diff includes Phase 1's commits; afterward it collapses to just Phase 2. Base is `ai-assist-embeddings`.

### What shipped
- **`embeddingClient.ts`** (new) — `callProviderEmbedding` dispatcher: `supportsEmbedding` up-front rejection → `resolveModel(..., 'embedding')` → `resolveEmbeddingCapability` → **empty-input short-circuit (no wire call)** → **`maxBatchSize` fail-fast (no auto-chunking)** → `resolveEffectiveBaseUrl` → no-op-knob notes → format switch. `callOpenAiEmbeddings` adapter: `POST {baseUrl}/embeddings`, bearer auth (omitted when keyless), `encoding_format:'float'` always, `dimensions` only when the capability supports it, **index-sort to align batch order**, usage → `{promptTokens,totalTokens}`, `number[][]` result.
- **`http.ts`** (new) — extracted the shared `fetchJson` + `IAiApiConfig` (previously private to `apiClient.ts`) into an internal module now reused by both clients. Behavior-preserving; also trims `apiClient.ts` back under its 2000-line ceiling.
- **`apiClient.ts`** — imports the helpers from `./http` (no behavior change).
- **`index.ts`** — exports `callProviderEmbedding` + `IProviderEmbeddingParams`. **`etc/ts-extras.api.md`** regenerated.
- **`embeddingClient.test.ts`** (new, 23 tests).

### Cross-provider knob handling (design §7, load-bearing)
Caller-supplied `dimensions`/`taskType` that the resolved model doesn't support are a **logged no-op, never a failure** — so a cross-provider call site passes them once and they apply only where they matter. The OpenAI adapter never puts `taskType` on the wire.

### §14 amendments honored
`AiEmbeddingApiFormat` naming ✅ · empty-input short-circuit (#2) ✅ · `maxBatchSize` fail-fast (#3) ✅ · `encoding_format:'float'` known-assumption documented (#5) ✅.

### Gates
- `rushx build` ✅ · `rushx lint` ✅ (0 problems) · `rushx test` ✅ **100% coverage**
- `rushx fixlint` before final commit ✅ · No `any`; additive-only.

### Review loop
- **`code-reviewer` run on the isolated Phase 2 diff before this PR → Approved, no P1/blocking issues.** All eight load-bearing design points verified, including the §10 request-**body** assertions (taskType absent on OpenAI + info note; dimensions present-when-supported / absent-with-note). P2 items were established-convention / pre-existing api-extractor warnings / Phase-3 reminders (no action). Applied the one cheap P3 (assert `taskType` absent on the dimensions happy-path test).

### Deferred to Phase 3
Gemini `batchEmbedContents` adapter (the dispatcher's `gemini-embeddings` case is a clearly-commented, tested placeholder until then) + `callProxiedEmbedding` + the docs (Phase 4).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XXKssj1G7jYcs8hFUWjqbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXKssj1G7jYcs8hFUWjqbZ)_