### PR TITLE
feat(ai-assist): Gemini embedding adapter + callProxiedEmbedding (Phase 3)

### DIFF
--- a/common/changes/@fgv/ts-extras/ai-assist-embeddings-phase3_2026-06-07-02-00.json
+++ b/common/changes/@fgv/ts-extras/ai-assist-embeddings-phase3_2026-06-07-02-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "ai-assist: complete the embedding primitive (Phase 3) — the Gemini :batchEmbedContents adapter (taskType kebab->SCREAMING_SNAKE mapping, outputDimensionality, models/{id} qualification with no-double-prefix, no usage) wired into callProviderEmbedding, plus callProxiedEmbedding (POST {proxyUrl}/api/ai/embedding mirror of the image-gen proxy leg). Cross-provider embeddings now cover OpenAI/Ollama/openai-compat/Mistral (OpenAI format) and Google Gemini.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -141,6 +141,7 @@ declare namespace AiAssist {
         IProviderImageGenerationParams,
         IProviderListModelsParams,
         callProviderEmbedding,
+        callProxiedEmbedding,
         IProviderEmbeddingParams,
         callProviderCompletionStream,
         callProxiedCompletionStream,
@@ -343,6 +344,11 @@ function callProxiedCompletion(proxyUrl: string, params: IProviderCompletionPara
 //
 // @public
 function callProxiedCompletionStream(proxyUrl: string, params: IProviderCompletionStreamParams): Promise<Result<AsyncIterable<IAiStreamEvent>>>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "callProviderEmbedding"
+//
+// @public
+function callProxiedEmbedding(proxyUrl: string, params: IProviderEmbeddingParams): Promise<Result<IAiEmbeddingResult>>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "callProviderImageGeneration"
 //

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -345,7 +345,7 @@ function callProxiedCompletion(proxyUrl: string, params: IProviderCompletionPara
 // @public
 function callProxiedCompletionStream(proxyUrl: string, params: IProviderCompletionStreamParams): Promise<Result<AsyncIterable<IAiStreamEvent>>>;
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "callProviderEmbedding"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
 function callProxiedEmbedding(proxyUrl: string, params: IProviderEmbeddingParams): Promise<Result<IAiEmbeddingResult>>;

--- a/libraries/ts-extras/src/packlets/ai-assist/embeddingClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/embeddingClient.ts
@@ -226,6 +226,102 @@ async function callOpenAiEmbeddings(
 }
 
 // ============================================================================
+// Gemini-format (`:batchEmbedContents`) response validators + adapter
+// ============================================================================
+
+/** @internal */
+interface IGeminiEmbedding {
+  values: number[];
+}
+/** @internal */
+interface IGeminiEmbeddingResponse {
+  embeddings: IGeminiEmbedding[];
+}
+
+const geminiEmbedding: Validator<IGeminiEmbedding> = Validators.object<IGeminiEmbedding>({
+  values: Validators.arrayOf(Validators.number)
+});
+const geminiEmbeddingResponse: Validator<IGeminiEmbeddingResponse> =
+  Validators.object<IGeminiEmbeddingResponse>({
+    embeddings: Validators.arrayOf(geminiEmbedding).withConstraint((arr) => arr.length > 0)
+  });
+
+/**
+ * Maps a cross-provider {@link AiAssist.AiEmbeddingTaskType} (kebab-case) to the
+ * Gemini wire form (`SCREAMING_SNAKE_CASE`), e.g. `'retrieval-document'` becomes
+ * `'RETRIEVAL_DOCUMENT'`.
+ * @internal
+ */
+function toGeminiTaskType(taskType: string): string {
+  return taskType.replace(/-/g, '_').toUpperCase();
+}
+
+/**
+ * Strips a leading `models/` from a model id so the URL path and the per-request
+ * `model` field can each apply the prefix exactly once.
+ * @internal
+ */
+function bareGeminiModel(model: string): string {
+  return model.startsWith('models/') ? model.slice('models/'.length) : model;
+}
+
+/**
+ * Calls the Google Gemini `:batchEmbedContents` endpoint. Always uses the batch
+ * route (a single input is a one-element batch). Sends `taskType` /
+ * `outputDimensionality` only when the capability declares support. Gemini does
+ * not report token usage for embeddings, so `usage` is omitted.
+ * @internal
+ */
+async function callGeminiEmbeddings(
+  config: IAiApiConfig,
+  inputs: ReadonlyArray<string>,
+  request: IAiEmbeddingParams,
+  capability: IAiEmbeddingModelCapability,
+  logger?: Logging.ILogger,
+  signal?: AbortSignal
+): Promise<Result<IAiEmbeddingResult>> {
+  const bare = bareGeminiModel(config.model);
+  const qualified = `models/${bare}`;
+  // `request.taskType` is the open `AiEmbeddingTaskType` union (includes `string & {}`),
+  // which `!== undefined` cannot narrow to `string`; resolve it cast-free here.
+  const taskType =
+    capability.supportsTaskType && request.taskType !== undefined
+      ? toGeminiTaskType(request.taskType)
+      : undefined;
+  const sendDimensions = capability.supportsDimensions && request.dimensions !== undefined;
+
+  const requests = inputs.map((text) => ({
+    model: qualified,
+    content: { parts: [{ text }] },
+    ...(taskType !== undefined ? { taskType } : {}),
+    ...(sendDimensions ? { outputDimensionality: request.dimensions } : {})
+  }));
+  const body: Record<string, unknown> = { requests };
+  const headers: Record<string, string> = { 'x-goog-api-key': config.apiKey };
+  const url = `${config.baseUrl}/models/${bare}:batchEmbedContents`;
+
+  /* c8 ignore next 1 - optional logger */
+  logger?.info(`AI embedding: format=gemini-embeddings, model=${bare}, inputs=${inputs.length}`);
+
+  const jsonResult = await fetchJson(url, headers, body, logger, signal);
+  if (jsonResult.isFailure()) {
+    return fail(jsonResult.message);
+  }
+  return geminiEmbeddingResponse
+    .validate(jsonResult.value)
+    .withErrorFormat((msg) => `Gemini embeddings API response: ${msg}`)
+    .onSuccess((response) => {
+      // Gemini returns embeddings aligned to request order (no index field).
+      const vectors = response.embeddings.map((e) => e.values);
+      return succeed({
+        vectors,
+        model: bare,
+        dimensions: vectors[0].length
+      });
+    });
+}
+
+// ============================================================================
 // Dispatcher
 // ============================================================================
 
@@ -335,12 +431,72 @@ function dispatchEmbedding(
     case 'openai-embeddings':
       return callOpenAiEmbeddings(config, inputs, request, capability, logger, signal);
     case 'gemini-embeddings':
-      // Wired in Phase 3 (batchEmbedContents adapter).
-      return Promise.resolve(fail('gemini embeddings adapter not yet implemented'));
+      return callGeminiEmbeddings(config, inputs, request, capability, logger, signal);
     /* c8 ignore next 4 - defensive: exhaustive switch guaranteed by TypeScript */
     default: {
       const _exhaustive: never = format;
       return Promise.resolve(fail(`unsupported embedding API format: ${String(_exhaustive)}`));
     }
   }
+}
+
+// ============================================================================
+// Proxied embedding
+// ============================================================================
+
+const proxiedEmbeddingUsage: Validator<IAiEmbeddingUsage> = Validators.object<IAiEmbeddingUsage>({
+  promptTokens: Validators.number.optional(),
+  totalTokens: Validators.number.optional()
+});
+const proxiedEmbeddingResponse: Validator<IAiEmbeddingResult> = Validators.object<IAiEmbeddingResult>({
+  vectors: Validators.arrayOf(Validators.arrayOf(Validators.number)),
+  model: Validators.string,
+  dimensions: Validators.number,
+  usage: proxiedEmbeddingUsage.optional()
+});
+
+/**
+ * Calls the embedding endpoint on a proxy server instead of calling the provider
+ * API directly from the browser. Endpoint: `POST ${proxyUrl}/api/ai/embedding`.
+ * Request body: `{ providerId, apiKey, params, modelOverride? }`. The proxy
+ * handles descriptor lookup, model/capability resolution, and provider dispatch.
+ * Error body `{ error: string }` is surfaced as `proxy: ${error}`.
+ *
+ * @param proxyUrl - Base URL of the proxy server (e.g. `http://localhost:3001`).
+ * @param params - Same parameters as {@link callProviderEmbedding}.
+ * @returns The embedding result, or a failure.
+ * @public
+ */
+export async function callProxiedEmbedding(
+  proxyUrl: string,
+  params: IProviderEmbeddingParams
+): Promise<Result<IAiEmbeddingResult>> {
+  const { descriptor, apiKey, params: request, modelOverride, logger, signal } = params;
+
+  const body: Record<string, unknown> = {
+    providerId: descriptor.id,
+    apiKey,
+    params: request
+  };
+  if (modelOverride !== undefined) {
+    body.modelOverride = modelOverride;
+  }
+
+  /* c8 ignore next 1 - optional logger */
+  logger?.info(`AI embedding proxy request: provider=${descriptor.id}, proxy=${proxyUrl}`);
+
+  const url = `${proxyUrl}/api/ai/embedding`;
+  const jsonResult = await fetchJson(url, {}, body, logger, signal);
+  if (jsonResult.isFailure()) {
+    return fail(jsonResult.message);
+  }
+
+  const response = jsonResult.value;
+  if (typeof response.error === 'string') {
+    return fail(`proxy: ${response.error}`);
+  }
+
+  return proxiedEmbeddingResponse
+    .validate(response)
+    .withErrorFormat((msg) => `proxy returned invalid response: ${msg}`);
 }

--- a/libraries/ts-extras/src/packlets/ai-assist/embeddingClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/embeddingClient.ts
@@ -463,7 +463,7 @@ const proxiedEmbeddingResponse: Validator<IAiEmbeddingResult> = Validators.objec
  * Error body `{ error: string }` is surfaced as `proxy: ${error}`.
  *
  * @param proxyUrl - Base URL of the proxy server (e.g. `http://localhost:3001`).
- * @param params - Same parameters as {@link callProviderEmbedding}.
+ * @param params - Same parameters as {@link AiAssist.callProviderEmbedding}.
  * @returns The embedding result, or a failure.
  * @public
  */

--- a/libraries/ts-extras/src/packlets/ai-assist/index.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/index.ts
@@ -130,7 +130,11 @@ export {
   type IProviderListModelsParams
 } from './apiClient';
 
-export { callProviderEmbedding, type IProviderEmbeddingParams } from './embeddingClient';
+export {
+  callProviderEmbedding,
+  callProxiedEmbedding,
+  type IProviderEmbeddingParams
+} from './embeddingClient';
 
 export {
   callProviderCompletionStream,

--- a/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
@@ -19,8 +19,9 @@
 // SOFTWARE.
 
 /**
- * Tests for callProviderEmbedding (Phase 2 — OpenAI-format adapter + dispatcher).
- * Mock fetch, per-format fixtures, no live calls.
+ * Tests for callProviderEmbedding and callProxiedEmbedding — OpenAI and Gemini
+ * adapters, the dispatcher, and the proxy leg. Mock fetch, per-format fixtures,
+ * no live calls.
  */
 
 import '@fgv/ts-utils-jest';
@@ -92,6 +93,15 @@ function openAiEmbeddingBody(
 
 function openAiDescriptor(): IAiProviderDescriptor {
   return AiAssist.getProviderDescriptor('openai').orThrow();
+}
+
+function geminiDescriptor(): IAiProviderDescriptor {
+  return AiAssist.getProviderDescriptor('google-gemini').orThrow();
+}
+
+/** Gemini `:batchEmbedContents` response body. */
+function geminiEmbeddingBody(vectors: number[][]): unknown {
+  return { embeddings: vectors.map((values) => ({ values })) };
 }
 
 // ============================================================================
@@ -491,14 +501,222 @@ describe('callProviderEmbedding', () => {
     });
   });
 
-  describe('gemini-embeddings format (Phase 2 — not yet implemented)', () => {
-    test('the gemini adapter is pending until Phase 3', async () => {
+  describe('Gemini-format adapter', () => {
+    test('embeds a batch via batchEmbedContents with qualified model + parts', async () => {
+      mockFetchResponse(
+        geminiEmbeddingBody([
+          [0.1, 0.2, 0.3],
+          [0.4, 0.5, 0.6]
+        ])
+      );
+
       const result = await AiAssist.callProviderEmbedding({
-        descriptor: AiAssist.getProviderDescriptor('google-gemini').orThrow(),
+        descriptor: geminiDescriptor(),
         apiKey: 'gk-test',
+        params: { input: ['a', 'b'] }
+      });
+
+      expect(result).toSucceedAndSatisfy((embedding) => {
+        expect(embedding.vectors).toEqual([
+          [0.1, 0.2, 0.3],
+          [0.4, 0.5, 0.6]
+        ]);
+        expect(embedding.model).toBe('gemini-embedding-001');
+        expect(embedding.dimensions).toBe(3);
+        // Gemini does not report token usage for embeddings.
+        expect(embedding.usage).toBeUndefined();
+      });
+
+      expect(lastRequestUrl()).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents'
+      );
+      expect(lastRequestHeaders()['x-goog-api-key']).toBe('gk-test');
+      const body = lastRequestBody();
+      const requests = body.requests as Array<Record<string, unknown>>;
+      expect(requests).toHaveLength(2);
+      expect(requests[0]).toMatchObject({
+        model: 'models/gemini-embedding-001',
+        content: { parts: [{ text: 'a' }] }
+      });
+      expect(requests[1].content).toEqual({ parts: [{ text: 'b' }] });
+    });
+
+    test('maps taskType to SCREAMING_SNAKE on the wire (request-body assertion)', async () => {
+      mockFetchResponse(geminiEmbeddingBody([[0.1]]));
+
+      await AiAssist.callProviderEmbedding({
+        descriptor: geminiDescriptor(),
+        apiKey: 'gk-test',
+        params: { input: 'q', taskType: 'retrieval-query' }
+      });
+
+      const requests = lastRequestBody().requests as Array<Record<string, unknown>>;
+      expect(requests[0].taskType).toBe('RETRIEVAL_QUERY');
+    });
+
+    test('maps a hyphenated taskType (code-retrieval-query) correctly', async () => {
+      mockFetchResponse(geminiEmbeddingBody([[0.1]]));
+
+      await AiAssist.callProviderEmbedding({
+        descriptor: geminiDescriptor(),
+        apiKey: 'gk-test',
+        params: { input: 'q', taskType: 'code-retrieval-query' }
+      });
+
+      const requests = lastRequestBody().requests as Array<Record<string, unknown>>;
+      expect(requests[0].taskType).toBe('CODE_RETRIEVAL_QUERY');
+    });
+
+    test('sends outputDimensionality and reports the reduced length', async () => {
+      // Reduced-dimension response (MRL truncation to 2).
+      mockFetchResponse(geminiEmbeddingBody([[0.1, 0.2]]));
+
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: geminiDescriptor(),
+        apiKey: 'gk-test',
+        params: { input: 'q', dimensions: 2 }
+      });
+
+      const requests = lastRequestBody().requests as Array<Record<string, unknown>>;
+      expect(requests[0].outputDimensionality).toBe(2);
+      expect(result).toSucceedAndSatisfy((embedding) => {
+        expect(embedding.dimensions).toBe(2);
+      });
+    });
+
+    test('omits taskType and outputDimensionality when not supplied', async () => {
+      mockFetchResponse(geminiEmbeddingBody([[0.1]]));
+
+      await AiAssist.callProviderEmbedding({
+        descriptor: geminiDescriptor(),
+        apiKey: 'gk-test',
+        params: { input: 'q' }
+      });
+
+      const requests = lastRequestBody().requests as Array<Record<string, unknown>>;
+      expect(requests[0].taskType).toBeUndefined();
+      expect(requests[0].outputDimensionality).toBeUndefined();
+    });
+
+    test('does not double-prefix an already-qualified model id', async () => {
+      mockFetchResponse(geminiEmbeddingBody([[0.1]]));
+
+      await AiAssist.callProviderEmbedding({
+        descriptor: geminiDescriptor(),
+        apiKey: 'gk-test',
+        modelOverride: 'models/gemini-embedding-001',
+        params: { input: 'q' }
+      });
+
+      expect(lastRequestUrl()).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents'
+      );
+      const requests = lastRequestBody().requests as Array<Record<string, unknown>>;
+      expect(requests[0].model).toBe('models/gemini-embedding-001');
+    });
+
+    test('fails when the response is missing the embeddings array', async () => {
+      mockFetchResponse({ notEmbeddings: [] });
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: geminiDescriptor(),
+        apiKey: 'gk-test',
+        params: { input: 'q' }
+      });
+      expect(result).toFailWith(/Gemini embeddings API response/i);
+    });
+
+    test('surfaces an HTTP error from the Gemini endpoint', async () => {
+      mockFetchHttpError(503, 'unavailable');
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: geminiDescriptor(),
+        apiKey: 'gk-test',
+        params: { input: 'q' }
+      });
+      expect(result).toFailWith(/503.*unavailable/i);
+    });
+  });
+
+  describe('callProxiedEmbedding', () => {
+    test('posts to the proxy embedding endpoint and returns the validated result', async () => {
+      mockFetchResponse({
+        vectors: [[0.1, 0.2]],
+        model: 'text-embedding-3-small',
+        dimensions: 2,
+        usage: { promptTokens: 3, totalTokens: 3 }
+      });
+
+      const result = await AiAssist.callProxiedEmbedding('http://localhost:3001', {
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        modelOverride: 'text-embedding-3-small',
         params: { input: 'x' }
       });
-      expect(result).toFailWith(/gemini embeddings adapter not yet implemented/i);
+
+      expect(result).toSucceedAndSatisfy((embedding) => {
+        expect(embedding.vectors).toEqual([[0.1, 0.2]]);
+        expect(embedding.dimensions).toBe(2);
+        expect(embedding.usage).toEqual({ promptTokens: 3, totalTokens: 3 });
+      });
+
+      expect(lastRequestUrl()).toBe('http://localhost:3001/api/ai/embedding');
+      expect(lastRequestBody()).toMatchObject({
+        providerId: 'openai',
+        apiKey: 'sk-test',
+        modelOverride: 'text-embedding-3-small',
+        params: { input: 'x' }
+      });
+    });
+
+    test('omits modelOverride from the proxy body when not supplied', async () => {
+      mockFetchResponse({ vectors: [[0.1]], model: 'm', dimensions: 1 });
+
+      await AiAssist.callProxiedEmbedding('http://localhost:3001', {
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+
+      expect(lastRequestBody().modelOverride).toBeUndefined();
+    });
+
+    test('surfaces a proxy error body', async () => {
+      mockFetchResponse({ error: 'provider exploded' });
+      const result = await AiAssist.callProxiedEmbedding('http://localhost:3001', {
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/proxy: provider exploded/i);
+    });
+
+    test('fails when the proxy returns an invalid response shape', async () => {
+      mockFetchResponse({ vectors: 'not-an-array', model: 'm', dimensions: 1 });
+      const result = await AiAssist.callProxiedEmbedding('http://localhost:3001', {
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/proxy returned invalid response/i);
+    });
+
+    test('surfaces an HTTP error from the proxy', async () => {
+      mockFetchHttpError(502, 'bad gateway');
+      const result = await AiAssist.callProxiedEmbedding('http://localhost:3001', {
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/502.*bad gateway/i);
+    });
+
+    test('surfaces a network error from the proxy', async () => {
+      mockFetchError(new Error('connection refused'));
+      const result = await AiAssist.callProxiedEmbedding('http://localhost:3001', {
+        descriptor: openAiDescriptor(),
+        apiKey: 'sk-test',
+        params: { input: 'x' }
+      });
+      expect(result).toFailWith(/connection refused/i);
     });
   });
 });


### PR DESCRIPTION
## Phase 3 — Gemini adapter + proxy leg (completes the primitive)

Implements **Phase 3** of `.ai/tasks/active/ai-assist-embeddings/design.md` (§13): the Google Gemini `:batchEmbedContents` adapter and `callProxiedEmbedding`. With this, the cross-provider embedding primitive is functionally complete — **OpenAI / Ollama (via `/v1`) / openai-compat / Mistral** (OpenAI format, Phase 2) **and Google Gemini** (Phase 3).

> **Stacked on [#482](https://github.com/ErikFortune/fgv/pull/482) (Phase 2) → [#481](https://github.com/ErikFortune/fgv/pull/481) (Phase 1).** Base is `ai-assist-embeddings`; the diff collapses to just Phase 3 once the earlier PRs merge. Phase 4 (docs) follows separately.

### What shipped
- **`callGeminiEmbeddings`** — `POST {baseUrl}/models/{model}:batchEmbedContents`, `x-goog-api-key` auth. One `requests[]` entry per input aligned by response order. `taskType` mapped kebab→`SCREAMING_SNAKE` and `outputDimensionality` sent **only** when the capability declares support (Gemini supports both). `models/{id}` qualification with **no double-prefix** when the caller passes an already-qualified id. No `usage` (Gemini doesn't report it for embeddings). Wired into the dispatcher, replacing the Phase 2 placeholder.
- **`callProxiedEmbedding`** — `POST {proxyUrl}/api/ai/embedding`, body `{ providerId, apiKey, params, modelOverride? }`, validates the response into `IAiEmbeddingResult`, surfaces `{error}` as `proxy: ${error}`. Mirrors `callProxiedImageGeneration`.
- **`index.ts`** — exports `callProxiedEmbedding`. **`etc/ts-extras.api.md`** regenerated.
- **Tests** — real Gemini adapter tests (request-**body** assertions for `taskType`→`RETRIEVAL_QUERY`/`CODE_RETRIEVAL_QUERY` and `outputDimensionality`; no-double-prefix; omitted-knobs; reduced-dimension; HTTP error) + full `callProxiedEmbedding` tests (body shape, `modelOverride` omission, `{error}` surfacing, invalid-shape, HTTP + network errors).

### Gates
- `rushx build` ✅ · `rushx lint` ✅ (0 problems) · `rushx test` ✅ **100% coverage** · `rushx fixlint` ✅
- No `any`; additive-only.

### Review loop
- **`code-reviewer` run on the isolated Phase 3 diff → Approved.** All design §6.2/§7/§3.2 points and the §10 request-body assertions verified. Two non-blocking P2s addressed/dispositioned: (P2-1) removed the `request.taskType as string` cast in favor of a cast-free narrowing; (P2-2) `callProxiedEmbedding` reads `jsonResult.value` (typed `JsonObject`) **without** the sibling proxies' `as Record<string, unknown>` cast — kept cast-free intentionally (type-safe via `JsonObject` indexing; avoids an unnecessary cast per CODING_STANDARDS). Applied both P3s (stale header comment; proxy network-error test).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XXKssj1G7jYcs8hFUWjqbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXKssj1G7jYcs8hFUWjqbZ)_