### PR TITLE
test(testbed): cross-provider-embedding-search live gate scenario

### DIFF
--- a/.ai/tasks/completed/2026-06/ai-assist-embeddings/result.md
+++ b/.ai/tasks/completed/2026-06/ai-assist-embeddings/result.md
@@ -58,3 +58,28 @@ summary).
 regenerated; `rush change` (type none); no `any`; additive-only. `code-reviewer` run
 on each phase diff before its PR; Copilot review loop driven per phase to diminishing
 returns.
+
+## Live empirical gate (PR #485) — PASSED
+
+The four phased PRs landed with 100% unit coverage but **mock-fetch only** — no real
+network call had ever exercised the adapters. The live gate was commissioned as a
+single `@fgv/testbed` scenario (`cross-provider-embedding-search`, see
+[testbed-scenario-brief.md](./testbed-scenario-brief.md)) and delivered in **PR #485**
+(into `ai-assist-embeddings`; testbed-only, primitive untouched).
+
+- **Scenario:** embeds a query (`retrieval-query`) + a 5-doc corpus in one batch call
+  (`retrieval-document`), cosine-ranks, prints a computed PASS/FAIL gate matrix; runs
+  against OpenAI-shaped providers or Gemini via `EMBED_PROVIDER`. Mock-fetch unit tests
+  drive the **real** `callProviderEmbedding` and assert the outgoing request body
+  (taskType reaching the wire, no-op on OpenAI, dimensions, batch alignment). 204 tests,
+  100% coverage; `code-reviewer` (1 round, no P1) + Copilot (3 rounds → diminishing
+  returns: doc-accuracy → a real query-batch-count silent-ignore gap on the Gemini path,
+  now caught → a fail-fast `EMBED_ENDPOINT` diagnostic).
+- **Live run (Erik, 2026-06-07):** **PASS on both wire formats.** OpenAI
+  `text-embedding-3-small` (1536-d; `EMBED_DIMENSIONS=512` honored → 512-d) and Gemini
+  `gemini-embedding-001` (3072-d, **`taskType` HONORED** — the `batchEmbedContents`
+  retrieval-asymmetry path that had never made a real call). Ranking sane on every run
+  (the password-reset doc ranks #1). **No primitive gap surfaced under live fire.**
+
+**Verdict:** the embedding modality is empirically verified end-to-end; the
+`ai-assist-embeddings` → `release` promotion is unblocked.

--- a/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/index.ts
+++ b/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/index.ts
@@ -1,0 +1,110 @@
+/**
+ * `cross-provider-embedding-search` scenario (CLI-only) — the **live empirical gate** for the
+ * `ai-assist-embeddings` primitive and the cloud sibling of `local-embedding-search`.
+ *
+ * Where `local-embedding-search` runs the model in-process, this scenario exercises the
+ * **distant-HTTP** primitive `AiAssist.callProviderEmbedding` against a real provider: it embeds
+ * a query and a small document corpus, computes cosine similarity, and ranks the documents.
+ * It runs against either an **OpenAI-shaped** provider (`openai`, and reachable: Ollama-via-`/v1`,
+ * `openai-compat`, Mistral) or **Gemini** (`google-gemini` — the divergent `batchEmbedContents`
+ * wire path), so both embedding wire formats are exercised live.
+ *
+ * ## Why this scenario exists
+ *
+ * The primitive shipped with 100% unit coverage but had **never made a real network call** —
+ * mock-fetch tests assert what we *send*, not that a provider *accepts* it. This scenario is the
+ * live verification. The highest-risk path is Gemini's `taskType` retrieval asymmetry
+ * (`RETRIEVAL_QUERY` for the query vs `RETRIEVAL_DOCUMENT` for the documents) on the
+ * `batchEmbedContents` route, which the primitive's mock tests describe but no live call had
+ * confirmed.
+ *
+ * ## Usage (env-gated; live network required)
+ *
+ * The testbed CLI does not forward trailing argv to scenarios, so configuration is via env vars:
+ *
+ * ```sh
+ * # OpenAI (default provider):
+ * OPENAI_API_KEY=sk-... node bin/testbed.js --scenario cross-provider-embedding-search
+ *
+ * # Gemini (exercises the batchEmbedContents + taskType-asymmetry wire path):
+ * EMBED_PROVIDER=gemini GEMINI_API_KEY=... \
+ *   node bin/testbed.js --scenario cross-provider-embedding-search
+ *
+ * # Request a reduced dimension (OpenAI text-embedding-3-* / Gemini):
+ * EMBED_PROVIDER=openai OPENAI_API_KEY=sk-... EMBED_DIMENSIONS=512 \
+ *   node bin/testbed.js --scenario cross-provider-embedding-search
+ *
+ * # Self-hosted (Ollama via /v1; keyless — EMBED_MODEL required):
+ * EMBED_PROVIDER=ollama EMBED_MODEL=nomic-embed-text EMBED_ENDPOINT=http://localhost:11434/v1 \
+ *   node bin/testbed.js --scenario cross-provider-embedding-search
+ * ```
+ *
+ * Without the provider's key the scenario fails immediately with the exact missing-config
+ * diagnostic (the "live gate PENDING" signal), rather than silently skipping.
+ *
+ * @packageDocumentation
+ */
+
+import { fail, succeed } from '@fgv/ts-utils';
+import type { Result } from '@fgv/ts-utils';
+
+import type { IScenario, ICliScenarioImpl, IScenarioContext } from '../../shell';
+import { formatEmbeddingReport, parseEmbeddingScenarioConfig, runEmbeddingSearch } from './search';
+
+const cliImpl: ICliScenarioImpl = {
+  async run(context: IScenarioContext): Promise<Result<string>> {
+    const configResult = parseEmbeddingScenarioConfig(process.env);
+    if (configResult.isFailure()) {
+      return fail(configResult.message);
+    }
+    const config = configResult.value;
+
+    context.logger.info(
+      `cross-provider-embedding-search: provider=${config.providerLabel}, model=${config.model}` +
+        (config.dimensions !== undefined ? `, dimensions=${config.dimensions}` : '') +
+        (config.endpoint !== undefined ? `, endpoint=${config.endpoint}` : '')
+    );
+
+    const outcomeResult = await runEmbeddingSearch(config, undefined, context.logger);
+    if (outcomeResult.isFailure()) {
+      return fail(`cross-provider-embedding-search (${config.providerLabel}): ${outcomeResult.message}`);
+    }
+
+    const report = formatEmbeddingReport(outcomeResult.value);
+    context.logger.info(report.text);
+
+    // Surface a genuine failure (mis-shaped vectors, mis-ranked, dimension not honored) to the
+    // CLI rather than masking it behind succeed().
+    return report.pass ? succeed(report.text) : fail(report.text);
+  }
+};
+
+/**
+ * The cross-provider embedding-search scenario (CLI-only). Registered in `scenarios/index.ts`.
+ * @public
+ */
+export const crossProviderEmbeddingSearchScenario: IScenario = {
+  id: 'cross-provider-embedding-search',
+  title: 'Cross-Provider Embedding Search',
+  description:
+    'Live-wire verification of AiAssist.callProviderEmbedding: embeds a query + document ' +
+    'corpus via a real provider (OpenAI-shaped or Gemini), ranks by cosine similarity, and ' +
+    'checks both wire formats, batch alignment, the Gemini taskType retrieval asymmetry, and ' +
+    'dimension honoring. Configure via EMBED_PROVIDER + the provider key (OPENAI_API_KEY / ' +
+    'GEMINI_API_KEY). CLI-only.',
+  category: 'ai',
+  tags: ['ai-assist', 'embeddings', 'semantic-search', 'cross-provider', 'live-api', 'cli'],
+  requiredSecrets: [
+    {
+      id: 'openai-api-key',
+      envVarName: 'OPENAI_API_KEY',
+      description: 'OpenAI API key (default provider) for live embedding verification'
+    },
+    {
+      id: 'gemini-api-key',
+      envVarName: 'GEMINI_API_KEY',
+      description: 'Gemini API key (EMBED_PROVIDER=gemini) for the batchEmbedContents wire path'
+    }
+  ],
+  cli: cliImpl
+};

--- a/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/index.ts
+++ b/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/index.ts
@@ -90,8 +90,9 @@ export const crossProviderEmbeddingSearchScenario: IScenario = {
     'Live-wire verification of AiAssist.callProviderEmbedding: embeds a query + document ' +
     'corpus via a real provider (OpenAI-shaped or Gemini), ranks by cosine similarity, and ' +
     'checks both wire formats, batch alignment, the Gemini taskType retrieval asymmetry, and ' +
-    'dimension honoring. Configure via EMBED_PROVIDER + the provider key (OPENAI_API_KEY / ' +
-    'GEMINI_API_KEY). CLI-only.',
+    'dimension honoring. Configure via EMBED_PROVIDER (openai default; also gemini, mistral, ' +
+    'ollama, openai-compat) + the provider key (OPENAI_API_KEY, GEMINI_API_KEY / GOOGLE_API_KEY, ' +
+    'MISTRAL_API_KEY; self-hosted ollama / openai-compat are keyless). CLI-only.',
   category: 'ai',
   tags: ['ai-assist', 'embeddings', 'semantic-search', 'cross-provider', 'live-api', 'cli'],
   requiredSecrets: [
@@ -103,7 +104,14 @@ export const crossProviderEmbeddingSearchScenario: IScenario = {
     {
       id: 'gemini-api-key',
       envVarName: 'GEMINI_API_KEY',
-      description: 'Gemini API key (EMBED_PROVIDER=gemini) for the batchEmbedContents wire path'
+      description:
+        'Gemini API key (EMBED_PROVIDER=gemini) for the batchEmbedContents wire path; ' +
+        'GOOGLE_API_KEY is also accepted'
+    },
+    {
+      id: 'mistral-api-key',
+      envVarName: 'MISTRAL_API_KEY',
+      description: 'Mistral API key (EMBED_PROVIDER=mistral; mistral-embed is OpenAI-shaped)'
     }
   ],
   cli: cliImpl

--- a/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/index.ts
+++ b/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/index.ts
@@ -71,10 +71,11 @@ const cliImpl: ICliScenarioImpl = {
     }
 
     const report = formatEmbeddingReport(outcomeResult.value);
-    context.logger.info(report.text);
 
-    // Surface a genuine failure (mis-shaped vectors, mis-ranked, dimension not honored) to the
-    // CLI rather than masking it behind succeed().
+    // Return the report as the single source of output: the CLI prints a success value to stdout
+    // and surfaces a failure value through its structured error path. (Logging report.text here
+    // too would duplicate the whole block on stderr.) The short progress line above stays on
+    // stderr for live diagnostics.
     return report.pass ? succeed(report.text) : fail(report.text);
   }
 };

--- a/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
+++ b/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
@@ -1,0 +1,467 @@
+/**
+ * Pure / deps-injected core of the `cross-provider-embedding-search` scenario — the cloud
+ * sibling of `local-embedding-search`. Where the local scenario runs the model in-process
+ * (`@fgv/ts-extras-transformers`), this one exercises the **distant-HTTP** embedding primitive
+ * `AiAssist.callProviderEmbedding` against a real provider (OpenAI-shaped or Gemini).
+ *
+ * The embedding call is injected via {@link EmbedFn} (defaulting to the real
+ * `AiAssist.callProviderEmbedding`) so the orchestration is unit-testable by mocking `fetch`
+ * — the test then drives the **real** primitive + adapters over a faked network and asserts
+ * the outgoing request body (the load-bearing class of test per TESTING_GUIDELINES "never
+ * paper over failures"). The config parser is a pure `env -> Result` function (the `mcpProbe`
+ * idiom).
+ *
+ * The ranking math (`rankBySimilarity` / cosine) is reused verbatim from `local-embedding-search`
+ * — there is exactly one cosine-similarity implementation in the testbed.
+ *
+ * @packageDocumentation
+ */
+
+import { type Logging, Result, fail, succeed } from '@fgv/ts-utils';
+import { AiAssist } from '@fgv/ts-extras';
+
+import { rankBySimilarity } from '../localEmbeddingSearch/similarity';
+import type { ICorpusEntry, IRankedResult } from '../localEmbeddingSearch/similarity';
+
+// ---------------------------------------------------------------------------
+// The injected embedding operation
+// ---------------------------------------------------------------------------
+
+/**
+ * The embedding operation the search core depends on. Defaults to the real
+ * {@link AiAssist.callProviderEmbedding}; injected in unit tests (either as the real
+ * primitive over a mocked `fetch`, or as a stub for the pure ranking paths).
+ * @public
+ */
+export type EmbedFn = (
+  params: AiAssist.IProviderEmbeddingParams
+) => Promise<Result<AiAssist.IAiEmbeddingResult>>;
+
+// ---------------------------------------------------------------------------
+// Fixed demo corpus + query (semantic search)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed document corpus for the demo. Deliberately spread across unrelated topics so a
+ * well-formed retrieval embedding ranks the single relevant document first — the sanity
+ * signal for the live gate.
+ * @public
+ */
+export const CORPUS_DOCUMENTS: readonly string[] = [
+  "To reset your password, click 'Forgot password' on the sign-in page and follow the emailed link.",
+  'Our support office is open Monday through Friday, from 9am to 5pm local time.',
+  'The Eiffel Tower is a wrought-iron lattice tower on the Champ de Mars in Paris, France.',
+  'Photosynthesis is the process by which green plants convert sunlight into chemical energy.',
+  'You can update your billing information and payment method from the account settings page.'
+];
+
+/** The search query. Unambiguously about the password-reset document (index 0). */
+export const QUERY_TEXT: string = 'How do I reset the password for my account?';
+
+/** Index into {@link CORPUS_DOCUMENTS} a sane ranking must place first. */
+export const EXPECTED_TOP_INDEX: number = 0;
+
+/** Query-side task-type hint (Gemini retrieval asymmetry; no-op on symmetric providers). */
+export const QUERY_TASK_TYPE: AiAssist.AiEmbeddingTaskType = 'retrieval-query';
+
+/** Document-side task-type hint (Gemini retrieval asymmetry; no-op on symmetric providers). */
+export const DOCUMENT_TASK_TYPE: AiAssist.AiEmbeddingTaskType = 'retrieval-document';
+
+// ---------------------------------------------------------------------------
+// Scenario configuration (provider selection + key resolution from env)
+// ---------------------------------------------------------------------------
+
+/**
+ * A resolved, ready-to-run configuration for the scenario: which provider descriptor to use,
+ * the API key, the resolved embedding model, and the optional knobs.
+ * @public
+ */
+export interface IEmbeddingScenarioConfig {
+  /** Human-facing provider label (the value the caller selected, e.g. `'openai'`, `'gemini'`). */
+  readonly providerLabel: string;
+  /** The resolved provider descriptor. */
+  readonly descriptor: AiAssist.IAiProviderDescriptor;
+  /** The API key (empty string for keyless self-hosted providers). */
+  readonly apiKey: string;
+  /** The resolved embedding model id (default or overridden). */
+  readonly model: string;
+  /** Requested output dimensionality, when the caller set `EMBED_DIMENSIONS`. */
+  readonly dimensions?: number;
+  /** Base-URL override, when the caller set `EMBED_ENDPOINT` (self-hosted). */
+  readonly endpoint?: string;
+}
+
+/** Maps a friendly provider label to its descriptor id. */
+const PROVIDER_LABEL_TO_ID: Readonly<Record<string, string>> = {
+  openai: 'openai',
+  gemini: 'google-gemini',
+  'google-gemini': 'google-gemini',
+  mistral: 'mistral',
+  ollama: 'ollama',
+  'openai-compat': 'openai-compat'
+};
+
+/** Providers that need no API key (self-hosted / keyless). */
+const KEYLESS_PROVIDER_IDS: ReadonlySet<string> = new Set(['ollama', 'openai-compat']);
+
+/**
+ * Resolve the API key for a provider from the environment, honoring the same env-var
+ * conventions the sibling `*ClientTools` scenarios use.
+ * @internal
+ */
+function resolveApiKey(providerId: string, env: Record<string, string | undefined>): Result<string> {
+  if (KEYLESS_PROVIDER_IDS.has(providerId)) {
+    return succeed('');
+  }
+  switch (providerId) {
+    case 'openai':
+      return env.OPENAI_API_KEY
+        ? succeed(env.OPENAI_API_KEY)
+        : fail('OPENAI_API_KEY is not set. Run: export OPENAI_API_KEY=<your-key>');
+    case 'google-gemini': {
+      const key = env.GEMINI_API_KEY ?? env.GOOGLE_API_KEY;
+      return key
+        ? succeed(key)
+        : fail('Neither GEMINI_API_KEY nor GOOGLE_API_KEY is set. Run: export GEMINI_API_KEY=<your-key>');
+    }
+    case 'mistral':
+      return env.MISTRAL_API_KEY
+        ? succeed(env.MISTRAL_API_KEY)
+        : fail('MISTRAL_API_KEY is not set. Run: export MISTRAL_API_KEY=<your-key>');
+    /* c8 ignore next 2 - unreachable: every id in PROVIDER_LABEL_TO_ID is handled above. */
+    default:
+      return fail(`no API-key convention is wired for provider "${providerId}"`);
+  }
+}
+
+/**
+ * Parse the scenario configuration from environment variables (the CLI-dispatch idiom — the
+ * testbed CLI does not forward trailing argv to scenarios).
+ *
+ * - `EMBED_PROVIDER` selects the provider (default `openai`). Accepts `openai`, `gemini`,
+ *   `mistral`, `ollama`, `openai-compat`.
+ * - `EMBED_MODEL` overrides the embedding model (required for `ollama` / `openai-compat`,
+ *   which declare no default embedding model).
+ * - `EMBED_DIMENSIONS` requests a reduced output dimensionality (OpenAI 3-* / Gemini).
+ * - `EMBED_ENDPOINT` overrides the base URL (self-hosted servers).
+ * - The API key comes from the provider's conventional env var (e.g. `OPENAI_API_KEY`,
+ *   `GEMINI_API_KEY`/`GOOGLE_API_KEY`).
+ *
+ * @param env - The environment record (`process.env` in production; a fixture in tests).
+ * @returns The resolved config, or a `Failure` describing the missing piece (the "live gate
+ *   PENDING" diagnostic).
+ * @public
+ */
+export function parseEmbeddingScenarioConfig(
+  env: Record<string, string | undefined>
+): Result<IEmbeddingScenarioConfig> {
+  const providerLabel = (env.EMBED_PROVIDER ?? 'openai').trim().toLowerCase();
+  const providerId = PROVIDER_LABEL_TO_ID[providerLabel];
+  if (providerId === undefined) {
+    return fail(
+      `cross-provider-embedding-search: unknown EMBED_PROVIDER "${providerLabel}". ` +
+        `Supported: ${Object.keys(PROVIDER_LABEL_TO_ID).join(', ')}`
+    );
+  }
+
+  const descriptorResult = AiAssist.getProviderDescriptor(providerId);
+  /* c8 ignore next 3 - unreachable: every id in PROVIDER_LABEL_TO_ID is a registered descriptor. */
+  if (descriptorResult.isFailure()) {
+    return fail(`cross-provider-embedding-search: ${descriptorResult.message}`);
+  }
+  const descriptor = descriptorResult.value;
+
+  const keyResult = resolveApiKey(providerId, env);
+  if (keyResult.isFailure()) {
+    return fail(`cross-provider-embedding-search (provider=${providerLabel}): ${keyResult.message}`);
+  }
+
+  const modelOverride = env.EMBED_MODEL?.trim();
+  const model =
+    modelOverride !== undefined && modelOverride.length > 0
+      ? modelOverride
+      : AiAssist.resolveModel(descriptor.defaultModel, 'embedding');
+  if (model.length === 0) {
+    return fail(
+      `cross-provider-embedding-search (provider=${providerLabel}): no embedding model resolved. ` +
+        `Set EMBED_MODEL (self-hosted providers declare no default embedding model).`
+    );
+  }
+
+  const dimensionsResult = parseDimensions(env.EMBED_DIMENSIONS);
+  if (dimensionsResult.isFailure()) {
+    return fail(`cross-provider-embedding-search: ${dimensionsResult.message}`);
+  }
+
+  const endpoint = env.EMBED_ENDPOINT?.trim();
+
+  return succeed({
+    providerLabel,
+    descriptor,
+    apiKey: keyResult.value,
+    model,
+    ...(dimensionsResult.value !== undefined ? { dimensions: dimensionsResult.value } : {}),
+    ...(endpoint !== undefined && endpoint.length > 0 ? { endpoint } : {})
+  });
+}
+
+/** Parse the optional `EMBED_DIMENSIONS` value into a positive integer, or `undefined`. */
+function parseDimensions(raw: string | undefined): Result<number | undefined> {
+  if (raw === undefined || raw.trim().length === 0) {
+    return succeed(undefined);
+  }
+  const value = Number(raw.trim());
+  if (!Number.isInteger(value) || value <= 0) {
+    return fail(`EMBED_DIMENSIONS must be a positive integer; got "${raw}"`);
+  }
+  return succeed(value);
+}
+
+// ---------------------------------------------------------------------------
+// The search core
+// ---------------------------------------------------------------------------
+
+/**
+ * The empirical outcome of a cross-provider embedding search — the raw material the report
+ * formatter turns into a PASS/FAIL gate matrix.
+ * @public
+ */
+export interface IEmbeddingSearchOutcome {
+  /** Provider label the caller selected. */
+  readonly providerLabel: string;
+  /** Embedding model that produced the vectors. */
+  readonly model: string;
+  /** Dimensionality of the query vector. */
+  readonly queryDimensions: number;
+  /** Dimensionality of the document vectors. */
+  readonly documentDimensions: number;
+  /** Number of document vectors returned (must equal the document count — batch alignment). */
+  readonly documentCount: number;
+  /** Requested dimensionality, when the caller asked for one. */
+  readonly requestedDimensions?: number;
+  /** Whether the resolved capability declares `supportsDimensions`. */
+  readonly capabilitySupportsDimensions: boolean;
+  /** Whether the resolved capability declares `supportsTaskType` (Gemini retrieval asymmetry). */
+  readonly capabilitySupportsTaskType: boolean;
+  /** The ranked documents (highest cosine similarity first). */
+  readonly ranked: readonly IRankedResult[];
+  /** Token usage reported for the query call, when the provider reports it. */
+  readonly queryUsage?: AiAssist.IAiEmbeddingUsage;
+}
+
+/**
+ * Run the cross-provider embedding search: embed the query (with `retrieval-query` task type)
+ * and the documents in a single batch call (with `retrieval-document` task type), then rank
+ * the documents by cosine similarity to the query.
+ *
+ * The two-call, asymmetric-task-type shape is the load-bearing exercise: on Gemini it drives
+ * the `batchEmbedContents` wire path with `RETRIEVAL_QUERY` vs `RETRIEVAL_DOCUMENT`; on the
+ * OpenAI-shaped providers the same task-type hints are a harmless no-op (the design's
+ * cross-provider call-site promise). Batching the documents in one call exercises index
+ * alignment.
+ *
+ * @param config - The resolved scenario configuration.
+ * @param embedFn - The embedding operation (defaults to {@link AiAssist.callProviderEmbedding}).
+ * @param logger - Optional logger threaded to the primitive (the no-op-knob notes surface here).
+ * @returns The empirical outcome, or a `Failure` carrying the wire error.
+ * @public
+ */
+export async function runEmbeddingSearch(
+  config: IEmbeddingScenarioConfig,
+  embedFn: EmbedFn = AiAssist.callProviderEmbedding,
+  logger?: Logging.ILogger
+): Promise<Result<IEmbeddingSearchOutcome>> {
+  const capability = AiAssist.resolveEmbeddingCapability(config.descriptor, config.model);
+  if (capability === undefined) {
+    return fail(
+      `provider "${config.descriptor.id}" declares no embedding capability for model "${config.model}"`
+    );
+  }
+
+  const common = {
+    descriptor: config.descriptor,
+    apiKey: config.apiKey,
+    modelOverride: config.model,
+    ...(config.endpoint !== undefined ? { endpoint: config.endpoint } : {}),
+    ...(logger !== undefined ? { logger } : {})
+  };
+
+  // 1. Embed the query (retrieval-query).
+  const queryResult = await embedFn({
+    ...common,
+    params: {
+      input: QUERY_TEXT,
+      taskType: QUERY_TASK_TYPE,
+      ...(config.dimensions !== undefined ? { dimensions: config.dimensions } : {})
+    }
+  });
+  if (queryResult.isFailure()) {
+    return fail(`query embedding failed: ${queryResult.message}`);
+  }
+  const query = queryResult.value;
+
+  // 2. Embed all documents in one batch call (retrieval-document).
+  const docResult = await embedFn({
+    ...common,
+    params: {
+      input: CORPUS_DOCUMENTS,
+      taskType: DOCUMENT_TASK_TYPE,
+      ...(config.dimensions !== undefined ? { dimensions: config.dimensions } : {})
+    }
+  });
+  if (docResult.isFailure()) {
+    return fail(`document embedding failed: ${docResult.message}`);
+  }
+  const docs = docResult.value;
+
+  if (docs.vectors.length !== CORPUS_DOCUMENTS.length) {
+    return fail(
+      `batch misalignment: requested ${CORPUS_DOCUMENTS.length} document embeddings, ` +
+        `received ${docs.vectors.length}`
+    );
+  }
+
+  const queryVec = query.vectors[0];
+  if (queryVec === undefined) {
+    return fail('query embedding returned no vector');
+  }
+
+  const corpus: ICorpusEntry[] = CORPUS_DOCUMENTS.map((text, i) => ({
+    text,
+    vec: docs.vectors[i]!
+  }));
+
+  const rankResult = rankBySimilarity(queryVec, corpus);
+  if (rankResult.isFailure()) {
+    return fail(`ranking failed: ${rankResult.message}`);
+  }
+
+  return succeed({
+    providerLabel: config.providerLabel,
+    model: docs.model,
+    queryDimensions: query.dimensions,
+    documentDimensions: docs.dimensions,
+    documentCount: docs.vectors.length,
+    ...(config.dimensions !== undefined ? { requestedDimensions: config.dimensions } : {}),
+    capabilitySupportsDimensions: capability.supportsDimensions === true,
+    capabilitySupportsTaskType: capability.supportsTaskType === true,
+    ranked: rankResult.value,
+    ...(query.usage !== undefined ? { queryUsage: query.usage } : {})
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Report formatting + gate evaluation
+// ---------------------------------------------------------------------------
+
+/** A single empirical gate's evaluation. */
+interface IGate {
+  readonly label: string;
+  /** `true` = PASS, `false` = FAIL, `undefined` = SKIP (not applicable this run). */
+  readonly status: boolean | undefined;
+  readonly detail: string;
+}
+
+/** The result of evaluating all gates for a search outcome. */
+export interface IEmbeddingReport {
+  /** Overall PASS (every applicable gate passed) / FAIL. */
+  readonly pass: boolean;
+  /** The full multi-line human-readable report. */
+  readonly text: string;
+}
+
+/** Render a gate status to its display token. */
+function gateToken(status: boolean | undefined): string {
+  return status === undefined ? 'SKIP' : status ? 'PASS' : 'FAIL';
+}
+
+/**
+ * Evaluate the empirical gates for a search outcome and format the report. The verdict is
+ * COMPUTED from the outcome (never hardcoded): a live HTTP 200 that returns mis-shaped or
+ * mis-ranked vectors is a FAIL, not a PASS.
+ *
+ * Gates:
+ *  1. Query + document vectors are non-empty and equal-dimensioned (both wire formats yield
+ *     usable `number[][]`).
+ *  2. Batch alignment — document vector count equals the document count.
+ *  3. Ranking sanity — the expected document ranks first.
+ *  4. `dimensions` honored where the capability supports it (returned dimension equals the
+ *     requested one); SKIP when not requested or not supported.
+ *
+ * @param outcome - The empirical search outcome.
+ * @returns The pass/fail verdict and the printable report.
+ * @public
+ */
+export function formatEmbeddingReport(outcome: IEmbeddingSearchOutcome): IEmbeddingReport {
+  const dimsUsable =
+    outcome.queryDimensions > 0 &&
+    outcome.documentDimensions > 0 &&
+    outcome.queryDimensions === outcome.documentDimensions;
+  const batchAligned = outcome.documentCount === CORPUS_DOCUMENTS.length;
+  const topText = outcome.ranked[0]?.text;
+  const rankingSane = topText === CORPUS_DOCUMENTS[EXPECTED_TOP_INDEX];
+
+  // Dimensions gate: only applicable when the caller requested a dimension AND the capability
+  // honors it; then the returned dimension must equal the request.
+  let dimsHonored: boolean | undefined;
+  if (outcome.requestedDimensions === undefined || !outcome.capabilitySupportsDimensions) {
+    dimsHonored = undefined;
+  } else {
+    dimsHonored =
+      outcome.documentDimensions === outcome.requestedDimensions &&
+      outcome.queryDimensions === outcome.requestedDimensions;
+  }
+
+  const gates: readonly IGate[] = [
+    {
+      label: 'Both vectors usable + equal-dimensioned',
+      status: dimsUsable,
+      detail: `query=${outcome.queryDimensions}d, documents=${outcome.documentDimensions}d`
+    },
+    {
+      label: 'Batch alignment (one vector per document)',
+      status: batchAligned,
+      detail: `${outcome.documentCount}/${CORPUS_DOCUMENTS.length} document vectors`
+    },
+    {
+      label: 'Ranking sanity (expected document ranks #1)',
+      status: rankingSane,
+      detail: `top="${(topText ?? '(none)').slice(0, 60)}"`
+    },
+    {
+      label: 'dimensions honored',
+      status: dimsHonored,
+      detail:
+        outcome.requestedDimensions === undefined
+          ? 'no dimension requested'
+          : !outcome.capabilitySupportsDimensions
+          ? `model does not support dimensions (returned native ${outcome.documentDimensions}d)`
+          : `requested ${outcome.requestedDimensions}d, returned ${outcome.documentDimensions}d`
+    }
+  ];
+
+  // PASS = every applicable (non-SKIP) gate passed.
+  const pass = gates.every((g) => g.status !== false);
+
+  const lines: string[] = [
+    `cross-provider-embedding-search (${outcome.providerLabel}): ${pass ? 'PASS' : 'FAIL'}`,
+    '',
+    `Provider: ${outcome.providerLabel}`,
+    `Model: ${outcome.model}`,
+    `Vector dimensions: ${outcome.documentDimensions}`,
+    `Task-type asymmetry: query="${QUERY_TASK_TYPE}" documents="${DOCUMENT_TASK_TYPE}" ` +
+      `(capability ${outcome.capabilitySupportsTaskType ? 'HONORS' : 'ignores (no-op)'} taskType)`,
+    outcome.queryUsage !== undefined
+      ? `Query token usage: ${JSON.stringify(outcome.queryUsage)}`
+      : 'Query token usage: (not reported by provider)',
+    '',
+    `Query: "${QUERY_TEXT}"`,
+    'Ranking (cosine similarity, highest first):',
+    ...outcome.ranked.map((r, i) => `  ${i + 1}. [${r.score.toFixed(4)}] ${r.text}`),
+    '',
+    'Empirical gates:',
+    ...gates.map((g) => `  [${gateToken(g.status)}] ${g.label} — ${g.detail}`)
+  ];
+
+  return { pass, text: lines.join('\n') };
+}

--- a/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
+++ b/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
@@ -164,45 +164,43 @@ export function parseEmbeddingScenarioConfig(
     );
   }
 
-  const descriptorResult = AiAssist.getProviderDescriptor(providerId);
-  /* c8 ignore next 3 - unreachable: every id in PROVIDER_LABEL_TO_ID is a registered descriptor. */
-  if (descriptorResult.isFailure()) {
-    return fail(`cross-provider-embedding-search: ${descriptorResult.message}`);
-  }
-  const descriptor = descriptorResult.value;
-
-  const keyResult = resolveApiKey(providerId, env);
-  if (keyResult.isFailure()) {
-    return fail(`cross-provider-embedding-search (provider=${providerLabel}): ${keyResult.message}`);
-  }
-
-  const modelOverride = env.EMBED_MODEL?.trim();
-  const model =
-    modelOverride !== undefined && modelOverride.length > 0
-      ? modelOverride
-      : AiAssist.resolveModel(descriptor.defaultModel, 'embedding');
-  if (model.length === 0) {
-    return fail(
-      `cross-provider-embedding-search (provider=${providerLabel}): no embedding model resolved. ` +
-        `Set EMBED_MODEL (self-hosted providers declare no default embedding model).`
+  // Chain the three fallible resolutions (descriptor, key, dimensions); error context is applied
+  // once at each boundary rather than scattered across imperative `fail()` branches. Chaining
+  // also removes the otherwise-unreachable descriptor-failure branch (every id in
+  // PROVIDER_LABEL_TO_ID is a registered descriptor) without a coverage directive.
+  return AiAssist.getProviderDescriptor(providerId)
+    .withErrorFormat((msg) => `cross-provider-embedding-search: ${msg}`)
+    .onSuccess((descriptor) =>
+      resolveApiKey(providerId, env)
+        .withErrorFormat((msg) => `cross-provider-embedding-search (provider=${providerLabel}): ${msg}`)
+        .onSuccess((apiKey) =>
+          parseDimensions(env.EMBED_DIMENSIONS)
+            .withErrorFormat((msg) => `cross-provider-embedding-search: ${msg}`)
+            .onSuccess((dimensions) => {
+              const modelOverride = env.EMBED_MODEL?.trim();
+              const model =
+                modelOverride !== undefined && modelOverride.length > 0
+                  ? modelOverride
+                  : AiAssist.resolveModel(descriptor.defaultModel, 'embedding');
+              if (model.length === 0) {
+                return fail(
+                  `cross-provider-embedding-search (provider=${providerLabel}): no embedding ` +
+                    `model resolved. Set EMBED_MODEL (self-hosted providers declare no default ` +
+                    `embedding model).`
+                );
+              }
+              const endpoint = env.EMBED_ENDPOINT?.trim();
+              return succeed({
+                providerLabel,
+                descriptor,
+                apiKey,
+                model,
+                ...(dimensions !== undefined ? { dimensions } : {}),
+                ...(endpoint !== undefined && endpoint.length > 0 ? { endpoint } : {})
+              });
+            })
+        )
     );
-  }
-
-  const dimensionsResult = parseDimensions(env.EMBED_DIMENSIONS);
-  if (dimensionsResult.isFailure()) {
-    return fail(`cross-provider-embedding-search: ${dimensionsResult.message}`);
-  }
-
-  const endpoint = env.EMBED_ENDPOINT?.trim();
-
-  return succeed({
-    providerLabel,
-    descriptor,
-    apiKey: keyResult.value,
-    model,
-    ...(dimensionsResult.value !== undefined ? { dimensions: dimensionsResult.value } : {}),
-    ...(endpoint !== undefined && endpoint.length > 0 ? { endpoint } : {})
-  });
 }
 
 /** Parse the optional `EMBED_DIMENSIONS` value into a positive integer, or `undefined`. */

--- a/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
+++ b/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
@@ -155,7 +155,11 @@ function resolveApiKey(providerId: string, env: Record<string, string | undefine
 export function parseEmbeddingScenarioConfig(
   env: Record<string, string | undefined>
 ): Result<IEmbeddingScenarioConfig> {
-  const providerLabel = (env.EMBED_PROVIDER ?? 'openai').trim().toLowerCase();
+  // Treat a blank/whitespace-only EMBED_PROVIDER as unset (default `openai`), consistent with
+  // how EMBED_MODEL / EMBED_DIMENSIONS / EMBED_ENDPOINT treat blank-as-absent.
+  const rawProvider = env.EMBED_PROVIDER?.trim();
+  const providerLabel =
+    rawProvider !== undefined && rawProvider.length > 0 ? rawProvider.toLowerCase() : 'openai';
   const providerId = PROVIDER_LABEL_TO_ID[providerLabel];
   if (providerId === undefined) {
     return fail(
@@ -319,10 +323,15 @@ export async function runEmbeddingSearch(
     );
   }
 
-  const queryVec = query.vectors[0];
-  if (queryVec === undefined) {
-    return fail('query embedding returned no vector');
+  // The query is a single-item batch: require exactly one vector. This catches an empty result
+  // AND extra vectors that would otherwise be silently dropped — notably on the Gemini path,
+  // where the adapter does not enforce the response count against the request.
+  if (query.vectors.length !== 1) {
+    return fail(
+      `query batch misalignment: expected exactly 1 query vector, received ${query.vectors.length}`
+    );
   }
+  const queryVec = query.vectors[0]!;
 
   const corpus: ICorpusEntry[] = CORPUS_DOCUMENTS.map((text, i) => ({
     text,

--- a/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
+++ b/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
@@ -138,8 +138,8 @@ function resolveApiKey(providerId: string, env: Record<string, string | undefine
  * Parse the scenario configuration from environment variables (the CLI-dispatch idiom — the
  * testbed CLI does not forward trailing argv to scenarios).
  *
- * - `EMBED_PROVIDER` selects the provider (default `openai`). Accepts `openai`, `gemini`,
- *   `mistral`, `ollama`, `openai-compat`.
+ * - `EMBED_PROVIDER` selects the provider (default `openai`). Accepts `openai`, `gemini`
+ *   (alias `google-gemini`), `mistral`, `ollama`, `openai-compat`.
  * - `EMBED_MODEL` overrides the embedding model (required for `ollama` / `openai-compat`,
  *   which declare no default embedding model).
  * - `EMBED_DIMENSIONS` requests a reduced output dimensionality (OpenAI 3-* / Gemini).

--- a/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
+++ b/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
@@ -194,13 +194,23 @@ export function parseEmbeddingScenarioConfig(
                 );
               }
               const endpoint = env.EMBED_ENDPOINT?.trim();
+              const hasEndpoint = endpoint !== undefined && endpoint.length > 0;
+              // A provider with no default base URL (e.g. `openai-compat`, `baseUrl: ''`) needs an
+              // explicit EMBED_ENDPOINT. Fail fast here with a targeted diagnostic rather than
+              // letting the embedding primitive fail later with a vaguer "no API endpoint" error.
+              if (!hasEndpoint && descriptor.baseUrl.length === 0) {
+                return fail(
+                  `cross-provider-embedding-search (provider=${providerLabel}): this provider has ` +
+                    `no default base URL; set EMBED_ENDPOINT (e.g. http://localhost:8000/v1).`
+                );
+              }
               return succeed({
                 providerLabel,
                 descriptor,
                 apiKey,
                 model,
                 ...(dimensions !== undefined ? { dimensions } : {}),
-                ...(endpoint !== undefined && endpoint.length > 0 ? { endpoint } : {})
+                ...(hasEndpoint ? { endpoint } : {})
               });
             })
         )

--- a/samples/testbed/src/scenarios/index.ts
+++ b/samples/testbed/src/scenarios/index.ts
@@ -11,6 +11,7 @@
 
 import type { IScenario } from '../shell';
 import { anthropicClientToolsScenario } from './anthropicClientTools';
+import { crossProviderEmbeddingSearchScenario } from './crossProviderEmbeddingSearch';
 import { geminiClientToolsScenario } from './geminiClientTools';
 import { localClassifierSafetyScenario } from './localClassifierSafety';
 import { localEmbeddingSearchScenario } from './localEmbeddingSearch';
@@ -31,5 +32,6 @@ export const scenarios: readonly IScenario[] = [
   localClassifierSafetyScenario,
   localEmbeddingSearchScenario,
   localSummarizationScenario,
-  mcpProbeScenario
+  mcpProbeScenario,
+  crossProviderEmbeddingSearchScenario
 ];

--- a/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
+++ b/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
@@ -10,5 +10,6 @@ Array [
   "local-embedding-search",
   "local-summarization",
   "mcp-probe",
+  "cross-provider-embedding-search",
 ]
 `;

--- a/samples/testbed/src/test/unit/scenarios/crossProviderEmbeddingSearch.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/crossProviderEmbeddingSearch.test.ts
@@ -217,6 +217,15 @@ describe('parseEmbeddingScenarioConfig', () => {
     );
   });
 
+  test('treats a blank/whitespace EMBED_PROVIDER as unset (defaults to openai)', () => {
+    expect(parseEmbeddingScenarioConfig({ EMBED_PROVIDER: '   ', OPENAI_API_KEY: 'sk' })).toSucceedAndSatisfy(
+      (config) => {
+        expect(config.providerLabel).toBe('openai');
+        expect(config.descriptor.id).toBe('openai');
+      }
+    );
+  });
+
   test('treats a blank EMBED_DIMENSIONS / EMBED_MODEL as absent', () => {
     expect(
       parseEmbeddingScenarioConfig({ OPENAI_API_KEY: 'sk', EMBED_DIMENSIONS: '   ', EMBED_MODEL: '  ' })
@@ -402,6 +411,21 @@ describe('runEmbeddingSearch (real callProviderEmbedding + mocked fetch)', () =>
         /batch misalignment.*requested 5.*received 3/
       );
     });
+
+    test('detects extra query vectors that Gemini would otherwise silently return', async () => {
+      // The query is a single-item batch; Gemini's adapter does not enforce count, so a
+      // 2-vector response for a 1-input query must be caught by the scenario, not silently sliced.
+      mockTwoFetches(
+        geminiBody([
+          [1, 0, 0],
+          [0, 1, 0]
+        ]),
+        geminiBody(DOC_VECS)
+      );
+      expect(await runEmbeddingSearch(geminiConfig())).toFailWith(
+        /query batch misalignment: expected exactly 1 query vector, received 2/
+      );
+    });
   });
 
   test('threads a logger through to the primitive (no-op-knob note path)', async () => {
@@ -438,7 +462,9 @@ describe('runEmbeddingSearch (injected EmbedFn — defensive branches)', () => {
         ? succeed({ vectors: [], model: 'm', dimensions: 0 })
         : succeed({ vectors: input.map(() => [1, 0, 0]), model: 'm', dimensions: 3 });
     };
-    expect(await runEmbeddingSearch(openAiConfig(), stub)).toFailWith(/query embedding returned no vector/);
+    expect(await runEmbeddingSearch(openAiConfig(), stub)).toFailWith(
+      /query batch misalignment: expected exactly 1 query vector, received 0/
+    );
   });
 
   test('propagates a query-side failure from the injected embed function', async () => {

--- a/samples/testbed/src/test/unit/scenarios/crossProviderEmbeddingSearch.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/crossProviderEmbeddingSearch.test.ts
@@ -200,6 +200,27 @@ describe('parseEmbeddingScenarioConfig', () => {
     );
   });
 
+  test('fails fast for openai-compat (empty default base URL) without EMBED_ENDPOINT', () => {
+    // Model present, but openai-compat has baseUrl: '' — the endpoint is mandatory.
+    expect(
+      parseEmbeddingScenarioConfig({ EMBED_PROVIDER: 'openai-compat', EMBED_MODEL: 'bge-m3' })
+    ).toFailWith(/no default base URL; set EMBED_ENDPOINT/);
+  });
+
+  test('succeeds for openai-compat when both EMBED_MODEL and EMBED_ENDPOINT are set', () => {
+    expect(
+      parseEmbeddingScenarioConfig({
+        EMBED_PROVIDER: 'openai-compat',
+        EMBED_MODEL: 'bge-m3',
+        EMBED_ENDPOINT: 'http://localhost:8000/v1'
+      })
+    ).toSucceedAndSatisfy((config) => {
+      expect(config.descriptor.id).toBe('openai-compat');
+      expect(config.model).toBe('bge-m3');
+      expect(config.endpoint).toBe('http://localhost:8000/v1');
+    });
+  });
+
   test('parses EMBED_DIMENSIONS as a positive integer', () => {
     expect(
       parseEmbeddingScenarioConfig({ OPENAI_API_KEY: 'sk', EMBED_DIMENSIONS: '512' })

--- a/samples/testbed/src/test/unit/scenarios/crossProviderEmbeddingSearch.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/crossProviderEmbeddingSearch.test.ts
@@ -1,0 +1,713 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Unit tests for the `cross-provider-embedding-search` scenario.
+ *
+ * The deterministic CI gate. These tests mock the global `fetch` and drive the **real**
+ * `AiAssist.callProviderEmbedding` primitive + its OpenAI / Gemini adapters over a faked
+ * network — so they assert the actual outgoing request body (the load-bearing class: that the
+ * Gemini `taskType` asymmetry and `dimensions` reach the wire, and that the OpenAI no-op path
+ * omits `taskType`). The live run against real provider APIs is env-gated in the scenario.
+ *
+ * @packageDocumentation
+ */
+
+import '@fgv/ts-utils-jest';
+import { Logging, type Result, fail, succeed } from '@fgv/ts-utils';
+import { AiAssist } from '@fgv/ts-extras';
+
+import {
+  CORPUS_DOCUMENTS,
+  DOCUMENT_TASK_TYPE,
+  EXPECTED_TOP_INDEX,
+  QUERY_TASK_TYPE,
+  QUERY_TEXT,
+  formatEmbeddingReport,
+  parseEmbeddingScenarioConfig,
+  runEmbeddingSearch
+} from '../../../scenarios/crossProviderEmbeddingSearch/search';
+import type {
+  EmbedFn,
+  IEmbeddingScenarioConfig,
+  IEmbeddingSearchOutcome
+} from '../../../scenarios/crossProviderEmbeddingSearch/search';
+import { crossProviderEmbeddingSearchScenario } from '../../../scenarios/crossProviderEmbeddingSearch';
+import type { IScenarioContext } from '../../../shell';
+
+// ===========================================================================
+// fetch mock helpers (mirrors libraries/ts-extras embeddingClient.test.ts)
+// ===========================================================================
+
+function okResponse(body: unknown): unknown {
+  return {
+    ok: true,
+    status: 200,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(JSON.stringify(body))
+  };
+}
+
+function httpErrorResponse(status: number, errorText: string): unknown {
+  return { ok: false, status, text: jest.fn().mockResolvedValue(errorText) };
+}
+
+/** Queue the query response then the document response (the scenario's two-call order). */
+function mockTwoFetches(queryBody: unknown, docBody: unknown): void {
+  (global.fetch as jest.Mock)
+    .mockResolvedValueOnce(okResponse(queryBody))
+    .mockResolvedValueOnce(okResponse(docBody));
+}
+
+function callOf(i: number): [string, { method: string; headers: Record<string, string>; body: string }] {
+  return (global.fetch as jest.Mock).mock.calls[i];
+}
+function bodyOf(i: number): Record<string, unknown> {
+  return JSON.parse(callOf(i)[1].body);
+}
+function urlOf(i: number): string {
+  return callOf(i)[0];
+}
+function headersOf(i: number): Record<string, string> {
+  return callOf(i)[1].headers;
+}
+
+// ===========================================================================
+// Fixtures
+// ===========================================================================
+
+/** A query vector identical to document[0], orthogonal to the rest → document[0] ranks #1. */
+const QUERY_VEC: number[] = [1, 0, 0];
+const DOC_VECS: number[][] = [
+  [1, 0, 0], // document 0 — same direction as the query → top rank
+  [0, 1, 0],
+  [0, 0, 1],
+  [0, 1, 0],
+  [0, 0, 1]
+];
+
+function openAiBody(vectors: number[][]): unknown {
+  return {
+    object: 'list',
+    data: vectors.map((embedding, index) => ({ object: 'embedding', index, embedding })),
+    model: 'text-embedding-3-small',
+    usage: { prompt_tokens: 8, total_tokens: 8 }
+  };
+}
+
+function geminiBody(vectors: number[][]): unknown {
+  return { embeddings: vectors.map((values) => ({ values })) };
+}
+
+function openAiConfig(overrides: Partial<IEmbeddingScenarioConfig> = {}): IEmbeddingScenarioConfig {
+  return {
+    providerLabel: 'openai',
+    descriptor: AiAssist.getProviderDescriptor('openai').orThrow(),
+    apiKey: 'sk-test',
+    model: 'text-embedding-3-small',
+    ...overrides
+  };
+}
+
+function geminiConfig(overrides: Partial<IEmbeddingScenarioConfig> = {}): IEmbeddingScenarioConfig {
+  return {
+    providerLabel: 'gemini',
+    descriptor: AiAssist.getProviderDescriptor('google-gemini').orThrow(),
+    apiKey: 'gemini-test',
+    model: 'gemini-embedding-001',
+    ...overrides
+  };
+}
+
+// ===========================================================================
+// parseEmbeddingScenarioConfig
+// ===========================================================================
+
+describe('parseEmbeddingScenarioConfig', () => {
+  test('defaults to OpenAI with the default embedding model when EMBED_PROVIDER is unset', () => {
+    expect(parseEmbeddingScenarioConfig({ OPENAI_API_KEY: 'sk-x' })).toSucceedAndSatisfy((config) => {
+      expect(config.providerLabel).toBe('openai');
+      expect(config.descriptor.id).toBe('openai');
+      expect(config.apiKey).toBe('sk-x');
+      expect(config.model).toBe('text-embedding-3-small');
+      expect(config.dimensions).toBeUndefined();
+      expect(config.endpoint).toBeUndefined();
+    });
+  });
+
+  test('resolves Gemini and accepts either GEMINI_API_KEY or GOOGLE_API_KEY', () => {
+    expect(
+      parseEmbeddingScenarioConfig({ EMBED_PROVIDER: 'gemini', GEMINI_API_KEY: 'g1' })
+    ).toSucceedAndSatisfy((config) => {
+      expect(config.descriptor.id).toBe('google-gemini');
+      expect(config.apiKey).toBe('g1');
+      expect(config.model).toBe('gemini-embedding-001');
+    });
+    expect(
+      parseEmbeddingScenarioConfig({ EMBED_PROVIDER: 'google-gemini', GOOGLE_API_KEY: 'g2' })
+    ).toSucceedAndSatisfy((config) => {
+      expect(config.apiKey).toBe('g2');
+    });
+  });
+
+  test('resolves Mistral via MISTRAL_API_KEY', () => {
+    expect(
+      parseEmbeddingScenarioConfig({ EMBED_PROVIDER: 'mistral', MISTRAL_API_KEY: 'm1' })
+    ).toSucceedAndSatisfy((config) => {
+      expect(config.descriptor.id).toBe('mistral');
+      expect(config.apiKey).toBe('m1');
+      expect(config.model).toBe('mistral-embed');
+    });
+  });
+
+  test('keyless self-hosted (ollama) needs EMBED_MODEL but no key', () => {
+    expect(
+      parseEmbeddingScenarioConfig({
+        EMBED_PROVIDER: 'ollama',
+        EMBED_MODEL: 'nomic-embed-text',
+        EMBED_ENDPOINT: 'http://localhost:11434/v1'
+      })
+    ).toSucceedAndSatisfy((config) => {
+      expect(config.descriptor.id).toBe('ollama');
+      expect(config.apiKey).toBe('');
+      expect(config.model).toBe('nomic-embed-text');
+      expect(config.endpoint).toBe('http://localhost:11434/v1');
+    });
+  });
+
+  test('fails for a self-hosted provider with no EMBED_MODEL (no default embedding model)', () => {
+    expect(parseEmbeddingScenarioConfig({ EMBED_PROVIDER: 'openai-compat' })).toFailWith(
+      /no embedding model resolved.*EMBED_MODEL/i
+    );
+  });
+
+  test('parses EMBED_DIMENSIONS as a positive integer', () => {
+    expect(
+      parseEmbeddingScenarioConfig({ OPENAI_API_KEY: 'sk', EMBED_DIMENSIONS: '512' })
+    ).toSucceedAndSatisfy((config) => {
+      expect(config.dimensions).toBe(512);
+    });
+  });
+
+  test('rejects a non-positive-integer EMBED_DIMENSIONS', () => {
+    expect(parseEmbeddingScenarioConfig({ OPENAI_API_KEY: 'sk', EMBED_DIMENSIONS: '0' })).toFailWith(
+      /EMBED_DIMENSIONS must be a positive integer/
+    );
+    expect(parseEmbeddingScenarioConfig({ OPENAI_API_KEY: 'sk', EMBED_DIMENSIONS: 'abc' })).toFailWith(
+      /EMBED_DIMENSIONS must be a positive integer/
+    );
+  });
+
+  test('treats a blank EMBED_DIMENSIONS / EMBED_MODEL as absent', () => {
+    expect(
+      parseEmbeddingScenarioConfig({ OPENAI_API_KEY: 'sk', EMBED_DIMENSIONS: '   ', EMBED_MODEL: '  ' })
+    ).toSucceedAndSatisfy((config) => {
+      expect(config.dimensions).toBeUndefined();
+      expect(config.model).toBe('text-embedding-3-small');
+    });
+  });
+
+  test('fails for an unknown EMBED_PROVIDER with the supported list', () => {
+    expect(parseEmbeddingScenarioConfig({ EMBED_PROVIDER: 'cohere' })).toFailWith(
+      /unknown EMBED_PROVIDER "cohere".*openai.*gemini/i
+    );
+  });
+
+  test('fails with the OPENAI_API_KEY diagnostic when the key is missing', () => {
+    expect(parseEmbeddingScenarioConfig({})).toFailWith(/OPENAI_API_KEY is not set/);
+  });
+
+  test('fails with the Gemini diagnostic when neither Gemini key is set', () => {
+    expect(parseEmbeddingScenarioConfig({ EMBED_PROVIDER: 'gemini' })).toFailWith(
+      /Neither GEMINI_API_KEY nor GOOGLE_API_KEY/
+    );
+  });
+
+  test('fails with the Mistral diagnostic when the key is missing', () => {
+    expect(parseEmbeddingScenarioConfig({ EMBED_PROVIDER: 'mistral' })).toFailWith(
+      /MISTRAL_API_KEY is not set/
+    );
+  });
+});
+
+// ===========================================================================
+// runEmbeddingSearch — real primitive over mocked fetch
+// ===========================================================================
+
+describe('runEmbeddingSearch (real callProviderEmbedding + mocked fetch)', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  describe('OpenAI-shaped wire path', () => {
+    test('sends two well-formed requests and ranks the matching document first', async () => {
+      mockTwoFetches(openAiBody([QUERY_VEC]), openAiBody(DOC_VECS));
+
+      const outcome = await runEmbeddingSearch(openAiConfig());
+      expect(outcome).toSucceedAndSatisfy((value: IEmbeddingSearchOutcome) => {
+        expect(value.queryDimensions).toBe(3);
+        expect(value.documentDimensions).toBe(3);
+        expect(value.documentCount).toBe(CORPUS_DOCUMENTS.length);
+        expect(value.capabilitySupportsDimensions).toBe(true);
+        expect(value.capabilitySupportsTaskType).toBe(false);
+        expect(value.ranked[0]!.text).toBe(CORPUS_DOCUMENTS[EXPECTED_TOP_INDEX]);
+        expect(value.queryUsage).toEqual({ promptTokens: 8, totalTokens: 8 });
+      });
+
+      // Query call: single-element batch, encoding_format float, NO taskType (no-op path).
+      expect(urlOf(0)).toMatch(/\/embeddings$/);
+      expect(headersOf(0).Authorization).toBe('Bearer sk-test');
+      const queryBody = bodyOf(0);
+      expect(queryBody.input).toEqual([QUERY_TEXT]);
+      expect(queryBody.model).toBe('text-embedding-3-small');
+      expect(queryBody.encoding_format).toBe('float');
+      expect(queryBody.taskType).toBeUndefined();
+      expect(queryBody.dimensions).toBeUndefined();
+
+      // Document call: the full corpus batched in one request, aligned by index.
+      const docBody = bodyOf(1);
+      expect(docBody.input).toEqual(CORPUS_DOCUMENTS);
+      expect(docBody.taskType).toBeUndefined();
+    });
+
+    test('sends dimensions when requested and reports it honored', async () => {
+      const q4 = [[1, 0, 0, 0]];
+      const d4 = [
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+        [0, 1, 0, 0]
+      ];
+      mockTwoFetches(openAiBody(q4), openAiBody(d4));
+
+      const outcome = await runEmbeddingSearch(openAiConfig({ dimensions: 4 }));
+      expect(outcome).toSucceedAndSatisfy((value: IEmbeddingSearchOutcome) => {
+        expect(value.requestedDimensions).toBe(4);
+        expect(value.documentDimensions).toBe(4);
+      });
+      expect(bodyOf(0).dimensions).toBe(4);
+      expect(bodyOf(1).dimensions).toBe(4);
+    });
+
+    test('fails (with context) when the query call returns an HTTP error', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(httpErrorResponse(401, 'bad key'));
+      expect(await runEmbeddingSearch(openAiConfig())).toFailWith(/query embedding failed.*401.*bad key/);
+    });
+
+    test('fails (with context) when the document call returns an HTTP error', async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(okResponse(openAiBody([QUERY_VEC])))
+        .mockResolvedValueOnce(httpErrorResponse(500, 'server boom'));
+      expect(await runEmbeddingSearch(openAiConfig())).toFailWith(
+        /document embedding failed.*500.*server boom/
+      );
+    });
+
+    test('routes through an endpoint override (self-hosted base URL)', async () => {
+      mockTwoFetches(openAiBody([QUERY_VEC]), openAiBody(DOC_VECS));
+      expect(await runEmbeddingSearch(openAiConfig({ endpoint: 'http://localhost:11434/v1' }))).toSucceed();
+      expect(urlOf(0)).toBe('http://localhost:11434/v1/embeddings');
+    });
+
+    test('fails ranking when the query and document dimensions disagree', async () => {
+      // Query is 2-D, documents are 3-D → cosine similarity rejects the mismatch.
+      mockTwoFetches(openAiBody([[1, 0]]), openAiBody(DOC_VECS));
+      expect(await runEmbeddingSearch(openAiConfig())).toFailWith(/ranking failed.*dimension mismatch/i);
+    });
+  });
+
+  describe('Gemini wire path (the highest-risk batchEmbedContents + taskType asymmetry)', () => {
+    test('drives the asymmetric taskType end-to-end and ranks sanely', async () => {
+      mockTwoFetches(geminiBody([QUERY_VEC]), geminiBody(DOC_VECS));
+
+      const outcome = await runEmbeddingSearch(geminiConfig());
+      expect(outcome).toSucceedAndSatisfy((value: IEmbeddingSearchOutcome) => {
+        expect(value.documentDimensions).toBe(3);
+        expect(value.documentCount).toBe(CORPUS_DOCUMENTS.length);
+        expect(value.capabilitySupportsTaskType).toBe(true);
+        expect(value.capabilitySupportsDimensions).toBe(true);
+        expect(value.ranked[0]!.text).toBe(CORPUS_DOCUMENTS[EXPECTED_TOP_INDEX]);
+        // Gemini does not report token usage for embeddings.
+        expect(value.queryUsage).toBeUndefined();
+      });
+
+      // Query call: batchEmbedContents route, x-goog-api-key auth, RETRIEVAL_QUERY task type.
+      expect(urlOf(0)).toMatch(/\/models\/gemini-embedding-001:batchEmbedContents$/);
+      expect(headersOf(0)['x-goog-api-key']).toBe('gemini-test');
+      const queryReqs = bodyOf(0).requests as Array<Record<string, unknown>>;
+      expect(queryReqs).toHaveLength(1);
+      expect(queryReqs[0]!.taskType).toBe('RETRIEVAL_QUERY');
+      expect(queryReqs[0]!.model).toBe('models/gemini-embedding-001');
+      expect(queryReqs[0]!.content).toEqual({ parts: [{ text: QUERY_TEXT }] });
+
+      // Document call: one request per document, all RETRIEVAL_DOCUMENT, aligned by order.
+      const docReqs = bodyOf(1).requests as Array<Record<string, unknown>>;
+      expect(docReqs).toHaveLength(CORPUS_DOCUMENTS.length);
+      for (let i = 0; i < docReqs.length; i++) {
+        expect(docReqs[i]!.taskType).toBe('RETRIEVAL_DOCUMENT');
+        expect(docReqs[i]!.content).toEqual({ parts: [{ text: CORPUS_DOCUMENTS[i] }] });
+      }
+    });
+
+    test('sends outputDimensionality when dimensions are requested', async () => {
+      const q4 = [[1, 0, 0, 0]];
+      const d4 = [
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+        [0, 1, 0, 0]
+      ];
+      mockTwoFetches(geminiBody(q4), geminiBody(d4));
+
+      expect(await runEmbeddingSearch(geminiConfig({ dimensions: 4 }))).toSucceedAndSatisfy(
+        (value: IEmbeddingSearchOutcome) => {
+          expect(value.documentDimensions).toBe(4);
+        }
+      );
+      const queryReqs = bodyOf(0).requests as Array<Record<string, unknown>>;
+      expect(queryReqs[0]!.outputDimensionality).toBe(4);
+    });
+
+    test('detects batch misalignment when Gemini returns fewer vectors than documents', async () => {
+      // Gemini's adapter does not enforce the batch count; the scenario does.
+      mockTwoFetches(geminiBody([QUERY_VEC]), geminiBody(DOC_VECS.slice(0, 3)));
+      expect(await runEmbeddingSearch(geminiConfig())).toFailWith(
+        /batch misalignment.*requested 5.*received 3/
+      );
+    });
+  });
+
+  test('threads a logger through to the primitive (no-op-knob note path)', async () => {
+    mockTwoFetches(openAiBody([QUERY_VEC]), openAiBody(DOC_VECS));
+    const logger = new Logging.InMemoryLogger();
+    const infoSpy = jest.spyOn(logger, 'info');
+    expect(await runEmbeddingSearch(openAiConfig(), undefined, logger)).toSucceed();
+    // The primitive logs that OpenAI ignores the supplied taskType.
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringMatching(/ignores taskType/i));
+  });
+});
+
+// ===========================================================================
+// runEmbeddingSearch — injected stub (defensive branches not reachable via the real primitive)
+// ===========================================================================
+
+describe('runEmbeddingSearch (injected EmbedFn — defensive branches)', () => {
+  test('fails when the provider declares no embedding capability for the model', async () => {
+    const config: IEmbeddingScenarioConfig = {
+      providerLabel: 'anthropic',
+      descriptor: AiAssist.getProviderDescriptor('anthropic').orThrow(),
+      apiKey: 'k',
+      model: 'claude-sonnet-4-5'
+    };
+    const neverCalled: EmbedFn = jest.fn();
+    expect(await runEmbeddingSearch(config, neverCalled)).toFailWith(/no embedding capability/i);
+    expect(neverCalled).not.toHaveBeenCalled();
+  });
+
+  test('fails when the query call yields no vector', async () => {
+    const stub: EmbedFn = async (params) => {
+      const input = params.params.input;
+      return typeof input === 'string'
+        ? succeed({ vectors: [], model: 'm', dimensions: 0 })
+        : succeed({ vectors: input.map(() => [1, 0, 0]), model: 'm', dimensions: 3 });
+    };
+    expect(await runEmbeddingSearch(openAiConfig(), stub)).toFailWith(/query embedding returned no vector/);
+  });
+
+  test('propagates a query-side failure from the injected embed function', async () => {
+    const stub: EmbedFn = async (): Promise<Result<AiAssist.IAiEmbeddingResult>> => fail('transport down');
+    expect(await runEmbeddingSearch(openAiConfig(), stub)).toFailWith(
+      /query embedding failed.*transport down/
+    );
+  });
+});
+
+// ===========================================================================
+// formatEmbeddingReport (pure)
+// ===========================================================================
+
+describe('formatEmbeddingReport', () => {
+  function baseOutcome(overrides: Partial<IEmbeddingSearchOutcome> = {}): IEmbeddingSearchOutcome {
+    return {
+      providerLabel: 'openai',
+      model: 'text-embedding-3-small',
+      queryDimensions: 3,
+      documentDimensions: 3,
+      documentCount: CORPUS_DOCUMENTS.length,
+      capabilitySupportsDimensions: true,
+      capabilitySupportsTaskType: false,
+      ranked: CORPUS_DOCUMENTS.map((text, i) => ({
+        text,
+        score: i === EXPECTED_TOP_INDEX ? 1 : 0
+      })),
+      ...overrides
+    };
+  }
+
+  test('PASS when vectors are usable, batch aligns, and the expected document ranks #1', () => {
+    const report = formatEmbeddingReport(baseOutcome());
+    expect(report.pass).toBe(true);
+    expect(report.text).toMatch(/cross-provider-embedding-search \(openai\): PASS/);
+    expect(report.text).toMatch(/\[PASS\] Both vectors usable/);
+    expect(report.text).toMatch(/\[PASS\] Batch alignment/);
+    expect(report.text).toMatch(/\[PASS\] Ranking sanity/);
+    // No dimension requested → the dimensions gate is SKIP.
+    expect(report.text).toMatch(/\[SKIP\] dimensions honored — no dimension requested/);
+    expect(report.text).toMatch(/ignores \(no-op\) taskType/);
+    expect(report.text).toMatch(/not reported by provider/);
+  });
+
+  test('FAIL when the expected document does not rank first', () => {
+    const ranked = [
+      { text: CORPUS_DOCUMENTS[1]!, score: 0.9 },
+      { text: CORPUS_DOCUMENTS[EXPECTED_TOP_INDEX]!, score: 0.1 }
+    ];
+    const report = formatEmbeddingReport(baseOutcome({ ranked }));
+    expect(report.pass).toBe(false);
+    expect(report.text).toMatch(/\[FAIL\] Ranking sanity/);
+  });
+
+  test('FAIL when query and document dimensions differ (vectors not usable)', () => {
+    const report = formatEmbeddingReport(baseOutcome({ queryDimensions: 2 }));
+    expect(report.pass).toBe(false);
+    expect(report.text).toMatch(/\[FAIL\] Both vectors usable/);
+  });
+
+  test('FAIL when batch alignment is off', () => {
+    const report = formatEmbeddingReport(baseOutcome({ documentCount: 3 }));
+    expect(report.pass).toBe(false);
+    expect(report.text).toMatch(/\[FAIL\] Batch alignment/);
+  });
+
+  test('PASS with the dimensions gate when requested + honored', () => {
+    const report = formatEmbeddingReport(
+      baseOutcome({ requestedDimensions: 3, queryDimensions: 3, documentDimensions: 3 })
+    );
+    expect(report.pass).toBe(true);
+    expect(report.text).toMatch(/\[PASS\] dimensions honored — requested 3d, returned 3d/);
+  });
+
+  test('FAIL when a requested dimension is not honored', () => {
+    const report = formatEmbeddingReport(
+      baseOutcome({ requestedDimensions: 512, queryDimensions: 3, documentDimensions: 3 })
+    );
+    expect(report.pass).toBe(false);
+    expect(report.text).toMatch(/\[FAIL\] dimensions honored — requested 512d, returned 3d/);
+  });
+
+  test('SKIP the dimensions gate when requested but the model does not support it', () => {
+    const report = formatEmbeddingReport(
+      baseOutcome({ requestedDimensions: 512, capabilitySupportsDimensions: false })
+    );
+    // SKIP does not fail the run.
+    expect(report.pass).toBe(true);
+    expect(report.text).toMatch(/\[SKIP\] dimensions honored — model does not support dimensions/);
+  });
+
+  test('reports taskType honored and token usage when present', () => {
+    const report = formatEmbeddingReport(
+      baseOutcome({
+        providerLabel: 'gemini',
+        capabilitySupportsTaskType: true,
+        queryUsage: { totalTokens: 12 }
+      })
+    );
+    expect(report.text).toMatch(/HONORS taskType/);
+    expect(report.text).toMatch(/Query token usage: \{"totalTokens":12\}/);
+    expect(report.text).toContain(`query="${QUERY_TASK_TYPE}"`);
+    expect(report.text).toContain(`documents="${DOCUMENT_TASK_TYPE}"`);
+  });
+
+  test('handles an empty ranking (top "(none)") without throwing', () => {
+    const report = formatEmbeddingReport(baseOutcome({ ranked: [], documentCount: 0 }));
+    expect(report.pass).toBe(false);
+    expect(report.text).toMatch(/top="\(none\)"/);
+  });
+});
+
+// ===========================================================================
+// Scenario metadata + cli.run
+// ===========================================================================
+
+describe('crossProviderEmbeddingSearchScenario', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  function makeContext(): IScenarioContext {
+    return {
+      logger: new Logging.LogReporter<unknown>({ logger: new Logging.InMemoryLogger() })
+    } as unknown as IScenarioContext;
+  }
+
+  test('is a CLI-only ai scenario with the expected id and tags', () => {
+    expect(crossProviderEmbeddingSearchScenario.id).toBe('cross-provider-embedding-search');
+    expect(crossProviderEmbeddingSearchScenario.category).toBe('ai');
+    expect(crossProviderEmbeddingSearchScenario.cli).toBeDefined();
+    expect(crossProviderEmbeddingSearchScenario.web).toBeUndefined();
+    expect(crossProviderEmbeddingSearchScenario.tags).toContain('embeddings');
+    expect(crossProviderEmbeddingSearchScenario.tags).toContain('cross-provider');
+    expect(crossProviderEmbeddingSearchScenario.requiredSecrets?.map((s) => s.envVarName)).toEqual([
+      'OPENAI_API_KEY',
+      'GEMINI_API_KEY'
+    ]);
+  });
+
+  test('cli.run fails with the live-gate-PENDING diagnostic when no key is in the environment', async () => {
+    const saved = { openai: process.env.OPENAI_API_KEY, provider: process.env.EMBED_PROVIDER };
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.EMBED_PROVIDER;
+    try {
+      expect(await crossProviderEmbeddingSearchScenario.cli!.run(makeContext())).toFailWith(
+        /OPENAI_API_KEY is not set/
+      );
+    } finally {
+      if (saved.openai !== undefined) {
+        process.env.OPENAI_API_KEY = saved.openai;
+      }
+      if (saved.provider !== undefined) {
+        process.env.EMBED_PROVIDER = saved.provider;
+      }
+    }
+  });
+
+  test('cli.run succeeds end-to-end against a mocked OpenAI fetch', async () => {
+    const saved = { openai: process.env.OPENAI_API_KEY, provider: process.env.EMBED_PROVIDER };
+    process.env.OPENAI_API_KEY = 'sk-test';
+    delete process.env.EMBED_PROVIDER;
+    global.fetch = jest.fn();
+    mockTwoFetches(openAiBody([QUERY_VEC]), openAiBody(DOC_VECS));
+    try {
+      expect(await crossProviderEmbeddingSearchScenario.cli!.run(makeContext())).toSucceedAndSatisfy(
+        (summary: string) => {
+          expect(summary).toMatch(/cross-provider-embedding-search \(openai\): PASS/);
+        }
+      );
+    } finally {
+      if (saved.openai !== undefined) {
+        process.env.OPENAI_API_KEY = saved.openai;
+      } else {
+        delete process.env.OPENAI_API_KEY;
+      }
+      if (saved.provider !== undefined) {
+        process.env.EMBED_PROVIDER = saved.provider;
+      }
+    }
+  });
+
+  test('cli.run honors EMBED_DIMENSIONS and EMBED_ENDPOINT (logged config)', async () => {
+    const saved = {
+      openai: process.env.OPENAI_API_KEY,
+      dims: process.env.EMBED_DIMENSIONS,
+      endpoint: process.env.EMBED_ENDPOINT
+    };
+    process.env.OPENAI_API_KEY = 'sk-test';
+    process.env.EMBED_DIMENSIONS = '4';
+    process.env.EMBED_ENDPOINT = 'http://localhost:11434/v1';
+    global.fetch = jest.fn();
+    const q4 = [[1, 0, 0, 0]];
+    const d4 = [
+      [1, 0, 0, 0],
+      [0, 1, 0, 0],
+      [0, 0, 1, 0],
+      [0, 0, 0, 1],
+      [0, 1, 0, 0]
+    ];
+    mockTwoFetches(openAiBody(q4), openAiBody(d4));
+    try {
+      expect(await crossProviderEmbeddingSearchScenario.cli!.run(makeContext())).toSucceedAndSatisfy(
+        (summary: string) => {
+          expect(summary).toMatch(/dimensions honored — requested 4d, returned 4d/);
+        }
+      );
+      expect(urlOf(0)).toBe('http://localhost:11434/v1/embeddings');
+    } finally {
+      const restore = (
+        key: 'OPENAI_API_KEY' | 'EMBED_DIMENSIONS' | 'EMBED_ENDPOINT',
+        v: string | undefined
+      ): void => {
+        if (v !== undefined) {
+          process.env[key] = v;
+        } else {
+          delete process.env[key];
+        }
+      };
+      restore('OPENAI_API_KEY', saved.openai);
+      restore('EMBED_DIMENSIONS', saved.dims);
+      restore('EMBED_ENDPOINT', saved.endpoint);
+    }
+  });
+
+  test('cli.run surfaces a wire failure as a CLI failure', async () => {
+    const saved = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = 'sk-test';
+    global.fetch = jest.fn().mockResolvedValueOnce(httpErrorResponse(429, 'rate limited'));
+    try {
+      expect(await crossProviderEmbeddingSearchScenario.cli!.run(makeContext())).toFailWith(
+        /query embedding failed.*429.*rate limited/
+      );
+    } finally {
+      if (saved !== undefined) {
+        process.env.OPENAI_API_KEY = saved;
+      } else {
+        delete process.env.OPENAI_API_KEY;
+      }
+    }
+  });
+
+  test('cli.run surfaces a non-passing report (mis-ranked vectors) as a CLI failure', async () => {
+    const saved = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = 'sk-test';
+    global.fetch = jest.fn();
+    // Query matches document 1 instead of the expected document 0 → ranking-sanity gate FAILs.
+    const misranked: number[][] = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+      [1, 0, 0],
+      [0, 0, 1]
+    ];
+    mockTwoFetches(openAiBody([[0, 1, 0]]), openAiBody(misranked));
+    try {
+      expect(await crossProviderEmbeddingSearchScenario.cli!.run(makeContext())).toFailWith(
+        /cross-provider-embedding-search \(openai\): FAIL[\s\S]*Ranking sanity/
+      );
+    } finally {
+      if (saved !== undefined) {
+        process.env.OPENAI_API_KEY = saved;
+      } else {
+        delete process.env.OPENAI_API_KEY;
+      }
+    }
+  });
+});

--- a/samples/testbed/src/test/unit/scenarios/crossProviderEmbeddingSearch.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/crossProviderEmbeddingSearch.test.ts
@@ -579,7 +579,8 @@ describe('crossProviderEmbeddingSearchScenario', () => {
     expect(crossProviderEmbeddingSearchScenario.tags).toContain('cross-provider');
     expect(crossProviderEmbeddingSearchScenario.requiredSecrets?.map((s) => s.envVarName)).toEqual([
       'OPENAI_API_KEY',
-      'GEMINI_API_KEY'
+      'GEMINI_API_KEY',
+      'MISTRAL_API_KEY'
     ]);
   });
 


### PR DESCRIPTION
## What

Adds the single `cross-provider-embedding-search` testbed scenario — the cloud sibling of `local-embedding-search` and the **live empirical gate** for the `ai-assist-embeddings` primitive (`AiAssist.callProviderEmbedding`), per `.ai/tasks/completed/2026-06/ai-assist-embeddings/testbed-scenario-brief.md`.

The scenario embeds a query (`retrieval-query`) + a fixed document corpus in one batch call (`retrieval-document`), computes cosine similarity, ranks the docs, and prints a **computed** PASS/FAIL gate matrix. It runs against an OpenAI-shaped provider (default `openai`; also `ollama` via `/v1`, `openai-compat`, `mistral`) **or** Gemini (`google-gemini` — the divergent `batchEmbedContents` + `taskType`-asymmetry path), selected via `EMBED_PROVIDER`.

**The embedding primitive is not modified** — this is a testbed-only change.

### Files
- `samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts` — deps-injected core (env→config parse, `runEmbeddingSearch`, `formatEmbeddingReport`); reuses the cosine/ranking math from `local-embedding-search`.
- `…/crossProviderEmbeddingSearch/index.ts` — CLI-only, env-gated; surfaces a non-passing report as a CLI **failure** (never masked behind `succeed()`).
- `…/scenarios/index.ts` + snapshot — registration.
- `…/test/unit/scenarios/crossProviderEmbeddingSearch.test.ts` — mock-fetch unit tests.

## Primary deliverable #1 — primitive gap analysis

**No gap found** (confirmed statically *and* under live fire — see #2). The unit tests mock `global.fetch` and drive the **real** `callProviderEmbedding` + its OpenAI/Gemini adapters over a faked network, asserting the **outgoing request body** (the load-bearing class per TESTING_GUIDELINES "never paper over failures"):

- **Gemini (highest-risk path):** `taskType` reaches the wire as `RETRIEVAL_QUERY` (query) / `RETRIEVAL_DOCUMENT` (docs); per-request `model: models/gemini-embedding-001` qualification; `outputDimensionality` flows from `dimensions`; URL `…/v1beta/models/{model}:batchEmbedContents` + `x-goog-api-key`; `{embeddings:[{values}]}` parsed; batch aligned by request order.
- **OpenAI:** `encoding_format: 'float'`, array input, `dimensions` when requested, and `taskType` **absent** (the cross-provider no-op path).
- Both base URLs match the providers' documented endpoints; the Gemini base/auth pattern is identical to the already-live-verified completion sibling.

## Primary deliverable #2 — live run

**✅ Live gate PASSED** — manually verified by @ErikFortune (2026-06-07) against the real **OpenAI** and **Gemini** APIs: both providers pass, and the explicit-`dimensions` path passes. The Gemini `batchEmbedContents` + `taskType`-asymmetry path — which had **never made a real network call before this PR** — succeeds end-to-end and ranks sanely. **No primitive gap surfaced under live fire**, so the `ai-assist-embeddings` → `release` promotion is unblocked.

Run commands (for reproducibility):

```sh
cd samples/testbed && rushx build
# OpenAI (default):
OPENAI_API_KEY=sk-... node bin/testbed.js --scenario cross-provider-embedding-search
# Gemini — the must-pass taskType-asymmetry / batchEmbedContents path:
EMBED_PROVIDER=gemini GEMINI_API_KEY=... node bin/testbed.js --scenario cross-provider-embedding-search
# Reduced dimension (OpenAI 3-* / Gemini):
OPENAI_API_KEY=sk-... EMBED_DIMENSIONS=512 node bin/testbed.js --scenario cross-provider-embedding-search
```

The four must-pass live checks (Gemini taskType asymmetry end-to-end; both formats yield correctly-shaped `number[][]` at the expected dimension; batch alignment by index; dimensions honored where supported) map 1:1 onto the printed gate matrix, all PASS.

## Gates
- `rushx build` ✅ · `rushx lint` ✅ (post-`fixlint`) · `rushx test` ✅ — **204 passing, 100% coverage** on the new scenario.

## Review loop
- **Layer 1 (`code-reviewer`)** run on the diff before coverage closure. No P1. P2 findings on imperative-vs-chained config resolution applied (chained `parseEmbeddingScenarioConfig`, which also removed a `c8 ignore` the reviewer flagged as masking a refactor). One P2 (`runEmbeddingSearch` chaining) dispositioned: the ranking step needs both the query and document vectors simultaneously — the standards' documented "complex logic / readability" exception.
- **Layer 2 (Copilot) — loop driven by implementer; stopped at 3 rounds on diminishing returns.** R1 (doc/metadata-accuracy drift) → R2 (a real correctness gap: unvalidated query-batch count → silent-ignore on the Gemini path, now caught) → R3 (fail-fast `EMBED_ENDPOINT` diagnostic for no-base-URL providers). Findings 4 → 2 → 1, bug → polish; all resolved, gates green each round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01717evFg1wMegtXKymcG1Yv)_