### PR TITLE
fix(ts-extras): validate Gemini embedding batch alignment + address Copilot review

### DIFF
--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -191,9 +191,6 @@ const aiAssistSettings: Converter<IAiAssistSettings>;
 // @public
 const aiClientToolConfig: Converter<IAiClientToolConfig>;
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "AiApiFormat"
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "AiImageApiFormat"
-//
 // @public
 type AiEmbeddingApiFormat = 'openai-embeddings' | 'gemini-embeddings';
 
@@ -278,8 +275,6 @@ const allKeyStoreSecretTypes: ReadonlyArray<KeyStoreSecretType>;
 // @public
 const allKeyStoreSymmetricSecretTypes: ReadonlyArray<KeyStoreSymmetricSecretType>;
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "AiModelCapability"
-//
 // @public
 const allModelCapabilities: ReadonlyArray<AiModelCapability>;
 

--- a/libraries/ts-extras/src/packlets/ai-assist/embeddingClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/embeddingClient.ts
@@ -311,13 +311,28 @@ async function callGeminiEmbeddings(
     .validate(jsonResult.value)
     .withErrorFormat((msg) => `Gemini embeddings API response: ${msg}`)
     .onSuccess((response) => {
-      // Gemini returns embeddings aligned to request order (no index field).
+      // Gemini returns embeddings aligned to request order (no index field), so
+      // there is no per-item index to re-sort or gap-check (unlike the OpenAI
+      // path). Validate the response is well-formed against the request before
+      // trusting the positional alignment: a truncated batch or ragged
+      // dimensions would silently yield misaligned/partial vectors. (inputs is
+      // non-empty here; the empty-input case short-circuits before the wire call.)
       const vectors = response.embeddings.map((e) => e.values);
-      return succeed({
-        vectors,
-        model: bare,
-        dimensions: vectors[0].length
-      });
+      if (vectors.length !== inputs.length) {
+        return fail(
+          `Gemini embeddings API response: expected ${inputs.length} embedding(s), got ${vectors.length}`
+        );
+      }
+      const dimensions = vectors[0].length;
+      const ragged = vectors.findIndex((v) => v.length !== dimensions);
+      if (ragged !== -1) {
+        return fail(
+          `Gemini embeddings API response: inconsistent vector dimensionality ` +
+            `(vector ${ragged} has length ${vectors[ragged].length}, expected ${dimensions})`
+        );
+      }
+      const result: IAiEmbeddingResult = { vectors, model: bare, dimensions };
+      return succeed(result);
     });
 }
 

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -586,8 +586,8 @@ export type AiImageApiFormat =
  *   genuinely divergent shape (different route, auth header, request body, and
  *   the `taskType` retrieval-asymmetry knob that has no OpenAI analog).
  *
- * Named with the `ApiFormat` suffix for symmetry with {@link AiApiFormat} and
- * {@link AiImageApiFormat}.
+ * Named with the `ApiFormat` suffix for symmetry with `AiApiFormat` and
+ * `AiImageApiFormat`.
  *
  * @public
  */
@@ -1280,7 +1280,7 @@ export interface IAiGeneratedImage extends IAiImageData {
 export type AiModelCapability = 'chat' | 'tools' | 'vision' | 'image-generation' | 'thinking' | 'embedding';
 
 /**
- * All valid {@link AiModelCapability} values — the single source of truth for
+ * All valid `AiModelCapability` values — the single source of truth for
  * the capability vocabulary (used by validators and capability filters).
  * @public
  */

--- a/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
@@ -634,6 +634,28 @@ describe('callProviderEmbedding', () => {
       });
       expect(result).toFailWith(/503.*unavailable/i);
     });
+
+    test('fails when the embedding count does not match the input count', async () => {
+      // Two inputs, but the server returns only one embedding. Gemini aligns by
+      // request order with no index field, so a short batch must be rejected.
+      mockFetchResponse(geminiEmbeddingBody([[0.1]]));
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: geminiDescriptor(),
+        apiKey: 'gk-test',
+        params: { input: ['a', 'b'] }
+      });
+      expect(result).toFailWith(/expected 2 embedding\(s\), got 1/i);
+    });
+
+    test('fails when vectors have inconsistent dimensionality', async () => {
+      mockFetchResponse(geminiEmbeddingBody([[0.1, 0.2], [0.3]]));
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: geminiDescriptor(),
+        apiKey: 'gk-test',
+        params: { input: ['a', 'b'] }
+      });
+      expect(result).toFailWith(/inconsistent vector dimensionality .*vector 1 has length 1, expected 2/i);
+    });
   });
 
   describe('callProxiedEmbedding', () => {

--- a/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/embeddingClient.test.ts
@@ -625,6 +625,18 @@ describe('callProviderEmbedding', () => {
       expect(result).toFailWith(/Gemini embeddings API response/i);
     });
 
+    test('fails when the response embeddings array is empty', async () => {
+      // Mirrors the OpenAI empty-data case: the non-empty validator constraint
+      // rejects a zero-length batch up front (symmetric with the OpenAI adapter).
+      mockFetchResponse({ embeddings: [] });
+      const result = await AiAssist.callProviderEmbedding({
+        descriptor: geminiDescriptor(),
+        apiKey: 'gk-test',
+        params: { input: 'q' }
+      });
+      expect(result).toFailWith(/Gemini embeddings API response/i);
+    });
+
     test('surfaces an HTTP error from the Gemini endpoint', async () => {
       mockFetchHttpError(503, 'unavailable');
       const result = await AiAssist.callProviderEmbedding({

--- a/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
+++ b/samples/testbed/src/scenarios/crossProviderEmbeddingSearch/search.ts
@@ -17,7 +17,7 @@
  * @packageDocumentation
  */
 
-import { type Logging, Result, fail, succeed } from '@fgv/ts-utils';
+import { type Logging, type Result, fail, succeed } from '@fgv/ts-utils';
 import { AiAssist } from '@fgv/ts-extras';
 
 import { rankBySimilarity } from '../localEmbeddingSearch/similarity';
@@ -326,6 +326,11 @@ export async function runEmbeddingSearch(
   }
   const docs = docResult.value;
 
+  // The real embedding adapter (callProviderEmbedding) now enforces batch alignment on both
+  // the OpenAI and Gemini paths, so on the production path a count mismatch is already caught
+  // and surfaced through the `query embedding failed:` / `document embedding failed:` wrappers
+  // above. These re-checks guard the injectable `embedFn` seam (a custom or test embed function
+  // is not bound by the adapter's guarantees) so the scenario never indexes past a short batch.
   if (docs.vectors.length !== CORPUS_DOCUMENTS.length) {
     return fail(
       `batch misalignment: requested ${CORPUS_DOCUMENTS.length} document embeddings, ` +
@@ -334,8 +339,7 @@ export async function runEmbeddingSearch(
   }
 
   // The query is a single-item batch: require exactly one vector. This catches an empty result
-  // AND extra vectors that would otherwise be silently dropped — notably on the Gemini path,
-  // where the adapter does not enforce the response count against the request.
+  // AND extra vectors that would otherwise be silently dropped.
   if (query.vectors.length !== 1) {
     return fail(
       `query batch misalignment: expected exactly 1 query vector, received ${query.vectors.length}`

--- a/samples/testbed/src/test/unit/scenarios/crossProviderEmbeddingSearch.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/crossProviderEmbeddingSearch.test.ts
@@ -426,16 +426,17 @@ describe('runEmbeddingSearch (real callProviderEmbedding + mocked fetch)', () =>
     });
 
     test('detects batch misalignment when Gemini returns fewer vectors than documents', async () => {
-      // Gemini's adapter does not enforce the batch count; the scenario does.
+      // The Gemini adapter enforces the batch count; the mismatch surfaces through the
+      // scenario's `document embedding failed:` wrapper.
       mockTwoFetches(geminiBody([QUERY_VEC]), geminiBody(DOC_VECS.slice(0, 3)));
       expect(await runEmbeddingSearch(geminiConfig())).toFailWith(
-        /batch misalignment.*requested 5.*received 3/
+        /document embedding failed.*expected 5 embedding\(s\), got 3/
       );
     });
 
     test('detects extra query vectors that Gemini would otherwise silently return', async () => {
-      // The query is a single-item batch; Gemini's adapter does not enforce count, so a
-      // 2-vector response for a 1-input query must be caught by the scenario, not silently sliced.
+      // The query is a single-item batch; the Gemini adapter rejects a 2-vector response for a
+      // 1-input query, surfacing through the scenario's `query embedding failed:` wrapper.
       mockTwoFetches(
         geminiBody([
           [1, 0, 0],
@@ -444,7 +445,7 @@ describe('runEmbeddingSearch (real callProviderEmbedding + mocked fetch)', () =>
         geminiBody(DOC_VECS)
       );
       expect(await runEmbeddingSearch(geminiConfig())).toFailWith(
-        /query batch misalignment: expected exactly 1 query vector, received 2/
+        /query embedding failed.*expected 1 embedding\(s\), got 2/
       );
     });
   });
@@ -485,6 +486,20 @@ describe('runEmbeddingSearch (injected EmbedFn — defensive branches)', () => {
     };
     expect(await runEmbeddingSearch(openAiConfig(), stub)).toFailWith(
       /query batch misalignment: expected exactly 1 query vector, received 0/
+    );
+  });
+
+  test('fails when the document batch yields fewer vectors than requested', async () => {
+    // A custom embedFn is not bound by the adapter's alignment guarantee, so the scenario's
+    // own re-check is the guard: a short document batch must fail rather than index past it.
+    const stub: EmbedFn = async (params) => {
+      const input = params.params.input;
+      return typeof input === 'string'
+        ? succeed({ vectors: [[1, 0, 0]], model: 'm', dimensions: 3 })
+        : succeed({ vectors: input.slice(0, 3).map(() => [1, 0, 0]), model: 'm', dimensions: 3 });
+    };
+    expect(await runEmbeddingSearch(openAiConfig(), stub)).toFailWith(
+      /batch misalignment: requested 5 document embeddings, received 3/
     );
   });
 
@@ -613,8 +628,11 @@ describe('crossProviderEmbeddingSearchScenario', () => {
 
   function makeContext(): IScenarioContext {
     return {
-      logger: new Logging.LogReporter<unknown>({ logger: new Logging.InMemoryLogger() })
-    } as unknown as IScenarioContext;
+      logger: new Logging.LogReporter<unknown>({ logger: new Logging.InMemoryLogger() }),
+      keyStore: undefined,
+      resolveSecret: jest.fn(),
+      dataTree: {} as IScenarioContext['dataTree']
+    };
   }
 
   test('is a CLI-only ai scenario with the expected id and tags', () => {


### PR DESCRIPTION
Addresses the 5 Copilot review threads on #486.

## P2 — real bug fix (Gemini batch-alignment validation)

`callGeminiEmbeddings` in `embeddingClient.ts` previously trusted the provider to return one vector per input with consistent dimensionality — unlike `callOpenAiEmbeddings` in the same file, which validates the response. A truncated batch or ragged vectors would silently yield misaligned/partial results downstream.

The Gemini adapter now mirrors the OpenAI adapter's validation (same shape and error style):
- **Count check** — `response.embeddings.length === inputs.length`, else `fail("Gemini embeddings API response: expected N embedding(s), got M")`. Gemini aligns by request order (no `index` field), so there is no index/gap check (the OpenAI path's index walk does not apply).
- **Ragged-dimensionality check** — `fail("Gemini embeddings API response: inconsistent vector dimensionality (vector i has length X, expected Y)")`.

Added two Gemini fail-path unit tests (count mismatch, ragged dimensionality) alongside the existing OpenAI ones.

## P3 — advisory (all applied)

- **`model.ts` `@link` warnings** — the `AiApiFormat` / `AiImageApiFormat` / `AiModelCapability` `@link` targets are type aliases the api-extractor resolver cannot link (namespacing them only swapped one warning message for another), so they were switched to plain backtick code formatting. This removes three `ae-unresolved-link` warnings from `etc/ts-extras.api.md` (regenerated; no new warnings).
- **`crossProviderEmbeddingSearch/search.ts:20`** — `Result` is now a type-only import.
- **`crossProviderEmbeddingSearch.test.ts` `makeContext`** — replaced the broad `as unknown as IScenarioContext` cast with a shape-correct stub (stubbed `resolveSecret` / `dataTree`), matching the sibling scenario tests.

## Testbed scenario follow-through

The scenario keeps its own batch-alignment re-checks because `embedFn` is an injectable seam (a custom/test embed function isn't bound by the adapter's new guarantee); the comments were corrected and the two real-adapter tests realigned to the adapter-level message now raised on the production path, plus a new injected-stub test covering the scenario's document-count branch so it stays covered.

## Review-loop notes

- **Layer 1 (`code-reviewer`)** run on the diff before opening; findings resolved/dispositioned.
- Copilot review loop driven by implementer; will stop on diminishing returns or the 10-round cap.

## Gates

- `rushx build` + `rushx lint` + `rushx test` (100% coverage) green in **@fgv/ts-extras** and **@fgv/testbed**.
- `etc/ts-extras.api.md` regenerated; the only delta is the removal of three `ae-unresolved-link` warning lines (no export-signature change).
- `rushx fixlint` clean; no new change file needed (public export surface unchanged; the embeddings feature's phase1–3 change files already cover the unreleased surface on this integration branch).

https://claude.ai/code/session_01DwywfgJ879GpJvyZBZy8Hu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwywfgJ879GpJvyZBZy8Hu)_