### PR TITLE
docs(FUTURE): cache parsed store records in ts-prompt-assist resolve path

### DIFF
--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -23,6 +23,20 @@ Description with the user's framing expanded with the design space.
 
 ---
 
+## `ts-prompt-assist` — cache parsed store records in the resolve path
+
+`PromptLibrary.resolve` re-reads and **re-parses YAML from the store on every call**. The resolve path (`resolve/promptLibrary.ts:585`) calls `walkScopeChain(this._store, …)` unconditionally first, and `FileTreePromptStore` has no record cache — `store.get` → `_readPromptFile` → `yamlConverter.convert(text)` (`store/fileTreePromptStore.ts:160/239/254`) parses on every read. Per resolve this is **O(scope-chain depth) for the requested prompt only** — the `<id>.yaml` in each scope of *that resolve's* chain (`chainWalker.ts:44`) + the per-scope `_bindings.yaml` (`:67`) + recursively the inner-prompt files for any `kind: 'resource'` slots. It is NOT a re-parse of the whole library.
+
+What's already cached (the expensive work): the ts-res **materialization** (`_materialized`, keyed by descriptor-canonical, `:835/851`) and Mustache templates (`_mustacheCache`); `describe()` uses `_descriptorCache` (`:456`), but `resolve` does not. So only the YAML file read + parse of the requested prompt's chain is redundant on a repeat resolve of a hot prompt.
+
+**The fix:** add a parsed-store-record cache in the resolve path (or have `resolve` reuse a record/descriptor cache instead of hitting `walkScopeChain` raw). This is **invalidation-free today** because `FileTreePromptStore` is **read-only at v0.1** — records are immutable for the library's lifetime. The cache key must match the resolve lookup granularity (scope + id, plus the scope `_bindings.yaml`), not just id.
+
+**Why deferred**: not a problem at current scale — the per-resolve parse is a handful of small files and the heavy ts-res setup is already cached. Surfaced as an investigation finding, not a live bottleneck.
+
+**Dependencies**: the per-resolve YAML parse showing up as a real cost in a profiled workload. **Coupling note:** when a write API lands (`put`/`delete`/`watch` — itself a separate FUTURE item, the store is read-only at v0.1), this record cache needs invalidation wired to writes; design the cache so that hook is additive.
+
+**Reference**: 2026-06 investigation — an agent asserted "re-parses all prompt YAML files on every call"; verified the kernel (no record cache → per-resolve re-parse) but corrected the scope (requested prompt's chain files, not the whole library).
+
 ## Horizontal composition B+1 — dependency-ordered render-merge-reinject (topo-sort)
 
 `@fgv/ts-prompt-assist`'s `HorizontalComposer` (shipped Phase B) uses **render-then-merge**: each contributor resolves+renders independently, then the composer merges the rendered per-slot values. This loses **cross-slot placeholders** — a contributor slot value that references another logical slot (`{{otherSlot}}`) is inserted literally, not resolved.


### PR DESCRIPTION
## Tech-debt / FUTURE: parsed-record cache in `ts-prompt-assist` resolve path

Files one `docs/FUTURE.md` entry from a code investigation (no code change).

**Finding:** `PromptLibrary.resolve` re-reads and **re-parses the requested prompt's scope-chain YAML on every call** — `walkScopeChain` (`promptLibrary.ts:585` → `chainWalker.ts:44/67`) hits `FileTreePromptStore.get`/`getBindings`, which `yamlConverter.convert(text)` on every read (`fileTreePromptStore.ts:160/254`, no record cache). It is **O(chain depth) for the requested prompt only** (its `<id>.yaml` per scope + per-scope `_bindings.yaml` + recursive resource-bound inner prompts) — *not* a re-parse of the whole library. The expensive ts-res materialization (`_materialized`) and Mustache templates are already cached; only the per-resolve file read + parse of the hot prompt's chain is redundant.

**Fix (deferred):** a parsed-store-record cache in the resolve path — invalidation-free today because `FileTreePromptStore` is read-only at v0.1, with a noted coupling to wire invalidation when a write API eventually lands.

**Why now:** not a current-scale problem (heavy work already cached); filed so it's captured for when the per-resolve parse shows up in a profiled workload.

Context: corrects an agent's overstated assertion ("re-parses *all* prompt YAML files on every call") while preserving the real kernel (no record cache → per-resolve re-parse of the requested prompt's chain).

Doc-only — CI is incidental.

https://claude.ai/code/session_01CbUfvtALfVNHjXeSZKRSXZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbUfvtALfVNHjXeSZKRSXZ)_