### PR TITLE
feat(ts-agent-memory): vector/semantic-recall fast-follow — InMemoryCosineIndex + embed-on-write

### DIFF
--- a/.ai/tasks/active/ts-agent-memory-vector/state.md
+++ b/.ai/tasks/active/ts-agent-memory-vector/state.md
@@ -144,3 +144,27 @@ Post-fix gates: `heft build` (+ api-extractor, no surface drift) clean; `heft li
 
 Final gates after the best-effort redesign: `heft build` + api-extractor (no surface drift), `heft
 lint` clean, `heft test` **317 tests, 100% coverage**.
+
+#### CodeRabbit round 3 (on the best-effort commits)
+
+The three round-1 Major findings were confirmed `✅ Addressed`. Round 3 surfaced:
+
+- **`put` returns `Failure` after a committed write if a cap-cull eviction fails** (Major, new) →
+  **fixed**: `_applyEvictions` is now best-effort — it runs only after the authoritative `_persist`,
+  logs an eviction failure via `_warnSwallowed` (the `(scope,kind)` cap may transiently exceed by one;
+  the next write's admission restores it), and returns only the successfully-evicted ids (so
+  observations + vector pruning cover only those). A committed `put` never fails on cleanup. This is
+  strictly safer than CodeRabbit's alternative (evict-before-persist), which would delete old records
+  before the replacement is durable — violating B2's persist-then-evict rule. Test updated:
+  eviction-of-a-missing-record now asserts the put **succeeds** + the failure is logged.
+- **Embed/`add` runs before `_persist`** (Major, Duplicate) → **dispositioned (kept).** This is the
+  irreducible residual of stamping the index-returned `embeddingRef` in a single durable write: under
+  the endorsed best-effort model, embed+add must precede the one `_persist` so the ref lands on disk,
+  OR `embeddingRef` becomes a second-write (untestable failure branch) / a vestigial set-only-on-return
+  hint. The residual — a `_persist` failure *after* a successful same-id `add` — is near-unreachable on
+  the in-memory/git FileTree backends (the only failure points are `Yaml.yamlStringify` and a mutable
+  FileTree write, neither of which realistically fails for a valid envelope) and self-heals via
+  `rebuild` (the vector index is the embedded-truth). Documented inline on `_admitWrite`.
+
+Final gates after round 3: `heft build` + api-extractor (no drift), `heft lint` clean, `heft test`
+**317 tests, 100% coverage**.

--- a/.ai/tasks/active/ts-agent-memory-vector/state.md
+++ b/.ai/tasks/active/ts-agent-memory-vector/state.md
@@ -31,17 +31,34 @@ Made semantic recall operational end-to-end:
    deterministic keyword-count embedder — no network). Seam tests updated to `Float32Array`.
    **314 tests, 100% coverage** (statements/branches/functions/lines).
 
-## Embedding-failure policy decision (+ rationale)
+## Embedding-failure policy decision (+ rationale) — REVISED to best-effort (PR #502 CodeRabbit round)
 
-**Fail the `put` loudly; persist nothing.** The embed step runs BEFORE the file is persisted, so an
-embedding (or vector-index) failure rejects the put with no file written and no index entry — the
-store never ends up with a record on disk whose vector is silently missing from the index (the
-"silently corrupt the index" failure mode the brief warns against). This also orders the risk
-correctly: the most-likely-to-fail operation (embed — a network call / model inference) happens
-first, before any disk mutation; the least-likely (in-memory FileTree persist) happens last. The only
-residual window — persist failing *after* a vector `add` — leaves a harmless stale vector entry that
-is dropped at hydration time (SemanticRetriever re-resolves hits against the record index and skips
-unknown ids) and cleared by the next `rebuild`. Documented inline on `_admitWrite` / `_embedOnWrite`.
+**Initial choice (superseded):** fail the `put` loudly on an embedding/index failure.
+
+**Final model — "best-effort derived index"** (owner decision during the PR #502 CodeRabbit loop):
+the durable FileTree record store is **authoritative**; the vector index is a **derived, rebuildable**
+view (`InMemoryCosineIndex.rebuild`). Therefore vector maintenance is **best-effort**:
+
+- A failed `embed` / `add` / `remove` — whether a returned `fail` OR a thrown/rejected hook — is
+  **logged at `warn`** via the injected logger and the **record operation still succeeds**. Only
+  genuine record-store failures (body/codec/policy, persist, file eviction) fail a `put`; only the
+  authoritative file+index delete failing fails a `delete`.
+- **`put`:** embed + `add` run immediately before the single `_persist`, so the index-returned
+  `embeddingRef` lands in one durable write on success (a post-persist stamp would need a second write
+  whose failure path is effectively untestable). On embed/add failure the record is persisted
+  **without** an embedding (`embeddingRef` undefined) and a warn is logged.
+- **`delete` / cap-cull eviction:** the record file + index entry are removed first (authoritative);
+  vector pruning is best-effort afterward, so a committed delete **never** returns `Failure` because a
+  derived index could not be pruned (fixes the post-commit-delete edge CodeRabbit raised).
+- The redundant eager `remove(oldId)` before `add` on a content change was **dropped** —
+  `IVectorIndex.add` has documented replace semantics.
+- Residual: a persist failure *after* a successful `add` (near-unreachable on the in-memory/git
+  FileTree backends) can orphan a vector; it is dropped at hydration (SemanticRetriever skips unknown
+  ids) and cleared by the next `rebuild`.
+
+Helpers: `_tryVectorOp` (normalizes reject→`fail`, logs at warn), `_removeVectorBestEffort`,
+`_removeEvictedVectors`, and the shared `_warnSwallowed` (renamed from `_warnObserverIssue`, now also
+used for vector warnings).
 
 ## Deviations from design-lock / brief
 
@@ -106,3 +123,24 @@ Layer-1 `code-reviewer` pass on the final diff. **No P1s.** Three P2s, three P3s
 
 Post-fix gates: `heft build` (+ api-extractor, no surface drift) clean; `heft lint` clean; `heft test`
 **314 tests, 100% coverage**.
+
+### CodeRabbit (PR #502) — rounds + dispositions
+
+- **Clone vector on `add`** (Major) → fixed (`Float32Array.from`) + defensive-copy test.
+- **`rebuild` reset-before-list** (Major) → fixed (`_reset()` first) + seeded rollback test.
+- **Retriever normalizes rejecting backend** (Major) → fixed (`_callBackend` try/catch) + 2 rejection tests.
+- **Store async-hook rejection guard** (Major) → CodeRabbit self-marked "✅ Addressed" (the put/delete
+  paths were already `thenOnSuccess`-guarded); the best-effort refactor now also `try/catch`es every
+  vector hook in `_tryVectorOp`.
+- **Vector-before-persist (put) + committed-delete-fails-on-cleanup (delete/evict)** (Major, heavy
+  lift) → resolved by the **best-effort derived-index** redesign above (owner decision).
+- **Seed the list-failure test** (Minor) → done.
+- **Docstring Coverage 16.67% pre-merge warning** → dispositioned: this is CodeRabbit's 80% default
+  counting private helpers + test arrow-fns; the repo's gate is `rushx lint` + api-extractor (public
+  TSDoc), both green. Adding docstrings to every private one-liner/test fn would be the over-commenting
+  the repo's CODING_STANDARDS discourage. Not actioned.
+- **ESLint / markdownlint tool-run failures** (CodeRabbit infra: "install failed", "wrapper config not
+  available") → not our code; repo's own `rushx lint` passes.
+
+Final gates after the best-effort redesign: `heft build` + api-extractor (no surface drift), `heft
+lint` clean, `heft test` **317 tests, 100% coverage**.

--- a/.ai/tasks/active/ts-agent-memory-vector/state.md
+++ b/.ai/tasks/active/ts-agent-memory-vector/state.md
@@ -1,0 +1,78 @@
+# ts-agent-memory-vector — semantic-recall fast-follow
+
+## Branch / base
+
+- **Base branch:** `ts-agent-memory` (PR #501 promoting the v1 substrate to `release` is still
+  OPEN/unmerged at stream start, so per the brief we branch off — and PR back into —
+  `ts-agent-memory`, whose tip `95bc909d` already contains the full B0–C + cap-cull substrate).
+- **Actual branch:** `claude/ts-agent-memory-vector-4z2z2t` (harness-suffixed stem
+  `claude/ts-agent-memory-vector`).
+
+## What shipped
+
+Made semantic recall operational end-to-end:
+
+1. **`vector/inMemoryCosineIndex.ts`** — `InMemoryCosineIndex` implements `IVectorIndex` as a
+   brute-force in-memory cosine over `Map<MemoryId, Float32Array>`. `create()`; `add`/`remove`/`query`;
+   `rebuild(source, embed)`. Single index dimension established by the first `add`; mismatched
+   dimensions fail loudly; zero-magnitude vectors score `0` (never `NaN`); idempotent `remove`;
+   `topK<=0` / empty-index queries short-circuit to `[]`. No external dependency.
+2. **`store/fileTreeMemoryStore.ts`** — additive `vectorIndex?` + `embed?` create params; embed-on-write
+   hook on `put` (embed → invalidate-stale-on-contentHash-change → add → stamp `embeddingRef` →
+   persist); vector removal on `delete` and cap-cull eviction. Zero-overhead and byte-identical when
+   unwired.
+3. **`retrieve/semanticRetriever.ts`** — already operational via the B2 backend seam; only the
+   `QueryEmbedder` boundary type changed (see deviation 1). `HybridRetriever` composes the now-real
+   semantic child unchanged.
+4. **Tests** — `inMemoryCosineIndex.test.ts` (cosine ordering, dimension invariant, degenerate
+   vectors, rebuild + its failure modes); `store/embedOnWrite.test.ts` (embeddingRef + index entry,
+   re-embed on contentHash change, dedup-no-op skips re-embed, remove on delete + cap-cull evict,
+   embedding/add/remove failures fail the op loudly, unwired byte-identical, semantic recall e2e with a
+   deterministic keyword-count embedder — no network). Seam tests updated to `Float32Array`.
+   **314 tests, 100% coverage** (statements/branches/functions/lines).
+
+## Embedding-failure policy decision (+ rationale)
+
+**Fail the `put` loudly; persist nothing.** The embed step runs BEFORE the file is persisted, so an
+embedding (or vector-index) failure rejects the put with no file written and no index entry — the
+store never ends up with a record on disk whose vector is silently missing from the index (the
+"silently corrupt the index" failure mode the brief warns against). This also orders the risk
+correctly: the most-likely-to-fail operation (embed — a network call / model inference) happens
+first, before any disk mutation; the least-likely (in-memory FileTree persist) happens last. The only
+residual window — persist failing *after* a vector `add` — leaves a harmless stale vector entry that
+is dropped at hydration time (SemanticRetriever re-resolves hits against the record index and skips
+unknown ids) and cleared by the next `rebuild`. Documented inline on `_admitWrite` / `_embedOnWrite`.
+
+## Deviations from design-lock / brief
+
+1. **`IVectorIndex` / `QueryEmbedder` boundary: `ReadonlyArray<number>` → `Float32Array`.** The merged
+   B2 seam shipped `ReadonlyArray<number>`, but design.md §5.1 specifies `Float32Array` and the
+   stream's non-negotiable convention is "vectors are `Float32Array` at the index boundary (`number[]`
+   only at JSON-wire edges)". Corrected the seam to `Float32Array` (justified for an unpublished,
+   active-development library per ACTIVE_DEVELOPMENT — "break compatibility and fix consumers rather
+   than accumulating cruft"). The two existing seam tests were updated to match.
+2. **`rebuild(source, embed)` takes an `IMemoryRecordSource`, not the concrete store.** The brief
+   phrases it `rebuild(store, embed)`. A direct `vector → store` import would be a packlet cycle (the
+   store already imports `vector` for `IVectorIndex`). Resolved by defining a minimal
+   `IMemoryRecordSource { list(): … }` in the vector packlet, which `FileTreeMemoryStore` satisfies
+   structurally — so a consumer still calls `index.rebuild(store, embed)` with the store directly, no
+   cycle, no extra wiring.
+3. **Vector removal gated on BOTH `vectorIndex` AND `embed` being wired** (symmetric with the
+   embed-on-write gate). The vector lifecycle is wholly on or wholly off, so a `remove` never fires
+   for a record that could never have been embedded.
+
+## Out of scope (unchanged from brief)
+
+Sidecar vector persistence (noted as a future nicety in the `InMemoryCosineIndex` TSDoc); temporal
+write path / retrievers; L2 tools; L3 ingest; external ANN; any `callProviderEmbedding` call from the
+core (the embedder is consumer-injected — core stays embedder-agnostic, no `ai-assist` import).
+
+## Gates
+
+- `heft build` (incl. api-extractor) — clean; `etc/ts-agent-memory.api.md` regenerated + committed.
+- `heft lint` — clean (0 errors, 0 warnings) after `fixlint`.
+- `heft test` — 314 tests, 100% coverage.
+
+## code-reviewer findings + dispositions
+
+_(filled in below after the layer-1 pass)_

--- a/.ai/tasks/active/ts-agent-memory-vector/state.md
+++ b/.ai/tasks/active/ts-agent-memory-vector/state.md
@@ -75,4 +75,34 @@ core (the embedder is consumer-injected — core stays embedder-agnostic, no `ai
 
 ## code-reviewer findings + dispositions
 
-_(filled in below after the layer-1 pass)_
+Layer-1 `code-reviewer` pass on the final diff. **No P1s.** Three P2s, three P3s.
+
+**P1 — none.** Clear of `any`, unsafe casts, `Result<void>`, cross-boundary throws, security issues.
+
+**P2 (all resolved):**
+1. *Unsafe cast `r.body as string` in the test embedder* (`embedOnWrite.test.ts`). **Fixed** —
+   the `recordEmbed` test helper now validates the body via `Converters.string.convert(r.body)`
+   (modelling the idiom a real `MemoryEmbedder` over `IMemoryRecord<unknown>` should use) instead of
+   casting.
+2. *`seeded()` and the zero-magnitude tests discarded `Result`s from `add()`* (`inMemoryCosineIndex.test.ts`).
+   **Fixed** — all setup `add`/`remove` calls are now `(await …).orThrow()`.
+3. *`rebuild` left the index in a partial state on failure* (`inMemoryCosineIndex.ts`). **Fixed** —
+   added a `_reset()` rollback on every failure path (list/embed/add), so a failed rebuild leaves a
+   clean empty index. Documented the contract in TSDoc and added two tests asserting `size === 0`
+   after a mid-rebuild embed failure (seeded beforehand so the rollback is observable) and after an
+   add failure.
+
+**P3:**
+1. *`query` dimension comparison reads `_dimension` (`number | undefined`) without TS narrowing.*
+   **Dispositioned (kept).** The `_vectors.size === 0` guard guarantees `_dimension` is defined when
+   the comparison runs (a dimension is always set on the first `add`). An explicit narrow would
+   introduce an unreachable `undefined` branch requiring a `c8 ignore` directive — net negative
+   against the no-unwarranted-directives discipline. The guard ordering is load-bearing and commented.
+2. *`hits.length > topK ? slice : hits` micro-branch.* **Dispositioned (kept).** Intentional — avoids
+   a redundant full-array copy when `hits.length <= topK`. Both arms are covered.
+3. *e2e test builds a `MemoryIndex` manually.* **Resolved** — added a comment explaining the
+   intentional store/retriever decoupling (the store's derived index is private; the retriever takes a
+   separate `IMemoryIndex`), keyed on the shared `vectorIndex` instance.
+
+Post-fix gates: `heft build` (+ api-extractor, no surface drift) clean; `heft lint` clean; `heft test`
+**314 tests, 100% coverage**.

--- a/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
+++ b/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
@@ -110,11 +110,13 @@ export interface IFileTreeMemoryStoreCreateParams {
     readonly clock?: () => number;
     readonly codecs?: ReadonlyMap<Kind, IIdentityCodec>;
     readonly defaultCodec?: IIdentityCodec;
+    readonly embed?: MemoryEmbedder;
     readonly logger?: Logging.ILogger;
     readonly observers?: ReadonlyArray<IMemoryObserver>;
     readonly registry: IBodyConverterRegistry;
     readonly root: FileTree.IMutableFileTreeDirectoryItem;
     readonly scopeEncoding?: (scope: MemoryScopeKey) => Result<string>;
+    readonly vectorIndex?: IVectorIndex;
     readonly writePolicies?: ReadonlyMap<Kind, IWritePolicy>;
 }
 
@@ -236,6 +238,11 @@ export interface IMemoryRecord<TBody = unknown> {
 }
 
 // @public
+export interface IMemoryRecordSource {
+    list(): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>>;
+}
+
+// @public
 export interface IMemoryRetriever {
     readonly capabilities: IMemoryRetrieverCapabilities;
     retrieve(query: IMemoryQuery): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>>;
@@ -274,6 +281,16 @@ export interface IMergeStrategy {
 export function indexedRecordMatchesQuery(entry: IIndexedMemoryRecord, query: IMemoryQuery): boolean;
 
 // @public
+export class InMemoryCosineIndex implements IVectorIndex {
+    add(id: MemoryId, vector: Float32Array): Promise<Result<string>>;
+    static create(): Result<InMemoryCosineIndex>;
+    query(vector: Float32Array, topK: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>>;
+    rebuild(source: IMemoryRecordSource, embed: MemoryEmbedder): Promise<Result<number>>;
+    remove(id: MemoryId): Promise<Result<MemoryId>>;
+    get size(): number;
+}
+
+// @public
 export interface IProvenance {
     readonly [key: string]: unknown;
     readonly by?: string;
@@ -303,8 +320,8 @@ export interface ITemporalBlock {
 
 // @public
 export interface IVectorIndex {
-    add(id: MemoryId, vector: ReadonlyArray<number>): Promise<Result<string>>;
-    query(vector: ReadonlyArray<number>, topK: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>>;
+    add(id: MemoryId, vector: Float32Array): Promise<Result<string>>;
+    query(vector: Float32Array, topK: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>>;
     remove(id: MemoryId): Promise<Result<MemoryId>>;
 }
 
@@ -382,6 +399,9 @@ export class MemoryCapCullPolicy implements IWritePolicy {
 }
 
 // @public
+export type MemoryEmbedder = (record: IMemoryRecord<unknown>) => Promise<Result<Float32Array>>;
+
+// @public
 export type MemoryId = Brand<string, 'MemoryId'>;
 
 // @public
@@ -440,7 +460,7 @@ export const provenanceConverter: Converter<IProvenance>;
 export type ProvenanceSource = 'agent' | 'host-ingest' | 'human' | (string & {});
 
 // @public
-export type QueryEmbedder = (text: string) => Promise<Result<ReadonlyArray<number>>>;
+export type QueryEmbedder = (text: string) => Promise<Result<Float32Array>>;
 
 // @public
 export function recencyCompare(a: IMemoryRecord<unknown>, b: IMemoryRecord<unknown>): number;

--- a/libraries/ts-agent-memory/src/packlets/retrieve/semanticRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/semanticRetriever.ts
@@ -6,7 +6,7 @@
 import { Result, fail, succeed } from '@fgv/ts-utils';
 import { IMemoryRecord, MemoryId } from '../types';
 import { IIndexedMemoryRecord, IMemoryIndex } from '../index';
-import { IVectorIndex } from '../vector';
+import { IVectorIndex, IVectorQueryHit } from '../vector';
 import {
   IMemoryQuery,
   IMemoryRetriever,
@@ -101,13 +101,22 @@ export class SemanticRetriever implements IMemoryRetriever {
     if (this._backend === undefined) {
       return fail(SEMANTIC_UNWIRED_MESSAGE);
     }
-    const embedded: Result<Float32Array> = await this._backend.embedQuery(query.semantic);
+    const backend: ISemanticBackend = this._backend;
+    // The backend hooks are consumer-supplied; a rejecting (throwing) impl must
+    // still surface as a `Failure`, never escape `retrieve` as a rejected
+    // promise. `_callBackend` normalizes both a returned `fail` and a rejection.
+    const embedded: Result<Float32Array> = await SemanticRetriever._callBackend('query embedding', () =>
+      backend.embedQuery(query.semantic as string)
+    );
     if (embedded.isFailure()) {
-      return fail(`semantic recall: query embedding failed: ${embedded.message}`);
+      return fail(embedded.message);
     }
-    const hits = await this._backend.vectorIndex.query(embedded.value, query.topK ?? 10);
+    const hits: Result<ReadonlyArray<IVectorQueryHit>> = await SemanticRetriever._callBackend(
+      'vector query',
+      () => backend.vectorIndex.query(embedded.value, query.topK ?? 10)
+    );
     if (hits.isFailure()) {
-      return fail(`semantic recall: vector query failed: ${hits.message}`);
+      return fail(hits.message);
     }
     const byId: Map<MemoryId, IIndexedMemoryRecord> = new Map(
       this._index.entries().map((entry) => [entry.record.envelope.id, entry])
@@ -120,5 +129,19 @@ export class SemanticRetriever implements IMemoryRetriever {
       }
     }
     return succeed(limitRecords(records, query.limit));
+  }
+
+  /**
+   * Invoke a consumer-supplied backend hook, normalizing both a returned `fail`
+   * and a thrown/rejected promise into a single `semantic recall: <label> failed`
+   * `Failure`. Keeps `retrieve` within the `Promise<Result<...>>` contract even
+   * when the injected `embedQuery` / `vectorIndex` misbehaves.
+   */
+  private static async _callBackend<T>(label: string, op: () => Promise<Result<T>>): Promise<Result<T>> {
+    try {
+      return (await op()).withErrorFormat((msg) => `semantic recall: ${label} failed: ${msg}`);
+    } catch (err) {
+      return fail(`semantic recall: ${label} failed: ${String(err)}`);
+    }
   }
 }

--- a/libraries/ts-agent-memory/src/packlets/retrieve/semanticRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/semanticRetriever.ts
@@ -22,7 +22,7 @@ import {
  * `Result`-returning, since a real embedder does a network call.
  * @public
  */
-export type QueryEmbedder = (text: string) => Promise<Result<ReadonlyArray<number>>>;
+export type QueryEmbedder = (text: string) => Promise<Result<Float32Array>>;
 
 /**
  * The semantic backend wired into a {@link SemanticRetriever}: the vector index
@@ -101,7 +101,7 @@ export class SemanticRetriever implements IMemoryRetriever {
     if (this._backend === undefined) {
       return fail(SEMANTIC_UNWIRED_MESSAGE);
     }
-    const embedded: Result<ReadonlyArray<number>> = await this._backend.embedQuery(query.semantic);
+    const embedded: Result<Float32Array> = await this._backend.embedQuery(query.semantic);
     if (embedded.isFailure()) {
       return fail(`semantic recall: query embedding failed: ${embedded.message}`);
     }

--- a/libraries/ts-agent-memory/src/packlets/retrieve/semanticRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/semanticRetriever.ts
@@ -61,8 +61,8 @@ export interface ISemanticRetrieverCreateParams {
  * loudly — it NEVER returns a silent empty.
  *
  * @remarks
- * The full embed-on-write path (and the in-package cosine index) is a post-v1
- * fast-follow; B2 ships the seam and the loud-degradation behavior.
+ * A consumer-supplied backend that rejects (throws) is normalized into a
+ * `Failure` — `retrieve` always honors its `Promise<Result<...>>` contract.
  * @public
  */
 export class SemanticRetriever implements IMemoryRetriever {

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -142,8 +142,11 @@ export interface IFileTreeMemoryStoreCreateParams {
    * {@link IFileTreeMemoryStoreCreateParams.vectorIndex | vectorIndex}. The
    * consumer supplies it (e.g. `callProviderEmbedding` or in-process
    * transformers); the store never calls an embedding provider directly, so the
-   * core stays embedder-agnostic. A failed embedding fails the `put` loudly — a
-   * record is never persisted with a silently missing index entry.
+   * core stays embedder-agnostic. Embedding/index maintenance is **best-effort**:
+   * a failed (or throwing) `embed` / `add` / `remove` is logged at `warn` via
+   * {@link IFileTreeMemoryStoreCreateParams.logger | logger} and the record
+   * operation still succeeds — the vector index is a derived view that a later
+   * `rebuild` reconciles, so a vector failure never fails an authoritative write.
    */
   readonly embed?: MemoryEmbedder;
 }

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -591,18 +591,17 @@ export class FileTreeMemoryStore implements IMemoryStore {
     if (decision.decision === 'reject') {
       return fail(`memory put: rejected by policy: ${decision.reason}`);
     }
-    const evicted: ReadonlyArray<MemoryId> = decision.decision === 'cull-oldest' ? decision.evict : [];
     return this._buildRecord(record, body, existing, policy, hash)
       .thenOnSuccess((built) => this._embedOnWrite(built))
       .onSuccess((embeddedBuilt) => this._persist(embeddedBuilt, scope, idStem))
       .thenOnSuccess(async (persisted) => {
-        const evictResult: Result<true> = this._applyEvictions(decision, scope);
-        if (evictResult.isFailure()) {
-          return fail(evictResult.message);
-        }
-        // Best-effort: prune the evicted cohort's vectors after their files are
-        // gone. A removal failure is logged, never fatal (the record store has
-        // already committed the eviction).
+        // Everything after the authoritative `_persist` commit is best-effort and
+        // never turns a committed write into a `Failure`:
+        //   - a cull-oldest eviction that fails is logged (the per-(scope,kind)
+        //     cap may be transiently exceeded; the next write's admission restores
+        //     it), and only the successfully-evicted ids flow onward;
+        //   - vector pruning of the evicted cohort is likewise best-effort.
+        const evicted: ReadonlyArray<MemoryId> = this._applyEvictions(decision, scope);
         await this._removeEvictedVectors(evicted);
         return succeed({ record: persisted, evicted });
       });
@@ -643,12 +642,29 @@ export class FileTreeMemoryStore implements IMemoryStore {
     return succeed({ envelope: { ...built.envelope, embeddingRef: added.value }, body: built.body });
   }
 
-  /** Evict the records named by a `cull-oldest` decision (`accept` is a no-op). */
-  private _applyEvictions(decision: AdmissionDecision, scope: MemoryScopeKey): Result<true> {
-    if (decision.decision === 'cull-oldest') {
-      return mapResults(decision.evict.map((id) => this._evict(scope, id))).onSuccess(() => succeed(true));
+  /**
+   * Evict the records named by a `cull-oldest` decision, best-effort. Runs only
+   * after the authoritative `_persist`, so a failed eviction is logged (never
+   * fatal) and the cap self-corrects on the next admission. Returns the ids that
+   * were actually evicted (so observations / vector pruning cover only those).
+   * `accept` / `reject` decisions evict nothing.
+   */
+  private _applyEvictions(decision: AdmissionDecision, scope: MemoryScopeKey): ReadonlyArray<MemoryId> {
+    if (decision.decision !== 'cull-oldest') {
+      return [];
     }
-    return succeed(true);
+    const evicted: MemoryId[] = [];
+    for (const id of decision.evict) {
+      const result: Result<MemoryId> = this._evict(scope, id);
+      if (result.isSuccess()) {
+        evicted.push(result.value);
+      } else {
+        this._warnSwallowed(
+          `memory put: best-effort eviction of '${id}' failed (cap may be transiently exceeded; restored on the next write): ${result.message}`
+        );
+      }
+    }
+    return evicted;
   }
 
   /** Best-effort vector removal for each evicted record (never fails the put). */

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -440,18 +440,19 @@ export class FileTreeMemoryStore implements IMemoryStore {
     try {
       const observed: Result<unknown> = await observer.observe(record);
       if (observed.isFailure()) {
-        this._warnObserverIssue(`memory observer failed (swallowed): ${observed.message}`);
+        this._warnSwallowed(`memory observer failed (swallowed): ${observed.message}`);
       }
     } catch (error) {
-      this._warnObserverIssue(`memory observer threw (swallowed): ${String(error)}`);
+      this._warnSwallowed(`memory observer threw (swallowed): ${String(error)}`);
     }
   }
 
   /**
-   * Log an observer-issue warning, swallowing a logger that itself throws —
-   * diagnostic logging must never make a store op reject.
+   * Log a swallowed-issue warning (observer failure or best-effort vector
+   * maintenance), tolerating a logger that itself throws — diagnostic logging
+   * must never make a store op reject.
    */
-  private _warnObserverIssue(message: string): void {
+  private _warnSwallowed(message: string): void {
     try {
       this._logger.warn(message);
     } catch {
@@ -560,12 +561,19 @@ export class FileTreeMemoryStore implements IMemoryStore {
   }
 
   /**
-   * Build → embed → persist → evict for an admitted write. Build and durably
-   * persist the new record BEFORE evicting anything: a cull-oldest decision must
-   * not delete existing records until the replacement is on disk, otherwise a
-   * later failure would lose data with nothing written in its place. The embed
-   * step runs before persist so an embedding failure rejects the `put` without
-   * leaving a file on disk that the vector index doesn't know about.
+   * Build → embed → persist → evict for an admitted write.
+   *
+   * The durable record store is authoritative; the vector index is a **derived,
+   * rebuildable** view, so vector maintenance is **best-effort** — a failed embed
+   * or `add` is logged and the durable write still succeeds (the index can be
+   * rebuilt via {@link InMemoryCosineIndex.rebuild}). Only genuine record-store
+   * failures (body/codec/policy, persist, file eviction) fail the `put`.
+   *
+   * Ordering: the embed + `add` run immediately before the single `_persist` so
+   * the index-returned `embeddingRef` lands in one durable write (a post-persist
+   * stamp would need a second write whose failure path is effectively untestable).
+   * Build and persist the replacement BEFORE evicting the cull-oldest cohort, so a
+   * later eviction failure never loses data with nothing written in its place.
    */
   private async _admitWrite(
     record: IMemoryRecord<unknown>,
@@ -582,63 +590,103 @@ export class FileTreeMemoryStore implements IMemoryStore {
     }
     const evicted: ReadonlyArray<MemoryId> = decision.decision === 'cull-oldest' ? decision.evict : [];
     return this._buildRecord(record, body, existing, policy, hash)
-      .thenOnSuccess((built) => this._embedOnWrite(built, existing))
-      .onSuccess((built) => this._persist(built, scope, idStem))
-      .thenOnSuccess(async (persisted) =>
-        (await this._applyEvictions(decision, scope)).onSuccess(() => succeed({ record: persisted, evicted }))
-      );
+      .thenOnSuccess((built) => this._embedOnWrite(built))
+      .onSuccess((embeddedBuilt) => this._persist(embeddedBuilt, scope, idStem))
+      .thenOnSuccess(async (persisted) => {
+        const evictResult: Result<true> = this._applyEvictions(decision, scope);
+        if (evictResult.isFailure()) {
+          return fail(evictResult.message);
+        }
+        // Best-effort: prune the evicted cohort's vectors after their files are
+        // gone. A removal failure is logged, never fatal (the record store has
+        // already committed the eviction).
+        await this._removeEvictedVectors(evicted);
+        return succeed({ record: persisted, evicted });
+      });
   }
 
   /**
-   * Embed-on-write hook. When a vector index AND an embedder are wired, embeds the
-   * built record, invalidates a now-stale vector when the content hash changed
-   * (re-embed-on-edit), adds the new vector, and stamps the returned
-   * `embeddingRef` onto the envelope. A pass-through no-op when unwired — the
-   * additive default, so an unwired store persists a byte-identical record.
+   * Best-effort embed-on-write. When a vector index AND an embedder are wired,
+   * embeds the built record, `add`s the vector (replace semantics handle a same-id
+   * re-embed — no explicit remove), and stamps the returned `embeddingRef`. A
+   * failure (returned `fail` OR a thrown/rejected hook) is logged and the
+   * unembedded record is returned unchanged — the put still persists, and the
+   * derived index is reconciled by a later `rebuild`. A pass-through no-op when
+   * unwired (byte-identical record).
    *
-   * Embedding (or index) failure fails the whole `put`: the record is not yet
-   * persisted at this point, so the store never ends up with a file on disk whose
-   * vector is silently missing from the index.
+   * Always succeeds (`Result` is the chain's shape, never a vector-induced
+   * failure).
    */
-  private async _embedOnWrite(
-    built: IMemoryRecord<string>,
-    existing: IMemoryRecord<unknown> | undefined
-  ): Promise<Result<IMemoryRecord<string>>> {
+  private async _embedOnWrite(built: IMemoryRecord<string>): Promise<Result<IMemoryRecord<string>>> {
     if (this._vectorIndex === undefined || this._embed === undefined) {
       return succeed(built);
     }
     const vectorIndex: IVectorIndex = this._vectorIndex;
-    const embedded: Result<Float32Array> = await this._embed(built);
+    const embed: MemoryEmbedder = this._embed;
+    const embedded: Result<Float32Array> = await this._tryVectorOp(
+      () => embed(built),
+      `embedding '${built.envelope.id}'`
+    );
     if (embedded.isFailure()) {
-      return fail(`memory put '${built.envelope.id}': embedding failed: ${embedded.message}`);
+      return succeed(built);
     }
-    // Re-embed-on-edit: a content change makes the prior vector stale. Invalidate
-    // it before adding the replacement. In the flat layout the old and new id are
-    // identical, so the subsequent `add` would overwrite anyway; the explicit
-    // `remove` honors the design-lock contract and keeps a backend whose `add`
-    // does not replace consistent.
-    if (existing !== undefined && existing.envelope.contentHash !== built.envelope.contentHash) {
-      const removed: Result<MemoryId> = await vectorIndex.remove(existing.envelope.id);
-      if (removed.isFailure()) {
-        return fail(`memory put '${built.envelope.id}': stale vector removal failed: ${removed.message}`);
-      }
-    }
-    const added: Result<string> = await vectorIndex.add(built.envelope.id, embedded.value);
+    const added: Result<string> = await this._tryVectorOp(
+      () => vectorIndex.add(built.envelope.id, embedded.value),
+      `vector add for '${built.envelope.id}'`
+    );
     if (added.isFailure()) {
-      return fail(`memory put '${built.envelope.id}': vector add failed: ${added.message}`);
+      return succeed(built);
     }
     return succeed({ envelope: { ...built.envelope, embeddingRef: added.value }, body: built.body });
   }
 
   /** Evict the records named by a `cull-oldest` decision (`accept` is a no-op). */
-  private async _applyEvictions(decision: AdmissionDecision, scope: MemoryScopeKey): Promise<Result<true>> {
+  private _applyEvictions(decision: AdmissionDecision, scope: MemoryScopeKey): Result<true> {
     if (decision.decision === 'cull-oldest') {
-      const evictions: Result<MemoryId>[] = await Promise.all(
-        decision.evict.map((id) => this._evict(scope, id))
-      );
-      return mapResults(evictions).onSuccess(() => succeed(true));
+      return mapResults(decision.evict.map((id) => this._evict(scope, id))).onSuccess(() => succeed(true));
     }
     return succeed(true);
+  }
+
+  /** Best-effort vector removal for each evicted record (never fails the put). */
+  private async _removeEvictedVectors(evicted: ReadonlyArray<MemoryId>): Promise<void> {
+    for (const id of evicted) {
+      await this._removeVectorBestEffort(id);
+    }
+  }
+
+  /**
+   * Run a consumer-supplied vector hook, normalizing a thrown/rejected hook into a
+   * `Failure` and logging any failure at `warn`. Best-effort: the caller proceeds
+   * regardless, since the index is rebuildable.
+   */
+  private async _tryVectorOp<T>(op: () => Promise<Result<T>>, label: string): Promise<Result<T>> {
+    let result: Result<T>;
+    try {
+      result = await op();
+    } catch (err) {
+      result = fail(`${label} threw: ${String(err)}`);
+    }
+    if (result.isFailure()) {
+      this._warnSwallowed(
+        `memory: ${label} failed (best-effort; vector index left for rebuild): ${result.message}`
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Best-effort vector removal. A no-op unless the full vector lifecycle is wired
+   * (both an index AND an embedder), so an unwired store does no vector work and
+   * behaves byte-identically. Failures are logged, never surfaced — a committed
+   * delete/eviction must not fail because a derived index could not be pruned.
+   */
+  private async _removeVectorBestEffort(id: MemoryId): Promise<void> {
+    if (this._vectorIndex === undefined || this._embed === undefined) {
+      return;
+    }
+    const vectorIndex: IVectorIndex = this._vectorIndex;
+    await this._tryVectorOp(() => vectorIndex.remove(id), `vector removal for '${id}'`);
   }
 
   /**
@@ -719,44 +767,29 @@ export class FileTreeMemoryStore implements IMemoryStore {
           if (existing === undefined) {
             return Promise.resolve(fail<MemoryId>(`memory delete '${entityId}': no record found`));
           }
+          // Delete the record file + index entry (authoritative), then prune the
+          // vector best-effort: a committed delete must not fail because the
+          // derived index could not be pruned.
           return this._deleteFile(addr.scope, addr.idStem)
             .onSuccess(() => this._index.patch('delete', { scope: addr.scope, record: existing }))
-            .thenOnSuccess(() => this._removeFromVectorIndex(existing.envelope.id))
-            .onSuccess(() => succeed(existing.envelope.id));
+            .thenOnSuccess(async () => {
+              await this._removeVectorBestEffort(existing.envelope.id);
+              return succeed(existing.envelope.id);
+            });
         });
       });
   }
 
-  /** Evict (physically delete) a single record by id, patching the index. */
-  private async _evict(scope: MemoryScopeKey, id: MemoryId): Promise<Result<MemoryId>> {
-    return this._readRecord(scope, id).thenOnSuccess((existing) => {
+  /** Evict (physically delete) a single record file by id, patching the index. */
+  private _evict(scope: MemoryScopeKey, id: MemoryId): Result<MemoryId> {
+    return this._readRecord(scope, id).onSuccess((existing) => {
       if (existing === undefined) {
-        return Promise.resolve(
-          fail<MemoryId>(`memory put: cannot evict '${id}' in scope '${scope}': not found`)
-        );
+        return fail(`memory put: cannot evict '${id}' in scope '${scope}': not found`);
       }
       return this._deleteFile(scope, id)
         .onSuccess(() => this._index.patch('delete', { scope, record: existing }))
-        .thenOnSuccess(() => this._removeFromVectorIndex(id))
         .onSuccess(() => succeed(id));
     });
-  }
-
-  /**
-   * Remove a record's vector from the index. A no-op unless the full vector
-   * lifecycle is wired (both an index AND an embedder), so an unwired — or only
-   * partially wired — store does no vector work and behaves byte-identically.
-   * The gate mirrors {@link FileTreeMemoryStore._embedOnWrite}: vector
-   * maintenance is wholly on or wholly off, so a `remove` never fires for a
-   * record that was never embedded.
-   */
-  private async _removeFromVectorIndex(id: MemoryId): Promise<Result<MemoryId>> {
-    if (this._vectorIndex === undefined || this._embed === undefined) {
-      return succeed(id);
-    }
-    return (await this._vectorIndex.remove(id)).withErrorFormat(
-      (msg) => `memory: vector removal for '${id}' failed: ${msg}`
-    );
   }
 
   /** Project the incoming record's mutable fields into a merge-patch. */

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -29,6 +29,7 @@ import {
   MemoryObservationOutcome,
   MemoryObservationPhase
 } from '../observe';
+import { IVectorIndex, MemoryEmbedder } from '../vector';
 import { defaultMemoryScopeEncoding } from './scopeEncoding';
 
 /** The on-disk extension for a memory record file. */
@@ -126,6 +127,25 @@ export interface IFileTreeMemoryStoreCreateParams {
    * `Logging.NoOpLogger`.
    */
   readonly logger?: Logging.ILogger;
+  /**
+   * Optional vector index for semantic recall. Wired together with
+   * {@link IFileTreeMemoryStoreCreateParams.embed | embed}: when both are present
+   * the store embeds each written record and maintains the index on
+   * `put` / `delete` / cap-cull eviction. Absent (or `embed` absent) → no
+   * embedding work happens and the store behaves exactly as it does without this
+   * parameter (the additive, zero-overhead-when-unwired default — mirrors the
+   * observer hook).
+   */
+  readonly vectorIndex?: IVectorIndex;
+  /**
+   * Optional embedder applied to each record on write, wired together with
+   * {@link IFileTreeMemoryStoreCreateParams.vectorIndex | vectorIndex}. The
+   * consumer supplies it (e.g. `callProviderEmbedding` or in-process
+   * transformers); the store never calls an embedding provider directly, so the
+   * core stays embedder-agnostic. A failed embedding fails the `put` loudly — a
+   * record is never persisted with a silently missing index entry.
+   */
+  readonly embed?: MemoryEmbedder;
 }
 
 /**
@@ -142,6 +162,16 @@ interface IPutOutcome {
   readonly evicted: ReadonlyArray<MemoryId>;
 }
 
+/**
+ * The resolved storage address + content hash for a put, produced by the
+ * synchronous prefix of `_putLocked` and handed to the async write tail.
+ */
+interface IResolvedWriteAddress {
+  readonly scope: MemoryScopeKey;
+  readonly idStem: string;
+  readonly hash: string;
+}
+
 interface IInternalParams {
   readonly root: FileTree.IMutableFileTreeDirectoryItem;
   readonly registry: IRegistry;
@@ -154,6 +184,8 @@ interface IInternalParams {
   readonly index: IMemoryIndex;
   readonly observers: ReadonlyArray<IMemoryObserver>;
   readonly logger: Logging.ILogger;
+  readonly vectorIndex?: IVectorIndex;
+  readonly embed?: MemoryEmbedder;
 }
 
 /**
@@ -181,6 +213,8 @@ export class FileTreeMemoryStore implements IMemoryStore {
   private readonly _hasher: Hash.Crc32Normalizer;
   private readonly _observers: ReadonlyArray<IMemoryObserver>;
   private readonly _logger: Logging.ILogger;
+  private readonly _vectorIndex: IVectorIndex | undefined;
+  private readonly _embed: MemoryEmbedder | undefined;
 
   /** Monotonic write counter; incremented inside the write-lock on each put. */
   private _seq: number;
@@ -225,6 +259,8 @@ export class FileTreeMemoryStore implements IMemoryStore {
     this._hasher = new Hash.Crc32Normalizer();
     this._observers = params.observers;
     this._logger = params.logger;
+    this._vectorIndex = params.vectorIndex;
+    this._embed = params.embed;
     this._seq = 0;
     this._observationSeq = 0;
     this._writeTail = Promise.resolve();
@@ -249,7 +285,9 @@ export class FileTreeMemoryStore implements IMemoryStore {
           clock: params.clock ?? Date.now,
           index,
           observers: params.observers ?? [],
-          logger: params.logger ?? new Logging.NoOpLogger()
+          logger: params.logger ?? new Logging.NoOpLogger(),
+          vectorIndex: params.vectorIndex,
+          embed: params.embed
         });
         return store._initialIndex().onSuccess(() => succeed(store));
       })
@@ -437,37 +475,48 @@ export class FileTreeMemoryStore implements IMemoryStore {
       );
     }
     const body: string = record.body;
+    // Resolve the synchronous prefix (body validation → codec address → content
+    // hash) into a small descriptor, then bridge to the async write tail (which
+    // embeds on write). Keeping the sync prefix intact preserves the exact
+    // dedup/policy ordering of the original; only the embed step is new.
     return this._registry
       .convert(envelope.kind, body)
       .withErrorFormat((msg) => `memory put '${envelope.id}': invalid body: ${msg}`)
       .onSuccess(() => this._codecFor(envelope.kind))
-      .onSuccess((codec) =>
-        codec.encode(envelope.entityId).onSuccess((addr) => {
-          if (addr.isVersioned) {
-            return fail(`memory put '${envelope.entityId}': versioned/temporal layout not yet supported`);
-          }
-          if (envelope.id !== addr.idStem) {
-            return fail(
-              `memory put: envelope id '${envelope.id}' does not match codec-derived stem '${addr.idStem}'`
+      .onSuccess(
+        (codec): Result<IResolvedWriteAddress> =>
+          codec.encode(envelope.entityId).onSuccess((addr): Result<IResolvedWriteAddress> => {
+            if (addr.isVersioned) {
+              return fail(`memory put '${envelope.entityId}': versioned/temporal layout not yet supported`);
+            }
+            if (envelope.id !== addr.idStem) {
+              return fail(
+                `memory put: envelope id '${envelope.id}' does not match codec-derived stem '${addr.idStem}'`
+              );
+            }
+            return this._contentHash(envelope.kind, body, envelope.links).onSuccess((hash) =>
+              succeed({ scope: addr.scope, idStem: addr.idStem, hash })
             );
-          }
-          return this._contentHash(envelope.kind, body, envelope.links).onSuccess((hash) =>
-            this._writeResolved(record, body, addr.scope, addr.idStem, hash)
-          );
-        })
+          })
+      )
+      .thenOnSuccess((resolved) =>
+        this._writeResolved(record, body, resolved.scope, resolved.idStem, resolved.hash)
       );
   }
 
   /**
-   * Run dedup → policy → stamp → write for a resolved address and content hash.
+   * Run dedup → policy → stamp → embed → write for a resolved address and content
+   * hash. Async because the embed-on-write hook (when wired) does a network call
+   * or in-process inference; the whole chain runs inside the write-lock so the
+   * vector index, the on-disk file, and the derived index never interleave.
    */
-  private _writeResolved(
+  private async _writeResolved(
     record: IMemoryRecord<unknown>,
     body: string,
     scope: MemoryScopeKey,
     idStem: string,
     hash: string
-  ): Result<IPutOutcome> {
+  ): Promise<Result<IPutOutcome>> {
     const policy: IWritePolicy = this._policyFor(record.envelope.kind);
     const dedupScope: DedupScope = policy.dedupScope ?? DEFAULT_DEDUP_SCOPE;
     // Content-hash dedup runs BEFORE policy. Its granularity is the kind's
@@ -485,10 +534,10 @@ export class FileTreeMemoryStore implements IMemoryStore {
         return succeed({ record: duplicate, evicted: [] });
       }
     }
-    return this._readRecord(scope, idStem).onSuccess((existing) => {
+    return this._readRecord(scope, idStem).thenOnSuccess((existing) => {
       if (dedupScope === 'entity' && existing !== undefined && existing.envelope.contentHash === hash) {
         // Entity-scoped dedup: an identical re-put of the same entity is a no-op.
-        return succeed({ record: existing, evicted: [] });
+        return Promise.resolve(succeed({ record: existing, evicted: [] }));
       }
       // The admission cohort is the set of records the policy's cap applies to:
       // every record in this scope of this kind EXCEPT the target id. On a first
@@ -502,32 +551,92 @@ export class FileTreeMemoryStore implements IMemoryStore {
         record.envelope.kind,
         idStem
       );
-      return policy.admit(record, cohort).onSuccess((decision) => {
-        if (decision.decision === 'reject') {
-          return fail(`memory put: rejected by policy: ${decision.reason}`);
-        }
-        // Build and durably persist the new record BEFORE evicting anything: a
-        // cull-oldest decision must not delete existing records until the
-        // replacement is on disk, otherwise a later failure would lose data with
-        // nothing written in its place.
-        return this._buildRecord(record, body, existing, policy, hash)
-          .onSuccess((built) => this._persist(built, scope, idStem))
-          .onSuccess((persisted) =>
-            this._applyEvictions(decision, scope).onSuccess(() =>
-              succeed({
-                record: persisted,
-                evicted: decision.decision === 'cull-oldest' ? decision.evict : []
-              })
-            )
-          );
-      });
+      return policy
+        .admit(record, cohort)
+        .thenOnSuccess((decision) =>
+          this._admitWrite(record, body, scope, idStem, hash, policy, existing, decision)
+        );
     });
   }
 
+  /**
+   * Build → embed → persist → evict for an admitted write. Build and durably
+   * persist the new record BEFORE evicting anything: a cull-oldest decision must
+   * not delete existing records until the replacement is on disk, otherwise a
+   * later failure would lose data with nothing written in its place. The embed
+   * step runs before persist so an embedding failure rejects the `put` without
+   * leaving a file on disk that the vector index doesn't know about.
+   */
+  private async _admitWrite(
+    record: IMemoryRecord<unknown>,
+    body: string,
+    scope: MemoryScopeKey,
+    idStem: string,
+    hash: string,
+    policy: IWritePolicy,
+    existing: IMemoryRecord<unknown> | undefined,
+    decision: AdmissionDecision
+  ): Promise<Result<IPutOutcome>> {
+    if (decision.decision === 'reject') {
+      return fail(`memory put: rejected by policy: ${decision.reason}`);
+    }
+    const evicted: ReadonlyArray<MemoryId> = decision.decision === 'cull-oldest' ? decision.evict : [];
+    return this._buildRecord(record, body, existing, policy, hash)
+      .thenOnSuccess((built) => this._embedOnWrite(built, existing))
+      .onSuccess((built) => this._persist(built, scope, idStem))
+      .thenOnSuccess(async (persisted) =>
+        (await this._applyEvictions(decision, scope)).onSuccess(() => succeed({ record: persisted, evicted }))
+      );
+  }
+
+  /**
+   * Embed-on-write hook. When a vector index AND an embedder are wired, embeds the
+   * built record, invalidates a now-stale vector when the content hash changed
+   * (re-embed-on-edit), adds the new vector, and stamps the returned
+   * `embeddingRef` onto the envelope. A pass-through no-op when unwired — the
+   * additive default, so an unwired store persists a byte-identical record.
+   *
+   * Embedding (or index) failure fails the whole `put`: the record is not yet
+   * persisted at this point, so the store never ends up with a file on disk whose
+   * vector is silently missing from the index.
+   */
+  private async _embedOnWrite(
+    built: IMemoryRecord<string>,
+    existing: IMemoryRecord<unknown> | undefined
+  ): Promise<Result<IMemoryRecord<string>>> {
+    if (this._vectorIndex === undefined || this._embed === undefined) {
+      return succeed(built);
+    }
+    const vectorIndex: IVectorIndex = this._vectorIndex;
+    const embedded: Result<Float32Array> = await this._embed(built);
+    if (embedded.isFailure()) {
+      return fail(`memory put '${built.envelope.id}': embedding failed: ${embedded.message}`);
+    }
+    // Re-embed-on-edit: a content change makes the prior vector stale. Invalidate
+    // it before adding the replacement. In the flat layout the old and new id are
+    // identical, so the subsequent `add` would overwrite anyway; the explicit
+    // `remove` honors the design-lock contract and keeps a backend whose `add`
+    // does not replace consistent.
+    if (existing !== undefined && existing.envelope.contentHash !== built.envelope.contentHash) {
+      const removed: Result<MemoryId> = await vectorIndex.remove(existing.envelope.id);
+      if (removed.isFailure()) {
+        return fail(`memory put '${built.envelope.id}': stale vector removal failed: ${removed.message}`);
+      }
+    }
+    const added: Result<string> = await vectorIndex.add(built.envelope.id, embedded.value);
+    if (added.isFailure()) {
+      return fail(`memory put '${built.envelope.id}': vector add failed: ${added.message}`);
+    }
+    return succeed({ envelope: { ...built.envelope, embeddingRef: added.value }, body: built.body });
+  }
+
   /** Evict the records named by a `cull-oldest` decision (`accept` is a no-op). */
-  private _applyEvictions(decision: AdmissionDecision, scope: MemoryScopeKey): Result<true> {
+  private async _applyEvictions(decision: AdmissionDecision, scope: MemoryScopeKey): Promise<Result<true>> {
     if (decision.decision === 'cull-oldest') {
-      return mapResults(decision.evict.map((id) => this._evict(scope, id))).onSuccess(() => succeed(true));
+      const evictions: Result<MemoryId>[] = await Promise.all(
+        decision.evict.map((id) => this._evict(scope, id))
+      );
+      return mapResults(evictions).onSuccess(() => succeed(true));
     }
     return succeed(true);
   }
@@ -598,33 +707,56 @@ export class FileTreeMemoryStore implements IMemoryStore {
   }
 
   private async _deleteLocked(kind: Kind, entityId: EntityId): Promise<Result<MemoryId>> {
-    return this._codecFor(kind).onSuccess((codec) =>
-      codec.encode(entityId).onSuccess((addr) => {
+    return this._codecFor(kind)
+      .onSuccess((codec) => codec.encode(entityId))
+      .thenOnSuccess((addr) => {
         if (addr.isVersioned) {
-          return fail(`memory delete '${entityId}': versioned/temporal layout not yet supported`);
+          return Promise.resolve(
+            fail<MemoryId>(`memory delete '${entityId}': versioned/temporal layout not yet supported`)
+          );
         }
-        return this._readRecord(addr.scope, addr.idStem).onSuccess((existing) => {
+        return this._readRecord(addr.scope, addr.idStem).thenOnSuccess((existing) => {
           if (existing === undefined) {
-            return fail(`memory delete '${entityId}': no record found`);
+            return Promise.resolve(fail<MemoryId>(`memory delete '${entityId}': no record found`));
           }
           return this._deleteFile(addr.scope, addr.idStem)
             .onSuccess(() => this._index.patch('delete', { scope: addr.scope, record: existing }))
+            .thenOnSuccess(() => this._removeFromVectorIndex(existing.envelope.id))
             .onSuccess(() => succeed(existing.envelope.id));
         });
-      })
-    );
+      });
   }
 
   /** Evict (physically delete) a single record by id, patching the index. */
-  private _evict(scope: MemoryScopeKey, id: MemoryId): Result<MemoryId> {
-    return this._readRecord(scope, id).onSuccess((existing) => {
+  private async _evict(scope: MemoryScopeKey, id: MemoryId): Promise<Result<MemoryId>> {
+    return this._readRecord(scope, id).thenOnSuccess((existing) => {
       if (existing === undefined) {
-        return fail(`memory put: cannot evict '${id}' in scope '${scope}': not found`);
+        return Promise.resolve(
+          fail<MemoryId>(`memory put: cannot evict '${id}' in scope '${scope}': not found`)
+        );
       }
       return this._deleteFile(scope, id)
         .onSuccess(() => this._index.patch('delete', { scope, record: existing }))
+        .thenOnSuccess(() => this._removeFromVectorIndex(id))
         .onSuccess(() => succeed(id));
     });
+  }
+
+  /**
+   * Remove a record's vector from the index. A no-op unless the full vector
+   * lifecycle is wired (both an index AND an embedder), so an unwired — or only
+   * partially wired — store does no vector work and behaves byte-identically.
+   * The gate mirrors {@link FileTreeMemoryStore._embedOnWrite}: vector
+   * maintenance is wholly on or wholly off, so a `remove` never fires for a
+   * record that was never embedded.
+   */
+  private async _removeFromVectorIndex(id: MemoryId): Promise<Result<MemoryId>> {
+    if (this._vectorIndex === undefined || this._embed === undefined) {
+      return succeed(id);
+    }
+    return (await this._vectorIndex.remove(id)).withErrorFormat(
+      (msg) => `memory: vector removal for '${id}' failed: ${msg}`
+    );
   }
 
   /** Project the incoming record's mutable fields into a merge-patch. */

--- a/libraries/ts-agent-memory/src/packlets/vector/inMemoryCosineIndex.ts
+++ b/libraries/ts-agent-memory/src/packlets/vector/inMemoryCosineIndex.ts
@@ -64,7 +64,9 @@ export class InMemoryCosineIndex implements IVectorIndex {
         )
       );
     }
-    this._vectors.set(id, vector);
+    // Defensive copy: the caller may reuse or mutate the buffer after `add`, and
+    // the index must keep serving the embedding it was given.
+    this._vectors.set(id, Float32Array.from(vector));
     // The in-memory index keys entries by id, so the id IS the entry reference.
     return Promise.resolve(succeed(id as string));
   }
@@ -113,11 +115,14 @@ export class InMemoryCosineIndex implements IVectorIndex {
    * @param embed - The embedder applied to each record.
    */
   public async rebuild(source: IMemoryRecordSource, embed: MemoryEmbedder): Promise<Result<number>> {
+    // Reset up front so the "any failure leaves the index empty" contract holds
+    // even when the listing itself fails (no stale vectors survive a failed
+    // rebuild).
+    this._reset();
     const listed: Result<ReadonlyArray<IMemoryRecord<unknown>>> = await source.list();
     if (listed.isFailure()) {
       return fail(`vector index rebuild: failed to list records: ${listed.message}`);
     }
-    this._reset();
     for (const record of listed.value) {
       const embedded: Result<Float32Array> = await embed(record);
       if (embedded.isFailure()) {

--- a/libraries/ts-agent-memory/src/packlets/vector/inMemoryCosineIndex.ts
+++ b/libraries/ts-agent-memory/src/packlets/vector/inMemoryCosineIndex.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import { IMemoryRecord, MemoryId } from '../types';
+import { IMemoryRecordSource, IVectorIndex, IVectorQueryHit, MemoryEmbedder } from './vectorIndex';
+
+/**
+ * The brute-force, in-memory cosine {@link IVectorIndex}. Stores one
+ * `Float32Array` per record and answers a query by computing cosine similarity
+ * against every stored vector, returning the top-k by descending score.
+ *
+ * @remarks
+ * This is the **complete** vector implementation for the fgv regime — large-N is
+ * explicitly out of scope (the seam stays open for a consumer to swap an external
+ * ANN backend once N grows beyond "thousands of records"). No external dependency
+ * and no ANN structure: a linear scan over a few thousand vectors is well within
+ * an interactive budget.
+ *
+ * The index has a single dimension established by the first vector added; every
+ * subsequent `add` and every `query` vector must match that dimension or fail
+ * loudly — a mismatched dimension is an embedder-wiring bug, never a silent
+ * zero-similarity result. {@link InMemoryCosineIndex.rebuild | rebuild} clears
+ * the index, so a re-embed with a different model (hence dimension) is supported.
+ *
+ * Persistence (a JSON sidecar) is deliberately out of scope for this layer — the
+ * index is in-memory and rebuilt from the store via `rebuild`; a sidecar is a
+ * future nicety.
+ * @public
+ */
+export class InMemoryCosineIndex implements IVectorIndex {
+  private readonly _vectors: Map<MemoryId, Float32Array>;
+  /** The dimension of every stored vector; `undefined` until the first `add`. */
+  private _dimension: number | undefined;
+
+  private constructor() {
+    this._vectors = new Map<MemoryId, Float32Array>();
+    this._dimension = undefined;
+  }
+
+  /** The number of vectors currently held. */
+  public get size(): number {
+    return this._vectors.size;
+  }
+
+  /** Family-convention factory. */
+  public static create(): Result<InMemoryCosineIndex> {
+    return succeed(new InMemoryCosineIndex());
+  }
+
+  /** {@inheritDoc IVectorIndex.add} */
+  public add(id: MemoryId, vector: Float32Array): Promise<Result<string>> {
+    if (vector.length === 0) {
+      return Promise.resolve(fail(`vector index: cannot add '${id}': empty vector`));
+    }
+    if (this._dimension === undefined) {
+      this._dimension = vector.length;
+    } else if (vector.length !== this._dimension) {
+      return Promise.resolve(
+        fail(
+          `vector index: cannot add '${id}': dimension ${vector.length} does not match index dimension ${this._dimension}`
+        )
+      );
+    }
+    this._vectors.set(id, vector);
+    // The in-memory index keys entries by id, so the id IS the entry reference.
+    return Promise.resolve(succeed(id as string));
+  }
+
+  /** {@inheritDoc IVectorIndex.remove} */
+  public remove(id: MemoryId): Promise<Result<MemoryId>> {
+    this._vectors.delete(id);
+    return Promise.resolve(succeed(id));
+  }
+
+  /** {@inheritDoc IVectorIndex.query} */
+  public query(vector: Float32Array, topK: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>> {
+    if (topK <= 0 || this._vectors.size === 0) {
+      return Promise.resolve(succeed([]));
+    }
+    if (vector.length !== this._dimension) {
+      return Promise.resolve(
+        fail(
+          `vector index: query dimension ${vector.length} does not match index dimension ${this._dimension}`
+        )
+      );
+    }
+    const queryMagnitude: number = InMemoryCosineIndex._magnitude(vector);
+    const hits: IVectorQueryHit[] = [];
+    for (const [id, stored] of this._vectors) {
+      hits.push({ id, score: InMemoryCosineIndex._cosine(vector, queryMagnitude, stored) });
+    }
+    // Descending by score; a `seq`-free tiebreak is unnecessary here because the
+    // caller (SemanticRetriever) re-resolves hits against the record index.
+    hits.sort((a, b) => b.score - a.score);
+    return Promise.resolve(succeed(hits.length > topK ? hits.slice(0, topK) : hits));
+  }
+
+  /**
+   * Re-embed every record from `source` and rebuild the index from scratch.
+   * Clears the current contents (and the established dimension) first, so a
+   * re-embed with a different model is supported. Returns the number of vectors
+   * indexed.
+   *
+   * @param source - The record source to re-embed (an {@link IMemoryStore}
+   * satisfies this structurally).
+   * @param embed - The embedder applied to each record.
+   */
+  public async rebuild(source: IMemoryRecordSource, embed: MemoryEmbedder): Promise<Result<number>> {
+    const listed: Result<ReadonlyArray<IMemoryRecord<unknown>>> = await source.list();
+    if (listed.isFailure()) {
+      return fail(`vector index rebuild: failed to list records: ${listed.message}`);
+    }
+    this._vectors.clear();
+    this._dimension = undefined;
+    for (const record of listed.value) {
+      const embedded: Result<Float32Array> = await embed(record);
+      if (embedded.isFailure()) {
+        return fail(`vector index rebuild: embedding '${record.envelope.id}' failed: ${embedded.message}`);
+      }
+      const added: Result<string> = await this.add(record.envelope.id, embedded.value);
+      if (added.isFailure()) {
+        return fail(`vector index rebuild: ${added.message}`);
+      }
+    }
+    return succeed(this._vectors.size);
+  }
+
+  /** The Euclidean magnitude (L2 norm) of a vector. */
+  private static _magnitude(vector: Float32Array): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < vector.length; i++) {
+      sum += vector[i] * vector[i];
+    }
+    return Math.sqrt(sum);
+  }
+
+  /**
+   * Cosine similarity between the query (whose magnitude is precomputed once and
+   * reused across the scan) and a stored vector. A zero-magnitude vector on
+   * either side yields `0` rather than `NaN` — a degenerate vector is simply
+   * maximally dissimilar, not an error.
+   */
+  private static _cosine(query: Float32Array, queryMagnitude: number, stored: Float32Array): number {
+    const storedMagnitude: number = InMemoryCosineIndex._magnitude(stored);
+    if (queryMagnitude === 0 || storedMagnitude === 0) {
+      return 0;
+    }
+    let dot: number = 0;
+    for (let i: number = 0; i < query.length; i++) {
+      dot += query[i] * stored[i];
+    }
+    return dot / (queryMagnitude * storedMagnitude);
+  }
+}

--- a/libraries/ts-agent-memory/src/packlets/vector/inMemoryCosineIndex.ts
+++ b/libraries/ts-agent-memory/src/packlets/vector/inMemoryCosineIndex.ts
@@ -104,6 +104,10 @@ export class InMemoryCosineIndex implements IVectorIndex {
    * re-embed with a different model is supported. Returns the number of vectors
    * indexed.
    *
+   * On any failure (list, embed, or add) the index is rolled back to empty
+   * rather than left in a partially-rebuilt state — a caller that retries a query
+   * after a failed rebuild sees a clean empty index, never a half-populated one.
+   *
    * @param source - The record source to re-embed (an {@link IMemoryStore}
    * satisfies this structurally).
    * @param embed - The embedder applied to each record.
@@ -113,19 +117,26 @@ export class InMemoryCosineIndex implements IVectorIndex {
     if (listed.isFailure()) {
       return fail(`vector index rebuild: failed to list records: ${listed.message}`);
     }
-    this._vectors.clear();
-    this._dimension = undefined;
+    this._reset();
     for (const record of listed.value) {
       const embedded: Result<Float32Array> = await embed(record);
       if (embedded.isFailure()) {
+        this._reset();
         return fail(`vector index rebuild: embedding '${record.envelope.id}' failed: ${embedded.message}`);
       }
       const added: Result<string> = await this.add(record.envelope.id, embedded.value);
       if (added.isFailure()) {
+        this._reset();
         return fail(`vector index rebuild: ${added.message}`);
       }
     }
     return succeed(this._vectors.size);
+  }
+
+  /** Empty the index and forget the established dimension. */
+  private _reset(): void {
+    this._vectors.clear();
+    this._dimension = undefined;
   }
 
   /** The Euclidean magnitude (L2 norm) of a vector. */

--- a/libraries/ts-agent-memory/src/packlets/vector/index.ts
+++ b/libraries/ts-agent-memory/src/packlets/vector/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './vectorIndex';
+export * from './inMemoryCosineIndex';

--- a/libraries/ts-agent-memory/src/packlets/vector/vectorIndex.ts
+++ b/libraries/ts-agent-memory/src/packlets/vector/vectorIndex.ts
@@ -4,7 +4,7 @@
  */
 
 import { Result } from '@fgv/ts-utils';
-import { MemoryId } from '../types';
+import { IMemoryRecord, MemoryId } from '../types';
 
 /**
  * A single hit returned by {@link IVectorIndex.query}: the matched record id and
@@ -24,11 +24,11 @@ export interface IVectorQueryHit {
  * {@link SemanticRetriever | semantic recall} operational.
  *
  * @remarks
- * **Interface only.** B2 ships the seam — the {@link IMemoryEnvelope.embeddingRef}
- * field hangs off `add`, and {@link SemanticRetriever} degrades loudly until an
- * implementation is wired. The in-package brute-force cosine implementation
- * (`InMemoryCosineIndex`) and the embed-on-write store hook are a post-v1
- * fast-follow, deliberately out of B2 scope.
+ * Vectors cross this seam as `Float32Array` (the in-memory representation an
+ * embedding model produces); `number[]` is reserved for the JSON-wire edges
+ * (e.g. a provider's embedding response). The in-package brute-force cosine
+ * implementation is {@link InMemoryCosineIndex}; a consumer can swap an external
+ * ANN backend behind the same seam once N grows beyond the in-memory regime.
  *
  * Every operation returns a `Result` (async, since a real backend does I/O) so
  * failure is explicit and never throws across the seam.
@@ -40,15 +40,39 @@ export interface IVectorIndex {
    * {@link IMemoryEnvelope.embeddingRef | embeddingRef} the store stamps onto
    * the envelope so a later read knows the record is embedded.
    */
-  add(id: MemoryId, vector: ReadonlyArray<number>): Promise<Result<string>>;
+  add(id: MemoryId, vector: Float32Array): Promise<Result<string>>;
 
   /**
-   * Remove the embedding for `id`. Returns the removed id.
+   * Remove the embedding for `id`. Returns the removed id. Idempotent — removing
+   * an id with no embedding still succeeds (returns the id).
    */
   remove(id: MemoryId): Promise<Result<MemoryId>>;
 
   /**
    * Return the `topK` nearest records to `vector`, in descending score order.
    */
-  query(vector: ReadonlyArray<number>, topK: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>>;
+  query(vector: Float32Array, topK: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>>;
+}
+
+/**
+ * Embeds a complete record into a vector for the store's embed-on-write hook.
+ * Async and `Result`-returning, since a real embedder does a network call (cloud
+ * provider) or in-process model inference. The consumer wires this — the core
+ * package never calls an embedding provider directly, staying embedder-agnostic.
+ * @public
+ */
+export type MemoryEmbedder = (record: IMemoryRecord<unknown>) => Promise<Result<Float32Array>>;
+
+/**
+ * The minimal record-source surface {@link InMemoryCosineIndex.rebuild} reads to
+ * re-embed an entire vault. {@link IMemoryStore} satisfies it structurally (its
+ * `list` accepts an optional filter, which is assignable to this no-argument
+ * shape), so a consumer passes the store directly — without the vector packlet
+ * taking a dependency on the store packlet (which depends on the vector packlet
+ * for {@link IVectorIndex}, so the reverse import would be a cycle).
+ * @public
+ */
+export interface IMemoryRecordSource {
+  /** List every record in the vault. */
+  list(): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>>;
 }

--- a/libraries/ts-agent-memory/src/test/unit/retrieve/retrievers.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/retrieve/retrievers.test.ts
@@ -431,6 +431,31 @@ describe('SemanticRetriever', () => {
     }).orThrow();
     expect(await r.retrieve({ semantic: 'q' })).toFailWith(/vector query failed: vector backend down/i);
   });
+
+  test('normalizes a rejecting embedder into a Failure (never escapes as a rejection)', async () => {
+    const r = SemanticRetriever.create({
+      index: buildIndex([{ id: 'a' }]),
+      backend: {
+        vectorIndex: new FakeVectorIndex([]),
+        embedQuery: () => Promise.reject(new Error('embedder blew up'))
+      }
+    }).orThrow();
+    expect(await r.retrieve({ semantic: 'q' })).toFailWith(/query embedding failed: .*embedder blew up/i);
+  });
+
+  test('normalizes a rejecting vector backend into a Failure', async () => {
+    // A vector index whose `query` rejects (throws) rather than returning a fail.
+    const rejectingIndex: IVectorIndex = {
+      add: (id: MemoryId) => Promise.resolve(succeed(`ref-${id}`)),
+      remove: (id: MemoryId) => Promise.resolve(succeed(id)),
+      query: () => Promise.reject(new Error('socket hangup'))
+    };
+    const r = SemanticRetriever.create({
+      index: buildIndex([{ id: 'a' }]),
+      backend: { vectorIndex: rejectingIndex, embedQuery: okEmbed }
+    }).orThrow();
+    expect(await r.retrieve({ semantic: 'q' })).toFailWith(/vector query failed: .*socket hangup/i);
+  });
 });
 
 describe('ScoreUnionMergeStrategy', () => {

--- a/libraries/ts-agent-memory/src/test/unit/retrieve/retrievers.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/retrieve/retrievers.test.ts
@@ -299,17 +299,15 @@ class FakeVectorIndex implements IVectorIndex {
   public remove(id: MemoryId): Promise<Result<MemoryId>> {
     return Promise.resolve(succeed(id));
   }
-  public query(
-    __vector: ReadonlyArray<number>,
-    topK: number
-  ): Promise<Result<ReadonlyArray<IVectorQueryHit>>> {
+  public query(__vector: Float32Array, topK: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>> {
     this.lastTopK = topK;
     return Promise.resolve(this._failQuery ? fail('vector backend down') : succeed(this._hits));
   }
 }
 
 describe('SemanticRetriever', () => {
-  const okEmbed = (): Promise<Result<ReadonlyArray<number>>> => Promise.resolve(succeed([0.1, 0.2]));
+  const okEmbed = (): Promise<Result<Float32Array>> =>
+    Promise.resolve(succeed(Float32Array.from([0.1, 0.2])));
 
   test('reports supportsSemanticRecall=false when no backend is wired', () => {
     const r = SemanticRetriever.create({ index: buildIndex([]) }).orThrow();
@@ -491,7 +489,7 @@ describe('HybridRetriever', () => {
       index,
       backend: {
         vectorIndex: new FakeVectorIndex([]),
-        embedQuery: () => Promise.resolve(succeed([1]))
+        embedQuery: () => Promise.resolve(succeed(Float32Array.from([1])))
       }
     }).orThrow();
     const hybrid = HybridRetriever.create(
@@ -529,7 +527,7 @@ describe('HybridRetriever', () => {
       index,
       backend: {
         vectorIndex: new FakeVectorIndex([{ id: 'b' as MemoryId, score: 0.9 }]),
-        embedQuery: () => Promise.resolve(succeed([1]))
+        embedQuery: () => Promise.resolve(succeed(Float32Array.from([1])))
       }
     }).orThrow();
     const hybrid = HybridRetriever.create(
@@ -582,7 +580,10 @@ describe('HybridRetriever', () => {
     const { index } = build();
     const semantic = SemanticRetriever.create({
       index,
-      backend: { vectorIndex: new FakeVectorIndex([], true), embedQuery: () => Promise.resolve(succeed([1])) }
+      backend: {
+        vectorIndex: new FakeVectorIndex([], true),
+        embedQuery: () => Promise.resolve(succeed(Float32Array.from([1])))
+      }
     }).orThrow();
     const hybrid = HybridRetriever.create([semantic], ScoreUnionMergeStrategy.create().orThrow()).orThrow();
     expect(await hybrid.retrieve({ semantic: 'q' })).toFailWith(/vector query failed/i);
@@ -608,7 +609,7 @@ describe('HybridRetriever', () => {
           { id: 'd' as MemoryId, score: 0.9 },
           { id: 'a' as MemoryId, score: 0.8 }
         ]),
-        embedQuery: () => Promise.resolve(succeed([1]))
+        embedQuery: () => Promise.resolve(succeed(Float32Array.from([1])))
       }
     }).orThrow();
     const hybrid = HybridRetriever.create(

--- a/libraries/ts-agent-memory/src/test/unit/store/embedOnWrite.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/embedOnWrite.test.ts
@@ -77,7 +77,14 @@ function featureVector(text: string): Float32Array {
   return Float32Array.from(MARKERS.map((m) => lower.split(m).length - 1));
 }
 const recordEmbed = (r: IMemoryRecord<unknown>): Promise<Result<Float32Array>> =>
-  Promise.resolve(succeed(featureVector(r.body as string)));
+  // A real embedder receives an `IMemoryRecord<unknown>` and must validate the
+  // body through a Converter rather than casting — this models that idiom.
+  Promise.resolve(
+    Converters.string
+      .convert(r.body)
+      .withErrorFormat((msg) => `cannot embed: body is not a string: ${msg}`)
+      .onSuccess((body) => succeed(featureVector(body)))
+  );
 const queryEmbed = (text: string): Promise<Result<Float32Array>> =>
   Promise.resolve(succeed(featureVector(text)));
 
@@ -285,7 +292,10 @@ describe('FileTreeMemoryStore embed-on-write', () => {
       (await store.put(makeRecord('dogs', 'dog dog dog'))).orThrow();
       (await store.put(makeRecord('fishes', 'fish fish fish'))).orThrow();
 
-      // Build a record index mirroring the store (knowledge scope) for hydration.
+      // SemanticRetriever takes an IMemoryIndex separate from the store (the
+      // store's derived index is private and the two are intentionally
+      // decoupled), so build a record index mirroring the store — keyed by the
+      // shared vectorIndex instance — for hit hydration.
       const listed: ReadonlyArray<IMemoryRecord<unknown>> = (await store.list()).orThrow();
       const recordIndex = MemoryIndex.create().orThrow();
       recordIndex

--- a/libraries/ts-agent-memory/src/test/unit/store/embedOnWrite.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/embedOnWrite.test.ts
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converters, Result, fail, succeed } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
+import {
+  BodyConverterRegistry,
+  FileTreeMemoryStore,
+  IBodyConverterRegistry,
+  IIdentityCodec,
+  IIndexedMemoryRecord,
+  IMemoryRecord,
+  IVectorIndex,
+  IVectorQueryHit,
+  InMemoryCosineIndex,
+  Kind,
+  KnowledgeIdentityCodec,
+  MemoryCapCullPolicy,
+  EntityId,
+  MemoryId,
+  MemoryIndex,
+  MemoryScopeKey,
+  MtmIdentityCodec,
+  IWritePolicy,
+  SemanticRetriever,
+  envelopeConverter
+} from '../../../index';
+
+const knowledgeKind: Kind = 'knowledge' as Kind;
+const mtmKind: Kind = 'mtm' as Kind;
+
+function mutableRoot(): FileTree.IMutableFileTreeDirectoryItem {
+  const tree = FileTree.inMemory([], { mutable: true }).orThrow();
+  const root = tree.getDirectory('/').orThrow();
+  if (!FileTree.isMutableDirectoryItem(root)) {
+    throw new Error('expected a mutable root directory');
+  }
+  return root;
+}
+
+function makeRecord(
+  id: string,
+  body: string,
+  kind: string = 'knowledge',
+  entityId?: string
+): IMemoryRecord<unknown> {
+  return {
+    envelope: envelopeConverter
+      .convert({
+        id,
+        entityId: entityId ?? id,
+        kind,
+        tags: [],
+        links: [],
+        created: 0,
+        updated: 0,
+        seq: 0,
+        contentHash: '',
+        provenance: { source: 'agent' }
+      })
+      .orThrow(),
+    body
+  };
+}
+
+/**
+ * Deterministic keyword-count embedder (no network). Counts occurrences of three
+ * marker words, so a record's vector and a query's vector live in the same space
+ * and cosine ordering is fully predictable.
+ */
+const MARKERS: ReadonlyArray<string> = ['cat', 'dog', 'fish'];
+function featureVector(text: string): Float32Array {
+  const lower: string = text.toLowerCase();
+  return Float32Array.from(MARKERS.map((m) => lower.split(m).length - 1));
+}
+const recordEmbed = (r: IMemoryRecord<unknown>): Promise<Result<Float32Array>> =>
+  Promise.resolve(succeed(featureVector(r.body as string)));
+const queryEmbed = (text: string): Promise<Result<Float32Array>> =>
+  Promise.resolve(succeed(featureVector(text)));
+
+/** Records add/remove call order and can be configured to fail either op. */
+class SpyVectorIndex implements IVectorIndex {
+  public readonly calls: string[] = [];
+  public failAdd: boolean = false;
+  public failRemove: boolean = false;
+  private readonly _inner: InMemoryCosineIndex = InMemoryCosineIndex.create().orThrow();
+
+  public async add(id: MemoryId, vector: Float32Array): Promise<Result<string>> {
+    this.calls.push(`add:${id}`);
+    return this.failAdd ? fail('add boom') : this._inner.add(id, vector);
+  }
+  public async remove(id: MemoryId): Promise<Result<MemoryId>> {
+    this.calls.push(`remove:${id}`);
+    return this.failRemove ? fail('remove boom') : this._inner.remove(id);
+  }
+  public query(vector: Float32Array, topK: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>> {
+    return this._inner.query(vector, topK);
+  }
+}
+
+function knowledgeStore(
+  vectorIndex?: IVectorIndex,
+  embed?: (r: IMemoryRecord<unknown>) => Promise<Result<Float32Array>>
+): FileTreeMemoryStore {
+  const registry: IBodyConverterRegistry = BodyConverterRegistry.create().orThrow();
+  registry.register(knowledgeKind, Converters.string);
+  return FileTreeMemoryStore.create({
+    root: mutableRoot(),
+    registry,
+    codecs: new Map<Kind, IIdentityCodec>([[knowledgeKind, new KnowledgeIdentityCodec()]]),
+    vectorIndex,
+    embed
+  }).orThrow();
+}
+
+describe('FileTreeMemoryStore embed-on-write', () => {
+  describe('when wired', () => {
+    test('embeds on write, stamps embeddingRef, and indexes the vector', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      const store = knowledgeStore(index, recordEmbed);
+      expect(await store.put(makeRecord('doc-a', 'cat cat'))).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown>) => {
+          // InMemoryCosineIndex keys entries by id, so the ref IS the id.
+          expect(record.envelope.embeddingRef).toBe('doc-a');
+        }
+      );
+      expect(index.size).toBe(1);
+      // The persisted file carries the embeddingRef (round-trips through disk).
+      expect(await store.getById('knowledge' as MemoryScopeKey, 'doc-a' as MemoryId)).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown> | undefined) => {
+          expect(record?.envelope.embeddingRef).toBe('doc-a');
+        }
+      );
+      // The vector is queryable.
+      expect(await index.query(featureVector('cat'), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits[0].id).toBe('doc-a');
+        }
+      );
+    });
+
+    test('re-embeds on a content change: removes the stale vector then adds the new one', async () => {
+      const spy = new SpyVectorIndex();
+      const store = knowledgeStore(spy, recordEmbed);
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      (await store.put(makeRecord('doc-a', 'dog'))).orThrow();
+      // First write adds; the content change removes the stale vector before
+      // adding the replacement.
+      expect(spy.calls).toEqual(['add:doc-a', 'remove:doc-a', 'add:doc-a']);
+      // The index now reflects the new content ('dog'), not the original.
+      expect(await spy.query(featureVector('dog'), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits[0].score).toBeCloseTo(1);
+        }
+      );
+    });
+
+    test('does not re-embed a dedup no-op (identical content)', async () => {
+      const spy = new SpyVectorIndex();
+      const store = knowledgeStore(spy, recordEmbed);
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      // The second identical put is a content-dedup no-op — no second embedding.
+      expect(spy.calls).toEqual(['add:doc-a']);
+    });
+
+    test('removes the vector on delete', async () => {
+      const spy = new SpyVectorIndex();
+      const store = knowledgeStore(spy, recordEmbed);
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      expect(await store.delete(knowledgeKind, 'doc-a' as unknown as EntityId)).toSucceedWith(
+        'doc-a' as MemoryId
+      );
+      expect(spy.calls).toEqual(['add:doc-a', 'remove:doc-a']);
+      expect(await spy.query(featureVector('cat'), 5)).toSucceedWith([]);
+    });
+
+    test('removes evicted vectors on cap-cull eviction', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      const capCull: IWritePolicy = MemoryCapCullPolicy.create({
+        maxRecords: 2,
+        mutableFields: ['body', 'tags', 'links', 'provenance', 'embeddingRef']
+      }).orThrow();
+      const registry: IBodyConverterRegistry = BodyConverterRegistry.create().orThrow();
+      registry.register(mtmKind, Converters.string);
+      const store = FileTreeMemoryStore.create({
+        root: mutableRoot(),
+        registry,
+        codecs: new Map<Kind, IIdentityCodec>([[mtmKind, new MtmIdentityCodec()]]),
+        writePolicies: new Map<Kind, IWritePolicy>([[mtmKind, capCull]]),
+        vectorIndex: index,
+        embed: recordEmbed
+      }).orThrow();
+
+      // Distinct bodies so each gets a distinct vector; maxRecords=2 evicts the
+      // oldest on the third write.
+      (await store.put(makeRecord('turn-0', 'cat', 'mtm', 'conv-1:0'))).orThrow();
+      (await store.put(makeRecord('turn-1', 'dog', 'mtm', 'conv-1:1'))).orThrow();
+      (await store.put(makeRecord('turn-2', 'fish', 'mtm', 'conv-1:2'))).orThrow();
+      // turn-0 was evicted from the store AND the vector index.
+      expect(index.size).toBe(2);
+      expect(await index.query(featureVector('cat'), 5)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits.map((h) => h.id)).not.toContain('turn-0');
+        }
+      );
+    });
+
+    test('fails the put loudly and persists nothing when embedding fails', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      const failEmbed = (): Promise<Result<Float32Array>> => Promise.resolve(fail('no model'));
+      const store = knowledgeStore(index, failEmbed);
+      expect(await store.put(makeRecord('doc-a', 'cat'))).toFailWith(/embedding failed: no model/i);
+      // The file was never written (embed runs before persist) and the index is empty.
+      expect(await store.getById('knowledge' as MemoryScopeKey, 'doc-a' as MemoryId)).toSucceedWith(
+        undefined
+      );
+      expect(index.size).toBe(0);
+    });
+
+    test('fails the put loudly when the vector add fails', async () => {
+      const spy = new SpyVectorIndex();
+      spy.failAdd = true;
+      const store = knowledgeStore(spy, recordEmbed);
+      expect(await store.put(makeRecord('doc-a', 'cat'))).toFailWith(/vector add failed: add boom/i);
+      expect(await store.getById('knowledge' as MemoryScopeKey, 'doc-a' as MemoryId)).toSucceedWith(
+        undefined
+      );
+    });
+
+    test('fails the put loudly when stale-vector removal fails on a content change', async () => {
+      const spy = new SpyVectorIndex();
+      const store = knowledgeStore(spy, recordEmbed);
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      spy.failRemove = true;
+      expect(await store.put(makeRecord('doc-a', 'dog'))).toFailWith(
+        /stale vector removal failed: remove boom/i
+      );
+    });
+
+    test('fails the delete loudly when vector removal fails', async () => {
+      const spy = new SpyVectorIndex();
+      const store = knowledgeStore(spy, recordEmbed);
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      spy.failRemove = true;
+      expect(await store.delete(knowledgeKind, 'doc-a' as unknown as EntityId)).toFailWith(
+        /vector removal for 'doc-a' failed: remove boom/i
+      );
+    });
+  });
+
+  describe('when unwired', () => {
+    test('a store without a vector index or embedder leaves embeddingRef unset', async () => {
+      const store = knowledgeStore();
+      expect(await store.put(makeRecord('doc-a', 'cat'))).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown>) => {
+          expect(record.envelope.embeddingRef).toBeUndefined();
+        }
+      );
+    });
+
+    test('a vector index without an embedder is fully inert (no add or remove)', async () => {
+      const spy = new SpyVectorIndex();
+      const store = knowledgeStore(spy, undefined);
+      expect(await store.put(makeRecord('doc-a', 'cat'))).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown>) => {
+          expect(record.envelope.embeddingRef).toBeUndefined();
+        }
+      );
+      // The vector lifecycle is wholly off without an embedder: neither put nor
+      // delete touches the index (a remove would target a record never embedded).
+      (await store.delete(knowledgeKind, 'doc-a' as unknown as EntityId)).orThrow();
+      expect(spy.calls).toEqual([]);
+    });
+  });
+
+  describe('semantic recall end-to-end', () => {
+    test('a wired store + InMemoryCosineIndex + SemanticRetriever returns cosine top-k', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      const store = knowledgeStore(index, recordEmbed);
+      (await store.put(makeRecord('cats', 'cat cat cat'))).orThrow();
+      (await store.put(makeRecord('dogs', 'dog dog dog'))).orThrow();
+      (await store.put(makeRecord('fishes', 'fish fish fish'))).orThrow();
+
+      // Build a record index mirroring the store (knowledge scope) for hydration.
+      const listed: ReadonlyArray<IMemoryRecord<unknown>> = (await store.list()).orThrow();
+      const recordIndex = MemoryIndex.create().orThrow();
+      recordIndex
+        .rebuild(
+          listed.map((record): IIndexedMemoryRecord => ({ scope: 'knowledge' as MemoryScopeKey, record }))
+        )
+        .orThrow();
+
+      const retriever = SemanticRetriever.create({
+        index: recordIndex,
+        backend: { vectorIndex: index, embedQuery: queryEmbed }
+      }).orThrow();
+      expect(retriever.capabilities.supportsSemanticRecall).toBe(true);
+
+      expect(await retriever.retrieve({ semantic: 'cat', topK: 2 })).toSucceedAndSatisfy(
+        (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+          // 'cats' is the closest; 'dogs'/'fishes' are orthogonal (cosine 0) so
+          // only the cat record ranks above them — it is first.
+          expect(records[0].envelope.id).toBe('cats');
+        }
+      );
+    });
+  });
+});

--- a/libraries/ts-agent-memory/src/test/unit/store/embedOnWrite.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/embedOnWrite.test.ts
@@ -4,7 +4,7 @@
  */
 
 import '@fgv/ts-utils-jest';
-import { Converters, Result, fail, succeed } from '@fgv/ts-utils';
+import { Converters, Logging, Result, fail, succeed } from '@fgv/ts-utils';
 import { FileTree } from '@fgv/ts-json-base';
 import {
   BodyConverterRegistry,
@@ -110,7 +110,8 @@ class SpyVectorIndex implements IVectorIndex {
 
 function knowledgeStore(
   vectorIndex?: IVectorIndex,
-  embed?: (r: IMemoryRecord<unknown>) => Promise<Result<Float32Array>>
+  embed?: (r: IMemoryRecord<unknown>) => Promise<Result<Float32Array>>,
+  logger?: Logging.ILogger
 ): FileTreeMemoryStore {
   const registry: IBodyConverterRegistry = BodyConverterRegistry.create().orThrow();
   registry.register(knowledgeKind, Converters.string);
@@ -119,7 +120,8 @@ function knowledgeStore(
     registry,
     codecs: new Map<Kind, IIdentityCodec>([[knowledgeKind, new KnowledgeIdentityCodec()]]),
     vectorIndex,
-    embed
+    embed,
+    logger
   }).orThrow();
 }
 
@@ -149,14 +151,14 @@ describe('FileTreeMemoryStore embed-on-write', () => {
       );
     });
 
-    test('re-embeds on a content change: removes the stale vector then adds the new one', async () => {
+    test('re-embeds on a content change by re-adding (replace semantics, no eager remove)', async () => {
       const spy = new SpyVectorIndex();
       const store = knowledgeStore(spy, recordEmbed);
       (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
       (await store.put(makeRecord('doc-a', 'dog'))).orThrow();
-      // First write adds; the content change removes the stale vector before
-      // adding the replacement.
-      expect(spy.calls).toEqual(['add:doc-a', 'remove:doc-a', 'add:doc-a']);
+      // The content change re-adds (IVectorIndex.add replaces for a same id) —
+      // no redundant eager remove.
+      expect(spy.calls).toEqual(['add:doc-a', 'add:doc-a']);
       // The index now reflects the new content ('dog'), not the original.
       expect(await spy.query(featureVector('dog'), 1)).toSucceedAndSatisfy(
         (hits: ReadonlyArray<IVectorQueryHit>) => {
@@ -216,46 +218,68 @@ describe('FileTreeMemoryStore embed-on-write', () => {
       );
     });
 
-    test('fails the put loudly and persists nothing when embedding fails', async () => {
+    test('persists the record (best-effort) and logs when embedding fails', async () => {
       const index = InMemoryCosineIndex.create().orThrow();
+      const logger = new Logging.InMemoryLogger();
       const failEmbed = (): Promise<Result<Float32Array>> => Promise.resolve(fail('no model'));
-      const store = knowledgeStore(index, failEmbed);
-      expect(await store.put(makeRecord('doc-a', 'cat'))).toFailWith(/embedding failed: no model/i);
-      // The file was never written (embed runs before persist) and the index is empty.
-      expect(await store.getById('knowledge' as MemoryScopeKey, 'doc-a' as MemoryId)).toSucceedWith(
-        undefined
+      const store = knowledgeStore(index, failEmbed, logger);
+      // The durable write succeeds; only the derived index is skipped (rebuildable).
+      expect(await store.put(makeRecord('doc-a', 'cat'))).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown>) => {
+          expect(record.envelope.embeddingRef).toBeUndefined();
+        }
+      );
+      expect(await store.getById('knowledge' as MemoryScopeKey, 'doc-a' as MemoryId)).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown> | undefined) => {
+          expect(record?.envelope.id).toBe('doc-a');
+        }
       );
       expect(index.size).toBe(0);
+      expect(logger.logged.some((m) => /embedding 'doc-a' failed.*no model/i.test(m))).toBe(true);
     });
 
-    test('fails the put loudly when the vector add fails', async () => {
+    test('persists the record (best-effort) and logs when the vector add fails', async () => {
       const spy = new SpyVectorIndex();
       spy.failAdd = true;
-      const store = knowledgeStore(spy, recordEmbed);
-      expect(await store.put(makeRecord('doc-a', 'cat'))).toFailWith(/vector add failed: add boom/i);
+      const logger = new Logging.InMemoryLogger();
+      const store = knowledgeStore(spy, recordEmbed, logger);
+      expect(await store.put(makeRecord('doc-a', 'cat'))).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown>) => {
+          expect(record.envelope.embeddingRef).toBeUndefined();
+        }
+      );
+      expect(await store.getById('knowledge' as MemoryScopeKey, 'doc-a' as MemoryId)).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown> | undefined) => {
+          expect(record?.envelope.id).toBe('doc-a');
+        }
+      );
+      expect(logger.logged.some((m) => /vector add for 'doc-a' failed.*add boom/i.test(m))).toBe(true);
+    });
+
+    test('best-effort embed survives a throwing/rejecting embedder', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      const logger = new Logging.InMemoryLogger();
+      const throwingEmbed = (): Promise<Result<Float32Array>> => Promise.reject(new Error('embedder kaboom'));
+      const store = knowledgeStore(index, throwingEmbed, logger);
+      expect(await store.put(makeRecord('doc-a', 'cat'))).toSucceed();
+      expect(index.size).toBe(0);
+      expect(logger.logged.some((m) => /embedding 'doc-a' threw.*embedder kaboom/i.test(m))).toBe(true);
+    });
+
+    test('a committed delete succeeds (best-effort) and logs when vector removal fails', async () => {
+      const spy = new SpyVectorIndex();
+      const logger = new Logging.InMemoryLogger();
+      const store = knowledgeStore(spy, recordEmbed, logger);
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      spy.failRemove = true;
+      // The record is already gone; vector cleanup failure must NOT fail the delete.
+      expect(await store.delete(knowledgeKind, 'doc-a' as unknown as EntityId)).toSucceedWith(
+        'doc-a' as MemoryId
+      );
       expect(await store.getById('knowledge' as MemoryScopeKey, 'doc-a' as MemoryId)).toSucceedWith(
         undefined
       );
-    });
-
-    test('fails the put loudly when stale-vector removal fails on a content change', async () => {
-      const spy = new SpyVectorIndex();
-      const store = knowledgeStore(spy, recordEmbed);
-      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
-      spy.failRemove = true;
-      expect(await store.put(makeRecord('doc-a', 'dog'))).toFailWith(
-        /stale vector removal failed: remove boom/i
-      );
-    });
-
-    test('fails the delete loudly when vector removal fails', async () => {
-      const spy = new SpyVectorIndex();
-      const store = knowledgeStore(spy, recordEmbed);
-      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
-      spy.failRemove = true;
-      expect(await store.delete(knowledgeKind, 'doc-a' as unknown as EntityId)).toFailWith(
-        /vector removal for 'doc-a' failed: remove boom/i
-      );
+      expect(logger.logged.some((m) => /vector removal for 'doc-a' failed.*remove boom/i.test(m))).toBe(true);
     });
   });
 

--- a/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
@@ -4,7 +4,7 @@
  */
 
 import '@fgv/ts-utils-jest';
-import { Converter, Converters, Result, fail, succeed } from '@fgv/ts-utils';
+import { Converter, Converters, Logging, Result, fail, succeed } from '@fgv/ts-utils';
 import { FileTree } from '@fgv/ts-json-base';
 import {
   AdmissionDecision,
@@ -396,18 +396,37 @@ describe('FileTreeMemoryStore', () => {
       expect(await store.get(knowledgeKind, 'old' as EntityId)).toSucceedWith(undefined);
     });
 
-    test("a 'cull-oldest' decision fails when an evicted record is missing", async () => {
+    test("a 'cull-oldest' eviction of a missing record is best-effort: the committed put still succeeds and the failure is logged", async () => {
       const cullPolicy: IWritePolicy = {
         mutableFields: ['body'],
         admit: (): Result<AdmissionDecision> =>
           succeed({ decision: 'cull-oldest', evict: ['ghost' as MemoryId] }),
         applyUpdate: (r): Result<IMemoryRecord<unknown>> => succeed(r)
       };
-      const store = createStore({
-        writePolicies: new Map<Kind, IWritePolicy>([[knowledgeKind, cullPolicy]])
+      const logger = new Logging.InMemoryLogger();
+      const store = FileTreeMemoryStore.create({
+        root: mutableRoot(),
+        registry: knowledgeRegistry(),
+        codecs: knowledgeCodecs,
+        writePolicies: new Map<Kind, IWritePolicy>([[knowledgeKind, cullPolicy]]),
+        clock,
+        logger
       }).orThrow();
-      expect(await store.put(makeRecord({ id: 'new', body: 'new' }))).toFailWith(
-        /cannot evict 'ghost'.*not found/i
+      // The new record is the authoritative commit; a failed best-effort eviction
+      // must NOT fail the put — it is logged and the cap self-heals next write.
+      expect(await store.put(makeRecord({ id: 'new', body: 'new' }))).toSucceedAndSatisfy(
+        (put: IMemoryRecord<unknown>) => {
+          expect(put.envelope.id).toBe('new');
+          expect(put.envelope.embeddingRef).toBeUndefined();
+        }
+      );
+      expect(await store.get(knowledgeKind, 'new' as EntityId)).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown> | undefined) => {
+          expect(record?.envelope.id).toBe('new');
+        }
+      );
+      expect(logger.logged.some((m) => /best-effort eviction of 'ghost' failed.*not found/i.test(m))).toBe(
+        true
       );
     });
   });

--- a/libraries/ts-agent-memory/src/test/unit/vector/inMemoryCosineIndex.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/vector/inMemoryCosineIndex.test.ts
@@ -72,9 +72,9 @@ describe('InMemoryCosineIndex', () => {
   describe('query', () => {
     async function seeded(): Promise<InMemoryCosineIndex> {
       const index = InMemoryCosineIndex.create().orThrow();
-      await index.add('a' as MemoryId, Float32Array.from([1, 0]));
-      await index.add('b' as MemoryId, Float32Array.from([0, 1]));
-      await index.add('c' as MemoryId, Float32Array.from([1, 1]));
+      (await index.add('a' as MemoryId, Float32Array.from([1, 0]))).orThrow();
+      (await index.add('b' as MemoryId, Float32Array.from([0, 1]))).orThrow();
+      (await index.add('c' as MemoryId, Float32Array.from([1, 1]))).orThrow();
       return index;
     }
 
@@ -119,8 +119,8 @@ describe('InMemoryCosineIndex', () => {
 
     test('scores a degenerate (zero-magnitude) stored vector as 0 rather than NaN', async () => {
       const index = InMemoryCosineIndex.create().orThrow();
-      await index.add('zero' as MemoryId, Float32Array.from([0, 0]));
-      await index.add('unit' as MemoryId, Float32Array.from([1, 0]));
+      (await index.add('zero' as MemoryId, Float32Array.from([0, 0]))).orThrow();
+      (await index.add('unit' as MemoryId, Float32Array.from([1, 0]))).orThrow();
       expect(await index.query(Float32Array.from([1, 0]), 2)).toSucceedAndSatisfy(
         (hits: ReadonlyArray<IVectorQueryHit>) => {
           expect(hits.map((h) => h.id)).toEqual(['unit', 'zero']);
@@ -131,7 +131,7 @@ describe('InMemoryCosineIndex', () => {
 
     test('scores against a degenerate (zero-magnitude) query as 0 rather than NaN', async () => {
       const index = InMemoryCosineIndex.create().orThrow();
-      await index.add('unit' as MemoryId, Float32Array.from([1, 0]));
+      (await index.add('unit' as MemoryId, Float32Array.from([1, 0]))).orThrow();
       expect(await index.query(Float32Array.from([0, 0]), 1)).toSucceedAndSatisfy(
         (hits: ReadonlyArray<IVectorQueryHit>) => {
           expect(hits[0].score).toBe(0);
@@ -143,8 +143,8 @@ describe('InMemoryCosineIndex', () => {
   describe('remove', () => {
     test('removes a vector and is reflected in subsequent queries', async () => {
       const index = InMemoryCosineIndex.create().orThrow();
-      await index.add('a' as MemoryId, Float32Array.from([1, 0]));
-      await index.add('b' as MemoryId, Float32Array.from([0, 1]));
+      (await index.add('a' as MemoryId, Float32Array.from([1, 0]))).orThrow();
+      (await index.add('b' as MemoryId, Float32Array.from([0, 1]))).orThrow();
       expect(await index.remove('a' as MemoryId)).toSucceedWith('a' as MemoryId);
       expect(index.size).toBe(1);
       expect(await index.query(Float32Array.from([1, 0]), 5)).toSucceedAndSatisfy(
@@ -183,7 +183,7 @@ describe('InMemoryCosineIndex', () => {
     test('clears prior contents and re-establishes the dimension', async () => {
       const index = InMemoryCosineIndex.create().orThrow();
       // Seed a 3-dim vector, then rebuild with a 2-dim embedder.
-      await index.add('old' as MemoryId, Float32Array.from([1, 2, 3]));
+      (await index.add('old' as MemoryId, Float32Array.from([1, 2, 3]))).orThrow();
       const source = new FakeSource(succeed([record('a')]));
       expect(await index.rebuild(source, embed)).toSucceedWith(1);
       expect(index.size).toBe(1);
@@ -197,18 +197,28 @@ describe('InMemoryCosineIndex', () => {
       expect(await index.rebuild(source, embed)).toFailWith(/failed to list records: disk gone/i);
     });
 
-    test('fails loudly when an embedding fails', async () => {
+    test('fails loudly and rolls back to empty when an embedding fails mid-rebuild', async () => {
       const index = InMemoryCosineIndex.create().orThrow();
-      const source = new FakeSource(succeed([record('a')]));
-      const badEmbed = (): Promise<Result<Float32Array>> => Promise.resolve(fail('no model'));
-      expect(await index.rebuild(source, badEmbed)).toFailWith(/embedding 'a' failed: no model/i);
+      // Seed an existing entry so the rollback (not merely "stayed empty") is observable.
+      (await index.add('seed' as MemoryId, Float32Array.from([1, 1]))).orThrow();
+      // First record embeds fine, the second fails — so a naive impl would leave
+      // record 'a' indexed; the rollback must clear it.
+      let calls: number = 0;
+      const flakyEmbed = (r: IMemoryRecord<unknown>): Promise<Result<Float32Array>> => {
+        calls += 1;
+        return Promise.resolve(calls === 1 ? succeed(Float32Array.from([1, 1])) : fail('no model'));
+      };
+      const source = new FakeSource(succeed([record('a'), record('b')]));
+      expect(await index.rebuild(source, flakyEmbed)).toFailWith(/embedding 'b' failed: no model/i);
+      expect(index.size).toBe(0);
     });
 
-    test('fails loudly when adding an embedded vector fails (e.g. empty vector)', async () => {
+    test('fails loudly and rolls back to empty when adding an embedded vector fails', async () => {
       const index = InMemoryCosineIndex.create().orThrow();
       const source = new FakeSource(succeed([record('a')]));
       const emptyEmbed = (): Promise<Result<Float32Array>> => Promise.resolve(succeed(new Float32Array(0)));
       expect(await index.rebuild(source, emptyEmbed)).toFailWith(/empty vector/i);
+      expect(index.size).toBe(0);
     });
   });
 });

--- a/libraries/ts-agent-memory/src/test/unit/vector/inMemoryCosineIndex.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/vector/inMemoryCosineIndex.test.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import {
+  IMemoryRecord,
+  IMemoryRecordSource,
+  IVectorQueryHit,
+  InMemoryCosineIndex,
+  MemoryId
+} from '../../../index';
+
+/** A trivial record carrying just the id + a marker body, for rebuild tests. */
+function record(id: string, body: string = `body-${id}`): IMemoryRecord<unknown> {
+  return {
+    // The cosine index only reads `envelope.id`; a minimal envelope suffices.
+    envelope: { id: id as MemoryId } as IMemoryRecord<unknown>['envelope'],
+    body
+  };
+}
+
+/** A scripted record source for `rebuild`. */
+class FakeSource implements IMemoryRecordSource {
+  private readonly _result: Result<ReadonlyArray<IMemoryRecord<unknown>>>;
+  public constructor(result: Result<ReadonlyArray<IMemoryRecord<unknown>>>) {
+    this._result = result;
+  }
+  public list(): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>> {
+    return Promise.resolve(this._result);
+  }
+}
+
+describe('InMemoryCosineIndex', () => {
+  describe('add', () => {
+    test('returns the id as the embedding ref and tracks size', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      expect(index.size).toBe(0);
+      expect(await index.add('a' as MemoryId, Float32Array.from([1, 0]))).toSucceedWith('a');
+      expect(index.size).toBe(1);
+    });
+
+    test('replaces the vector on a same-id add', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      expect(await index.add('a' as MemoryId, Float32Array.from([1, 0]))).toSucceed();
+      expect(await index.add('a' as MemoryId, Float32Array.from([0, 1]))).toSucceed();
+      expect(index.size).toBe(1);
+      // The query now matches the replacement vector ([0,1]) not the original.
+      expect(await index.query(Float32Array.from([0, 1]), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits[0].score).toBeCloseTo(1);
+        }
+      );
+    });
+
+    test('fails loudly on an empty vector', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      expect(await index.add('a' as MemoryId, new Float32Array(0))).toFailWith(/empty vector/i);
+    });
+
+    test('fails loudly on a dimension mismatch against the established dimension', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      expect(await index.add('a' as MemoryId, Float32Array.from([1, 0]))).toSucceed();
+      expect(await index.add('b' as MemoryId, Float32Array.from([1, 0, 0]))).toFailWith(
+        /dimension 3 does not match index dimension 2/i
+      );
+    });
+  });
+
+  describe('query', () => {
+    async function seeded(): Promise<InMemoryCosineIndex> {
+      const index = InMemoryCosineIndex.create().orThrow();
+      await index.add('a' as MemoryId, Float32Array.from([1, 0]));
+      await index.add('b' as MemoryId, Float32Array.from([0, 1]));
+      await index.add('c' as MemoryId, Float32Array.from([1, 1]));
+      return index;
+    }
+
+    test('returns hits in descending cosine-similarity order', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 3)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits.map((h) => h.id)).toEqual(['a', 'c', 'b']);
+          expect(hits[0].score).toBeCloseTo(1);
+          expect(hits[1].score).toBeCloseTo(1 / Math.sqrt(2));
+          expect(hits[2].score).toBeCloseTo(0);
+        }
+      );
+    });
+
+    test('truncates to topK', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 2)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits.map((h) => h.id)).toEqual(['a', 'c']);
+        }
+      );
+    });
+
+    test('returns empty for a non-positive topK', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 0)).toSucceedWith([]);
+      expect(await index.query(Float32Array.from([1, 0]), -1)).toSucceedWith([]);
+    });
+
+    test('returns empty when the index is empty (no dimension check)', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      expect(await index.query(Float32Array.from([1, 2, 3, 4]), 5)).toSucceedWith([]);
+    });
+
+    test('fails loudly on a query-dimension mismatch', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0, 0]), 3)).toFailWith(
+        /query dimension 3 does not match index dimension 2/i
+      );
+    });
+
+    test('scores a degenerate (zero-magnitude) stored vector as 0 rather than NaN', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      await index.add('zero' as MemoryId, Float32Array.from([0, 0]));
+      await index.add('unit' as MemoryId, Float32Array.from([1, 0]));
+      expect(await index.query(Float32Array.from([1, 0]), 2)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits.map((h) => h.id)).toEqual(['unit', 'zero']);
+          expect(hits[1].score).toBe(0);
+        }
+      );
+    });
+
+    test('scores against a degenerate (zero-magnitude) query as 0 rather than NaN', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      await index.add('unit' as MemoryId, Float32Array.from([1, 0]));
+      expect(await index.query(Float32Array.from([0, 0]), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits[0].score).toBe(0);
+        }
+      );
+    });
+  });
+
+  describe('remove', () => {
+    test('removes a vector and is reflected in subsequent queries', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      await index.add('a' as MemoryId, Float32Array.from([1, 0]));
+      await index.add('b' as MemoryId, Float32Array.from([0, 1]));
+      expect(await index.remove('a' as MemoryId)).toSucceedWith('a' as MemoryId);
+      expect(index.size).toBe(1);
+      expect(await index.query(Float32Array.from([1, 0]), 5)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits.map((h) => h.id)).toEqual(['b']);
+        }
+      );
+    });
+
+    test('is idempotent — removing an absent id still succeeds', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      expect(await index.remove('missing' as MemoryId)).toSucceedWith('missing' as MemoryId);
+    });
+  });
+
+  describe('rebuild', () => {
+    const embed = (r: IMemoryRecord<unknown>): Promise<Result<Float32Array>> => {
+      // Deterministic: encode the id's first char code into a 2-vector.
+      const code: number = (r.envelope.id as string).charCodeAt(0);
+      return Promise.resolve(succeed(Float32Array.from([code, 1])));
+    };
+
+    test('re-embeds every record from the source and reports the count', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      const source = new FakeSource(succeed([record('a'), record('b'), record('c')]));
+      expect(await index.rebuild(source, embed)).toSucceedWith(3);
+      expect(index.size).toBe(3);
+      expect(await index.query(Float32Array.from([99, 1]), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          // 'c' = char code 99, the closest to the query vector.
+          expect(hits[0].id).toBe('c');
+        }
+      );
+    });
+
+    test('clears prior contents and re-establishes the dimension', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      // Seed a 3-dim vector, then rebuild with a 2-dim embedder.
+      await index.add('old' as MemoryId, Float32Array.from([1, 2, 3]));
+      const source = new FakeSource(succeed([record('a')]));
+      expect(await index.rebuild(source, embed)).toSucceedWith(1);
+      expect(index.size).toBe(1);
+      // The 2-dim query now succeeds (dimension was reset by rebuild).
+      expect(await index.query(Float32Array.from([97, 1]), 1)).toSucceed();
+    });
+
+    test('fails loudly when the source list fails', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      const source = new FakeSource(fail('disk gone'));
+      expect(await index.rebuild(source, embed)).toFailWith(/failed to list records: disk gone/i);
+    });
+
+    test('fails loudly when an embedding fails', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      const source = new FakeSource(succeed([record('a')]));
+      const badEmbed = (): Promise<Result<Float32Array>> => Promise.resolve(fail('no model'));
+      expect(await index.rebuild(source, badEmbed)).toFailWith(/embedding 'a' failed: no model/i);
+    });
+
+    test('fails loudly when adding an embedded vector fails (e.g. empty vector)', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      const source = new FakeSource(succeed([record('a')]));
+      const emptyEmbed = (): Promise<Result<Float32Array>> => Promise.resolve(succeed(new Float32Array(0)));
+      expect(await index.rebuild(source, emptyEmbed)).toFailWith(/empty vector/i);
+    });
+  });
+});

--- a/libraries/ts-agent-memory/src/test/unit/vector/inMemoryCosineIndex.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/vector/inMemoryCosineIndex.test.ts
@@ -60,6 +60,21 @@ describe('InMemoryCosineIndex', () => {
       expect(await index.add('a' as MemoryId, new Float32Array(0))).toFailWith(/empty vector/i);
     });
 
+    test('stores a defensive copy — mutating the caller buffer after add does not corrupt the index', async () => {
+      const index = InMemoryCosineIndex.create().orThrow();
+      const buffer = Float32Array.from([1, 0]);
+      (await index.add('a' as MemoryId, buffer)).orThrow();
+      // Mutate the caller's buffer after the add; the stored vector must be unaffected.
+      buffer[0] = 0;
+      buffer[1] = 1;
+      expect(await index.query(Float32Array.from([1, 0]), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          // Still maximally similar to [1,0] — proves the index kept its own copy.
+          expect(hits[0].score).toBeCloseTo(1);
+        }
+      );
+    });
+
     test('fails loudly on a dimension mismatch against the established dimension', async () => {
       const index = InMemoryCosineIndex.create().orThrow();
       expect(await index.add('a' as MemoryId, Float32Array.from([1, 0]))).toSucceed();
@@ -193,8 +208,11 @@ describe('InMemoryCosineIndex', () => {
 
     test('fails loudly when the source list fails', async () => {
       const index = InMemoryCosineIndex.create().orThrow();
+      // Seed an entry so the reset-before-list rollback is observable, not just "stayed empty".
+      (await index.add('seed' as MemoryId, Float32Array.from([1, 1]))).orThrow();
       const source = new FakeSource(fail('disk gone'));
       expect(await index.rebuild(source, embed)).toFailWith(/failed to list records: disk gone/i);
+      expect(index.size).toBe(0);
     });
 
     test('fails loudly and rolls back to empty when an embedding fails mid-rebuild', async () => {

--- a/libraries/ts-agent-memory/src/test/unit/vector/vectorIndex.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/vector/vectorIndex.test.ts
@@ -12,9 +12,9 @@ import { IVectorIndex, IVectorQueryHit, MemoryId } from '../../../index';
  * seam is usable end-to-end (the in-package cosine impl is a post-v1 fast-follow).
  */
 class StubVectorIndex implements IVectorIndex {
-  private readonly _vectors: Map<MemoryId, ReadonlyArray<number>> = new Map();
+  private readonly _vectors: Map<MemoryId, Float32Array> = new Map();
 
-  public add(id: MemoryId, vector: ReadonlyArray<number>): Promise<Result<string>> {
+  public add(id: MemoryId, vector: Float32Array): Promise<Result<string>> {
     this._vectors.set(id, vector);
     return Promise.resolve(succeed(`ref-${id}`));
   }
@@ -24,7 +24,7 @@ class StubVectorIndex implements IVectorIndex {
     return Promise.resolve(succeed(id));
   }
 
-  public query(vector: ReadonlyArray<number>, topK: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>> {
+  public query(vector: Float32Array, topK: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>> {
     const hits: IVectorQueryHit[] = Array.from(this._vectors.keys())
       .map((id) => ({ id, score: vector.length }))
       .slice(0, topK);
@@ -35,12 +35,14 @@ class StubVectorIndex implements IVectorIndex {
 describe('IVectorIndex seam', () => {
   test('a conforming implementation supports add / query / remove', async () => {
     const index = new StubVectorIndex();
-    expect(await index.add('a' as MemoryId, [1, 2, 3])).toSucceedWith('ref-a');
-    expect(await index.add('b' as MemoryId, [4, 5, 6])).toSucceedWith('ref-b');
-    expect(await index.query([0.1, 0.2], 1)).toSucceedAndSatisfy((hits: ReadonlyArray<IVectorQueryHit>) => {
-      expect(hits).toHaveLength(1);
-      expect(hits[0].score).toBe(2);
-    });
+    expect(await index.add('a' as MemoryId, Float32Array.from([1, 2, 3]))).toSucceedWith('ref-a');
+    expect(await index.add('b' as MemoryId, Float32Array.from([4, 5, 6]))).toSucceedWith('ref-b');
+    expect(await index.query(Float32Array.from([0.1, 0.2]), 1)).toSucceedAndSatisfy(
+      (hits: ReadonlyArray<IVectorQueryHit>) => {
+        expect(hits).toHaveLength(1);
+        expect(hits[0].score).toBe(2);
+      }
+    );
     expect(await index.remove('a' as MemoryId)).toSucceedWith('a' as MemoryId);
   });
 });


### PR DESCRIPTION
Makes semantic recall **operational** for `@fgv/ts-agent-memory` — the vector / embed-on-write fast-follow whose seams shipped in the v1 substrate (B2). Branched off and targets `ts-agent-memory` (PR #501 promoting the substrate to `release` is still open at the time of writing).

## What ships

1. **`vector/inMemoryCosineIndex.ts` — `InMemoryCosineIndex`** implements the `IVectorIndex` seam as a brute-force in-memory cosine over `Map<MemoryId, Float32Array>`. `create()`; `add`/`remove`/`query`; `rebuild(source, embed)`. Single index dimension established by the first `add` (mismatches fail loudly); zero-magnitude vectors score `0` (never `NaN`); idempotent `remove`; `topK<=0`/empty-index queries short-circuit to `[]`; `rebuild` rolls back to empty on any failure. **No external dependency** — brute-force cosine is the complete answer for the fgv regime (large-N is out of scope; the seam stays open for an external ANN swap).

2. **`store/fileTreeMemoryStore.ts` — embed-on-write hook.** Additive `vectorIndex?` + `embed?` create params. On `put`: embed → invalidate-stale-vector-on-`contentHash`-change (remove + add) → stamp `embeddingRef` → persist. On `delete` / cap-cull eviction: remove the vector. **Zero-overhead and byte-identical when unwired** (mirrors the observer hook). The embed step runs *before* persist, so an embedding failure fails the `put` loudly with nothing written — the index is never silently left missing an entry.

3. **`retrieve/semanticRetriever.ts`** was already operational via the B2 backend seam; only the `QueryEmbedder` boundary type changed (see below). `HybridRetriever` composes the now-real semantic child unchanged.

## Locked decisions

- **Embedder is consumer-injected; core stays embedder-agnostic** — no `ai-assist` import in the store/vector path. The consumer wires `callProviderEmbedding` (cloud) or in-process transformers `embed`.
- **`Float32Array` at the index boundary.** `IVectorIndex.add/query` and `QueryEmbedder` move from `ReadonlyArray<number>` to `Float32Array`, per design.md §5.1 and the stream's convention (`number[]` only at JSON-wire edges). This corrects a B2-seam drift in an unpublished, active-development library.
- **Embedding-failure policy:** fail the `put` loudly, persist nothing (embed-before-persist).
- **`rebuild(source, embed)`** takes a minimal `IMemoryRecordSource` (which `FileTreeMemoryStore` satisfies structurally) rather than the concrete store, avoiding a `vector → store` packlet cycle — a consumer still calls `index.rebuild(store, embed)`.
- **Vector removal gated on both** `vectorIndex` + `embed` being wired (symmetric with the embed-on-write gate): the vector lifecycle is wholly on or wholly off.

## Out of scope (per brief)

Sidecar vector persistence (noted as a future nicety in TSDoc); temporal write path/retrievers; L2 tools; L3 ingest; external ANN; any `callProviderEmbedding` call from the core.

## Review-loop discipline

**Layer-1 `code-reviewer` pass run on the final diff before opening this PR.** No P1s. Three P2s — all resolved: (a) `rebuild` partial-state-on-failure → added rollback + tests; (b) unsafe `r.body as string` in the test embedder → validate via `Converters.string.convert`; (c) discarded `Result`s in test setup → `(await …).orThrow()`. Three P3s: e2e store/retriever decoupling comment added; query dimension-narrow and `topK` slice micro-branch dispositioned (kept, with rationale). Full findings + dispositions in `.ai/tasks/active/ts-agent-memory-vector/state.md`.

## Gates

- `rushx build` (+ api-extractor; `etc/ts-agent-memory.api.md` regenerated) — clean
- `rushx lint` — clean (`fixlint` run pre-commit)
- `rushx test` — **314 tests, 100% coverage** (statements/branches/functions/lines)
- Existing substrate tests stay green (unwired store byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Akfusq96dXiQds1jopuAzc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added embed-on-write support for file-tree memory stores, enabling automatic vector indexing and `embeddingRef` stamping when configured.
  * Introduced an in-memory cosine vector index to power semantic retrieval.
  * Updated semantic retrieval/embedding to use `Float32Array` vectors end-to-end.
* **Bug Fixes**
  * Improved vector-index maintenance to be best-effort: record persistence won’t fail on embedding/query/pruning issues; failures are logged.
  * Ensured derived index rebuilds roll back to an empty state on failure and idempotent vector removal behavior.
  * Vector cleanup now covers rewrites, deletes, and evictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->