### PR TITLE
fix(ts-extras/ai-assist): correlate client-tool continuation ids to the buffered tool_use id

### DIFF
--- a/.ai/tasks/active/ai-assist-client-tool-id-fix/state.md
+++ b/.ai/tasks/active/ai-assist-client-tool-id-fix/state.md
@@ -1,0 +1,118 @@
+# ai-assist-client-tool-id-fix — state
+
+**Library:** `@fgv/ts-extras` (`ai-assist` packlet, active surface)
+**Branch:** `claude/client-tool-id-mismatch-leu8do` (off `release`) — PR target `release`
+**Type:** bug-fix + hardening + root-cause. No public API surface change (api-extractor report unchanged).
+
+## Symptom (consumer: PersonAIlity)
+
+Anthropic intermittently returns `invalid Prompt - malformed identifier`, **only** on turns
+where the model calls a client tool. More tools offered → more frequent. Direct-answer turns
+on the same agent/model succeed.
+
+## Root cause
+
+The per-provider continuation builders never enforced that each
+`tool_result.tool_use_id` (Anthropic) / `function_call_output.call_id` (OpenAI) is drawn from
+the set of assistant `tool_use.id`s actually present in the accumulation buffer. They
+independently keyed the id off the tool-result record with
+`tool_use_id: r.callId ?? r.toolName`. Two compounding defects make that catastrophic rather
+than merely fragile:
+
+1. **Name fallback (`?? r.toolName`).** When `callId` is nullish, the builder emitted the tool
+   *name* as the id. A tool name is never a `toolu_*` / `call_*` id, so the provider rejects it
+   as a "malformed identifier." (`clientToolContinuationBuilder.ts` Anthropic ~line 151, OpenAI
+   ~line 219.)
+2. **`??` does not treat empty-string as missing.** An empty id flows straight through as
+   `tool_use_id: ''` — also a malformed identifier — with no fallback even firing.
+
+Because the builder *trusted* `callId` blindly and never cross-checked it against the buffered
+assistant `tool_use.id`s, **any** upstream loss/divergence of the id surfaced as a malformed
+wire body at the provider instead of a loud, field-attributable failure in our code.
+
+### The identified upstream divergence path (anthropic.ts:~333, the silent orphaned-block drop)
+
+`content_block_start` handling buffered a `tool_use` block only when
+`block.type === 'tool_use' && block.id && block.name`. A `tool_use` block_start that failed that
+guard (missing/empty id or name — provider drift or a truncated stream) fell through **silently**:
+no buffer entry, no `client-tool-call-start`, no `logger.warn`. Its subsequent
+`input_json_delta` chunks (same SSE index) then hit `if (block?.type === 'tool_use')` at
+~line 368 with `block === undefined` and were **silently ignored** too. The block simply vanished.
+
+This is a real silent-corruption path: the model's intended `tool_use` is dropped from the
+assistant turn with zero diagnostic. Note it does **not**, by itself, manufacture a
+*name-as-id* tool_result (a dropped block emits no `client-tool-call-done`, so no tool-result is
+produced for it). The decisive, end-to-end-reproducible divergence that *does* yield a
+tool_result whose id is absent from the final assistant turn is **buffer-index reuse**: if two
+`tool_use` blocks share an SSE `index` (e.g. an absent/duplicated `index`, which the payload type
+already marks optional and defaults to `0`), the later block overwrites the earlier one in the
+buffer after the earlier one already emitted its `client-tool-call-done`. The executed result is
+then keyed to an id no longer present in the buffer → the builder used to mask this with the name
+fallback; it now fails loud. This is captured as an end-to-end test (see below).
+
+**Honest scope note on the live trigger:** within a single, well-formed Anthropic stream the
+adapter's own guard means `callId` always equals a buffered id, so the pure single-turn path
+can't fire the bug. The bug is reachable when the id correlation is lost upstream (orphaned-block
+drop, index reuse, provider drift, or a multi-turn re-feed that loses the id). Rather than pin a
+single live trigger speculatively, the fix makes **every** such loss loud and impossible to
+mis-key, and adds a field-confirmable diagnostic so the consumer can corroborate on a live
+failing turn by capturing the request body.
+
+## Fix
+
+1. **Single source of truth (`clientToolContinuationBuilder.ts`).** Both
+   `buildAnthropicContinuation` and `buildOpenAiContinuation` now return
+   `Result<IAiClientToolContinuation>`. They build the set of buffered assistant tool_use ids and,
+   for each tool result, require `callId` to be non-empty **and** a member of that set; otherwise
+   they return a clear `Result.fail` naming the tool and the offending id. `tool_use_id` /
+   `call_id` is taken from the verified `callId` — **never** `toolName`. A buffered tool_use block
+   with an empty id also fails loud (the assistant side can't carry a malformed id either).
+2. **Empty-string = missing.** New `isUsableId(id)` predicate (`id !== undefined && id.length > 0`)
+   replaces every `??`-based id check.
+3. **No silent drop (`anthropic.ts`).** A `tool_use` `content_block_start` lacking a usable
+   id/name now emits a loud `logger.warn` prefixed with the new stable
+   `MALFORMED_TOOL_USE_WARN_TAG = 'ai-assist:malformed-tool-use'` (added to `common.ts`, sibling to
+   `UNRECOGNIZED_EVENT_WARN_TAG`), and issues no tool call — instead of vanishing.
+4. **OpenAI parity.** Same single-source-of-truth correlation on the Responses path; never key
+   `function_call_output.call_id` by tool name.
+5. **`executeClientToolTurn`** handles the Result-returning builders and fails `nextTurn` loud on a
+   bad correlation. The Gemini builder is unchanged (correlates by name by design — no call ids)
+   and is wrapped in `succeed()` at the call site.
+
+## Diagnostic added
+
+Both builders, when a `logger` is supplied, log the outgoing continuation's id pairing at
+`detail` (debug) level — `ai-assist:anthropic-continuation tool_use.id↔tool_result.tool_use_id [...]`
+and the OpenAI analogue. A failing turn is field-confirmable by capturing this line (or the
+assembled request body). `executeClientToolTurn` threads its `logger` into the builders.
+
+## Tests (all green; 100% coverage in ts-extras)
+
+`clientToolContinuationBuilder.test.ts`:
+- **Divergence repro → now fails loud (not mis-keys):** absent callId, empty-string callId,
+  mismatched callId, and empty buffered tool_use id — each `toFailWith(...)` instead of mis-keying
+  to the tool name (replaces the two old "uses toolName as fallback" tests).
+- **Happy path id-equality:** `tool_use.id === tool_use_id` for single and parallel calls (parallel
+  supplied out of order to prove correlation is by id, not position).
+- **OpenAI parity:** absent / empty / mismatched call_id all fail loud.
+- **Diagnostic logging:** asserts the detail-level pairing line for both builders.
+- **End-to-end fail-loud through `executeClientToolTurn`:** buffer-index-reuse SSE makes an
+  executed result's id diverge from the final buffered id → `nextTurn` fails loud
+  (`/toolu_A.*does not match any buffered/`).
+
+`streamingAdapters.test.ts`:
+- **Orphaned-block surfaced, not dropped:** tool_use block_start missing name / missing id →
+  `logger.warn` with the `ai-assist:malformed-tool-use` tag, no `client-tool-call-start/done`, empty
+  buffer; plus a no-logger variant (covers the `logger?.` undefined branch, no throw).
+
+## Gates
+
+- `rushx build` ✅  `rushx lint` ✅ (clean, after `fixlint`)  `rushx test` ✅ (100% stmts/branches/funcs/lines)
+- api-extractor report unchanged (builders are internal-only exports; `executeClientToolTurn`
+  signature unchanged) — no regen needed.
+- `code-reviewer` agent run on the final diff — findings: _(to be appended)_
+
+## Scope held
+
+Out: the Gemini builder (name-correlation by design), the alias refactor (separate stream). No
+behavior change beyond id-correlation + the diagnostic + the loud orphaned-block surface.

--- a/.ai/tasks/active/ai-assist-client-tool-id-fix/state.md
+++ b/.ai/tasks/active/ai-assist-client-tool-id-fix/state.md
@@ -110,7 +110,30 @@ assembled request body). `executeClientToolTurn` threads its `logger` into the b
 - `rushx build` ✅  `rushx lint` ✅ (clean, after `fixlint`)  `rushx test` ✅ (100% stmts/branches/funcs/lines)
 - api-extractor report unchanged (builders are internal-only exports; `executeClientToolTurn`
   signature unchanged) — no regen needed.
-- `code-reviewer` agent run on the final diff — findings: _(to be appended)_
+- `code-reviewer` agent run on the final diff — **no P1**, two P2, two P3. Dispositions below.
+
+### code-reviewer findings + dispositions
+
+- **P2 — continuation-failure path didn't yield an `error` event (builder ~808):** FIXED.
+  `executeClientToolTurn` now `yield`s `{ type: 'error', message }` before returning on a bad
+  id-correlation, mirroring the stream-open-failure path so the failure surfaces inline on the
+  event stream, not only via `nextTurn`. End-to-end test asserts the inline error event.
+- **P2 — add `c8 ignore` to the empty-id buffer guard (builder ~157):** DECLINED (intentional).
+  The branch is *tested* (the "empty buffered id" unit test exercises it; coverage is 100% without
+  a directive). `c8 ignore` is for genuinely unreachable code; ignoring a tested defensive guard
+  would contradict repo guidance ("try chaining/testing first; accept c8 ignore only after
+  determining the code is unreachable"). Kept the test, no directive.
+- **P3 — type-safe extraction in test helpers (test ~456):** FIXED. Replaced `b.id as string` /
+  `b.tool_use_id as string` with an `asString(v)` `typeof` guard.
+- **P3 — diagnostic logs an empty pairing when `toolResults` is empty (builder ~213/307):**
+  DECLINED. Unreachable via `executeClientToolTurn` (short-circuits to `continuation: undefined`
+  at `toolResults.length === 0`). Guarding would add an untested branch for a direct-caller-only
+  noise case of negligible value.
+
+Reviewer's correctness + coverage assessment: id-correlation logic sound, single-source-of-truth
+enforced on both Anthropic and OpenAI paths, no path where a malformed continuation escapes;
+test suite covers all four Anthropic failure paths + OpenAI parity + positive single/parallel
+invariant + orphaned-block (incl. no-logger) + end-to-end. Recommendation: **Approved.**
 
 ## Scope held
 

--- a/common/changes/@fgv/ts-extras/ai-assist-client-tool-id-fix_2026-06-29-21-40.json
+++ b/common/changes/@fgv/ts-extras/ai-assist-client-tool-id-fix_2026-06-29-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "ai-assist client-tool continuation: correlate each tool_result.tool_use_id (Anthropic) / function_call_output.call_id (OpenAI) to the buffered assistant tool_use id as the single source of truth, failing loud on a missing/empty/mismatched id instead of falling back to the tool name (the production \"malformed identifier\" bug); treat empty-string as a missing id; surface an orphaned Anthropic tool_use content_block_start (missing id/name) via a loud logger.warn with the new ai-assist:malformed-tool-use tag instead of silently dropping it; add a detail-level diagnostic logging the outgoing id pairing; executeClientToolTurn yields an inline error event on a bad correlation",
+      "type": "none",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/anthropic.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/anthropic.ts
@@ -41,6 +41,7 @@ import { toAnthropicTools } from '../toolFormats';
 import { anthropicEffortToBudgetTokens, type IResolvedThinkingConfig } from '../thinkingOptionsResolver';
 import {
   IStreamApiConfig,
+  MALFORMED_TOOL_USE_WARN_TAG,
   UNRECOGNIZED_EVENT_WARN_TAG,
   formatUnrecognizedEventPayloadPreview,
   openSseConnection,
@@ -330,14 +331,29 @@ async function* translateAnthropicStream(
           });
         } else if (block.type === 'text') {
           accumulationBuffer.set(index, { type: 'text', text: '' });
-        } else if (block.type === 'tool_use' && block.id && block.name) {
-          accumulationBuffer.set(index, {
-            type: 'tool_use',
-            id: block.id,
-            name: block.name,
-            argsBuffer: ''
-          });
-          yield { type: 'client-tool-call-start', toolName: block.name, callId: block.id };
+        } else if (block.type === 'tool_use') {
+          // A tool_use block_start MUST carry a non-empty id and name: the id is the
+          // sole correlation key for the follow-up tool_result, and dropping the block
+          // silently (then ignoring its input_json_delta chunks at the delta handler
+          // below) is exactly how an orphaned block leaves the harness without a clean
+          // id and corrupts the continuation. Surface it loudly instead of dropping it.
+          if (block.id && block.name) {
+            accumulationBuffer.set(index, {
+              type: 'tool_use',
+              id: block.id,
+              name: block.name,
+              argsBuffer: ''
+            });
+            yield { type: 'client-tool-call-start', toolName: block.name, callId: block.id };
+          } else {
+            logger?.warn(
+              `${MALFORMED_TOOL_USE_WARN_TAG} Anthropic streaming adapter: tool_use content_block_start ` +
+                `at index ${index} is missing a usable id and/or name ` +
+                `(id=${JSON.stringify(block.id)}, name=${JSON.stringify(block.name)}). ` +
+                `No client tool call will be issued for this block; its argument deltas are dropped. ` +
+                `This usually indicates provider drift or a truncated stream.`
+            );
+          }
         } else if (block.type === 'server_tool_use' && block.name === 'web_search') {
           yield { type: 'tool-event', toolType: 'web_search', phase: 'started' };
         } else if (block.type === 'web_search_tool_result') {

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
@@ -806,9 +806,12 @@ export function executeClientToolTurn(
     }
 
     // A bad id-correlation fails loud here rather than emitting a malformed
-    // continuation the provider would reject as a "malformed identifier".
+    // continuation the provider would reject as a "malformed identifier". Mirror
+    // the stream-open-failure path above: surface an `error` event so a consumer
+    // iterating `events` sees the failure inline, not only via `nextTurn`.
     if (continuationResult.isFailure()) {
       resolveNextTurn(fail(continuationResult.message));
+      yield { type: 'error', message: continuationResult.message };
       return;
     }
     let continuation = continuationResult.value;

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
@@ -82,11 +82,34 @@ interface IToolCallResult {
 // ============================================================================
 
 /**
+ * Returns `true` when `id` is a usable correlation id — present and non-empty.
+ *
+ * `??` is NOT sufficient for this check: an empty string is a *bad* id (a
+ * `tool_use_id: ''` is rejected by Anthropic as a "malformed identifier") but
+ * `'' ?? fallback` yields `''`, silently passing the empty id through. Every id
+ * correlation in this module must use this predicate, never `??`.
+ *
+ * @internal
+ */
+function isUsableId(id: string | undefined): id is string {
+  return id !== undefined && id.length > 0;
+}
+
+/**
  * Builds the Anthropic follow-up messages for a client-tool round-trip.
  *
  * Reconstructs the assistant turn from the ordered accumulation buffer
  * (all block types in original stream order) and appends a user turn
  * with `tool_result` blocks for each executed tool call.
+ *
+ * **Single source of truth for the id (id-correlation fix).** Each
+ * `tool_result.tool_use_id` is drawn from — and validated against — the set of
+ * assistant `tool_use.id`s actually present in the accumulation buffer. The id
+ * is NEVER derived from the tool name: a tool name can never match a `toolu_*`
+ * id, so a name fallback produces exactly the "malformed identifier" the
+ * provider rejects. If any tool result cannot be correlated to a buffered
+ * `tool_use` block with a non-empty id, the build fails loud (naming the tool)
+ * rather than emitting a malformed continuation.
  *
  * **Constraint (E3):** The returned continuation does NOT include a forced
  * `tool_choice` field. When thinking is active, Anthropic rejects
@@ -98,12 +121,16 @@ interface IToolCallResult {
  */
 export function buildAnthropicContinuation(
   accBuffer: Map<number, IAccumulatedBlock>,
-  toolResults: IToolCallResult[]
-): IAiClientToolContinuation {
+  toolResults: IToolCallResult[],
+  logger?: Logging.ILogger
+): Result<IAiClientToolContinuation> {
   // Reconstruct the assistant turn from the ordered accumulation buffer.
   // Sort by buffer key (SSE index) to restore original stream order.
   const sortedKeys = Array.from(accBuffer.keys()).sort((a, b) => a - b);
   const assistantContent: JsonArray = [];
+  // The set of assistant tool_use ids — the single source of truth every
+  // tool_result.tool_use_id must be drawn from.
+  const bufferedToolUseIds = new Set<string>();
 
   for (const key of sortedKeys) {
     const block = accBuffer.get(key);
@@ -125,6 +152,14 @@ export function buildAnthropicContinuation(
         assistantContent.push({ type: 'text', text: block.text });
       }
     } else if (block.type === 'tool_use') {
+      // A buffered tool_use with an empty id can never be referenced by a valid
+      // tool_result; emitting it would corrupt the assistant turn. Fail loud.
+      if (!isUsableId(block.id)) {
+        return fail(
+          `Anthropic continuation: buffered tool_use block for tool '${block.name}' has an empty id; ` +
+            `cannot build a valid continuation`
+        );
+      }
       let parsedInput: JsonObject;
       try {
         /* c8 ignore next 1 - defensive: argsBuffer is JSON-parsed in the adapter before emitting client-tool-call-done */
@@ -134,6 +169,7 @@ export function buildAnthropicContinuation(
         parsedInput = {};
       }
       /* c8 ignore stop */
+      bufferedToolUseIds.add(block.id);
       assistantContent.push({
         type: 'tool_use',
         id: block.id,
@@ -143,19 +179,41 @@ export function buildAnthropicContinuation(
     }
   }
 
-  // Build user turn with tool_result blocks for each tool call.
-  const userContent: JsonArray = toolResults.map((r): JsonObject => {
+  // Build user turn with tool_result blocks for each tool call. Correlate each
+  // result to a buffered tool_use id — the SAME id that keys the assistant
+  // tool_use block — and fail loud on a missing / empty / mismatched id. A
+  // missing callId is a bug to surface, not paper over with a name fallback.
+  const userContent: JsonArray = [];
+  for (const r of toolResults) {
+    if (!isUsableId(r.callId)) {
+      return fail(
+        `Anthropic continuation: tool '${r.toolName}' result has no call id (missing or empty); ` +
+          `cannot correlate it to an assistant tool_use block`
+      );
+    }
+    if (!bufferedToolUseIds.has(r.callId)) {
+      return fail(
+        `Anthropic continuation: tool '${r.toolName}' call id '${r.callId}' does not match any ` +
+          `buffered assistant tool_use block id`
+      );
+    }
     const block: JsonObject = {
       type: 'tool_result',
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      tool_use_id: r.callId ?? r.toolName,
+      tool_use_id: r.callId,
       content: r.result
     };
-    if (r.isError) {
-      return { ...block, is_error: true };
-    }
-    return block;
-  });
+    userContent.push(r.isError ? { ...block, is_error: true } : block);
+  }
+
+  // Decisive diagnostic: the tool_use.id ↔ tool_result.tool_use_id pairing for
+  // the outgoing continuation. A failing turn is field-confirmable by capturing
+  // this line (the pairing is by construction matched here — divergence fails
+  // loud above, before reaching this point).
+  if (logger) {
+    const pairing = toolResults.map((r) => `${r.toolName}:${r.callId}`).join(', ');
+    logger.detail(`ai-assist:anthropic-continuation tool_use.id↔tool_result.tool_use_id [${pairing}]`);
+  }
 
   const assistantMessage: JsonObject = {
     role: 'assistant',
@@ -166,7 +224,7 @@ export function buildAnthropicContinuation(
     content: userContent
   };
 
-  return {
+  return succeed({
     messages: [assistantMessage, userMessage],
     toolCallsSummary: toolResults.map((r) => ({
       toolName: r.toolName,
@@ -175,7 +233,7 @@ export function buildAnthropicContinuation(
       result: r.result,
       isError: r.isError
     }))
-  };
+  });
 }
 
 // ============================================================================
@@ -190,12 +248,20 @@ export function buildAnthropicContinuation(
  * `function_call_output` items (the harness execution result), one pair
  * per executed tool call.
  *
+ * **Single source of truth for the id (id-correlation fix).** Each
+ * `function_call_output.call_id` is drawn from — and validated against — the
+ * set of `function_call.call_id`s in the accumulation map. It is NEVER derived
+ * from the tool name (the OpenAI parity of the Anthropic `tool_use_id` fix). A
+ * missing / empty / unmatched call id fails the build loud rather than emitting
+ * a continuation the provider would reject.
+ *
  * @internal
  */
 export function buildOpenAiContinuation(
   calls: Map<string, IAccumulatedFunctionCall>,
-  toolResults: IToolCallResult[]
-): IAiClientToolContinuation {
+  toolResults: IToolCallResult[],
+  logger?: Logging.ILogger
+): Result<IAiClientToolContinuation> {
   const items: JsonObject[] = [];
 
   // Emit function_call items for each call (model's side). Per the Responses API spec
@@ -203,7 +269,9 @@ export function buildOpenAiContinuation(
   // match the matching function_call_output's `call_id` below. The optional `id` field
   // is the output-item id (`fc_*`) used to reference the streamed item; we omit it
   // because it is not load-bearing for input items.
+  const bufferedCallIds = new Set<string>();
   for (const [callId, call] of calls) {
+    bufferedCallIds.add(callId);
     items.push({
       type: 'function_call',
       call_id: callId,
@@ -212,16 +280,37 @@ export function buildOpenAiContinuation(
     });
   }
 
-  // Emit function_call_output items (harness execution results).
+  // Emit function_call_output items (harness execution results). Correlate each
+  // to a buffered function_call call_id — never the tool name — and fail loud on
+  // a missing / empty / mismatched id.
   for (const r of toolResults) {
+    if (!isUsableId(r.callId)) {
+      return fail(
+        `OpenAI continuation: tool '${r.toolName}' result has no call id (missing or empty); ` +
+          `cannot correlate it to a function_call item`
+      );
+    }
+    if (!bufferedCallIds.has(r.callId)) {
+      return fail(
+        `OpenAI continuation: tool '${r.toolName}' call id '${r.callId}' does not match any ` +
+          `accumulated function_call call_id`
+      );
+    }
     items.push({
       type: 'function_call_output',
-      call_id: r.callId ?? r.toolName,
+      call_id: r.callId,
       output: r.result
     });
   }
 
-  return {
+  // Decisive diagnostic: the function_call.call_id ↔ function_call_output.call_id
+  // pairing for the outgoing continuation (matched by construction here).
+  if (logger) {
+    const pairing = toolResults.map((r) => `${r.toolName}:${r.callId}`).join(', ');
+    logger.detail(`ai-assist:openai-continuation function_call.call_id↔output.call_id [${pairing}]`);
+  }
+
+  return succeed({
     messages: items,
     toolCallsSummary: toolResults.map((r) => ({
       toolName: r.toolName,
@@ -230,7 +319,7 @@ export function buildOpenAiContinuation(
       result: r.result,
       isError: r.isError
     }))
-  };
+  });
 }
 
 // ============================================================================
@@ -695,16 +784,18 @@ export function executeClientToolTurn(
       return;
     }
 
-    let continuation: IAiClientToolContinuation;
+    let continuationResult: Result<IAiClientToolContinuation>;
     switch (descriptor.apiFormat) {
       case 'anthropic':
-        continuation = buildAnthropicContinuation(anthropicBuffer, toolResults);
+        continuationResult = buildAnthropicContinuation(anthropicBuffer, toolResults, logger);
         break;
       case 'openai':
-        continuation = buildOpenAiContinuation(openAiCallMap, toolResults);
+        continuationResult = buildOpenAiContinuation(openAiCallMap, toolResults, logger);
         break;
       case 'gemini':
-        continuation = buildGeminiContinuation(geminiCalls, toolResults);
+        // Gemini correlates by tool name by design (no call ids) — its builder
+        // cannot mis-key and stays non-fallible.
+        continuationResult = succeed(buildGeminiContinuation(geminiCalls, toolResults));
         break;
       /* c8 ignore next 5 - defensive coding: exhaustive switch guaranteed by TypeScript */
       default: {
@@ -713,6 +804,14 @@ export function executeClientToolTurn(
         return;
       }
     }
+
+    // A bad id-correlation fails loud here rather than emitting a malformed
+    // continuation the provider would reject as a "malformed identifier".
+    if (continuationResult.isFailure()) {
+      resolveNextTurn(fail(continuationResult.message));
+      return;
+    }
+    let continuation = continuationResult.value;
 
     // Prepend inbound continuationMessages so the returned continuation is cumulative.
     // A consumer that does `tail = outcome.continuation.messages` (replace) is then

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/common.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/common.ts
@@ -103,6 +103,20 @@ export interface IStreamApiConfig {
 export const UNRECOGNIZED_EVENT_WARN_TAG: string = 'ai-assist:unrecognized-event';
 
 /**
+ * Stable prefix every "malformed tool_use block" warning starts with. Emitted
+ * when a streaming adapter sees a client tool_use `content_block_start` that is
+ * missing a usable correlation id and/or name — a block that, if silently
+ * dropped, would orphan its argument deltas and corrupt the follow-up tool
+ * continuation (the id-correlation defect class). Production deployments can
+ * filter / alert on this exact substring. Distinct from
+ * {@link UNRECOGNIZED_EVENT_WARN_TAG} (which is for unrecognized SSE *event
+ * names*); this is a malformed *payload* of a recognized event.
+ *
+ * @internal
+ */
+export const MALFORMED_TOOL_USE_WARN_TAG: string = 'ai-assist:malformed-tool-use';
+
+/**
  * Maximum characters of raw SSE payload to include in the
  * {@link UNRECOGNIZED_EVENT_WARN_TAG} warning when raw-preview mode is opted in
  * via {@link UNRECOGNIZED_EVENT_FULL_PAYLOAD_ENV_VAR}. Long enough to identify

--- a/libraries/ts-extras/src/test/unit/ai-assist/clientToolContinuationBuilder.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/clientToolContinuationBuilder.test.ts
@@ -24,7 +24,7 @@
 
 import '@fgv/ts-utils-jest';
 
-import { fail, succeed } from '@fgv/ts-utils';
+import { fail, Logging, succeed } from '@fgv/ts-utils';
 import { type JsonObject, JsonSchema } from '@fgv/ts-json-base';
 // eslint-disable-next-line @rushstack/packlets/mechanics
 import {
@@ -160,7 +160,7 @@ describe('buildAnthropicContinuation', () => {
         }
       ];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
 
       expect(cont.messages).toHaveLength(2);
       const assistantMsg = cont.messages[0];
@@ -192,7 +192,7 @@ describe('buildAnthropicContinuation', () => {
         { toolName: 'recall', callId: 'toolu_02', args: {}, result: '"found"', isError: false }
       ];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
       const assistantContent = cont.messages[0].content as unknown[];
       expect(assistantContent).toHaveLength(2);
       expect((assistantContent[0] as Record<string, unknown>).type).toBe('text');
@@ -209,7 +209,7 @@ describe('buildAnthropicContinuation', () => {
         { toolName: 'recall', callId: 'toolu_03', args: {}, result: '"found"', isError: false }
       ];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
       const assistantContent = cont.messages[0].content as unknown[];
       expect(assistantContent).toHaveLength(1);
       expect((assistantContent[0] as Record<string, unknown>).type).toBe('tool_use');
@@ -223,7 +223,7 @@ describe('buildAnthropicContinuation', () => {
         { toolName: 'recall', callId: 'toolu_04', args: {}, result: '"found"', isError: false }
       ];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
       // Neither the assistant message nor the user message should carry a tool_choice field.
       for (const msg of cont.messages) {
         expect(Object.keys(msg)).not.toContain('tool_choice');
@@ -243,7 +243,7 @@ describe('buildAnthropicContinuation', () => {
         { toolName: 'recall', callId: 'toolu_05', args: { q: 'x' }, result: '"result"', isError: false }
       ];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
       const assistantContent = cont.messages[0].content as unknown[];
       expect(assistantContent).toHaveLength(2);
       expect((assistantContent[0] as Record<string, unknown>).type).toBe('thinking');
@@ -262,7 +262,7 @@ describe('buildAnthropicContinuation', () => {
 
       const results = [{ toolName: 'recall', callId: 'toolu_06', args: {}, result: '"x"', isError: false }];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
       const assistantContent = cont.messages[0].content as unknown[];
       expect((assistantContent[0] as Record<string, unknown>).signature).toBe(fullSignature);
     });
@@ -274,7 +274,7 @@ describe('buildAnthropicContinuation', () => {
 
       const results = [{ toolName: 'recall', callId: 'toolu_07', args: {}, result: '"x"', isError: false }];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
       const assistantContent = cont.messages[0].content as unknown[];
       expect((assistantContent[0] as Record<string, unknown>).type).toBe('redacted_thinking');
       expect((assistantContent[0] as Record<string, unknown>).data).toBe('opaque-encrypted-string');
@@ -294,7 +294,7 @@ describe('buildAnthropicContinuation', () => {
         { toolName: 'recall', callId: 'toolu_b', args: { q: 'b' }, result: '"res-b"', isError: false }
       ];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
       const assistantContent = cont.messages[0].content as unknown[];
       // Must preserve original interleaved order: thinking, text, tool_use, thinking, tool_use
       expect(assistantContent).toHaveLength(5);
@@ -320,7 +320,7 @@ describe('buildAnthropicContinuation', () => {
         { toolName: 'search', callId: 'toolu_p2', args: { q: 'p2' }, result: '"r2"', isError: false }
       ];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
       expect(cont.messages).toHaveLength(2);
       const assistantContent = cont.messages[0].content as unknown[];
       expect(assistantContent).toHaveLength(3);
@@ -341,7 +341,7 @@ describe('buildAnthropicContinuation', () => {
 
       const results = [{ toolName: 'recall', callId: 'toolu_08', args: {}, result: '"x"', isError: false }];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
       for (const msg of cont.messages) {
         expect(Object.keys(msg)).not.toContain('tool_choice');
       }
@@ -358,30 +358,75 @@ describe('buildAnthropicContinuation', () => {
         { toolName: 'recall', callId: 'toolu_err', args: {}, result: 'validation failed', isError: true }
       ];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
       const userContent = cont.messages[1].content as unknown[];
       expect((userContent[0] as Record<string, unknown>).is_error).toBe(true);
       expect((userContent[0] as Record<string, unknown>).content).toBe('validation failed');
     });
 
-    test('uses toolName as tool_use_id fallback when callId is absent', () => {
+    // ----------------------------------------------------------------------
+    // id-correlation: divergence repro (the production "malformed identifier"
+    // bug). Before the fix, a missing/empty/mismatched callId was masked by a
+    // `?? toolName` fallback that emitted the tool *name* as the tool_use_id —
+    // a value that can never match a `toolu_*` id. The build must now fail loud
+    // rather than mis-key.
+    // ----------------------------------------------------------------------
+    interface ILooseToolResult {
+      toolName: string;
+      callId?: string;
+      args: JsonObject;
+      result: string;
+      isError: boolean;
+    }
+
+    test('fails loud (does NOT fall back to toolName) when callId is absent', () => {
       const buffer = new Map<number, IAccumulatedBlock>();
       buffer.set(0, { type: 'tool_use', id: 'toolu_noid', name: 'recall', argsBuffer: '{}' });
 
-      const results = [
+      const results: ILooseToolResult[] = [
         // callId omitted (undefined)
-        { toolName: 'recall', args: {} as JsonObject, result: '"x"', isError: false } as {
-          toolName: string;
-          callId?: string;
-          args: JsonObject;
-          result: string;
-          isError: boolean;
-        }
+        { toolName: 'recall', args: {}, result: '"x"', isError: false }
       ];
 
-      const cont = buildAnthropicContinuation(buffer, results);
-      const userContent = cont.messages[1].content as unknown[];
-      expect((userContent[0] as Record<string, unknown>).tool_use_id).toBe('recall');
+      expect(buildAnthropicContinuation(buffer, results)).toFailWith(/recall.*no call id.*missing or empty/i);
+    });
+
+    test('fails loud when callId is the empty string (?? would not catch it)', () => {
+      const buffer = new Map<number, IAccumulatedBlock>();
+      buffer.set(0, { type: 'tool_use', id: 'toolu_empty', name: 'recall', argsBuffer: '{}' });
+
+      const results: ILooseToolResult[] = [
+        { toolName: 'recall', callId: '', args: {}, result: '"x"', isError: false }
+      ];
+
+      expect(buildAnthropicContinuation(buffer, results)).toFailWith(/recall.*no call id.*missing or empty/i);
+    });
+
+    test('fails loud when callId does not match any buffered tool_use block id', () => {
+      const buffer = new Map<number, IAccumulatedBlock>();
+      buffer.set(0, { type: 'tool_use', id: 'toolu_real', name: 'recall', argsBuffer: '{}' });
+
+      const results = [
+        { toolName: 'recall', callId: 'toolu_mismatch', args: {}, result: '"x"', isError: false }
+      ];
+
+      expect(buildAnthropicContinuation(buffer, results)).toFailWith(
+        /recall.*toolu_mismatch.*does not match any buffered/i
+      );
+    });
+
+    test('fails loud when a buffered tool_use block has an empty id', () => {
+      const buffer = new Map<number, IAccumulatedBlock>();
+      // A tool_use block that somehow reached the buffer with an empty id can
+      // never be referenced by a valid tool_result — emitting it would corrupt
+      // the assistant turn.
+      buffer.set(0, { type: 'tool_use', id: '', name: 'recall', argsBuffer: '{}' });
+
+      const results = [{ toolName: 'recall', callId: '', args: {}, result: '"x"', isError: false }];
+
+      expect(buildAnthropicContinuation(buffer, results)).toFailWith(
+        /buffered tool_use block.*recall.*empty id/i
+      );
     });
   });
 
@@ -394,13 +439,70 @@ describe('buildAnthropicContinuation', () => {
         { toolName: 'recall', callId: 'toolu_sum', args: { q: 'summary' }, result: '"data"', isError: false }
       ];
 
-      const cont = buildAnthropicContinuation(buffer, results);
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
       expect(cont.toolCallsSummary).toHaveLength(1);
       expect(cont.toolCallsSummary[0].toolName).toBe('recall');
       expect(cont.toolCallsSummary[0].callId).toBe('toolu_sum');
       expect(cont.toolCallsSummary[0].args).toEqual({ q: 'summary' });
       expect(cont.toolCallsSummary[0].result).toBe('"data"');
       expect(cont.toolCallsSummary[0].isError).toBe(false);
+    });
+  });
+
+  describe('id-correlation: tool_use.id === tool_result.tool_use_id (single source of truth)', () => {
+    // The continuation MUST key every tool_result.tool_use_id off the assistant
+    // tool_use.id from the buffer — never the tool name. These assert the positive
+    // invariant for single and parallel tool calls.
+    function toolUseIds(cont: { messages: ReadonlyArray<JsonObject> }): string[] {
+      const content = cont.messages[0].content as Record<string, unknown>[];
+      return content.filter((b) => b.type === 'tool_use').map((b) => b.id as string);
+    }
+    function toolResultIds(cont: { messages: ReadonlyArray<JsonObject> }): string[] {
+      const content = cont.messages[1].content as Record<string, unknown>[];
+      return content.map((b) => b.tool_use_id as string);
+    }
+
+    test('single call: tool_result.tool_use_id equals the assistant tool_use.id', () => {
+      const buffer = new Map<number, IAccumulatedBlock>();
+      buffer.set(0, { type: 'tool_use', id: 'toolu_single', name: 'recall', argsBuffer: '{}' });
+      const results = [
+        { toolName: 'recall', callId: 'toolu_single', args: {}, result: '"x"', isError: false }
+      ];
+
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
+      expect(toolUseIds(cont)).toEqual(['toolu_single']);
+      expect(toolResultIds(cont)).toEqual(['toolu_single']);
+    });
+
+    test('parallel calls: each tool_result.tool_use_id equals its assistant tool_use.id', () => {
+      const buffer = new Map<number, IAccumulatedBlock>();
+      buffer.set(0, { type: 'tool_use', id: 'toolu_a', name: 'recall', argsBuffer: '{}' });
+      buffer.set(1, { type: 'tool_use', id: 'toolu_b', name: 'search', argsBuffer: '{}' });
+      // Supply results out of buffer order to prove correlation is by id, not position.
+      const results = [
+        { toolName: 'search', callId: 'toolu_b', args: {}, result: '"rb"', isError: false },
+        { toolName: 'recall', callId: 'toolu_a', args: {}, result: '"ra"', isError: false }
+      ];
+
+      const cont = buildAnthropicContinuation(buffer, results).orThrow();
+      expect(toolUseIds(cont).sort()).toEqual(['toolu_a', 'toolu_b']);
+      // tool_result order follows toolResults order; ids must match their own call.
+      expect(toolResultIds(cont)).toEqual(['toolu_b', 'toolu_a']);
+    });
+  });
+
+  describe('diagnostic logging', () => {
+    test('logs the tool_use.id ↔ tool_result.tool_use_id pairing at detail level', () => {
+      const buffer = new Map<number, IAccumulatedBlock>();
+      buffer.set(0, { type: 'tool_use', id: 'toolu_diag', name: 'recall', argsBuffer: '{}' });
+      const results = [{ toolName: 'recall', callId: 'toolu_diag', args: {}, result: '"x"', isError: false }];
+
+      const logger = new Logging.InMemoryLogger('all');
+      expect(buildAnthropicContinuation(buffer, results, logger)).toSucceed();
+
+      const line = logger.logged.find((m) => m.includes('ai-assist:anthropic-continuation'));
+      expect(line).toBeDefined();
+      expect(line).toContain('recall:toolu_diag');
     });
   });
 });
@@ -424,7 +526,7 @@ describe('buildOpenAiContinuation', () => {
       }
     ];
 
-    const cont = buildOpenAiContinuation(calls, results);
+    const cont = buildOpenAiContinuation(calls, results).orThrow();
     expect(cont.messages).toHaveLength(2);
     // Per ResponseFunctionToolCall spec, call_id is the required correlation field
     // and must match the matching function_call_output's call_id below. The optional
@@ -450,7 +552,7 @@ describe('buildOpenAiContinuation', () => {
       { toolName: 'search', callId: 'call_2', args: { q: 'b' }, result: '"r2"', isError: false }
     ];
 
-    const cont = buildOpenAiContinuation(calls, results);
+    const cont = buildOpenAiContinuation(calls, results).orThrow();
     expect(cont.messages).toHaveLength(4);
     const functionCallItems = cont.messages.filter((m) => m.type === 'function_call');
     const outputItems = cont.messages.filter((m) => m.type === 'function_call_output');
@@ -470,15 +572,17 @@ describe('buildOpenAiContinuation', () => {
 
     const results = [{ toolName: 'recall', callId: 'call_s', args: {}, result: '"x"', isError: false }];
 
-    const cont = buildOpenAiContinuation(calls, results);
+    const cont = buildOpenAiContinuation(calls, results).orThrow();
     expect(cont.toolCallsSummary).toHaveLength(1);
     expect(cont.toolCallsSummary[0].toolName).toBe('recall');
     expect(cont.toolCallsSummary[0].callId).toBe('call_s');
   });
 
-  test('uses toolName as call_id fallback when callId is absent', () => {
+  // OpenAI parity for the id-correlation fix: never key function_call_output by
+  // tool name; fail loud on a missing / empty / mismatched call_id.
+  test('fails loud (does NOT fall back to toolName) when callId is absent', () => {
     const calls = new Map<string, IAccumulatedFunctionCall>();
-    calls.set('recall', { id: 'recall', name: 'recall', argsBuffer: '{}' });
+    calls.set('call_real', { id: 'call_real', name: 'recall', argsBuffer: '{}' });
 
     const results = [
       { toolName: 'recall', args: {} as JsonObject, result: '"x"', isError: false } as {
@@ -490,8 +594,40 @@ describe('buildOpenAiContinuation', () => {
       }
     ];
 
-    const cont = buildOpenAiContinuation(calls, results);
-    expect(cont.messages[1].call_id).toBe('recall');
+    expect(buildOpenAiContinuation(calls, results)).toFailWith(/recall.*no call id.*missing or empty/i);
+  });
+
+  test('fails loud when callId is the empty string', () => {
+    const calls = new Map<string, IAccumulatedFunctionCall>();
+    calls.set('call_real', { id: 'call_real', name: 'recall', argsBuffer: '{}' });
+
+    const results = [{ toolName: 'recall', callId: '', args: {}, result: '"x"', isError: false }];
+
+    expect(buildOpenAiContinuation(calls, results)).toFailWith(/recall.*no call id.*missing or empty/i);
+  });
+
+  test('fails loud when callId does not match any accumulated function_call call_id', () => {
+    const calls = new Map<string, IAccumulatedFunctionCall>();
+    calls.set('call_real', { id: 'call_real', name: 'recall', argsBuffer: '{}' });
+
+    const results = [{ toolName: 'recall', callId: 'call_ghost', args: {}, result: '"x"', isError: false }];
+
+    expect(buildOpenAiContinuation(calls, results)).toFailWith(
+      /recall.*call_ghost.*does not match any accumulated/i
+    );
+  });
+
+  test('logs the function_call.call_id ↔ output.call_id pairing at detail level', () => {
+    const calls = new Map<string, IAccumulatedFunctionCall>();
+    calls.set('call_diag', { id: 'call_diag', name: 'recall', argsBuffer: '{}' });
+    const results = [{ toolName: 'recall', callId: 'call_diag', args: {}, result: '"x"', isError: false }];
+
+    const logger = new Logging.InMemoryLogger('all');
+    expect(buildOpenAiContinuation(calls, results, logger)).toSucceed();
+
+    const line = logger.logged.find((m) => m.includes('ai-assist:openai-continuation'));
+    expect(line).toBeDefined();
+    expect(line).toContain('recall:call_diag');
   });
 });
 
@@ -862,6 +998,52 @@ describe('executeClientToolTurn', () => {
   });
 
   // --------------------------------------------------------------------------
+
+  describe('id-correlation failure surfaces through nextTurn (defense-in-depth)', () => {
+    test('fails nextTurn loud when an executed tool result cannot be correlated to a buffered tool_use id', async () => {
+      // Drive a buffer-index collision: two tool_use blocks reuse SSE index 0, so
+      // the executed result (toolu_A) is keyed to a buffer entry that the later
+      // block (toolu_B) overwrote. The builder must fail loud rather than emit a
+      // continuation whose tool_result references an id absent from the assistant
+      // turn — exactly the "malformed identifier" class. End-to-end proof that the
+      // single-source-of-truth guard wires through executeClientToolTurn.
+      const sse = [
+        `event: content_block_start\ndata: ${JSON.stringify({
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_A', name: 'recall_memory' }
+        })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '{"query":"a"}' }
+        })}\n\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ index: 0 })}\n\n`,
+        // Second tool_use reuses index 0, overwriting toolu_A in the buffer.
+        `event: content_block_start\ndata: ${JSON.stringify({
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_B', name: 'recall_memory' }
+        })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({ delta: { stop_reason: 'tool_use' } })}\n\n`,
+        `event: message_stop\ndata: {}\n\n`
+      ];
+      mockSseResponse(sse);
+      const tool = makeMemoryTool(async (args) => `result-${args.query}`);
+
+      const result = executeClientToolTurn({
+        descriptor: makeAnthropicDescriptor(),
+        apiKey: 'test-key',
+        ...testPrompt.toRequest(),
+        clientTools: [tool] as IAiClientTool[],
+        model: 'claude-sonnet-4-6'
+      });
+      expect(result).toSucceed();
+      if (result.isFailure()) return;
+
+      await collect(result.value.events);
+      const turnResult = await result.value.nextTurn;
+
+      expect(turnResult).toFailWith(/toolu_A.*does not match any buffered/i);
+    });
+  });
 
   describe('happy-path round-trip (Anthropic)', () => {
     test('executes memory tool and resolves nextTurn with continuation', async () => {

--- a/libraries/ts-extras/src/test/unit/ai-assist/clientToolContinuationBuilder.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/clientToolContinuationBuilder.test.ts
@@ -364,13 +364,9 @@ describe('buildAnthropicContinuation', () => {
       expect((userContent[0] as Record<string, unknown>).content).toBe('validation failed');
     });
 
-    // ----------------------------------------------------------------------
-    // id-correlation: divergence repro (the production "malformed identifier"
-    // bug). Before the fix, a missing/empty/mismatched callId was masked by a
-    // `?? toolName` fallback that emitted the tool *name* as the tool_use_id —
-    // a value that can never match a `toolu_*` id. The build must now fail loud
-    // rather than mis-key.
-    // ----------------------------------------------------------------------
+    // id-correlation divergence repro (the production "malformed identifier" bug):
+    // a missing/empty/mismatched callId was masked by a `?? toolName` fallback that
+    // emitted the tool name (never a toolu_* id). The build must now fail loud.
     interface ILooseToolResult {
       toolName: string;
       callId?: string;
@@ -453,13 +449,14 @@ describe('buildAnthropicContinuation', () => {
     // The continuation MUST key every tool_result.tool_use_id off the assistant
     // tool_use.id from the buffer — never the tool name. These assert the positive
     // invariant for single and parallel tool calls.
+    const asString = (v: unknown): string => (typeof v === 'string' ? v : '');
     function toolUseIds(cont: { messages: ReadonlyArray<JsonObject> }): string[] {
       const content = cont.messages[0].content as Record<string, unknown>[];
-      return content.filter((b) => b.type === 'tool_use').map((b) => b.id as string);
+      return content.filter((b) => b.type === 'tool_use').map((b) => asString(b.id));
     }
     function toolResultIds(cont: { messages: ReadonlyArray<JsonObject> }): string[] {
       const content = cont.messages[1].content as Record<string, unknown>[];
-      return content.map((b) => b.tool_use_id as string);
+      return content.map((b) => asString(b.tool_use_id));
     }
 
     test('single call: tool_result.tool_use_id equals the assistant tool_use.id', () => {
@@ -1038,10 +1035,15 @@ describe('executeClientToolTurn', () => {
       expect(result).toSucceed();
       if (result.isFailure()) return;
 
-      await collect(result.value.events);
+      const events = await collect(result.value.events);
       const turnResult = await result.value.nextTurn;
 
       expect(turnResult).toFailWith(/toolu_A.*does not match any buffered/i);
+      // The failure also surfaces inline on the event stream (parity with the
+      // stream-open-failure path), not only via nextTurn.
+      expect(events.some((e) => e.type === 'error' && /does not match any buffered/i.test(e.message))).toBe(
+        true
+      );
     });
   });
 

--- a/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
@@ -27,6 +27,7 @@
 
 import '@fgv/ts-utils-jest';
 
+import { Logging } from '@fgv/ts-utils';
 import { AiAssist } from '../../..';
 import type { JsonArray, JsonObject } from '@fgv/ts-json-base';
 // eslint-disable-next-line @rushstack/packlets/mechanics
@@ -796,6 +797,71 @@ describe('Anthropic streaming adapter — C2 client tool extensions', () => {
     expect(types).toContain('client-tool-call-done');
     expect(types).toContain('text-delta');
     expect(types[types.length - 1]).toBe('done');
+  });
+
+  // --------------------------------------------------------------------------
+  // Orphaned tool_use block: a tool_use content_block_start missing a usable id
+  // and/or name must NOT be silently dropped. The id is the sole correlation key
+  // for the follow-up tool_result; a silent drop (and the subsequent silent
+  // ignore of its input_json_delta chunks) is the path that leaves the harness
+  // without a clean id and corrupts the continuation. The adapter must surface it
+  // loudly (logger.warn with the stable MALFORMED_TOOL_USE_WARN_TAG prefix) and
+  // issue no client tool call for the block.
+  // --------------------------------------------------------------------------
+
+  async function runOrphanedToolUse(
+    contentBlock: JsonObject,
+    logger?: Logging.InMemoryLogger
+  ): Promise<{ emitted: AiAssist.IAiStreamEvent[]; accBuffer: Map<number, IAccumulatedBlock> }> {
+    const accBuffer = new Map<number, IAccumulatedBlock>();
+    mockSseResponse([
+      `event: content_block_start\ndata: ${JSON.stringify({ index: 0, content_block: contentBlock })}\n\n`,
+      // A delta for the orphaned index must be harmlessly ignored (no buffer entry to attach to).
+      `event: content_block_delta\ndata: ${JSON.stringify({
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '{"q":"v"}' }
+      })}\n\n`,
+      `event: content_block_stop\ndata: ${JSON.stringify({ index: 0 })}\n\n`,
+      `event: message_stop\ndata: ${JSON.stringify({})}\n\n`
+    ]);
+    const { callAnthropicStream } = await import('../../../packlets/ai-assist/streamingAdapters/anthropic');
+    const streamResult = await callAnthropicStream(
+      { baseUrl: 'https://api.anthropic.com/v1', model: 'claude-3-5-sonnet-20241022', apiKey: 'sk-test' },
+      TEST_PROMPT,
+      undefined,
+      0.5,
+      undefined,
+      logger,
+      undefined,
+      undefined,
+      accBuffer
+    );
+    expect(streamResult).toSucceed();
+    const emitted = streamResult.isSuccess() ? await collect(streamResult.value) : [];
+    // The orphaned block issues no tool call and leaves no buffer entry.
+    expect(emitted.some((e) => e.type === 'client-tool-call-start')).toBe(false);
+    expect(emitted.some((e) => e.type === 'client-tool-call-done')).toBe(false);
+    expect(accBuffer.size).toBe(0);
+    return { emitted, accBuffer };
+  }
+
+  test('surfaces (not drops) a tool_use content_block_start missing its name', async () => {
+    const logger = new Logging.InMemoryLogger('all');
+    await runOrphanedToolUse({ type: 'tool_use', id: 'toolu_x' }, logger);
+    const warned = logger.logged.find((m) => m.includes('ai-assist:malformed-tool-use'));
+    expect(warned).toBeDefined();
+    expect(warned).toMatch(/missing a usable id and\/or name/i);
+  });
+
+  test('surfaces (not drops) a tool_use content_block_start missing its id', async () => {
+    const logger = new Logging.InMemoryLogger('all');
+    await runOrphanedToolUse({ type: 'tool_use', name: 'do_thing' }, logger);
+    expect(logger.logged.some((m) => m.includes('ai-assist:malformed-tool-use'))).toBe(true);
+  });
+
+  test('orphaned tool_use block is handled without a logger (no throw, no tool call)', async () => {
+    // No logger supplied — covers the logger?. undefined branch; must not throw.
+    await runOrphanedToolUse({ type: 'tool_use', id: 'toolu_x' });
   });
 
   test('appends continuationMessages as rawTail after the prompt user message (C4)', async () => {

--- a/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/streamingAdapters.test.ts
@@ -859,6 +859,14 @@ describe('Anthropic streaming adapter — C2 client tool extensions', () => {
     expect(logger.logged.some((m) => m.includes('ai-assist:malformed-tool-use'))).toBe(true);
   });
 
+  test('surfaces (not drops) a tool_use content_block_start with an empty-string id', async () => {
+    // Empty string is a *bad* id, not a present one. Guards the contract against a
+    // future refactor to `id !== undefined` that would reintroduce the malformed-id bug.
+    const logger = new Logging.InMemoryLogger('all');
+    await runOrphanedToolUse({ type: 'tool_use', id: '', name: 'do_thing' }, logger);
+    expect(logger.logged.some((m) => m.includes('ai-assist:malformed-tool-use'))).toBe(true);
+  });
+
   test('orphaned tool_use block is handled without a logger (no throw, no tool call)', async () => {
     // No logger supplied — covers the logger?. undefined branch; must not throw.
     await runOrphanedToolUse({ type: 'tool_use', id: 'toolu_x' });


### PR DESCRIPTION
## Summary

Fixes the production bug reported by PersonAIlity: Anthropic intermittently returns
`invalid Prompt - malformed identifier`, **only** on turns where the model calls a client tool
(more tools offered → more frequent). A direct-answer turn on the same agent/model succeeds.

This is a **bug-fix + hardening + root-cause** change to `@fgv/ts-extras`'s `ai-assist` packlet
(active surface). It is **additive / type-only at the public boundary** — the api-extractor report
is unchanged (`executeClientToolTurn`'s signature is untouched; the affected builders are
internal-only exports). No behavior change beyond the id-correlation fix + the diagnostic.

## Root cause

The per-provider continuation builders never enforced that each `tool_result.tool_use_id`
(Anthropic) / `function_call_output.call_id` (OpenAI) is drawn from the set of assistant
`tool_use.id`s actually present in the accumulation buffer. They keyed the id off the tool-result
record with `tool_use_id: r.callId ?? r.toolName`. Two compounding defects:

1. **Name fallback (`?? r.toolName`)** — when `callId` is nullish, the builder emitted the tool
   *name* as the id. A tool name is never a `toolu_*` / `call_*` id, so the provider rejects it as
   a "malformed identifier".
2. **`??` does not treat empty-string as missing** — an empty id flows straight through as
   `tool_use_id: ''`, also malformed, with no fallback even firing.

Because the builder trusted `callId` blindly and never cross-checked it against the buffered
assistant `tool_use.id`s, **any** upstream loss/divergence of the id surfaced as a malformed wire
body at the provider instead of a loud, field-attributable failure in our code. The identified
upstream divergence path is the **silent orphaned-block drop** in `anthropic.ts`: a `tool_use`
`content_block_start` that failed the `block.id && block.name` guard was dropped from the buffer
with no diagnostic, and its subsequent `input_json_delta` chunks were then silently ignored.

**Honest scope note on the live trigger:** within a single well-formed Anthropic stream the
adapter's own guard means `callId` always equals a buffered id, so the pure single-turn path
can't fire the bug. The decisive end-to-end-reproducible divergence is **buffer-index reuse**
(captured as a test). Rather than pin a single live trigger speculatively, the fix makes every
such loss loud and impossible to mis-key, and adds a field-confirmable diagnostic so the consumer
can corroborate on a live failing turn by capturing the request body. Full write-up in
`.ai/tasks/active/ai-assist-client-tool-id-fix/state.md`.

## Fix

1. **Single source of truth.** `buildAnthropicContinuation` / `buildOpenAiContinuation` now return
   `Result<IAiClientToolContinuation>` and validate that every result's `callId` is non-empty
   **and** present in the set of buffered assistant tool_use ids; otherwise they fail loud (naming
   the tool + offending id). `tool_use_id` / `call_id` is taken from the verified `callId` —
   **never** `toolName`.
2. **Empty-string = missing.** New `isUsableId(id)` predicate replaces every `??`-based id check.
3. **No silent drop.** `anthropic.ts` now emits a loud `logger.warn` (new stable
   `MALFORMED_TOOL_USE_WARN_TAG = 'ai-assist:malformed-tool-use'`) for an orphaned `tool_use`
   block instead of dropping it.
4. **OpenAI parity** — same correlation on the Responses path.
5. **Decisive diagnostic** — both builders log the outgoing id↔id pairing at `detail` (debug) level
   when a logger is supplied; `executeClientToolTurn` threads its logger through and now also yields
   an inline `error` event on a bad correlation (parity with the stream-open-failure path).

The Gemini builder is intentionally unchanged (correlates by tool name by design — Gemini has no
call ids).

## Tests

- **Divergence repro → now fails loud (not mis-keys):** absent / empty-string / mismatched callId,
  and empty buffered tool_use id — each fails loud (replaces the old "uses toolName as fallback"
  tests). OpenAI parity for the same paths.
- **Happy-path id-equality:** `tool_use.id === tool_use_id` for single + parallel calls (parallel
  supplied out of buffer order to prove correlation is by id, not position).
- **Orphaned-block:** missing id / missing name → `logger.warn` with the tag, no tool call, empty
  buffer; plus a no-logger variant.
- **End-to-end fail-loud through `executeClientToolTurn`:** buffer-index-reuse SSE → `nextTurn`
  fails loud and an inline `error` event is emitted.
- **Diagnostic logging** asserted for both builders.

## Gates

- `rushx build` ✅ · `rushx lint` ✅ (after `fixlint`) · `rushx test` ✅ — **100%** statements /
  branches / functions / lines in `@fgv/ts-extras`.
- api-extractor report unchanged → no public-surface change.

## Review loop

- **Internal `code-reviewer` pass run on the final diff before opening this PR.** Findings: **no
  P1**, two P2, two P3.
  - P2 (no `error` event yielded on continuation failure) — **fixed** (now yields inline error).
  - P2 (add `c8 ignore` to the empty-id buffer guard) — **dispositioned: declined**; the branch is
    *tested* and coverage is 100% without a directive (directives are for unreachable code).
  - P3 (unsafe `as string` in a test helper) — **fixed** (typeof guard).
  - P3 (diagnostic could log an empty pairing for a direct caller) — **dispositioned: declined**;
    unreachable via `executeClientToolTurn`, guarding would add an untested branch.

## Scope held

Out: the Gemini builder (name-correlated by design); any alias refactor (separate stream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2EBCaYjg9YveM8NPsEFLr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-call correlation during AI-assisted streaming so matching IDs are required and mismatches now fail clearly instead of falling back silently.
  * Malformed tool-use blocks now trigger a visible warning and no longer disappear without notice.
  * Continuation errors are now surfaced inline in the event stream, making failures easier to detect and debug.
  * Added stronger validation for parallel and single tool-call flows to prevent incorrect tool-result pairing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->