### PR TITLE
ts-utils: add enumerable-union arrays, converters, and exhaustiveness guards

### DIFF
--- a/common/changes/@fgv/ts-utils/claude-ts-utils-enum-exports-gk0vbw_2026-07-04-17-09.json
+++ b/common/changes/@fgv/ts-utils/claude-ts-utils-enum-exports-gk0vbw_2026-07-04-17-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add enumerable-union arrays, converters, and exhaustiveness guards to @fgv/ts-utils",
+      "type": "minor",
+      "packageName": "@fgv/ts-utils"
+    }
+  ],
+  "packageName": "@fgv/ts-utils",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-utils/etc/ts-utils.api.md
+++ b/libraries/ts-utils/etc/ts-utils.api.md
@@ -125,15 +125,21 @@ class AggregatedResultMapValidator<TCOMPOSITEID extends string, TCOLLECTIONID ex
     update(key: string, value: unknown): DetailedResult<TITEM, ResultMapResultDetail>;
 }
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
 // @public
 const allConversionErrorHandling: readonly ConversionErrorHandling[];
 
 // @public
 export const allMessageLogLevels: readonly MessageLogLevel[];
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
 // @public
 const allOnError: readonly OnError[];
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
 // @public
 const allReporterLogLevels: readonly ReporterLogLevel[];
 
@@ -715,6 +721,8 @@ type ConversionErrorFormatter<TC = unknown> = (val: unknown, message?: string, c
 // @public
 type ConversionErrorHandling = 'ignore' | 'warn' | 'fail';
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
 // @public
 const conversionErrorHandling: Converter<ConversionErrorHandling, ReadonlyArray<ConversionErrorHandling>>;
 
@@ -2380,6 +2388,8 @@ interface OneOfValidatorConstructorParams<T, TC = unknown> extends ValidatorBase
 // @public
 type OnError = 'failOnError' | 'ignoreErrors';
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
 // @public
 const onError: Converter<OnError, ReadonlyArray<OnError>>;
 
@@ -2512,6 +2522,8 @@ export function recordToMap<TS, TD, TK extends string = string>(src: Record<TK, 
 // @public
 type ReporterLogLevel = 'all' | 'detail' | 'info' | 'warning' | 'error' | 'silent';
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
 // @public
 const reporterLogLevel: Converter<ReporterLogLevel, ReadonlyArray<ReporterLogLevel>>;
 

--- a/libraries/ts-utils/etc/ts-utils.api.md
+++ b/libraries/ts-utils/etc/ts-utils.api.md
@@ -487,9 +487,7 @@ declare namespace Collections {
         ConvertingResultMapValueConverter,
         ConversionErrorHandling,
         allConversionErrorHandling,
-        _ConversionErrorHandlingExhaustivenessCheck,
-        _conversionErrorHandlingExhaustivenessCheck,
-        conversionErrorHandlingConverter,
+        conversionErrorHandling,
         IReadOnlyConvertingResultMapConstructorParams,
         ReadOnlyConvertingResultMap,
         IRetainedRecord,
@@ -702,8 +700,6 @@ declare namespace Conversion {
         BaseConverter,
         OnError,
         allOnError,
-        _OnErrorExhaustivenessCheck,
-        _onErrorExhaustivenessCheck,
         ConverterTraits,
         ConversionErrorFormatter,
         ConstraintOptions,
@@ -728,19 +724,7 @@ type ConversionErrorHandling = 'ignore' | 'warn' | 'fail';
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ConversionErrorHandling"
 //
 // @public
-const conversionErrorHandlingConverter: Converter<ConversionErrorHandling, ReadonlyArray<ConversionErrorHandling>>;
-
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "allConversionErrorHandling"
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ConversionErrorHandling"
-//
-// @internal
-type _ConversionErrorHandlingExhaustivenessCheck = [
-Exclude<ConversionErrorHandling, (typeof allConversionErrorHandling)[number]>,
-Exclude<(typeof allConversionErrorHandling)[number], ConversionErrorHandling>
-] extends [never, never] ? true : never;
-
-// @internal (undocumented)
-const _conversionErrorHandlingExhaustivenessCheck: _ConversionErrorHandlingExhaustivenessCheck;
+const conversionErrorHandling: Converter<ConversionErrorHandling, ReadonlyArray<ConversionErrorHandling>>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -808,8 +792,8 @@ declare namespace Converters {
         discriminatedObject,
         OnError,
         string,
-        messageLogLevelConverter,
-        onErrorConverter,
+        messageLogLevel,
+        onError,
         value,
         number,
         boolean,
@@ -2006,9 +1990,7 @@ declare namespace Logging {
         ILogger,
         IDetailLogger,
         allReporterLogLevels,
-        reporterLogLevelConverter,
-        _ReporterLogLevelExhaustivenessCheck,
-        _reporterLogLevelExhaustivenessCheck,
+        reporterLogLevel,
         LoggerBase,
         InMemoryLogger,
         ConsoleLogger,
@@ -2138,16 +2120,7 @@ export class MessageAggregator implements IMessageAggregator {
 export type MessageLogLevel = 'quiet' | 'detail' | 'info' | 'warning' | 'error';
 
 // @public
-const messageLogLevelConverter: Converter<MessageLogLevel, ReadonlyArray<MessageLogLevel>>;
-
-// @internal
-export type _MessageLogLevelExhaustivenessCheck = [
-Exclude<MessageLogLevel, (typeof allMessageLogLevels)[number]>,
-Exclude<(typeof allMessageLogLevels)[number], MessageLogLevel>
-] extends [never, never] ? true : never;
-
-// @internal (undocumented)
-export const _messageLogLevelExhaustivenessCheck: _MessageLogLevelExhaustivenessCheck;
+const messageLogLevel: Converter<MessageLogLevel, ReadonlyArray<MessageLogLevel>>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -2418,19 +2391,7 @@ type OnError = 'failOnError' | 'ignoreErrors';
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "OnError"
 //
 // @public
-const onErrorConverter: Converter<OnError, ReadonlyArray<OnError>>;
-
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "allOnError"
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "OnError"
-//
-// @internal
-type _OnErrorExhaustivenessCheck = [
-Exclude<OnError, (typeof allOnError)[number]>,
-Exclude<(typeof allOnError)[number], OnError>
-] extends [never, never] ? true : never;
-
-// @internal (undocumented)
-const _onErrorExhaustivenessCheck: _OnErrorExhaustivenessCheck;
+const onError: Converter<OnError, ReadonlyArray<OnError>>;
 
 // @public
 const optionalBoolean: Converter<boolean | undefined, unknown>;
@@ -2564,19 +2525,7 @@ type ReporterLogLevel = 'all' | 'detail' | 'info' | 'warning' | 'error' | 'silen
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ReporterLogLevel"
 //
 // @public
-const reporterLogLevelConverter: Converter<ReporterLogLevel, ReadonlyArray<ReporterLogLevel>>;
-
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "allReporterLogLevels"
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ReporterLogLevel"
-//
-// @internal
-type _ReporterLogLevelExhaustivenessCheck = [
-Exclude<ReporterLogLevel, (typeof allReporterLogLevels)[number]>,
-Exclude<(typeof allReporterLogLevels)[number], ReporterLogLevel>
-] extends [never, never] ? true : never;
-
-// @internal (undocumented)
-const _reporterLogLevelExhaustivenessCheck: _ReporterLogLevelExhaustivenessCheck;
+const reporterLogLevel: Converter<ReporterLogLevel, ReadonlyArray<ReporterLogLevel>>;
 
 // @public
 export type Result<T> = Success<T> | Failure<T>;

--- a/libraries/ts-utils/etc/ts-utils.api.md
+++ b/libraries/ts-utils/etc/ts-utils.api.md
@@ -125,7 +125,7 @@ class AggregatedResultMapValidator<TCOMPOSITEID extends string, TCOLLECTIONID ex
     update(key: string, value: unknown): DetailedResult<TITEM, ResultMapResultDetail>;
 }
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ConversionErrorHandling"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
 const allConversionErrorHandling: readonly ConversionErrorHandling[];
@@ -133,12 +133,12 @@ const allConversionErrorHandling: readonly ConversionErrorHandling[];
 // @public
 export const allMessageLogLevels: readonly MessageLogLevel[];
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "OnError"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
 const allOnError: readonly OnError[];
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ReporterLogLevel"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
 const allReporterLogLevels: readonly ReporterLogLevel[];
@@ -721,7 +721,7 @@ type ConversionErrorFormatter<TC = unknown> = (val: unknown, message?: string, c
 // @public
 type ConversionErrorHandling = 'ignore' | 'warn' | 'fail';
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ConversionErrorHandling"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
 const conversionErrorHandling: Converter<ConversionErrorHandling, ReadonlyArray<ConversionErrorHandling>>;
@@ -2388,7 +2388,7 @@ interface OneOfValidatorConstructorParams<T, TC = unknown> extends ValidatorBase
 // @public
 type OnError = 'failOnError' | 'ignoreErrors';
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "OnError"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
 const onError: Converter<OnError, ReadonlyArray<OnError>>;
@@ -2522,7 +2522,7 @@ export function recordToMap<TS, TD, TK extends string = string>(src: Record<TK, 
 // @public
 type ReporterLogLevel = 'all' | 'detail' | 'info' | 'warning' | 'error' | 'silent';
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ReporterLogLevel"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
 const reporterLogLevel: Converter<ReporterLogLevel, ReadonlyArray<ReporterLogLevel>>;

--- a/libraries/ts-utils/etc/ts-utils.api.md
+++ b/libraries/ts-utils/etc/ts-utils.api.md
@@ -125,21 +125,15 @@ class AggregatedResultMapValidator<TCOMPOSITEID extends string, TCOLLECTIONID ex
     update(key: string, value: unknown): DetailedResult<TITEM, ResultMapResultDetail>;
 }
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-//
 // @public
 const allConversionErrorHandling: readonly ConversionErrorHandling[];
 
 // @public
 export const allMessageLogLevels: readonly MessageLogLevel[];
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-//
 // @public
 const allOnError: readonly OnError[];
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-//
 // @public
 const allReporterLogLevels: readonly ReporterLogLevel[];
 
@@ -721,8 +715,6 @@ type ConversionErrorFormatter<TC = unknown> = (val: unknown, message?: string, c
 // @public
 type ConversionErrorHandling = 'ignore' | 'warn' | 'fail';
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-//
 // @public
 const conversionErrorHandling: Converter<ConversionErrorHandling, ReadonlyArray<ConversionErrorHandling>>;
 
@@ -2388,8 +2380,6 @@ interface OneOfValidatorConstructorParams<T, TC = unknown> extends ValidatorBase
 // @public
 type OnError = 'failOnError' | 'ignoreErrors';
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-//
 // @public
 const onError: Converter<OnError, ReadonlyArray<OnError>>;
 
@@ -2522,8 +2512,6 @@ export function recordToMap<TS, TD, TK extends string = string>(src: Record<TK, 
 // @public
 type ReporterLogLevel = 'all' | 'detail' | 'info' | 'warning' | 'error' | 'silent';
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-//
 // @public
 const reporterLogLevel: Converter<ReporterLogLevel, ReadonlyArray<ReporterLogLevel>>;
 

--- a/libraries/ts-utils/etc/ts-utils.api.md
+++ b/libraries/ts-utils/etc/ts-utils.api.md
@@ -125,6 +125,24 @@ class AggregatedResultMapValidator<TCOMPOSITEID extends string, TCOLLECTIONID ex
     update(key: string, value: unknown): DetailedResult<TITEM, ResultMapResultDetail>;
 }
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ConversionErrorHandling"
+//
+// @public
+const allConversionErrorHandling: readonly ConversionErrorHandling[];
+
+// @public
+export const allMessageLogLevels: readonly MessageLogLevel[];
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "OnError"
+//
+// @public
+const allOnError: readonly OnError[];
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ReporterLogLevel"
+//
+// @public
+const allReporterLogLevels: readonly ReporterLogLevel[];
+
 // @public
 export function allSucceed<T>(results: Iterable<Result<unknown>>, successValue: T, aggregatedErrors?: IMessageAggregator): Result<T>;
 
@@ -468,6 +486,10 @@ declare namespace Collections {
         IReadOnlyResultMap,
         ConvertingResultMapValueConverter,
         ConversionErrorHandling,
+        allConversionErrorHandling,
+        _ConversionErrorHandlingExhaustivenessCheck,
+        _conversionErrorHandlingExhaustivenessCheck,
+        conversionErrorHandlingConverter,
         IReadOnlyConvertingResultMapConstructorParams,
         ReadOnlyConvertingResultMap,
         IRetainedRecord,
@@ -679,6 +701,9 @@ declare namespace Conversion {
         ConverterFunc,
         BaseConverter,
         OnError,
+        allOnError,
+        _OnErrorExhaustivenessCheck,
+        _onErrorExhaustivenessCheck,
         ConverterTraits,
         ConversionErrorFormatter,
         ConstraintOptions,
@@ -699,6 +724,23 @@ type ConversionErrorFormatter<TC = unknown> = (val: unknown, message?: string, c
 
 // @public
 type ConversionErrorHandling = 'ignore' | 'warn' | 'fail';
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ConversionErrorHandling"
+//
+// @public
+const conversionErrorHandlingConverter: Converter<ConversionErrorHandling, ReadonlyArray<ConversionErrorHandling>>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "allConversionErrorHandling"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ConversionErrorHandling"
+//
+// @internal
+type _ConversionErrorHandlingExhaustivenessCheck = [
+Exclude<ConversionErrorHandling, (typeof allConversionErrorHandling)[number]>,
+Exclude<(typeof allConversionErrorHandling)[number], ConversionErrorHandling>
+] extends [never, never] ? true : never;
+
+// @internal (undocumented)
+const _conversionErrorHandlingExhaustivenessCheck: _ConversionErrorHandlingExhaustivenessCheck;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -766,6 +808,8 @@ declare namespace Converters {
         discriminatedObject,
         OnError,
         string,
+        messageLogLevelConverter,
+        onErrorConverter,
         value,
         number,
         boolean,
@@ -1961,6 +2005,10 @@ declare namespace Logging {
         ReporterLogLevel,
         ILogger,
         IDetailLogger,
+        allReporterLogLevels,
+        reporterLogLevelConverter,
+        _ReporterLogLevelExhaustivenessCheck,
+        _reporterLogLevelExhaustivenessCheck,
         LoggerBase,
         InMemoryLogger,
         ConsoleLogger,
@@ -2088,6 +2136,18 @@ export class MessageAggregator implements IMessageAggregator {
 
 // @public
 export type MessageLogLevel = 'quiet' | 'detail' | 'info' | 'warning' | 'error';
+
+// @public
+const messageLogLevelConverter: Converter<MessageLogLevel, ReadonlyArray<MessageLogLevel>>;
+
+// @internal
+export type _MessageLogLevelExhaustivenessCheck = [
+Exclude<MessageLogLevel, (typeof allMessageLogLevels)[number]>,
+Exclude<(typeof allMessageLogLevels)[number], MessageLogLevel>
+] extends [never, never] ? true : never;
+
+// @internal (undocumented)
+export const _messageLogLevelExhaustivenessCheck: _MessageLogLevelExhaustivenessCheck;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -2355,6 +2415,23 @@ interface OneOfValidatorConstructorParams<T, TC = unknown> extends ValidatorBase
 // @public
 type OnError = 'failOnError' | 'ignoreErrors';
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "OnError"
+//
+// @public
+const onErrorConverter: Converter<OnError, ReadonlyArray<OnError>>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "allOnError"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "OnError"
+//
+// @internal
+type _OnErrorExhaustivenessCheck = [
+Exclude<OnError, (typeof allOnError)[number]>,
+Exclude<(typeof allOnError)[number], OnError>
+] extends [never, never] ? true : never;
+
+// @internal (undocumented)
+const _onErrorExhaustivenessCheck: _OnErrorExhaustivenessCheck;
+
 // @public
 const optionalBoolean: Converter<boolean | undefined, unknown>;
 
@@ -2483,6 +2560,23 @@ export function recordToMap<TS, TD, TK extends string = string>(src: Record<TK, 
 
 // @public
 type ReporterLogLevel = 'all' | 'detail' | 'info' | 'warning' | 'error' | 'silent';
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ReporterLogLevel"
+//
+// @public
+const reporterLogLevelConverter: Converter<ReporterLogLevel, ReadonlyArray<ReporterLogLevel>>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "allReporterLogLevels"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-utils" does not have an export "ReporterLogLevel"
+//
+// @internal
+type _ReporterLogLevelExhaustivenessCheck = [
+Exclude<ReporterLogLevel, (typeof allReporterLogLevels)[number]>,
+Exclude<(typeof allReporterLogLevels)[number], ReporterLogLevel>
+] extends [never, never] ? true : never;
+
+// @internal (undocumented)
+const _reporterLogLevelExhaustivenessCheck: _ReporterLogLevelExhaustivenessCheck;
 
 // @public
 export type Result<T> = Success<T> | Failure<T>;

--- a/libraries/ts-utils/src/packlets/base/result.ts
+++ b/libraries/ts-utils/src/packlets/base/result.ts
@@ -125,19 +125,17 @@ export const allMessageLogLevels: readonly MessageLogLevel[] = [
 /**
  * Compile-time exhaustiveness guard ensuring {@link allMessageLogLevels} exactly matches every member of
  * {@link MessageLogLevel}. Adding or removing a union member without updating the array fails the build.
- * @internal
+ * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
-export type _MessageLogLevelExhaustivenessCheck = [
+type _MessageLogLevelExhaustivenessCheck = [
   Exclude<MessageLogLevel, (typeof allMessageLogLevels)[number]>,
   Exclude<(typeof allMessageLogLevels)[number], MessageLogLevel>
 ] extends [never, never]
   ? true
   : never;
 
-/**
- * @internal
- */
-export const _messageLogLevelExhaustivenessCheck: _MessageLogLevelExhaustivenessCheck = true;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _messageLogLevelExhaustivenessCheck: _MessageLogLevelExhaustivenessCheck = true;
 
 /**
  * Details for reporting a message.

--- a/libraries/ts-utils/src/packlets/base/result.ts
+++ b/libraries/ts-utils/src/packlets/base/result.ts
@@ -111,6 +111,35 @@ export interface IResultLogger<TD = unknown> {
 export type MessageLogLevel = 'quiet' | 'detail' | 'info' | 'warning' | 'error';
 
 /**
+ * Exhaustive list of all {@link MessageLogLevel} values.
+ * @public
+ */
+export const allMessageLogLevels: readonly MessageLogLevel[] = [
+  'quiet',
+  'detail',
+  'info',
+  'warning',
+  'error'
+] as const;
+
+/**
+ * Compile-time exhaustiveness guard ensuring {@link allMessageLogLevels} exactly matches every member of
+ * {@link MessageLogLevel}. Adding or removing a union member without updating the array fails the build.
+ * @internal
+ */
+export type _MessageLogLevelExhaustivenessCheck = [
+  Exclude<MessageLogLevel, (typeof allMessageLogLevels)[number]>,
+  Exclude<(typeof allMessageLogLevels)[number], MessageLogLevel>
+] extends [never, never]
+  ? true
+  : never;
+
+/**
+ * @internal
+ */
+export const _messageLogLevelExhaustivenessCheck: _MessageLogLevelExhaustivenessCheck = true;
+
+/**
  * Details for reporting a message.
  * @public
  */

--- a/libraries/ts-utils/src/packlets/base/result.ts
+++ b/libraries/ts-utils/src/packlets/base/result.ts
@@ -110,32 +110,31 @@ export interface IResultLogger<TD = unknown> {
  */
 export type MessageLogLevel = 'quiet' | 'detail' | 'info' | 'warning' | 'error';
 
-/**
- * Exhaustive list of all {@link MessageLogLevel} values.
- * @public
- */
-export const allMessageLogLevels: readonly MessageLogLevel[] = [
-  'quiet',
-  'detail',
-  'info',
-  'warning',
-  'error'
-] as const;
+// Untyped (literal-tuple-inferred) source of truth for allMessageLogLevels, kept separate from the
+// widened public export below so the exhaustiveness check actually inspects the literal values instead
+// of being widened away to `MessageLogLevel` before the check runs.
+const messageLogLevelValues = ['quiet', 'detail', 'info', 'warning', 'error'] as const;
 
 /**
- * Compile-time exhaustiveness guard ensuring {@link allMessageLogLevels} exactly matches every member of
+ * Compile-time exhaustiveness guard ensuring {@link messageLogLevelValues} exactly matches every member of
  * {@link MessageLogLevel}. Adding or removing a union member without updating the array fails the build.
  * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
 type _MessageLogLevelExhaustivenessCheck = [
-  Exclude<MessageLogLevel, (typeof allMessageLogLevels)[number]>,
-  Exclude<(typeof allMessageLogLevels)[number], MessageLogLevel>
+  Exclude<MessageLogLevel, (typeof messageLogLevelValues)[number]>,
+  Exclude<(typeof messageLogLevelValues)[number], MessageLogLevel>
 ] extends [never, never]
   ? true
   : never;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _messageLogLevelExhaustivenessCheck: _MessageLogLevelExhaustivenessCheck = true;
+
+/**
+ * Exhaustive list of all {@link MessageLogLevel} values.
+ * @public
+ */
+export const allMessageLogLevels: readonly MessageLogLevel[] = messageLogLevelValues;
 
 /**
  * Details for reporting a message.

--- a/libraries/ts-utils/src/packlets/collections/readOnlyConvertingResultMap.ts
+++ b/libraries/ts-utils/src/packlets/collections/readOnlyConvertingResultMap.ts
@@ -44,25 +44,20 @@ export type ConvertingResultMapValueConverter<TK extends string, TSRC, TTARGET> 
  */
 export type ConversionErrorHandling = 'ignore' | 'warn' | 'fail';
 
-/**
- * Exhaustive list of all {@link ConversionErrorHandling} values.
- * @public
- */
-export const allConversionErrorHandling: readonly ConversionErrorHandling[] = [
-  'ignore',
-  'warn',
-  'fail'
-] as const;
+// Untyped (literal-tuple-inferred) source of truth for allConversionErrorHandling, kept separate from
+// the widened public export below so the exhaustiveness check actually inspects the literal values
+// instead of being widened away to `ConversionErrorHandling` before the check runs.
+const conversionErrorHandlingValues = ['ignore', 'warn', 'fail'] as const;
 
 /**
- * Compile-time exhaustiveness guard ensuring {@link allConversionErrorHandling} exactly matches every
- * member of {@link ConversionErrorHandling}. Adding or removing a
+ * Compile-time exhaustiveness guard ensuring {@link conversionErrorHandlingValues} exactly matches every
+ * member of {@link Collections.ConversionErrorHandling | ConversionErrorHandling}. Adding or removing a
  * union member without updating the array fails the build.
  * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
 type _ConversionErrorHandlingExhaustivenessCheck = [
-  Exclude<ConversionErrorHandling, (typeof allConversionErrorHandling)[number]>,
-  Exclude<(typeof allConversionErrorHandling)[number], ConversionErrorHandling>
+  Exclude<ConversionErrorHandling, (typeof conversionErrorHandlingValues)[number]>,
+  Exclude<(typeof conversionErrorHandlingValues)[number], ConversionErrorHandling>
 ] extends [never, never]
   ? true
   : never;
@@ -71,8 +66,14 @@ type _ConversionErrorHandlingExhaustivenessCheck = [
 const _conversionErrorHandlingExhaustivenessCheck: _ConversionErrorHandlingExhaustivenessCheck = true;
 
 /**
+ * Exhaustive list of all {@link Collections.ConversionErrorHandling | ConversionErrorHandling} values.
+ * @public
+ */
+export const allConversionErrorHandling: readonly ConversionErrorHandling[] = conversionErrorHandlingValues;
+
+/**
  * A ready-made {@link Converter | Converter} for
- * {@link ConversionErrorHandling} values.
+ * {@link Collections.ConversionErrorHandling | ConversionErrorHandling} values.
  * @public
  */
 export const conversionErrorHandling: Converter<

--- a/libraries/ts-utils/src/packlets/collections/readOnlyConvertingResultMap.ts
+++ b/libraries/ts-utils/src/packlets/collections/readOnlyConvertingResultMap.ts
@@ -58,26 +58,24 @@ export const allConversionErrorHandling: readonly ConversionErrorHandling[] = [
  * Compile-time exhaustiveness guard ensuring {@link allConversionErrorHandling} exactly matches every
  * member of {@link ConversionErrorHandling}. Adding or removing a
  * union member without updating the array fails the build.
- * @internal
+ * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
-export type _ConversionErrorHandlingExhaustivenessCheck = [
+type _ConversionErrorHandlingExhaustivenessCheck = [
   Exclude<ConversionErrorHandling, (typeof allConversionErrorHandling)[number]>,
   Exclude<(typeof allConversionErrorHandling)[number], ConversionErrorHandling>
 ] extends [never, never]
   ? true
   : never;
 
-/**
- * @internal
- */
-export const _conversionErrorHandlingExhaustivenessCheck: _ConversionErrorHandlingExhaustivenessCheck = true;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _conversionErrorHandlingExhaustivenessCheck: _ConversionErrorHandlingExhaustivenessCheck = true;
 
 /**
  * A ready-made {@link Converter | Converter} for
  * {@link ConversionErrorHandling} values.
  * @public
  */
-export const conversionErrorHandlingConverter: Converter<
+export const conversionErrorHandling: Converter<
   ConversionErrorHandling,
   ReadonlyArray<ConversionErrorHandling>
 > = Converters.enumeratedValue<ConversionErrorHandling>(allConversionErrorHandling);

--- a/libraries/ts-utils/src/packlets/collections/readOnlyConvertingResultMap.ts
+++ b/libraries/ts-utils/src/packlets/collections/readOnlyConvertingResultMap.ts
@@ -51,7 +51,7 @@ const conversionErrorHandlingValues = ['ignore', 'warn', 'fail'] as const;
 
 /**
  * Compile-time exhaustiveness guard ensuring {@link conversionErrorHandlingValues} exactly matches every
- * member of {@link Collections.ConversionErrorHandling | ConversionErrorHandling}. Adding or removing a
+ * member of `ConversionErrorHandling`. Adding or removing a
  * union member without updating the array fails the build.
  * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
@@ -66,14 +66,14 @@ type _ConversionErrorHandlingExhaustivenessCheck = [
 const _conversionErrorHandlingExhaustivenessCheck: _ConversionErrorHandlingExhaustivenessCheck = true;
 
 /**
- * Exhaustive list of all {@link Collections.ConversionErrorHandling | ConversionErrorHandling} values.
+ * Exhaustive list of all `ConversionErrorHandling` values.
  * @public
  */
 export const allConversionErrorHandling: readonly ConversionErrorHandling[] = conversionErrorHandlingValues;
 
 /**
  * A ready-made {@link Converter | Converter} for
- * {@link Collections.ConversionErrorHandling | ConversionErrorHandling} values.
+ * `ConversionErrorHandling` values.
  * @public
  */
 export const conversionErrorHandling: Converter<

--- a/libraries/ts-utils/src/packlets/collections/readOnlyConvertingResultMap.ts
+++ b/libraries/ts-utils/src/packlets/collections/readOnlyConvertingResultMap.ts
@@ -21,6 +21,7 @@
  */
 
 import { captureResult, DetailedResult, failWithDetail, Result, succeedWithDetail } from '../base';
+import { Converter, Converters } from '../conversion';
 import { ILogger } from '../logging-interface';
 import { KeyValueEntry } from './common';
 import { IReadOnlyResultMap, ResultMapForEachCb, ResultMapResultDetail } from './readonlyResultMap';
@@ -42,6 +43,44 @@ export type ConvertingResultMapValueConverter<TK extends string, TSRC, TTARGET> 
  * @public
  */
 export type ConversionErrorHandling = 'ignore' | 'warn' | 'fail';
+
+/**
+ * Exhaustive list of all {@link ConversionErrorHandling} values.
+ * @public
+ */
+export const allConversionErrorHandling: readonly ConversionErrorHandling[] = [
+  'ignore',
+  'warn',
+  'fail'
+] as const;
+
+/**
+ * Compile-time exhaustiveness guard ensuring {@link allConversionErrorHandling} exactly matches every
+ * member of {@link ConversionErrorHandling}. Adding or removing a
+ * union member without updating the array fails the build.
+ * @internal
+ */
+export type _ConversionErrorHandlingExhaustivenessCheck = [
+  Exclude<ConversionErrorHandling, (typeof allConversionErrorHandling)[number]>,
+  Exclude<(typeof allConversionErrorHandling)[number], ConversionErrorHandling>
+] extends [never, never]
+  ? true
+  : never;
+
+/**
+ * @internal
+ */
+export const _conversionErrorHandlingExhaustivenessCheck: _ConversionErrorHandlingExhaustivenessCheck = true;
+
+/**
+ * A ready-made {@link Converter | Converter} for
+ * {@link ConversionErrorHandling} values.
+ * @public
+ */
+export const conversionErrorHandlingConverter: Converter<
+  ConversionErrorHandling,
+  ReadonlyArray<ConversionErrorHandling>
+> = Converters.enumeratedValue<ConversionErrorHandling>(allConversionErrorHandling);
 
 /**
  * Parameters for constructing a {@link Collections.ReadOnlyConvertingResultMap | ReadOnlyConvertingResultMap}.

--- a/libraries/ts-utils/src/packlets/collections/readOnlyConvertingResultMap.ts
+++ b/libraries/ts-utils/src/packlets/collections/readOnlyConvertingResultMap.ts
@@ -46,12 +46,12 @@ export type ConversionErrorHandling = 'ignore' | 'warn' | 'fail';
 
 // Untyped (literal-tuple-inferred) source of truth for allConversionErrorHandling, kept separate from
 // the widened public export below so the exhaustiveness check actually inspects the literal values
-// instead of being widened away to `ConversionErrorHandling` before the check runs.
+// instead of being widened away to {@link Collections.ConversionErrorHandling | ConversionErrorHandling} before the check runs.
 const conversionErrorHandlingValues = ['ignore', 'warn', 'fail'] as const;
 
 /**
  * Compile-time exhaustiveness guard ensuring {@link conversionErrorHandlingValues} exactly matches every
- * member of `ConversionErrorHandling`. Adding or removing a
+ * member of {@link Collections.ConversionErrorHandling | ConversionErrorHandling}. Adding or removing a
  * union member without updating the array fails the build.
  * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
@@ -66,14 +66,14 @@ type _ConversionErrorHandlingExhaustivenessCheck = [
 const _conversionErrorHandlingExhaustivenessCheck: _ConversionErrorHandlingExhaustivenessCheck = true;
 
 /**
- * Exhaustive list of all `ConversionErrorHandling` values.
+ * Exhaustive list of all {@link Collections.ConversionErrorHandling | ConversionErrorHandling} values.
  * @public
  */
 export const allConversionErrorHandling: readonly ConversionErrorHandling[] = conversionErrorHandlingValues;
 
 /**
  * A ready-made {@link Converter | Converter} for
- * `ConversionErrorHandling` values.
+ * {@link Collections.ConversionErrorHandling | ConversionErrorHandling} values.
  * @public
  */
 export const conversionErrorHandling: Converter<

--- a/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
+++ b/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
@@ -20,10 +20,10 @@
  * SOFTWARE.
  */
 
-import { Failure, Result, fail, isKeyOf, succeed } from '../base';
+import { Failure, MessageLogLevel, Result, allMessageLogLevels, fail, isKeyOf, succeed } from '../base';
 import { TypeGuardWithContext, Validator, Base as ValidationBase } from '../validation';
 import { BaseConverter, ConverterFunc } from './baseConverter';
-import { Converter, OnError } from './converter';
+import { Converter, OnError, allOnError } from './converter';
 import { FieldConverters, ObjectConverter, ObjectConverterOptions } from './objectConverter';
 import { StringConverter } from './stringConverter';
 
@@ -60,6 +60,23 @@ export function enumeratedValue<T>(values: ReadonlyArray<T>): Converter<T, Reado
     }
   );
 }
+
+/**
+ * A ready-made {@link Converter | Converter} for {@link MessageLogLevel} values.
+ * @public
+ */
+export const messageLogLevelConverter: Converter<
+  MessageLogLevel,
+  ReadonlyArray<MessageLogLevel>
+> = enumeratedValue<MessageLogLevel>(allMessageLogLevels);
+
+/**
+ * A ready-made {@link Converter | Converter} for {@link OnError} values.
+ * @public
+ */
+export const onErrorConverter: Converter<OnError, ReadonlyArray<OnError>> = enumeratedValue<OnError>(
+  allOnError
+);
 
 /**
  * Helper function to create a {@link Converter | Converter} which converts `unknown` to one of a set of supplied enumerated

--- a/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
+++ b/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
@@ -71,7 +71,7 @@ export const messageLogLevel: Converter<
 > = enumeratedValue<MessageLogLevel>(allMessageLogLevels);
 
 /**
- * A ready-made {@link Converter | Converter} for {@link OnError} values.
+ * A ready-made {@link Converter | Converter} for {@link Conversion.OnError | OnError} values.
  * @public
  */
 export const onError: Converter<OnError, ReadonlyArray<OnError>> = enumeratedValue<OnError>(allOnError);

--- a/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
+++ b/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
@@ -65,7 +65,7 @@ export function enumeratedValue<T>(values: ReadonlyArray<T>): Converter<T, Reado
  * A ready-made {@link Converter | Converter} for {@link MessageLogLevel} values.
  * @public
  */
-export const messageLogLevelConverter: Converter<
+export const messageLogLevel: Converter<
   MessageLogLevel,
   ReadonlyArray<MessageLogLevel>
 > = enumeratedValue<MessageLogLevel>(allMessageLogLevels);
@@ -74,9 +74,7 @@ export const messageLogLevelConverter: Converter<
  * A ready-made {@link Converter | Converter} for {@link OnError} values.
  * @public
  */
-export const onErrorConverter: Converter<OnError, ReadonlyArray<OnError>> = enumeratedValue<OnError>(
-  allOnError
-);
+export const onError: Converter<OnError, ReadonlyArray<OnError>> = enumeratedValue<OnError>(allOnError);
 
 /**
  * Helper function to create a {@link Converter | Converter} which converts `unknown` to one of a set of supplied enumerated

--- a/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
+++ b/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
@@ -71,7 +71,7 @@ export const messageLogLevel: Converter<
 > = enumeratedValue<MessageLogLevel>(allMessageLogLevels);
 
 /**
- * A ready-made {@link Converter | Converter} for `OnError` values.
+ * A ready-made {@link Converter | Converter} for {@link Conversion.OnError | OnError} values.
  * @public
  */
 export const onError: Converter<OnError, ReadonlyArray<OnError>> = enumeratedValue<OnError>(allOnError);

--- a/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
+++ b/libraries/ts-utils/src/packlets/conversion/basicConverters.ts
@@ -71,7 +71,7 @@ export const messageLogLevel: Converter<
 > = enumeratedValue<MessageLogLevel>(allMessageLogLevels);
 
 /**
- * A ready-made {@link Converter | Converter} for {@link Conversion.OnError | OnError} values.
+ * A ready-made {@link Converter | Converter} for `OnError` values.
  * @public
  */
 export const onError: Converter<OnError, ReadonlyArray<OnError>> = enumeratedValue<OnError>(allOnError);

--- a/libraries/ts-utils/src/packlets/conversion/converter.ts
+++ b/libraries/ts-utils/src/packlets/conversion/converter.ts
@@ -27,26 +27,31 @@ import { Brand, Result, Success } from '../base';
  */
 export type OnError = 'failOnError' | 'ignoreErrors';
 
-/**
- * Exhaustive list of all {@link OnError} values.
- * @public
- */
-export const allOnError: readonly OnError[] = ['failOnError', 'ignoreErrors'] as const;
+// Untyped (literal-tuple-inferred) source of truth for allOnError, kept separate from the widened
+// public export below so the exhaustiveness check actually inspects the literal values instead of
+// being widened away to `OnError` before the check runs.
+const onErrorValues = ['failOnError', 'ignoreErrors'] as const;
 
 /**
- * Compile-time exhaustiveness guard ensuring {@link allOnError} exactly matches every member of
- * {@link OnError}. Adding or removing a union member without updating the array fails the build.
+ * Compile-time exhaustiveness guard ensuring {@link onErrorValues} exactly matches every member of
+ * {@link Conversion.OnError | OnError}. Adding or removing a union member without updating the array fails the build.
  * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
 type _OnErrorExhaustivenessCheck = [
-  Exclude<OnError, (typeof allOnError)[number]>,
-  Exclude<(typeof allOnError)[number], OnError>
+  Exclude<OnError, (typeof onErrorValues)[number]>,
+  Exclude<(typeof onErrorValues)[number], OnError>
 ] extends [never, never]
   ? true
   : never;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _onErrorExhaustivenessCheck: _OnErrorExhaustivenessCheck = true;
+
+/**
+ * Exhaustive list of all {@link Conversion.OnError | OnError} values.
+ * @public
+ */
+export const allOnError: readonly OnError[] = onErrorValues;
 
 /**
  * Converter traits.

--- a/libraries/ts-utils/src/packlets/conversion/converter.ts
+++ b/libraries/ts-utils/src/packlets/conversion/converter.ts
@@ -34,7 +34,7 @@ const onErrorValues = ['failOnError', 'ignoreErrors'] as const;
 
 /**
  * Compile-time exhaustiveness guard ensuring {@link onErrorValues} exactly matches every member of
- * {@link Conversion.OnError | OnError}. Adding or removing a union member without updating the array fails the build.
+ * `OnError`. Adding or removing a union member without updating the array fails the build.
  * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
 type _OnErrorExhaustivenessCheck = [
@@ -48,7 +48,7 @@ type _OnErrorExhaustivenessCheck = [
 const _onErrorExhaustivenessCheck: _OnErrorExhaustivenessCheck = true;
 
 /**
- * Exhaustive list of all {@link Conversion.OnError | OnError} values.
+ * Exhaustive list of all `OnError` values.
  * @public
  */
 export const allOnError: readonly OnError[] = onErrorValues;

--- a/libraries/ts-utils/src/packlets/conversion/converter.ts
+++ b/libraries/ts-utils/src/packlets/conversion/converter.ts
@@ -28,6 +28,29 @@ import { Brand, Result, Success } from '../base';
 export type OnError = 'failOnError' | 'ignoreErrors';
 
 /**
+ * Exhaustive list of all {@link OnError} values.
+ * @public
+ */
+export const allOnError: readonly OnError[] = ['failOnError', 'ignoreErrors'] as const;
+
+/**
+ * Compile-time exhaustiveness guard ensuring {@link allOnError} exactly matches every member of
+ * {@link OnError}. Adding or removing a union member without updating the array fails the build.
+ * @internal
+ */
+export type _OnErrorExhaustivenessCheck = [
+  Exclude<OnError, (typeof allOnError)[number]>,
+  Exclude<(typeof allOnError)[number], OnError>
+] extends [never, never]
+  ? true
+  : never;
+
+/**
+ * @internal
+ */
+export const _onErrorExhaustivenessCheck: _OnErrorExhaustivenessCheck = true;
+
+/**
  * Converter traits.
  * @public
  */

--- a/libraries/ts-utils/src/packlets/conversion/converter.ts
+++ b/libraries/ts-utils/src/packlets/conversion/converter.ts
@@ -29,12 +29,12 @@ export type OnError = 'failOnError' | 'ignoreErrors';
 
 // Untyped (literal-tuple-inferred) source of truth for allOnError, kept separate from the widened
 // public export below so the exhaustiveness check actually inspects the literal values instead of
-// being widened away to `OnError` before the check runs.
+// being widened away to {@link Conversion.OnError | OnError} before the check runs.
 const onErrorValues = ['failOnError', 'ignoreErrors'] as const;
 
 /**
  * Compile-time exhaustiveness guard ensuring {@link onErrorValues} exactly matches every member of
- * `OnError`. Adding or removing a union member without updating the array fails the build.
+ * {@link Conversion.OnError | OnError}. Adding or removing a union member without updating the array fails the build.
  * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
 type _OnErrorExhaustivenessCheck = [
@@ -48,7 +48,7 @@ type _OnErrorExhaustivenessCheck = [
 const _onErrorExhaustivenessCheck: _OnErrorExhaustivenessCheck = true;
 
 /**
- * Exhaustive list of all `OnError` values.
+ * Exhaustive list of all {@link Conversion.OnError | OnError} values.
  * @public
  */
 export const allOnError: readonly OnError[] = onErrorValues;

--- a/libraries/ts-utils/src/packlets/conversion/converter.ts
+++ b/libraries/ts-utils/src/packlets/conversion/converter.ts
@@ -36,19 +36,17 @@ export const allOnError: readonly OnError[] = ['failOnError', 'ignoreErrors'] as
 /**
  * Compile-time exhaustiveness guard ensuring {@link allOnError} exactly matches every member of
  * {@link OnError}. Adding or removing a union member without updating the array fails the build.
- * @internal
+ * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
-export type _OnErrorExhaustivenessCheck = [
+type _OnErrorExhaustivenessCheck = [
   Exclude<OnError, (typeof allOnError)[number]>,
   Exclude<(typeof allOnError)[number], OnError>
 ] extends [never, never]
   ? true
   : never;
 
-/**
- * @internal
- */
-export const _onErrorExhaustivenessCheck: _OnErrorExhaustivenessCheck = true;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _onErrorExhaustivenessCheck: _OnErrorExhaustivenessCheck = true;
 
 /**
  * Converter traits.

--- a/libraries/ts-utils/src/packlets/logging-interface/index.ts
+++ b/libraries/ts-utils/src/packlets/logging-interface/index.ts
@@ -28,27 +28,19 @@ import { Converter, Converters } from '../conversion';
  */
 export type ReporterLogLevel = 'all' | 'detail' | 'info' | 'warning' | 'error' | 'silent';
 
-/**
- * Exhaustive list of all {@link ReporterLogLevel} values.
- * @public
- */
-export const allReporterLogLevels: readonly ReporterLogLevel[] = [
-  'all',
-  'detail',
-  'info',
-  'warning',
-  'error',
-  'silent'
-] as const;
+// Untyped (literal-tuple-inferred) source of truth for allReporterLogLevels, kept separate from the
+// widened public export below so the exhaustiveness check actually inspects the literal values instead
+// of being widened away to `ReporterLogLevel` before the check runs.
+const reporterLogLevelValues = ['all', 'detail', 'info', 'warning', 'error', 'silent'] as const;
 
 /**
- * Compile-time exhaustiveness guard ensuring {@link allReporterLogLevels} exactly matches every member of
- * {@link ReporterLogLevel}. Adding or removing a union member without updating the array fails the build.
+ * Compile-time exhaustiveness guard ensuring {@link reporterLogLevelValues} exactly matches every member of
+ * {@link Logging.ReporterLogLevel | ReporterLogLevel}. Adding or removing a union member without updating the array fails the build.
  * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
 type _ReporterLogLevelExhaustivenessCheck = [
-  Exclude<ReporterLogLevel, (typeof allReporterLogLevels)[number]>,
-  Exclude<(typeof allReporterLogLevels)[number], ReporterLogLevel>
+  Exclude<ReporterLogLevel, (typeof reporterLogLevelValues)[number]>,
+  Exclude<(typeof reporterLogLevelValues)[number], ReporterLogLevel>
 ] extends [never, never]
   ? true
   : never;
@@ -57,7 +49,13 @@ type _ReporterLogLevelExhaustivenessCheck = [
 const _reporterLogLevelExhaustivenessCheck: _ReporterLogLevelExhaustivenessCheck = true;
 
 /**
- * A ready-made {@link Converter | Converter} for {@link ReporterLogLevel} values.
+ * Exhaustive list of all {@link Logging.ReporterLogLevel | ReporterLogLevel} values.
+ * @public
+ */
+export const allReporterLogLevels: readonly ReporterLogLevel[] = reporterLogLevelValues;
+
+/**
+ * A ready-made {@link Converter | Converter} for {@link Logging.ReporterLogLevel | ReporterLogLevel} values.
  * @public
  */
 export const reporterLogLevel: Converter<

--- a/libraries/ts-utils/src/packlets/logging-interface/index.ts
+++ b/libraries/ts-utils/src/packlets/logging-interface/index.ts
@@ -35,7 +35,7 @@ const reporterLogLevelValues = ['all', 'detail', 'info', 'warning', 'error', 'si
 
 /**
  * Compile-time exhaustiveness guard ensuring {@link reporterLogLevelValues} exactly matches every member of
- * {@link Logging.ReporterLogLevel | ReporterLogLevel}. Adding or removing a union member without updating the array fails the build.
+ * `ReporterLogLevel`. Adding or removing a union member without updating the array fails the build.
  * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
 type _ReporterLogLevelExhaustivenessCheck = [
@@ -49,13 +49,13 @@ type _ReporterLogLevelExhaustivenessCheck = [
 const _reporterLogLevelExhaustivenessCheck: _ReporterLogLevelExhaustivenessCheck = true;
 
 /**
- * Exhaustive list of all {@link Logging.ReporterLogLevel | ReporterLogLevel} values.
+ * Exhaustive list of all `ReporterLogLevel` values.
  * @public
  */
 export const allReporterLogLevels: readonly ReporterLogLevel[] = reporterLogLevelValues;
 
 /**
- * A ready-made {@link Converter | Converter} for {@link Logging.ReporterLogLevel | ReporterLogLevel} values.
+ * A ready-made {@link Converter | Converter} for `ReporterLogLevel` values.
  * @public
  */
 export const reporterLogLevel: Converter<

--- a/libraries/ts-utils/src/packlets/logging-interface/index.ts
+++ b/libraries/ts-utils/src/packlets/logging-interface/index.ts
@@ -30,12 +30,12 @@ export type ReporterLogLevel = 'all' | 'detail' | 'info' | 'warning' | 'error' |
 
 // Untyped (literal-tuple-inferred) source of truth for allReporterLogLevels, kept separate from the
 // widened public export below so the exhaustiveness check actually inspects the literal values instead
-// of being widened away to `ReporterLogLevel` before the check runs.
+// of being widened away to {@link Logging.ReporterLogLevel | ReporterLogLevel} before the check runs.
 const reporterLogLevelValues = ['all', 'detail', 'info', 'warning', 'error', 'silent'] as const;
 
 /**
  * Compile-time exhaustiveness guard ensuring {@link reporterLogLevelValues} exactly matches every member of
- * `ReporterLogLevel`. Adding or removing a union member without updating the array fails the build.
+ * {@link Logging.ReporterLogLevel | ReporterLogLevel}. Adding or removing a union member without updating the array fails the build.
  * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
 type _ReporterLogLevelExhaustivenessCheck = [
@@ -49,13 +49,13 @@ type _ReporterLogLevelExhaustivenessCheck = [
 const _reporterLogLevelExhaustivenessCheck: _ReporterLogLevelExhaustivenessCheck = true;
 
 /**
- * Exhaustive list of all `ReporterLogLevel` values.
+ * Exhaustive list of all {@link Logging.ReporterLogLevel | ReporterLogLevel} values.
  * @public
  */
 export const allReporterLogLevels: readonly ReporterLogLevel[] = reporterLogLevelValues;
 
 /**
- * A ready-made {@link Converter | Converter} for `ReporterLogLevel` values.
+ * A ready-made {@link Converter | Converter} for {@link Logging.ReporterLogLevel | ReporterLogLevel} values.
  * @public
  */
 export const reporterLogLevel: Converter<

--- a/libraries/ts-utils/src/packlets/logging-interface/index.ts
+++ b/libraries/ts-utils/src/packlets/logging-interface/index.ts
@@ -44,25 +44,23 @@ export const allReporterLogLevels: readonly ReporterLogLevel[] = [
 /**
  * Compile-time exhaustiveness guard ensuring {@link allReporterLogLevels} exactly matches every member of
  * {@link ReporterLogLevel}. Adding or removing a union member without updating the array fails the build.
- * @internal
+ * Deliberately not exported - this exists only to force the compiler to evaluate the check below.
  */
-export type _ReporterLogLevelExhaustivenessCheck = [
+type _ReporterLogLevelExhaustivenessCheck = [
   Exclude<ReporterLogLevel, (typeof allReporterLogLevels)[number]>,
   Exclude<(typeof allReporterLogLevels)[number], ReporterLogLevel>
 ] extends [never, never]
   ? true
   : never;
 
-/**
- * @internal
- */
-export const _reporterLogLevelExhaustivenessCheck: _ReporterLogLevelExhaustivenessCheck = true;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _reporterLogLevelExhaustivenessCheck: _ReporterLogLevelExhaustivenessCheck = true;
 
 /**
  * A ready-made {@link Converter | Converter} for {@link ReporterLogLevel} values.
  * @public
  */
-export const reporterLogLevelConverter: Converter<
+export const reporterLogLevel: Converter<
   ReporterLogLevel,
   ReadonlyArray<ReporterLogLevel>
 > = Converters.enumeratedValue<ReporterLogLevel>(allReporterLogLevels);

--- a/libraries/ts-utils/src/packlets/logging-interface/index.ts
+++ b/libraries/ts-utils/src/packlets/logging-interface/index.ts
@@ -20,12 +20,52 @@
  * SOFTWARE.
  */
 import { MessageLogLevel, Success } from '../base';
+import { Converter, Converters } from '../conversion';
 
 /**
  * The level of logging to be used.
  * @public
  */
 export type ReporterLogLevel = 'all' | 'detail' | 'info' | 'warning' | 'error' | 'silent';
+
+/**
+ * Exhaustive list of all {@link ReporterLogLevel} values.
+ * @public
+ */
+export const allReporterLogLevels: readonly ReporterLogLevel[] = [
+  'all',
+  'detail',
+  'info',
+  'warning',
+  'error',
+  'silent'
+] as const;
+
+/**
+ * Compile-time exhaustiveness guard ensuring {@link allReporterLogLevels} exactly matches every member of
+ * {@link ReporterLogLevel}. Adding or removing a union member without updating the array fails the build.
+ * @internal
+ */
+export type _ReporterLogLevelExhaustivenessCheck = [
+  Exclude<ReporterLogLevel, (typeof allReporterLogLevels)[number]>,
+  Exclude<(typeof allReporterLogLevels)[number], ReporterLogLevel>
+] extends [never, never]
+  ? true
+  : never;
+
+/**
+ * @internal
+ */
+export const _reporterLogLevelExhaustivenessCheck: _ReporterLogLevelExhaustivenessCheck = true;
+
+/**
+ * A ready-made {@link Converter | Converter} for {@link ReporterLogLevel} values.
+ * @public
+ */
+export const reporterLogLevelConverter: Converter<
+  ReporterLogLevel,
+  ReadonlyArray<ReporterLogLevel>
+> = Converters.enumeratedValue<ReporterLogLevel>(allReporterLogLevels);
 
 /**
  * Generic Result-aware logger interface with multiple levels of logging.

--- a/libraries/ts-utils/src/packlets/logging/logger.ts
+++ b/libraries/ts-utils/src/packlets/logging/logger.ts
@@ -24,23 +24,12 @@ import {
   IDetailLogger,
   ILogger,
   ReporterLogLevel,
-  _ReporterLogLevelExhaustivenessCheck,
-  _reporterLogLevelExhaustivenessCheck,
   allReporterLogLevels,
   isDetailLogger,
-  reporterLogLevelConverter
+  reporterLogLevel
 } from '../logging-interface';
 
-export {
-  isDetailLogger,
-  ReporterLogLevel,
-  ILogger,
-  IDetailLogger,
-  allReporterLogLevels,
-  reporterLogLevelConverter,
-  _ReporterLogLevelExhaustivenessCheck,
-  _reporterLogLevelExhaustivenessCheck
-};
+export { isDetailLogger, ReporterLogLevel, ILogger, IDetailLogger, allReporterLogLevels, reporterLogLevel };
 
 /**
  * Compares two log levels.

--- a/libraries/ts-utils/src/packlets/logging/logger.ts
+++ b/libraries/ts-utils/src/packlets/logging/logger.ts
@@ -20,9 +20,27 @@
  * SOFTWARE.
  */
 import { MessageLogLevel, Success, captureResult, succeed } from '../base';
-import { IDetailLogger, ILogger, ReporterLogLevel, isDetailLogger } from '../logging-interface';
+import {
+  IDetailLogger,
+  ILogger,
+  ReporterLogLevel,
+  _ReporterLogLevelExhaustivenessCheck,
+  _reporterLogLevelExhaustivenessCheck,
+  allReporterLogLevels,
+  isDetailLogger,
+  reporterLogLevelConverter
+} from '../logging-interface';
 
-export { isDetailLogger, ReporterLogLevel, ILogger, IDetailLogger };
+export {
+  isDetailLogger,
+  ReporterLogLevel,
+  ILogger,
+  IDetailLogger,
+  allReporterLogLevels,
+  reporterLogLevelConverter,
+  _ReporterLogLevelExhaustivenessCheck,
+  _reporterLogLevelExhaustivenessCheck
+};
 
 /**
  * Compares two log levels.

--- a/libraries/ts-utils/src/test/unit/collections/readOnlyConvertingResultMap.test.ts
+++ b/libraries/ts-utils/src/test/unit/collections/readOnlyConvertingResultMap.test.ts
@@ -23,6 +23,8 @@
 import '../../helpers/jest';
 import { fail, succeed } from '../../../packlets/base';
 import {
+  allConversionErrorHandling,
+  conversionErrorHandlingConverter,
   ReadOnlyConvertingResultMap,
   ResultMap,
   ConvertingResultMapValueConverter
@@ -295,5 +297,25 @@ describe('ReadOnlyConvertingResultMap', () => {
 
       expect(map.size).toBe(inner.size);
     });
+  });
+});
+
+describe('conversionErrorHandlingConverter', () => {
+  test('has exactly the ConversionErrorHandling union values', () => {
+    expect(allConversionErrorHandling).toEqual(['ignore', 'warn', 'fail']);
+  });
+
+  test('converts each valid ConversionErrorHandling value', () => {
+    allConversionErrorHandling.forEach((value) => {
+      expect(conversionErrorHandlingConverter.convert(value)).toSucceedWith(value);
+    });
+  });
+
+  test('fails for an invalid string', () => {
+    expect(conversionErrorHandlingConverter.convert('not-a-handling-mode')).toFailWith(/invalid enumerated/i);
+  });
+
+  test('fails for a non-string value', () => {
+    expect(conversionErrorHandlingConverter.convert(123)).toFailWith(/invalid enumerated/i);
   });
 });

--- a/libraries/ts-utils/src/test/unit/collections/readOnlyConvertingResultMap.test.ts
+++ b/libraries/ts-utils/src/test/unit/collections/readOnlyConvertingResultMap.test.ts
@@ -24,7 +24,7 @@ import '../../helpers/jest';
 import { fail, succeed } from '../../../packlets/base';
 import {
   allConversionErrorHandling,
-  conversionErrorHandlingConverter,
+  conversionErrorHandling,
   ReadOnlyConvertingResultMap,
   ResultMap,
   ConvertingResultMapValueConverter
@@ -300,22 +300,22 @@ describe('ReadOnlyConvertingResultMap', () => {
   });
 });
 
-describe('conversionErrorHandlingConverter', () => {
+describe('conversionErrorHandling', () => {
   test('has exactly the ConversionErrorHandling union values', () => {
     expect(allConversionErrorHandling).toEqual(['ignore', 'warn', 'fail']);
   });
 
   test('converts each valid ConversionErrorHandling value', () => {
     allConversionErrorHandling.forEach((value) => {
-      expect(conversionErrorHandlingConverter.convert(value)).toSucceedWith(value);
+      expect(conversionErrorHandling.convert(value)).toSucceedWith(value);
     });
   });
 
   test('fails for an invalid string', () => {
-    expect(conversionErrorHandlingConverter.convert('not-a-handling-mode')).toFailWith(/invalid enumerated/i);
+    expect(conversionErrorHandling.convert('not-a-handling-mode')).toFailWith(/invalid enumerated/i);
   });
 
   test('fails for a non-string value', () => {
-    expect(conversionErrorHandlingConverter.convert(123)).toFailWith(/invalid enumerated/i);
+    expect(conversionErrorHandling.convert(123)).toFailWith(/invalid enumerated/i);
   });
 });

--- a/libraries/ts-utils/src/test/unit/converters.basic.test.ts
+++ b/libraries/ts-utils/src/test/unit/converters.basic.test.ts
@@ -97,43 +97,43 @@ describe('Basic converters', () => {
     });
   });
 
-  describe('messageLogLevelConverter', () => {
+  describe('messageLogLevel', () => {
     test('has exactly the MessageLogLevel union values', () => {
       expect(allMessageLogLevels).toEqual(['quiet', 'detail', 'info', 'warning', 'error']);
     });
 
     test('converts each valid MessageLogLevel value', () => {
       allMessageLogLevels.forEach((level) => {
-        expect(Converters.messageLogLevelConverter.convert(level)).toSucceedWith(level);
+        expect(Converters.messageLogLevel.convert(level)).toSucceedWith(level);
       });
     });
 
     test('fails for an invalid string', () => {
-      expect(Converters.messageLogLevelConverter.convert('not-a-level')).toFailWith(/invalid enumerated/i);
+      expect(Converters.messageLogLevel.convert('not-a-level')).toFailWith(/invalid enumerated/i);
     });
 
     test('fails for a non-string value', () => {
-      expect(Converters.messageLogLevelConverter.convert(123)).toFailWith(/invalid enumerated/i);
+      expect(Converters.messageLogLevel.convert(123)).toFailWith(/invalid enumerated/i);
     });
   });
 
-  describe('onErrorConverter', () => {
+  describe('onError', () => {
     test('has exactly the OnError union values', () => {
       expect(allOnError).toEqual(['failOnError', 'ignoreErrors']);
     });
 
     test('converts each valid OnError value', () => {
       allOnError.forEach((value) => {
-        expect(Converters.onErrorConverter.convert(value)).toSucceedWith(value);
+        expect(Converters.onError.convert(value)).toSucceedWith(value);
       });
     });
 
     test('fails for an invalid string', () => {
-      expect(Converters.onErrorConverter.convert('not-an-onerror-value')).toFailWith(/invalid enumerated/i);
+      expect(Converters.onError.convert('not-an-onerror-value')).toFailWith(/invalid enumerated/i);
     });
 
     test('fails for a non-string value', () => {
-      expect(Converters.onErrorConverter.convert(123)).toFailWith(/invalid enumerated/i);
+      expect(Converters.onError.convert(123)).toFailWith(/invalid enumerated/i);
     });
   });
 

--- a/libraries/ts-utils/src/test/unit/converters.basic.test.ts
+++ b/libraries/ts-utils/src/test/unit/converters.basic.test.ts
@@ -23,8 +23,8 @@
 import '../helpers/jest';
 
 import { Validation } from '../../index';
-import { fail, omit, Result, succeed } from '../../packlets/base';
-import { Converters, FieldConverters } from '../../packlets/conversion';
+import { allMessageLogLevels, fail, omit, Result, succeed } from '../../packlets/base';
+import { allOnError, Converters, FieldConverters } from '../../packlets/conversion';
 
 describe('Basic converters', () => {
   describe('string converter', () => {
@@ -94,6 +94,46 @@ describe('Basic converters', () => {
       [1, true, {}, (): string => 'hello', ['true']].forEach((v) => {
         expect(pie.convert(v)).toFailWith(/invalid enumerated/i);
       });
+    });
+  });
+
+  describe('messageLogLevelConverter', () => {
+    test('has exactly the MessageLogLevel union values', () => {
+      expect(allMessageLogLevels).toEqual(['quiet', 'detail', 'info', 'warning', 'error']);
+    });
+
+    test('converts each valid MessageLogLevel value', () => {
+      allMessageLogLevels.forEach((level) => {
+        expect(Converters.messageLogLevelConverter.convert(level)).toSucceedWith(level);
+      });
+    });
+
+    test('fails for an invalid string', () => {
+      expect(Converters.messageLogLevelConverter.convert('not-a-level')).toFailWith(/invalid enumerated/i);
+    });
+
+    test('fails for a non-string value', () => {
+      expect(Converters.messageLogLevelConverter.convert(123)).toFailWith(/invalid enumerated/i);
+    });
+  });
+
+  describe('onErrorConverter', () => {
+    test('has exactly the OnError union values', () => {
+      expect(allOnError).toEqual(['failOnError', 'ignoreErrors']);
+    });
+
+    test('converts each valid OnError value', () => {
+      allOnError.forEach((value) => {
+        expect(Converters.onErrorConverter.convert(value)).toSucceedWith(value);
+      });
+    });
+
+    test('fails for an invalid string', () => {
+      expect(Converters.onErrorConverter.convert('not-an-onerror-value')).toFailWith(/invalid enumerated/i);
+    });
+
+    test('fails for a non-string value', () => {
+      expect(Converters.onErrorConverter.convert(123)).toFailWith(/invalid enumerated/i);
     });
   });
 

--- a/libraries/ts-utils/src/test/unit/logger.test.ts
+++ b/libraries/ts-utils/src/test/unit/logger.test.ts
@@ -23,12 +23,14 @@
 import '../helpers/jest';
 
 import {
+  allReporterLogLevels,
   BootLogger,
   InMemoryLogger,
   ILogger,
   isDetailLogger,
   LogReporter,
-  NoOpLogger
+  NoOpLogger,
+  reporterLogLevelConverter
 } from '../../packlets/logging';
 
 import { fail, MessageLogLevel, Result, succeed } from '../../packlets/base';
@@ -1428,5 +1430,25 @@ describe('Logger class', () => {
       boot.log('error', 'post-ready error');
       expect(real.logged).toEqual(['pre-ready warning', 'post-ready error']);
     });
+  });
+});
+
+describe('reporterLogLevelConverter', () => {
+  test('has exactly the ReporterLogLevel union values', () => {
+    expect(allReporterLogLevels).toEqual(['all', 'detail', 'info', 'warning', 'error', 'silent']);
+  });
+
+  test('converts each valid ReporterLogLevel value', () => {
+    allReporterLogLevels.forEach((level) => {
+      expect(reporterLogLevelConverter.convert(level)).toSucceedWith(level);
+    });
+  });
+
+  test('fails for an invalid string', () => {
+    expect(reporterLogLevelConverter.convert('not-a-level')).toFailWith(/invalid enumerated/i);
+  });
+
+  test('fails for a non-string value', () => {
+    expect(reporterLogLevelConverter.convert(123)).toFailWith(/invalid enumerated/i);
   });
 });

--- a/libraries/ts-utils/src/test/unit/logger.test.ts
+++ b/libraries/ts-utils/src/test/unit/logger.test.ts
@@ -30,7 +30,7 @@ import {
   isDetailLogger,
   LogReporter,
   NoOpLogger,
-  reporterLogLevelConverter
+  reporterLogLevel
 } from '../../packlets/logging';
 
 import { fail, MessageLogLevel, Result, succeed } from '../../packlets/base';
@@ -1433,22 +1433,22 @@ describe('Logger class', () => {
   });
 });
 
-describe('reporterLogLevelConverter', () => {
+describe('reporterLogLevel', () => {
   test('has exactly the ReporterLogLevel union values', () => {
     expect(allReporterLogLevels).toEqual(['all', 'detail', 'info', 'warning', 'error', 'silent']);
   });
 
   test('converts each valid ReporterLogLevel value', () => {
     allReporterLogLevels.forEach((level) => {
-      expect(reporterLogLevelConverter.convert(level)).toSucceedWith(level);
+      expect(reporterLogLevel.convert(level)).toSucceedWith(level);
     });
   });
 
   test('fails for an invalid string', () => {
-    expect(reporterLogLevelConverter.convert('not-a-level')).toFailWith(/invalid enumerated/i);
+    expect(reporterLogLevel.convert('not-a-level')).toFailWith(/invalid enumerated/i);
   });
 
   test('fails for a non-string value', () => {
-    expect(reporterLogLevelConverter.convert(123)).toFailWith(/invalid enumerated/i);
+    expect(reporterLogLevel.convert(123)).toFailWith(/invalid enumerated/i);
   });
 });


### PR DESCRIPTION
## Summary

A consumer had to hand-declare an array of `ReporterLogLevel` values just to build a `Converters.enumeratedValue(...)` converter for a config object — `@fgv/ts-utils` owned the type but published neither the value list nor a ready-made converter. This PR fixes that at the source for `ReporterLogLevel` and sweeps the same gap for three sibling config-shaped unions.

For each of `ReporterLogLevel`, `MessageLogLevel`, `OnError`, and `ConversionErrorHandling`, adds:

- `allX: readonly X[]` — an exhaustive value list (`as const`), declared next to the type.
- A compile-time exhaustiveness guard (bidirectional `Exclude<...>` check) that fails the build if the union and the array ever diverge. The guard type/const are deliberately **not exported** — they only exist to force the compiler to evaluate the check, and this package's API rollup is untrimmed, so exporting them would leak internal scaffolding into the public `.d.ts`.
- A ready-made `Converter<X>` built via `Converters.enumeratedValue(allX)`, named to match each file's existing bare-noun converter convention (`messageLogLevel`, `onError`, `reporterLogLevel`, `conversionErrorHandling` — mirroring `string`, `number`, `boolean`, etc.).

Placement follows the packlet dependency graph: `base` cannot import `conversion`, so `MessageLogLevel`'s array lives in `base` but its converter lives in `conversion`; the other three types keep their array + converter in the same packlet as the type.

Excluded `ResultMapResultDetail` and `CollectorResultDetail` — internal diagnostic discriminators, not config-shaped unions. No other config-shaped union was found during the sweep.

All changes are purely additive — no existing export was renamed, retyped, or removed. `etc/ts-utils.api.md` diff versus `release` is additive-only (verified via `git diff origin/release -- etc/ts-utils.api.md`).

## Review

- `code-reviewer` agent ran on the diff before the coverage pass. Findings: no P1s. Two P2s — both addressed in a follow-up commit:
  - Exhaustiveness-guard type/const were exported (and re-exported through the `logging` barrel) with `@internal` tags, but this project's `api-extractor.json` doesn't trim `@internal` from the shipped rollup, so they'd have leaked into the public `.d.ts`. Fixed: made them module-private (with an `eslint-disable-next-line` for the resulting "assigned but never used" warning, which is intentional — the const's only job is to force TypeScript to evaluate the guard).
  - New converters were named with a `Converter` suffix, inconsistent with the established bare-noun convention in these files (`string`, `number`, `enumeratedValue`-built converters elsewhere in the repo like `conditionOperator`, `encryptedFileFormat`). Renamed accordingly.
  - P3 advisory (the "array equals literal" test is somewhat tautological, real enforcement is the type-level check) — noted, not changed.

## Test plan

- [x] `rushx build` passes (typescript + lint + api-extractor)
- [x] `rushx lint` passes with no warnings or errors
- [x] `rushx fixlint` run before final commit (no changes produced)
- [x] `rushx test` passes: 1610/1610, 100% coverage on every touched file (pre-existing, untouched gaps elsewhere in the package are unrelated to this change)
- [x] No `any` types; all fallible operations already routed through the existing `Converters.enumeratedValue` primitive
- [x] `etc/ts-utils.api.md` diff vs. `release` is additive-only
- [x] `code-reviewer` agent run on the diff; both P2 findings resolved in a follow-up commit
- [x] `rush change` file added (`type: minor`, lockstep `base-utils` policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMWYkgo5kXZtWJd2aNKtGC

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMWYkgo5kXZtWJd2aNKtGC)_