### PR TITLE
feat(ai-assist): quality-tier model axis + cascade resolver + composition rewire (B1)

### DIFF
--- a/common/changes/@fgv/ts-extras/claude-ai-assist-b1-model-tiers-bv3xas_2026-07-05-20-29.json
+++ b/common/changes/@fgv/ts-extras/claude-ai-assist-b1-model-tiers-bv3xas_2026-07-05-20-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add quality-tier model axis (base/advanced/frontier) with a cascade resolver; thinking/tools are now orthogonal to completion-model selection (breaking: ModelSpecKey drops 'thinking'/'tools')",
+      "type": "none",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -1671,6 +1671,7 @@ interface IProviderCompletionParams extends IChatRequest {
     readonly signal?: AbortSignal;
     readonly temperature?: number;
     readonly thinking?: IThinkingConfig;
+    readonly tier?: 'advanced' | 'frontier';
     readonly tools?: ReadonlyArray<AiServerToolConfig>;
 }
 
@@ -1686,6 +1687,7 @@ interface IProviderCompletionStreamParams extends IChatRequest {
     readonly signal?: AbortSignal;
     readonly temperature?: number;
     readonly thinking?: IThinkingConfig;
+    readonly tier?: 'advanced' | 'frontier';
     readonly tools?: ReadonlyArray<AiServerToolConfig>;
 }
 
@@ -2100,7 +2102,7 @@ type ModelSpec = string | IModelSpecMap;
 const modelSpec: Converter<ModelSpec>;
 
 // @public
-type ModelSpecKey = 'base' | 'tools' | 'image' | 'thinking' | 'embedding';
+type ModelSpecKey = 'base' | 'advanced' | 'frontier' | 'image' | 'embedding';
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "ModelSpecKey"
 //

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -50,6 +50,7 @@ import {
   type IChatRequest,
   type IThinkingConfig,
   type ModelSpec,
+  type ModelSpecKey,
   resolveProviderModel
 } from './model';
 import {
@@ -97,6 +98,13 @@ export interface IProviderCompletionParams extends IChatRequest {
   readonly temperature?: number;
   /** Optional model override — string or context-aware map (uses descriptor.defaultModel otherwise) */
   readonly modelOverride?: ModelSpec;
+  /**
+   * Optional quality tier selecting which completion model to use. `undefined`
+   * selects the `base` tier; `'frontier'` cascades to `advanced` then `base`
+   * when a tier is unset for a provider. Orthogonal to `thinking` and `tools`,
+   * which never select a model.
+   */
+  readonly tier?: 'advanced' | 'frontier';
   /** Optional logger for request/response observability. */
   readonly logger?: Logging.ILogger;
   /** Server-side tools to include in the request. Overrides settings-level tool config when provided. */
@@ -684,6 +692,7 @@ export async function callProviderCompletion(
     messages,
     temperature,
     modelOverride,
+    tier,
     logger,
     tools,
     signal,
@@ -707,11 +716,9 @@ export async function callProviderCompletion(
 
   const hasTools = tools !== undefined && tools.length > 0;
   const discriminator = providerDiscriminatorForId(descriptor.id);
-  const hasThinkingConfig =
-    discriminator !== undefined &&
-    (thinking?.effort !== undefined ||
-      thinking?.providers?.some((b) => b.provider === 'other' || b.provider === discriminator) === true);
-  const modelContext = hasThinkingConfig ? 'thinking' : hasTools ? 'tools' : undefined;
+  // The quality tier is the only completion-model selector; thinking and tools
+  // are orthogonal request params/capabilities and never pick a model.
+  const modelContext: ModelSpecKey | undefined = tier;
 
   const modelResult = resolveProviderModel(descriptor, modelOverride, modelContext);
   if (modelResult.isFailure()) {

--- a/libraries/ts-extras/src/packlets/ai-assist/converters.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/converters.ts
@@ -163,7 +163,9 @@ export const modelSpec: Converter<ModelSpec> = Converters.generic<ModelSpec>(
       Converters.string,
       Converters.recordOf(self, { keyConverter: modelSpecKey })
     ])
-      .withFormattedError(() => 'expected model spec (string or object with keys: base, tools, image)')
+      .withFormattedError(
+        () => 'expected model spec (string or object with keys: base, advanced, frontier, image, embedding)'
+      )
       .convert(from);
   }
 );

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -458,7 +458,7 @@ export interface IAiClientToolTurnResult {
  * Known context keys for model specification maps.
  * @public
  */
-export type ModelSpecKey = 'base' | 'tools' | 'image' | 'thinking' | 'embedding';
+export type ModelSpecKey = 'base' | 'advanced' | 'frontier' | 'image' | 'embedding';
 
 /**
  * All valid {@link ModelSpecKey} values.
@@ -466,9 +466,9 @@ export type ModelSpecKey = 'base' | 'tools' | 'image' | 'thinking' | 'embedding'
  */
 export const allModelSpecKeys: ReadonlyArray<ModelSpecKey> = [
   'base',
-  'tools',
+  'advanced',
+  'frontier',
   'image',
-  'thinking',
   'embedding'
 ];
 
@@ -485,18 +485,18 @@ export const MODEL_SPEC_BASE_KEY: ModelSpecKey = 'base';
  * @remarks
  * A bare string is equivalent to `{ base: string }`. This keeps the simple
  * case simple while allowing context-aware model selection (e.g. different
- * models for tool-augmented vs. base completions).
+ * models for different quality tiers).
  *
  * @example
  * ```typescript
  * // Simple — same model for all contexts:
  * const simple: ModelSpec = 'grok-4.3';
  *
- * // Context-aware — different model for tools and thinking:
- * const split: ModelSpec = { base: 'grok-4.3', tools: 'grok-4.3', thinking: 'grok-4.3' };
+ * // Context-aware — different model per quality tier:
+ * const split: ModelSpec = { base: 'gpt-5.4-mini', advanced: 'gpt-5.5', frontier: 'gpt-5.5-pro' };
  *
- * // Future nested — per-tool model selection:
- * const nested: ModelSpec = { base: 'grok-fast', tools: { base: 'grok-r', image: 'grok-v' } };
+ * // Nested — a tier branch is itself a spec:
+ * const nested: ModelSpec = { base: 'grok-fast', advanced: { base: 'grok-r', image: 'grok-v' } };
  * ```
  * @public
  */
@@ -510,17 +510,38 @@ export interface IModelSpecMap {
 export type ModelSpec = string | IModelSpecMap;
 
 /**
+ * Ordered fallback candidates for each quality-tier context key.
+ *
+ * @remarks
+ * A `frontier` request cascades `frontier → advanced → base`; an `advanced`
+ * request cascades `advanced → base`. Any context not listed here (the
+ * `image`/`embedding` modality keys, or an arbitrary caller-supplied string)
+ * resolves flat — just the context itself, then the shared `base` fallback
+ * below — matching the pre-tier behavior. `base` maps to `['base']` so a
+ * `base` request never over-reaches into a tier branch.
+ */
+const TIER_FALLBACK: { readonly [k: string]: ReadonlyArray<ModelSpecKey> } = {
+  base: ['base'],
+  advanced: ['advanced', 'base'],
+  frontier: ['frontier', 'advanced', 'base']
+};
+
+/**
  * Resolves a {@link ModelSpec} to a concrete model string given an optional context key.
  *
  * @remarks
  * Resolution rules:
  * 1. If the spec is a string, return it directly (context is irrelevant).
- * 2. If the spec is an object and the context key exists, recurse into that branch.
+ * 2. If the spec is an object, walk the ordered candidate keys for the context:
+ *    a quality-tier context (`advanced`/`frontier`) cascades through the
+ *    tier-fallback table (`frontier → advanced → base`, `advanced → base`);
+ *    every other context resolves flat (`[context]`); `undefined` resolves to
+ *    the shared `base` fallback. The first present key wins.
  * 3. Otherwise, fall back to the {@link MODEL_SPEC_BASE_KEY | 'base'} key.
  * 4. If neither context nor `'base'` exists, use the first available value.
  *
  * @param spec - The model specification to resolve
- * @param context - Optional context key (e.g. `'tools'`)
+ * @param context - Optional context key (e.g. `'advanced'`)
  * @returns The resolved model string
  * @public
  */
@@ -529,9 +550,14 @@ export function resolveModel(spec: ModelSpec, context?: string): string {
     return spec;
   }
 
-  // Try the requested context key first
-  if (context !== undefined && context in spec) {
-    return resolveModel(spec[context]);
+  // Ordered candidate keys for this context: a tier key cascades via
+  // TIER_FALLBACK; any other key resolves flat as [context]; undefined drops
+  // straight to the shared 'base' fallback below.
+  const order: ReadonlyArray<string> = context === undefined ? [] : TIER_FALLBACK[context] ?? [context];
+  for (const key of order) {
+    if (key in spec) {
+      return resolveModel(spec[key]);
+    }
   }
 
   // Fall back to 'base'

--- a/libraries/ts-extras/src/packlets/ai-assist/registry.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/registry.ts
@@ -79,7 +79,6 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
     defaultModel: {
       base: '@google-gemini:flash',
-      thinking: '@google-gemini:pro',
       image: '@google-gemini:flash-image',
       embedding: '@google-gemini:embedding'
     },
@@ -89,8 +88,8 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
       // line advanced to 3.5 while the other roles are on the 3.1 generation. The per-role version
       // split is exactly why the alias layer exists — consumers never see these numbers.
       '@google-gemini:flash': 'gemini-3.5-flash', // base (was gemini-2.5-flash, shutdown 2026-10-16)
-      '@google-gemini:pro': 'gemini-3.1-pro-preview', // thinking (was gemini-2.5-pro, 2026-10-16)
-      '@google-gemini:flash-lite': 'gemini-3.1-flash-lite', // thinking tier; available via modelOverride, NOT the 'thinking' default (was gemini-2.5-flash-lite, 2026-10-16)
+      '@google-gemini:pro': 'gemini-3.1-pro-preview', // advanced-tier role (wired to the 'advanced' defaultModel key in B4); reachable via modelOverride until then (was gemini-2.5-pro, 2026-10-16)
+      '@google-gemini:flash-lite': 'gemini-3.1-flash-lite', // cheaper thinking-capable line; available via modelOverride only (was gemini-2.5-flash-lite, 2026-10-16)
       '@google-gemini:flash-image': 'gemini-3.1-flash-image-preview', // image (was gemini-2.5-flash-image, 2026-10-02)
       '@google-gemini:embedding': 'gemini-embedding-001' // NOT deprecated — aliased for uniformity only
     },
@@ -255,8 +254,6 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     baseUrl: 'https://api.x.ai/v1',
     defaultModel: {
       base: 'grok-4.3',
-      tools: 'grok-4.3',
-      thinking: 'grok-4.3',
       image: 'grok-imagine-image-quality'
     },
     supportedTools: ['web_search'],

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/common.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/common.ts
@@ -58,6 +58,13 @@ export interface IProviderCompletionStreamParams extends IChatRequest {
   readonly temperature?: number;
   /** Optional model override — string or context-aware map. */
   readonly modelOverride?: ModelSpec;
+  /**
+   * Optional quality tier selecting which completion model to use. `undefined`
+   * selects the `base` tier; `'frontier'` cascades to `advanced` then `base`
+   * when a tier is unset for a provider. Orthogonal to `thinking` and `tools`,
+   * which never select a model.
+   */
+  readonly tier?: 'advanced' | 'frontier';
   /** Optional logger for request/response observability. */
   readonly logger?: Logging.ILogger;
   /** Server-side tools to include in the request. */

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingClient.ts
@@ -31,7 +31,7 @@ import { fail, Result } from '@fgv/ts-utils';
 
 import { splitChatRequest } from './chatRequestBuilders';
 import { resolveEffectiveBaseUrl } from './endpoint';
-import { type IAiStreamEvent, resolveProviderModel } from './model';
+import { type IAiStreamEvent, type ModelSpecKey, resolveProviderModel } from './model';
 import { callAnthropicStream } from './streamingAdapters/anthropic';
 import { type IProviderCompletionStreamParams, type IStreamApiConfig } from './streamingAdapters/common';
 import { callGeminiStream } from './streamingAdapters/gemini';
@@ -98,6 +98,7 @@ export async function callProviderCompletionStream(
     messages,
     temperature,
     modelOverride,
+    tier,
     logger,
     tools,
     signal,
@@ -124,11 +125,9 @@ export async function callProviderCompletionStream(
 
   const hasTools = tools !== undefined && tools.length > 0;
   const discriminator = providerDiscriminatorForId(descriptor.id);
-  const hasThinkingConfig =
-    discriminator !== undefined &&
-    (thinking?.effort !== undefined ||
-      thinking?.providers?.some((b) => b.provider === 'other' || b.provider === discriminator) === true);
-  const modelContext = hasThinkingConfig ? 'thinking' : hasTools ? 'tools' : undefined;
+  // The quality tier is the only completion-model selector; thinking and tools
+  // are orthogonal request params/capabilities and never pick a model.
+  const modelContext: ModelSpecKey | undefined = tier;
 
   const modelResult = resolveProviderModel(descriptor, modelOverride, modelContext);
   if (modelResult.isFailure()) {

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.test.ts
@@ -271,6 +271,98 @@ describe('callProviderCompletion', () => {
   });
 
   // ==========================================================================
+  // Quality-tier composition (B1): the tier is the ONLY completion-model
+  // selector; thinking and tools are orthogonal request params/capabilities
+  // and never pick a model.
+  // ==========================================================================
+
+  describe('quality-tier composition', () => {
+    const tieredDescriptor = makeDescriptor({
+      id: 'openai',
+      apiFormat: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      defaultModel: { base: 'm-base', advanced: 'm-adv', frontier: 'm-front' }
+    });
+
+    async function bodyForCompletion(
+      params: Partial<AiAssist.IProviderCompletionParams>,
+      descriptor: IAiProviderDescriptor = tieredDescriptor
+    ): Promise<Record<string, unknown>> {
+      mockFetchResponse(openAiResponse('ok'));
+      const result = await AiAssist.callProviderCompletion({
+        descriptor,
+        apiKey: 'test-key',
+        ...testPrompt.toRequest(),
+        ...params
+      });
+      expect(result).toSucceed();
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      return JSON.parse(fetchCall[1].body) as Record<string, unknown>;
+    }
+
+    test('no tier selects the base model', async () => {
+      expect((await bodyForCompletion({})).model).toBe('m-base');
+    });
+
+    test('tier "advanced" selects the advanced model', async () => {
+      expect((await bodyForCompletion({ tier: 'advanced' })).model).toBe('m-adv');
+    });
+
+    test('tier "frontier" selects the frontier model', async () => {
+      expect((await bodyForCompletion({ tier: 'frontier' })).model).toBe('m-front');
+    });
+
+    test('tier "frontier" cascades to advanced when no frontier key is defined', async () => {
+      const descriptor = makeDescriptor({
+        id: 'openai',
+        apiFormat: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        defaultModel: { base: 'm-base', advanced: 'm-adv' }
+      });
+      expect((await bodyForCompletion({ tier: 'frontier' }, descriptor)).model).toBe('m-adv');
+    });
+
+    test('a base-only descriptor + tier request cascades to base', async () => {
+      const descriptor = makeDescriptor({
+        id: 'openai',
+        apiFormat: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        defaultModel: { base: 'm-base' }
+      });
+      expect((await bodyForCompletion({ tier: 'frontier' }, descriptor)).model).toBe('m-base');
+    });
+
+    test('thinking without a tier resolves the base model and still rides as a wire param', async () => {
+      const body = await bodyForCompletion({ thinking: { effort: 'low' } });
+      // Composition: thinking does NOT upgrade the tier — model stays base...
+      expect(body.model).toBe('m-base');
+      // ...but the thinking config is still read and still sent to the API.
+      expect(body.reasoning_effort).toBe('low');
+    });
+
+    test('thinking composes on top of an explicit tier (model = tier, thinking rides)', async () => {
+      const body = await bodyForCompletion({ tier: 'advanced', thinking: { effort: 'low' } });
+      expect(body.model).toBe('m-adv');
+      expect(body.reasoning_effort).toBe('low');
+    });
+
+    test('tools without a tier resolves the base model', async () => {
+      // Tools route to the Responses API, so mock that wire shape directly
+      // rather than via the chat-format helper.
+      mockFetchResponse(responsesApiResponse('ok'));
+      const result = await AiAssist.callProviderCompletion({
+        descriptor: tieredDescriptor,
+        apiKey: 'test-key',
+        ...testPrompt.toRequest(),
+        tools: [{ type: 'web_search' }]
+      });
+      expect(result).toSucceed();
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(body.model).toBe('m-base');
+    });
+  });
+
+  // ==========================================================================
   // AbortSignal threading — one assertion per format proves wire-through.
   // ==========================================================================
 
@@ -688,9 +780,12 @@ describe('callProviderCompletion', () => {
       expect(body.input).toBeDefined();
     });
 
-    test('selects tools model from ModelSpec when tools provided', async () => {
+    test('tools no longer select a model — resolves base under composition', async () => {
+      // Under composition the tier is the only selector; a request with tools
+      // (and no tier) resolves the base model. A tiered descriptor's advanced
+      // key is never reached by a tools request.
       const splitDescriptor = makeDescriptor({
-        defaultModel: { base: 'grok-fast', tools: 'grok-reasoning' }
+        defaultModel: { base: 'grok-fast', advanced: 'grok-reasoning' }
       });
       mockFetchResponse(responsesApiResponse('ok'));
 
@@ -702,12 +797,12 @@ describe('callProviderCompletion', () => {
       });
 
       const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-      expect(body.model).toBe('grok-reasoning');
+      expect(body.model).toBe('grok-fast');
     });
 
-    test('prefers thinking model from ModelSpec when both thinking and tools are provided', async () => {
+    test('thinking no longer selects a model — tools+thinking resolves base under composition', async () => {
       const splitDescriptor = makeDescriptor({
-        defaultModel: { base: 'grok-fast', tools: 'grok-reasoning', thinking: 'grok-4.3' }
+        defaultModel: { base: 'grok-fast', advanced: 'grok-reasoning' }
       });
       mockFetchResponse(responsesApiResponse('ok'));
 
@@ -720,12 +815,12 @@ describe('callProviderCompletion', () => {
       });
 
       const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-      expect(body.model).toBe('grok-4.3');
+      expect(body.model).toBe('grok-fast');
     });
 
     test('selects base model from ModelSpec when no tools', async () => {
       const splitDescriptor = makeDescriptor({
-        defaultModel: { base: 'grok-fast', tools: 'grok-reasoning' }
+        defaultModel: { base: 'grok-fast', advanced: 'grok-reasoning' }
       });
       mockFetchResponse(openAiResponse('no tools'));
 
@@ -739,53 +834,34 @@ describe('callProviderCompletion', () => {
       expect(body.model).toBe('grok-fast');
     });
 
-    test('does not select thinking model when thinking config is empty object', async () => {
-      const splitDescriptor = makeDescriptor({
-        defaultModel: { base: 'grok-fast', tools: 'grok-reasoning', thinking: 'grok-4.3' }
-      });
-      mockFetchResponse(responsesApiResponse('ok'));
+    test('Gemini descriptor: base+thinking (no tier) resolves flash — the intended pro→flash change', async () => {
+      // The one intended behavior change in B1: with the `thinking` defaultModel
+      // key removed, a thinking completion with no tier resolves the base model
+      // (flash) instead of the old pro-for-all-thinking. Drive the real registry
+      // descriptor through the full completion chokepoint.
+      const gemini = AiAssist.getProviderDescriptor('google-gemini').orThrow();
+      mockFetchResponse(geminiResponse('ok'));
 
       await AiAssist.callProviderCompletion({
-        descriptor: splitDescriptor,
+        descriptor: gemini,
         apiKey: 'test-key',
         ...testPrompt.toRequest(),
-        tools,
-        thinking: {}
+        thinking: { effort: 'low' }
       });
 
-      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-      expect(body.model).toBe('grok-reasoning');
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      // Gemini puts the model id in the request URL, not the JSON body.
+      expect(fetchCall[0]).toContain('gemini-3.5-flash');
     });
 
-    test('does not select thinking model when providers block targets a different provider', async () => {
-      const splitDescriptor = makeDescriptor({
-        defaultModel: { base: 'grok-fast', tools: 'grok-reasoning', thinking: 'grok-4.3' }
-      });
+    test('xAI descriptor: a tools+thinking completion resolves grok-4.3 via base', async () => {
+      // The real xAI descriptor's dead tools/thinking keys were stripped in B1;
+      // a tools+thinking completion resolves base = grok-4.3 (behavior-neutral).
+      const xai = AiAssist.getProviderDescriptor('xai-grok').orThrow();
       mockFetchResponse(responsesApiResponse('ok'));
 
       await AiAssist.callProviderCompletion({
-        descriptor: splitDescriptor,
-        apiKey: 'test-key',
-        ...testPrompt.toRequest(),
-        tools,
-        thinking: { providers: [{ provider: 'openai', config: { effort: 'medium' } }] }
-      });
-
-      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-      expect(body.model).toBe('grok-reasoning');
-    });
-
-    test('does not select thinking model for unknown provider even when thinking is provided', async () => {
-      const ollamaDescriptor = makeDescriptor({
-        id: 'ollama',
-        baseUrl: 'http://localhost:11434/v1',
-        defaultModel: { base: 'llama3', tools: 'llama3-tools', thinking: 'llama3-think' },
-        corsRestricted: false
-      });
-      mockFetchResponse(responsesApiResponse('ok'));
-
-      await AiAssist.callProviderCompletion({
-        descriptor: ollamaDescriptor,
+        descriptor: xai,
         apiKey: 'test-key',
         ...testPrompt.toRequest(),
         tools,
@@ -793,7 +869,7 @@ describe('callProviderCompletion', () => {
       });
 
       const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-      expect(body.model).toBe('llama3-tools');
+      expect(body.model).toBe('grok-4.3');
     });
 
     test('extracts text from Responses API output', async () => {

--- a/libraries/ts-extras/src/test/unit/ai-assist/model.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/model.test.ts
@@ -76,35 +76,35 @@ describe('toDataUrl', () => {
 describe('resolveModel', () => {
   test('returns a string spec directly regardless of context', () => {
     expect(AiAssist.resolveModel('grok-4-1-fast')).toBe('grok-4-1-fast');
-    expect(AiAssist.resolveModel('grok-4-1-fast', 'tools')).toBe('grok-4-1-fast');
+    expect(AiAssist.resolveModel('grok-4-1-fast', 'advanced')).toBe('grok-4-1-fast');
   });
 
   test('resolves context key from an object spec', () => {
-    const spec: AiAssist.ModelSpec = { base: 'grok-fast', tools: 'grok-reasoning' };
-    expect(AiAssist.resolveModel(spec, 'tools')).toBe('grok-reasoning');
+    const spec: AiAssist.ModelSpec = { base: 'grok-fast', advanced: 'grok-reasoning' };
+    expect(AiAssist.resolveModel(spec, 'advanced')).toBe('grok-reasoning');
   });
 
   test('falls back to base when context key is missing', () => {
-    const spec: AiAssist.ModelSpec = { base: 'grok-fast', tools: 'grok-reasoning' };
+    const spec: AiAssist.ModelSpec = { base: 'grok-fast', advanced: 'grok-reasoning' };
     expect(AiAssist.resolveModel(spec, 'image')).toBe('grok-fast');
   });
 
   test('falls back to base when no context provided', () => {
-    const spec: AiAssist.ModelSpec = { base: 'grok-fast', tools: 'grok-reasoning' };
+    const spec: AiAssist.ModelSpec = { base: 'grok-fast', advanced: 'grok-reasoning' };
     expect(AiAssist.resolveModel(spec)).toBe('grok-fast');
   });
 
   test('resolves nested spec — context key leads to another object', () => {
     const spec: AiAssist.ModelSpec = {
       base: 'grok-fast',
-      tools: { base: 'grok-reasoning', image: 'grok-vision' }
+      advanced: { base: 'grok-reasoning', image: 'grok-vision' }
     };
-    // 'tools' resolves to nested object, which then falls back to 'base'
-    expect(AiAssist.resolveModel(spec, 'tools')).toBe('grok-reasoning');
+    // 'advanced' resolves to nested object, which then falls back to 'base'
+    expect(AiAssist.resolveModel(spec, 'advanced')).toBe('grok-reasoning');
   });
 
   test('falls back to first value when no base key exists', () => {
-    const spec: AiAssist.ModelSpec = { tools: 'grok-reasoning', image: 'grok-vision' };
+    const spec: AiAssist.ModelSpec = { advanced: 'grok-reasoning', image: 'grok-vision' };
     expect(AiAssist.resolveModel(spec)).toBe('grok-reasoning');
   });
 
@@ -112,11 +112,80 @@ describe('resolveModel', () => {
     const spec: AiAssist.ModelSpec = { base: 'gpt-4o', embedding: 'text-embedding-3-small' };
     expect(AiAssist.resolveModel(spec, 'embedding')).toBe('text-embedding-3-small');
   });
+
+  describe('tier cascade (Q2)', () => {
+    test('base-only map: a frontier request cascades to base (back-compat floor)', () => {
+      const spec: AiAssist.ModelSpec = { base: 'X' };
+      expect(AiAssist.resolveModel(spec, 'frontier')).toBe('X');
+    });
+
+    test('base-only map: an advanced request cascades to base', () => {
+      const spec: AiAssist.ModelSpec = { base: 'X' };
+      expect(AiAssist.resolveModel(spec, 'advanced')).toBe('X');
+    });
+
+    test('advanced set, frontier requested: cascade stops at advanced', () => {
+      const spec: AiAssist.ModelSpec = { base: 'B', advanced: 'A' };
+      expect(AiAssist.resolveModel(spec, 'frontier')).toBe('A');
+    });
+
+    test('frontier set: a frontier request hits frontier directly', () => {
+      const spec: AiAssist.ModelSpec = { base: 'B', advanced: 'A', frontier: 'F' };
+      expect(AiAssist.resolveModel(spec, 'frontier')).toBe('F');
+    });
+
+    test('advanced request with advanced+base present hits advanced directly', () => {
+      const spec: AiAssist.ModelSpec = { base: 'B', advanced: 'A' };
+      expect(AiAssist.resolveModel(spec, 'advanced')).toBe('A');
+    });
+
+    test('tier value is a nested spec — recurses into its base branch', () => {
+      const spec: AiAssist.ModelSpec = { base: 'B', frontier: { base: 'F' } };
+      expect(AiAssist.resolveModel(spec, 'frontier')).toBe('F');
+    });
+
+    test('tier value is an alias — returned verbatim (resolved downstream)', () => {
+      const spec: AiAssist.ModelSpec = { base: 'B', frontier: '@openai:pro' };
+      expect(AiAssist.resolveModel(spec, 'frontier')).toBe('@openai:pro');
+    });
+
+    test('a base request never over-reaches into a tier branch', () => {
+      const spec: AiAssist.ModelSpec = { base: 'B', advanced: 'A', frontier: 'F' };
+      expect(AiAssist.resolveModel(spec, 'base')).toBe('B');
+    });
+
+    test('modality key (image) is unchanged — flat resolution, no cascade', () => {
+      const spec: AiAssist.ModelSpec = { base: 'B', image: 'I' };
+      expect(AiAssist.resolveModel(spec, 'image')).toBe('I');
+    });
+
+    test('modality key (embedding) is unchanged — flat resolution, no cascade', () => {
+      const spec: AiAssist.ModelSpec = { base: 'B', embedding: 'E' };
+      expect(AiAssist.resolveModel(spec, 'embedding')).toBe('E');
+    });
+
+    test('an arbitrary (non-tier) string context resolves flat, then falls to base', () => {
+      const spec: AiAssist.ModelSpec = { base: 'B', custom: 'C' };
+      expect(AiAssist.resolveModel(spec, 'custom')).toBe('C');
+      expect(AiAssist.resolveModel(spec, 'other')).toBe('B');
+    });
+
+    test('undefined context resolves to base — unchanged', () => {
+      const spec: AiAssist.ModelSpec = { base: 'B', advanced: 'A', frontier: 'F' };
+      expect(AiAssist.resolveModel(spec)).toBe('B');
+    });
+  });
 });
 
 describe('capability + spec-key vocabularies', () => {
   test('allModelSpecKeys includes the embedding key', () => {
     expect(AiAssist.allModelSpecKeys).toContain('embedding');
+  });
+
+  test('allModelSpecKeys carries the tier keys and not the removed thinking/tools keys', () => {
+    expect(AiAssist.allModelSpecKeys).toEqual(['base', 'advanced', 'frontier', 'image', 'embedding']);
+    expect(AiAssist.allModelSpecKeys).not.toContain('thinking');
+    expect(AiAssist.allModelSpecKeys).not.toContain('tools');
   });
 
   test('allModelCapabilities includes the embedding capability', () => {
@@ -130,16 +199,27 @@ describe('modelSpec converter', () => {
   });
 
   test('converts an object with string values', () => {
-    expect(AiAssist.modelSpec.convert({ base: 'grok-fast', tools: 'grok-reasoning' })).toSucceedWith({
+    expect(AiAssist.modelSpec.convert({ base: 'grok-fast', advanced: 'grok-reasoning' })).toSucceedWith({
       base: 'grok-fast',
-      tools: 'grok-reasoning'
+      advanced: 'grok-reasoning'
     });
+  });
+
+  test('accepts all tier + modality keys', () => {
+    const input = {
+      base: 'b',
+      advanced: 'a',
+      frontier: 'f',
+      image: 'i',
+      embedding: 'e'
+    };
+    expect(AiAssist.modelSpec.convert(input)).toSucceedWith(input);
   });
 
   test('converts a deeply nested object', () => {
     const input = {
       base: 'grok-fast',
-      tools: { base: 'grok-reasoning', image: 'grok-vision' }
+      advanced: { base: 'grok-reasoning', image: 'grok-vision' }
     };
     expect(AiAssist.modelSpec.convert(input)).toSucceedWith(input);
   });
@@ -164,7 +244,12 @@ describe('modelSpec converter', () => {
     expect(AiAssist.modelSpec.convert({ base: 'ok', bogus: 'bad' })).toFailWith(/expected model spec/i);
   });
 
+  test('rejects the removed thinking/tools keys', () => {
+    expect(AiAssist.modelSpec.convert({ base: 'ok', thinking: 'x' })).toFailWith(/expected model spec/i);
+    expect(AiAssist.modelSpec.convert({ base: 'ok', tools: 'x' })).toFailWith(/expected model spec/i);
+  });
+
   test('fails for nested invalid value', () => {
-    expect(AiAssist.modelSpec.convert({ base: 'ok', tools: 123 })).toFailWith(/expected model spec/i);
+    expect(AiAssist.modelSpec.convert({ base: 'ok', advanced: 123 })).toFailWith(/expected model spec/i);
   });
 });

--- a/libraries/ts-extras/src/test/unit/ai-assist/modelAlias.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/modelAlias.test.ts
@@ -147,16 +147,16 @@ describe('resolveProviderModel', () => {
   test('walks the ModelSpecKey branch then returns the concrete id (no aliases)', () => {
     const descriptor = makeDescriptor({
       id: 'openai',
-      defaultModel: { base: 'gpt-4o', tools: 'gpt-4o-tools' }
+      defaultModel: { base: 'gpt-4o', advanced: 'gpt-4o-advanced' }
     });
-    expect(AiAssist.resolveProviderModel(descriptor, undefined, 'tools')).toSucceedWith('gpt-4o-tools');
+    expect(AiAssist.resolveProviderModel(descriptor, undefined, 'advanced')).toSucceedWith('gpt-4o-advanced');
     expect(AiAssist.resolveProviderModel(descriptor, undefined, 'base')).toSucceedWith('gpt-4o');
   });
 
   test('falls back to base when the requested context key is absent', () => {
     const descriptor = makeDescriptor({
       id: 'openai',
-      defaultModel: { base: 'gpt-4o', tools: 'gpt-4o-tools' }
+      defaultModel: { base: 'gpt-4o', advanced: 'gpt-4o-advanced' }
     });
     expect(AiAssist.resolveProviderModel(descriptor, undefined, 'image')).toSucceedWith('gpt-4o');
   });
@@ -278,15 +278,19 @@ describe('google-gemini Tier 2 alias migration', () => {
 
   test('defaultModel resolves through the aliases to the concrete 3.x ids', () => {
     expect(AiAssist.resolveProviderModel(gemini, undefined, 'base')).toSucceedWith('gemini-3.5-flash');
-    expect(AiAssist.resolveProviderModel(gemini, undefined, 'thinking')).toSucceedWith(
-      'gemini-3.1-pro-preview'
-    );
     expect(AiAssist.resolveProviderModel(gemini, undefined, 'image')).toSucceedWith(
       'gemini-3.1-flash-image-preview'
     );
     expect(AiAssist.resolveProviderModel(gemini, undefined, 'embedding')).toSucceedWith(
       'gemini-embedding-001'
     );
+  });
+
+  test('a tier request cascades to base (flash) — no advanced/frontier key defined yet at B1', () => {
+    // The `advanced: '@google-gemini:pro'` key is added in B4; at B1 the Gemini
+    // descriptor has no tier key, so a tier request cascades to base = flash.
+    expect(AiAssist.resolveProviderModel(gemini, undefined, 'advanced')).toSucceedWith('gemini-3.5-flash');
+    expect(AiAssist.resolveProviderModel(gemini, undefined, 'frontier')).toSucceedWith('gemini-3.5-flash');
   });
 
   test('each declared alias maps to its concrete target', () => {

--- a/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
@@ -52,8 +52,6 @@ describe('AiAssist.registry', () => {
         expect(desc.baseUrl).toBeTruthy();
         expect(desc.defaultModel).toEqual({
           base: 'grok-4.3',
-          tools: 'grok-4.3',
-          thinking: 'grok-4.3',
           image: 'grok-imagine-image-quality'
         });
         expect(desc.supportedTools).toContain('web_search');

--- a/libraries/ts-extras/src/test/unit/ai-assist/streamingClient.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/streamingClient.test.ts
@@ -297,9 +297,28 @@ describe('callProviderCompletionStream', () => {
       expect(body.stream).toBe(true);
     });
 
-    test('prefers thinking model from ModelSpec when both thinking and tools are provided', async () => {
+    test('tier selects the streaming model; thinking/tools do not (composition)', async () => {
       const descriptor = makeDescriptor({
-        defaultModel: { base: 'gpt-4o', tools: 'gpt-4o-tools', thinking: 'gpt-o3' },
+        defaultModel: { base: 'gpt-4o', advanced: 'gpt-5-adv', frontier: 'gpt-5-front' },
+        supportedTools: ['web_search']
+      });
+      const tools: ReadonlyArray<AiAssist.AiServerToolConfig> = [{ type: 'web_search' }];
+      mockSseResponse(responsesApiSse({ textDeltas: ['ok'] }));
+      await AiAssist.callProviderCompletionStream({
+        descriptor,
+        apiKey: 'sk',
+        ...TEST_PROMPT.toRequest(),
+        tier: 'advanced',
+        tools,
+        thinking: { effort: 'medium' }
+      });
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(body.model).toBe('gpt-5-adv');
+    });
+
+    test('thinking without a tier resolves the base streaming model', async () => {
+      const descriptor = makeDescriptor({
+        defaultModel: { base: 'gpt-4o', advanced: 'gpt-5-adv' },
         supportedTools: ['web_search']
       });
       const tools: ReadonlyArray<AiAssist.AiServerToolConfig> = [{ type: 'web_search' }];
@@ -312,64 +331,22 @@ describe('callProviderCompletionStream', () => {
         thinking: { effort: 'medium' }
       });
       const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-      expect(body.model).toBe('gpt-o3');
+      expect(body.model).toBe('gpt-4o');
     });
 
-    test('does not select thinking model when thinking config is empty object', async () => {
+    test('tier "frontier" cascades to advanced when no frontier key is defined (streaming)', async () => {
       const descriptor = makeDescriptor({
-        defaultModel: { base: 'gpt-4o', tools: 'gpt-4o-tools', thinking: 'gpt-o3' },
-        supportedTools: ['web_search']
+        defaultModel: { base: 'gpt-4o', advanced: 'gpt-5-adv' }
       });
-      const tools: ReadonlyArray<AiAssist.AiServerToolConfig> = [{ type: 'web_search' }];
-      mockSseResponse(responsesApiSse({ textDeltas: ['ok'] }));
+      mockSseResponse(openAiChatSse(['ok']));
       await AiAssist.callProviderCompletionStream({
         descriptor,
         apiKey: 'sk',
         ...TEST_PROMPT.toRequest(),
-        tools,
-        thinking: {}
+        tier: 'frontier'
       });
       const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-      expect(body.model).toBe('gpt-4o-tools');
-    });
-
-    test('does not select thinking model when providers block targets a different provider', async () => {
-      const descriptor = makeDescriptor({
-        id: 'xai-grok',
-        defaultModel: { base: 'grok-fast', tools: 'grok-reasoning', thinking: 'grok-4.3' },
-        supportedTools: ['web_search']
-      });
-      const tools: ReadonlyArray<AiAssist.AiServerToolConfig> = [{ type: 'web_search' }];
-      mockSseResponse(responsesApiSse({ textDeltas: ['ok'] }));
-      await AiAssist.callProviderCompletionStream({
-        descriptor,
-        apiKey: 'sk',
-        ...TEST_PROMPT.toRequest(),
-        tools,
-        thinking: { providers: [{ provider: 'anthropic', config: { effort: 'high' } }] }
-      });
-      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-      expect(body.model).toBe('grok-reasoning');
-    });
-
-    test('does not select thinking model for unknown provider even when thinking is provided', async () => {
-      const ollamaDescriptor = makeDescriptor({
-        id: 'ollama',
-        baseUrl: 'http://localhost:11434/v1',
-        defaultModel: { base: 'llama3', tools: 'llama3-tools', thinking: 'llama3-think' },
-        supportedTools: ['web_search']
-      });
-      const tools: ReadonlyArray<AiAssist.AiServerToolConfig> = [{ type: 'web_search' }];
-      mockSseResponse(responsesApiSse({ textDeltas: ['ok'] }));
-      await AiAssist.callProviderCompletionStream({
-        descriptor: ollamaDescriptor,
-        apiKey: 'sk',
-        ...TEST_PROMPT.toRequest(),
-        tools,
-        thinking: { effort: 'medium' }
-      });
-      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-      expect(body.model).toBe('llama3-tools');
+      expect(body.model).toBe('gpt-5-adv');
     });
 
     test('forwards explicit temperature to request body', async () => {


### PR DESCRIPTION
## Summary

Slice **B1** of the ai-assist model-tiers stream (spec: `.ai/tasks/active/ai-assist-model-tiers/design.md`, Q1/Q2/Q3/Q7). This is the provider-agnostic axis change; it carries the composition rewire and the coupled xAI/Gemini dead-key strip. **No per-provider alias adoption** (that's B2–B4). Surface: `@fgv/ts-extras/ai-assist` (active/alpha; breaking OK).

### What changed

1. **`ModelSpecKey` (model.ts)** — replaced the completion-selecting members: **added** `advanced`/`frontier`, **removed** `thinking`/`tools` → `base | advanced | frontier | image | embedding`. `allModelSpecKeys` and the `converters.ts` error string updated to match. `MODEL_SPEC_BASE_KEY = 'base'` unchanged.
2. **`resolveModel` cascade (Q2)** — a module-private `TIER_FALLBACK` table teaches the resolver an ordered fallback: `frontier → advanced → base`, `advanced → base`. Modality keys (`image`/`embedding`) and arbitrary string contexts resolve flat (unchanged); `undefined` → `base` (unchanged); nested-spec and alias-passthrough recursion unchanged. Alias resolution stays strictly downstream in `resolveProviderModel`.
3. **Composition rewire (Q3)** — at the completion (`apiClient.ts`) and streaming (`streamingClient.ts`) chokepoints, the `hasThinkingConfig ? 'thinking' : hasTools ? 'tools' : undefined` model-selection branches are **deleted**. The quality **tier is now the only completion-model selector**, exposed as a new caller-facing `tier?: 'advanced' | 'frontier'` param on the completion and streaming params. The thinking config is still read and still sent to the wire — only its role as a *model selector* is removed.
4. **Dead-key strip (Q4)** — removed the now-dead `thinking`/`tools` keys from descriptor `defaultModel`s: Gemini's `thinking` (**intended behavior change**: `base + thinking` now resolves flash instead of pro; callers wanting pro reasoning ask for the `advanced` tier — wired in B4) and xAI's `tools` + `thinking` (**behavior-neutral**: both targeted `grok-4.3` = base).

### Tests

- **Cascade edge cases** — every row of the Q2 table (`model.test.ts` `tier cascade (Q2)`): base-only + tier → base; advanced-set + frontier → advanced (cascade stop); frontier direct hit; nested-spec tier; alias-valued tier returned verbatim; base request never over-reaches; image/embedding flat; arbitrary-string context; undefined → base.
- **Composition (`apiClient.test.ts` / `streamingClient.test.ts`)** — base/advanced/frontier select the right model; `frontier` cascades to `advanced` when no frontier key; base-only + tier → base; **thinking without a tier resolves base AND still emits `reasoning_effort` to the wire** (proves thinking rides on top of the tier); thinking composes on top of an explicit tier; tools without a tier → base.
- **Converter** — rejects the removed `thinking`/`tools` keys; accepts all five current keys; `allModelSpecKeys` equals the new set and excludes `thinking`/`tools`.
- **Real-descriptor regressions** — Gemini `base + thinking` (no tier) → `gemini-3.5-flash` through the full completion chokepoint (the one intended change); xAI tools+thinking completion → `grok-4.3` via base.
- Retargeted the breaking enumerated tests (`model.test.ts`, `modelAlias.test.ts`, `registry.test.ts`) off the removed keys.

### Gates

- `rushx build` — passes (api-extractor regenerated: `tier?` added to both param interfaces, `ModelSpecKey` narrowed).
- `rushx lint` — clean; `rushx fixlint` run before the final commit.
- Coverage — `heft test` (the enforcing gate; `jest.config.json` `coverageThreshold: global 100%`) passes with **every changed file at 100/100/100/100** (`apiClient.ts`, `converters.ts`, `model.ts`, `registry.ts`, `streamingClient.ts`, `streamingAdapters/common.ts`). The bare `rushx coverage` (`jest --coverage`) script cannot parse TS in this environment — a pre-existing limitation unrelated to this diff (it fails identically on untouched files, since the heft-jest TS transform is only wired through `heft test`).

### Code review (layer 1)

`code-reviewer` run on the final diff before coverage-chasing.
- **P1:** none.
- **P2:** (a) stale Gemini alias comments referencing the removed `thinking` default key → **fixed** (reworded to the advanced-tier role); (b) design-requested Gemini `base + thinking → flash` end-to-end completion test was only proven at the resolver layer → **fixed** (added a completion-chokepoint test against the real Gemini descriptor).
- **P3:** `@internal` tag on the private `TIER_FALLBACK` const → **removed** (no-op on an unexported binding). The `modelContext` rename note → no action (aids readability).

Scope discipline confirmed: no B2 (OpenAI aliases / DALL·E removal), B3 (Anthropic aliases / capability broadening), or B4 (Gemini `advanced` key, docs) work leaked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6Wx4eqcTrYhKe7ijMatao

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6Wx4eqcTrYhKe7ijMatao)_