### PR TITLE
feat(ai-assist): Anthropic alias adoption + quality-tier defaults + sonnet-5 capability fix (B3)

### DIFF
--- a/common/changes/@fgv/ts-extras/claude-ai-assist-b3-anthropic-ieggnj_2026-07-05-22-28.json
+++ b/common/changes/@fgv/ts-extras/claude-ai-assist-b3-anthropic-ieggnj_2026-07-05-22-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "ai-assist: Anthropic alias adoption + tier defaults (base=sonnet-5, advanced=opus-4-8) and claude-sonnet-/opus- thinking-capability broadening (B3)",
+      "type": "none",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -285,7 +285,7 @@ const allProviderIds: ReadonlyArray<AiProviderId>;
 function anthropicEffortToBudgetTokens(effort: NonNullable<IAnthropicThinkingConfig['effort']>): number;
 
 // @public
-type AnthropicThinkingModelNames = 'claude-sonnet-4-5' | 'claude-sonnet-4-6' | 'claude-opus-4-6' | 'claude-opus-4-7';
+type AnthropicThinkingModelNames = 'claude-sonnet-4-5' | 'claude-sonnet-4-6' | 'claude-sonnet-5' | 'claude-opus-4-6' | 'claude-opus-4-7' | 'claude-opus-4-8';
 
 // @public
 const ARGON2ID_OWASP_MIN: IArgon2idParams;

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -1435,13 +1435,20 @@ export interface IAiImageGenerationResponse {
 
 /**
  * Model IDs for Anthropic thinking-capable models.
+ *
+ * @remarks
+ * Only thinking-capable lines are listed. The non-tier `@anthropic:haiku` / `@anthropic:fable`
+ * aliases (reachable via `modelOverride` only) are deliberately omitted — they are not
+ * documented as thinking-capable, so naming them in a thinking-model filter would be misleading.
  * @public
  */
 export type AnthropicThinkingModelNames =
   | 'claude-sonnet-4-5'
   | 'claude-sonnet-4-6'
+  | 'claude-sonnet-5'
   | 'claude-opus-4-6'
-  | 'claude-opus-4-7';
+  | 'claude-opus-4-7'
+  | 'claude-opus-4-8';
 
 /**
  * Model IDs for OpenAI thinking-capable models.

--- a/libraries/ts-extras/src/packlets/ai-assist/registry.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/registry.ts
@@ -63,7 +63,20 @@ const BUILTIN_PROVIDERS: ReadonlyArray<IAiProviderDescriptor> = [
     needsSecret: true,
     apiFormat: 'anthropic',
     baseUrl: 'https://api.anthropic.com/v1',
-    defaultModel: 'claude-sonnet-4-5-20250929',
+    defaultModel: {
+      base: '@anthropic:sonnet', // claude-sonnet-5 (was 'claude-sonnet-4-5-20250929')
+      advanced: '@anthropic:opus' // claude-opus-4-8
+      // no frontier key → a frontier request cascades advanced → opus (see resolveModel)
+    },
+    aliases: {
+      '@anthropic:sonnet': 'claude-sonnet-5', // base tier
+      '@anthropic:opus': 'claude-opus-4-8', // advanced tier
+      '@anthropic:haiku': 'claude-haiku-4-5-20251001', // NON-tier alias; modelOverride only
+      '@anthropic:fable': 'claude-fable-5' // NON-tier alias; modelOverride only
+      // NOTE: no thinking/image/embedding keys — Anthropic completions are all text; base
+      // (sonnet-5) and advanced (opus-4-8) are both thinking-capable, so a thinking-context
+      // call flat-falls to base safely.
+    },
     supportedTools: ['web_search'],
     corsRestricted: false,
     streamingCorsRestricted: false,
@@ -435,8 +448,13 @@ export const DEFAULT_MODEL_CAPABILITY_CONFIG: IAiModelCapabilityConfig = {
       { idPattern: /^gemini-/, capabilities: ['chat', 'tools', 'vision'] }
     ],
     anthropic: [
-      { idPattern: /^claude-opus-4/, capabilities: ['chat', 'tools', 'vision', 'thinking'] },
-      { idPattern: /^claude-sonnet-4/, capabilities: ['chat', 'tools', 'vision', 'thinking'] },
+      // Broadened from /^claude-opus-4/ and /^claude-sonnet-4/ so the sonnet-5+ / opus-5+ lines
+      // are detected as thinking-capable. Detection accumulates across matching rules, so this is
+      // purely additive: every existing opus-4 / sonnet-4 id still matches. The sonnet broadening
+      // is required (claude-sonnet-5 otherwise hits only /^claude-/ and loses thinking); the opus
+      // broadening is future-proofing (claude-opus-4-8 already matches /^claude-opus-4/).
+      { idPattern: /^claude-opus-/, capabilities: ['chat', 'tools', 'vision', 'thinking'] },
+      { idPattern: /^claude-sonnet-/, capabilities: ['chat', 'tools', 'vision', 'thinking'] },
       { idPattern: /^claude-/, capabilities: ['chat', 'tools', 'vision'] }
     ],
     groq: [{ idPattern: /./, capabilities: ['chat'] }],

--- a/libraries/ts-extras/src/test/unit/ai-assist/listModels.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/listModels.test.ts
@@ -350,6 +350,34 @@ describe('callProviderListModels', () => {
       });
     });
 
+    test('classifies claude-sonnet-5 as thinking-capable via the broadened idPattern (B3)', async () => {
+      // Guards the required Q5 fix: /^claude-sonnet-4/ was broadened to /^claude-sonnet-/ so the
+      // sonnet-5 base default accumulates the thinking capability. Without the broadening,
+      // claude-sonnet-5 would hit only /^claude-/ (chat/tools/vision, no thinking).
+      mockFetchResponse(anthropicListBody([{ id: 'claude-sonnet-5' }, { id: 'claude-opus-4-8' }]));
+
+      const result = await AiAssist.callProviderListModels({
+        descriptor: makeDescriptor({
+          id: 'anthropic',
+          apiFormat: 'anthropic',
+          baseUrl: 'https://api.anthropic.com/v1'
+        }),
+        apiKey: 'test-key'
+      });
+
+      expect(result).toSucceedAndSatisfy((models) => {
+        const byId = new Map(models.map((m) => [m.id, m]));
+        const sonnet = byId.get('claude-sonnet-5')!;
+        expect(sonnet.capabilities.has('chat')).toBe(true);
+        expect(sonnet.capabilities.has('tools')).toBe(true);
+        expect(sonnet.capabilities.has('vision')).toBe(true);
+        expect(sonnet.capabilities.has('thinking')).toBe(true);
+        // The parallel opus broadening keeps claude-opus-4-8 thinking-capable too.
+        const opus = byId.get('claude-opus-4-8')!;
+        expect(opus.capabilities.has('thinking')).toBe(true);
+      });
+    });
+
     test('uses x-api-key auth header', async () => {
       mockFetchResponse(anthropicListBody([{ id: 'claude-1' }]));
 

--- a/libraries/ts-extras/src/test/unit/ai-assist/modelAlias.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/modelAlias.test.ts
@@ -262,10 +262,10 @@ describe('alias layer resolution for built-in descriptors', () => {
     expect(AiAssist.resolveProviderModel(ollama, 'llama3.2:3b')).toSucceedWith('llama3.2:3b');
   });
 
-  test('only google-gemini and openai define an aliases map (Tier 2)', () => {
-    // Gemini was migrated first; OpenAI adopted the alias layer in B2. Other
-    // providers still resolve raw ids and carry no aliases map.
-    const withAliases = new Set(['google-gemini', 'openai']);
+  test('only google-gemini, openai, and anthropic define an aliases map (Tier 2)', () => {
+    // Gemini was migrated first; OpenAI adopted the alias layer in B2; Anthropic in B3.
+    // Other providers still resolve raw ids and carry no aliases map.
+    const withAliases = new Set(['google-gemini', 'openai', 'anthropic']);
     for (const descriptor of descriptors) {
       if (withAliases.has(descriptor.id)) {
         expect(descriptor.aliases).toBeDefined();

--- a/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
@@ -89,6 +89,45 @@ describe('AiAssist.registry', () => {
     });
   });
 
+  describe('anthropic model tiers (B3)', () => {
+    const desc = AiAssist.getProviderDescriptor('anthropic').orThrow();
+
+    test('base tier resolves to claude-sonnet-5', () => {
+      // undefined context falls to base; explicit 'base' resolves identically.
+      expect(AiAssist.resolveProviderModel(desc, undefined, undefined)).toSucceedWith('claude-sonnet-5');
+      expect(AiAssist.resolveProviderModel(desc, undefined, 'base')).toSucceedWith('claude-sonnet-5');
+    });
+
+    test('advanced tier resolves to claude-opus-4-8', () => {
+      expect(AiAssist.resolveProviderModel(desc, undefined, 'advanced')).toSucceedWith('claude-opus-4-8');
+    });
+
+    test('frontier cascades to the advanced id (no frontier key on the descriptor)', () => {
+      // The Anthropic map deliberately omits a frontier key, so a frontier request must
+      // cascade frontier → advanced → opus. This is the real registry descriptor (not a
+      // synthetic one), so it is the live proof of the cascade against shipped defaults.
+      expect(AiAssist.resolveProviderModel(desc, undefined, 'frontier')).toSucceedWith('claude-opus-4-8');
+    });
+
+    test('the non-tier @anthropic:haiku alias resolves via modelOverride only', () => {
+      expect(AiAssist.resolveProviderModel(desc, '@anthropic:haiku', undefined)).toSucceedWith(
+        'claude-haiku-4-5-20251001'
+      );
+    });
+
+    test('the non-tier @anthropic:fable alias resolves via modelOverride only', () => {
+      expect(AiAssist.resolveProviderModel(desc, '@anthropic:fable', undefined)).toSucceedWith(
+        'claude-fable-5'
+      );
+    });
+
+    test('a raw modelOverride passes through verbatim (no alias resolution)', () => {
+      expect(AiAssist.resolveProviderModel(desc, 'claude-custom-tuned:v1', 'advanced')).toSucceedWith(
+        'claude-custom-tuned:v1'
+      );
+    });
+  });
+
   describe('getProviderDescriptor', () => {
     test('returns descriptor for known provider', () => {
       expect(AiAssist.getProviderDescriptor('xai-grok')).toSucceedAndSatisfy((desc) => {


### PR DESCRIPTION
## Summary

B3 of the ai-assist model-tiers stream (design: `.ai/tasks/active/ai-assist-model-tiers/design.md`, scope Q4/Q5/Q7). **Anthropic-only** — no OpenAI/Gemini changes. Builds on the merged B1 (tier axis + cascade resolver) and B2 (OpenAI adoption). Surface `@fgv/ts-extras/ai-assist` (active/alpha; breaking OK).

### Changes

**Anthropic descriptor (`registry.ts`)** — promote `defaultModel` from a bare string (`'claude-sonnet-4-5-20250929'`) to a tiered map + add an `aliases` block:

```
defaultModel: { base: '@anthropic:sonnet', advanced: '@anthropic:opus' }   // no frontier key
aliases: {
  '@anthropic:sonnet': 'claude-sonnet-5',            // base tier
  '@anthropic:opus':   'claude-opus-4-8',            // advanced tier
  '@anthropic:haiku':  'claude-haiku-4-5-20251001',  // NON-tier; modelOverride only
  '@anthropic:fable':  'claude-fable-5'              // NON-tier; modelOverride only
}
```

No `frontier` key: a frontier request cascades `advanced → opus` through the B1 `resolveModel`/`TIER_FALLBACK` machinery. No `thinking`/`image`/`embedding` keys — Anthropic completions are all text, and both tier models are thinking-capable, so a thinking-context call flat-falls to base safely.

**Capability fix (`registry.ts`, required)** — broaden the anthropic `idPattern` rules:
- `/^claude-sonnet-4/` → `/^claude-sonnet-/` **(required)**: `claude-sonnet-5` (the new base) otherwise matches only the generic `/^claude-/` rule (chat/tools/vision, no thinking). Capability detection accumulates across all matching rules, so broadening is purely additive — every existing `claude-sonnet-4-*` id still matches.
- `/^claude-opus-4/` → `/^claude-opus-/` (future-proofing): `claude-opus-4-8` already matched; broadened in the same edit to keep the two Claude reasoning lines parallel.

**Typed union (`model.ts`)** — add `'claude-sonnet-5'` and `'claude-opus-4-8'` to `AnthropicThinkingModelNames`; added a `@remarks` note on why non-tier aliases (haiku/fable) are omitted.

### Tests

- `registry.test.ts` — new `anthropic model tiers (B3)` block: base → `claude-sonnet-5`; advanced → `claude-opus-4-8`; **frontier cascades to `claude-opus-4-8`** (against the real descriptor — the cascade proof, since it has no frontier key); non-tier `@anthropic:haiku`/`@anthropic:fable` via `modelOverride`; raw `modelOverride` passthrough.
- `listModels.test.ts` — guards the required capability fix: `claude-sonnet-5` now derives `thinking` (via the real accumulation path in `callProviderListModels`), and `claude-opus-4-8` stays thinking-capable.
- `modelAlias.test.ts` — the "which descriptors define an aliases map" test now includes `anthropic`.

### Gates

- [x] `rushx build` passes (api-extractor regenerated — `AnthropicThinkingModelNames` additions; the descriptor default is runtime registry data, so no other signature drift)
- [x] `rushx lint` passes (exit 0)
- [x] Tests pass with **100% coverage** in ts-extras (1669 tests, via `heft test`)
- [x] `rushx fixlint` run (no changes)
- [x] `rush change` generated (`type: none`, matching the B1/B2 precedent for this stream)

### Review loop

- **Layer 1 (`code-reviewer` on the final diff, pre-push):** **Approved — no P1/P2 findings.** The reviewer verified the cascade proof against the live `resolveModel`, confirmed the idPattern broadening is strictly additive against the real capability-accumulation implementation, and confirmed the union additions match the established convention. Three P3 advisories: (1) inline-comment redundancy — left as intentional readability; (2) test `!` non-null assertion on a locally-built `Map` — standard pattern in the file, left as-is; (3) add a note on why non-tier aliases aren't in the union — **applied** (the `@remarks` on `AnthropicThinkingModelNames`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVJzoPZrsmg9EzuYX24EwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVJzoPZrsmg9EzuYX24EwQ)_