### PR TITLE
fix(heft-dual-rig): enforce jest coverage-threshold misses as build failures

### DIFF
--- a/.ai/tasks/active/heft-rig-coverage-gate/brief.md
+++ b/.ai/tasks/active/heft-rig-coverage-gate/brief.md
@@ -1,0 +1,54 @@
+# Brief — fix `@fgv/heft-dual-rig` coverage-threshold gate (threshold miss must fail the build)
+
+**Branch:** `claude/heft-rig-coverage-gate` (off `release`).
+**Surface:** `rigs/heft-dual-rig` (+ possibly heft/jest config it owns). Build-tooling.
+**You are the worker.** Do not sub-delegate. Reproduce, locate, fix, prove — with real command exit codes.
+
+## The bug (confirmed by V2-track probe, 2026-07-05)
+
+With an unmeetable `coverageThreshold` (e.g. `statements: 101`) in a package's `config/jest.config.json`, `rushx test` **prints** the Jest warning —
+`Jest: "global" coverage threshold for statements (101%) not met: 100%` —
+but **exits 0**. Test *failures* correctly fail the command; coverage-*threshold* misses do not. Every consuming package (all of PersonAIlity's, and this repo's) inherits this, so **the repo's "100% coverage to merge" rule is currently unenforced by CI.** This is a gate-integrity defect: every "100% coverage via `heft test`" claim to date has been unverified by exit code.
+
+## Goal
+
+A coverage-threshold miss must make the test command exit **non-zero**, so CI (and `rushx test`) actually block on it — identically to how a failing test does.
+
+## Investigate → locate → fix (in order)
+
+1. **Reproduce.** Pick a small package that uses the rig (or the rig's own test config). Set `statements: 101` in its `config/jest.config.json` `coverageThreshold.global`, run `rushx test`, and confirm: warning printed, exit code `0` (`echo $?`). This is the failing baseline.
+2. **Locate the swallow.** Trace how the rig runs Jest. `@fgv/heft-dual-rig` wraps `@rushstack/heft` + `@rushstack/heft-node-rig`; coverage runs via `@rushstack/heft-jest-plugin`. Determine where jest's non-zero exit (on threshold failure) is lost:
+   - Does the heft-jest-plugin invocation capture jest's result and fail the heft task, or does it only surface test-run failures and ignore `coverageThreshold` outcomes?
+   - Is jest run with a flag/mode that reports-but-doesn't-enforce (e.g. threshold checked in a reporter path rather than the run's exit)?
+   - Is this the rig's wiring, the shared jest profile the packages `extends`, or upstream `@rushstack/heft-jest-plugin` behavior?
+3. **Fix at the right layer.**
+   - **If it's the rig / a config the rig owns:** make the fix there so every consuming package inherits it (the whole point — a per-package fix doesn't scale).
+   - **If it's genuinely upstream `@rushstack/heft-jest-plugin`:** do NOT fork it silently. Surface the finding with the minimal viable options (a rig-level post-jest exit-code check, a heft task that re-asserts coverage, a plugin config flag if one exists, or a pinned-version bump if upstream fixed it) + your recommendation, and flag for the orchestrator before implementing a heavyweight workaround.
+
+## Load-bearing caveat — the fix will surface real debt; do NOT paper over it
+
+Once the gate actually enforces, **any package currently below its declared threshold will start failing.** That's the fix working, not a regression. After the fix:
+
+- Run the **full** `rush test` (or `rush test` across the affected packages) and report exactly which packages fail coverage now that the gate bites.
+- **Do NOT lower any package's `coverageThreshold` to make the suite green**, and do NOT add blanket `c8 ignore`s. If real sub-threshold packages surface, that is a genuine finding — list them (package + metric + actual %) and surface to the orchestrator. We decide per-package whether to fill the gap or accept an explicit, justified threshold — that is a separate decision, not part of this fix.
+- Note ts-utils' profile currently sets thresholds at **98**, not 100 — do not "correct" thresholds as part of this stream; only fix the *enforcement*.
+
+## Constraints
+
+- No `any`; follow repo conventions. `__`-prefix unused params (lint-mandated) if you touch TS.
+- The fix's own change must not itself lower a gate.
+
+## Deliverable
+
+`.ai/tasks/active/heft-rig-coverage-gate/{brief.md, findings.md}` — this brief + a short `findings.md` recording: the reproduction (with exit codes), the root-cause layer (rig vs shared profile vs upstream), the fix applied, and the full-suite result after the fix (which packages, if any, the now-live gate flags).
+
+## Proof of work (paste in your final report)
+
+- The **before**: `statements: 101` probe → warning + `echo $?` = `0`.
+- The **after**: same probe → warning + `echo $?` = **non-zero** (gate now bites); and a real 100%/at-threshold package still exits `0` (no false positive).
+- The full `rush test` result post-fix, naming any packages the enforced gate now flags (or "all packages pass at their declared thresholds").
+- `git diff --stat` of the fix (should be small + in the rig / shared config layer).
+
+## Escalation
+
+If the root cause is upstream and every in-rig remedy is a heavyweight workaround, STOP and surface options + recommendation rather than committing a large shim.

--- a/.ai/tasks/active/heft-rig-coverage-gate/findings.md
+++ b/.ai/tasks/active/heft-rig-coverage-gate/findings.md
@@ -1,0 +1,131 @@
+# Findings — `@fgv/heft-dual-rig` coverage-threshold gate fix
+
+## Summary
+
+`rushx test` / `rush test` (via `@fgv/heft-dual-rig` → `@rushstack/heft-jest-plugin`)
+printed the Jest coverage-threshold warning but **exited 0**, so the repo's
+"100% coverage to merge" rule was never enforced by an exit code. Fixed at the
+rig layer with a Jest `testResultsProcessor` hook. A coverage-threshold miss now
+exits non-zero, identically to a failing test.
+
+## Reproduction (baseline, before fix)
+
+Package: `libraries/ts-utils`. Set `coverageThreshold.global.statements: 101` in
+`config/jest.config.json`, then `rushx test` (exit code read directly, not through a pipe):
+
+```
+Jest: "global" coverage threshold for statements (101%) not met: 99.2%
+REAL EXIT CODE: 0
+```
+
+Warning printed, exit 0 → gate unenforced. Confirmed.
+
+## Root cause layer: upstream plugin behavior, remediated in the rig
+
+`@rushstack/heft-jest-plugin@1.2.7` (`JestPlugin.js`) inspects `runCLI()`'s
+returned `results` and only calls `logger.emitError(...)` (which fails the Heft
+task) when `results.numFailedTests > 0` or `results.numFailedTestSuites > 0`:
+
+```js
+const { globalConfig, results: jestResults } = await runCLI(jestArgv, [buildFolderPath]);
+if (jestResults.numFailedTests > 0) { logger.emitError(...); }
+else if (jestResults.numFailedTestSuites > 0) { logger.emitError(...); }
+```
+
+Jest reflects a coverage-**threshold** failure in `results.success === false`
+(the `CoverageReporter._checkThreshold` → `_setError` path flips `success` in
+`TestScheduler`), but it does **not** increment the failed-test/suite counters.
+The plugin therefore never sees the failure and exits 0.
+
+There is no plugin option to enforce coverage (its options schema only exposes
+`configurationPath`, `disableConfigurationModuleResolution`,
+`enableNodeEnvManagement`), and per-package edits do not scale. Rather than fork
+the upstream plugin, the fix uses a Jest-native, rig-owned hook.
+
+## Fix applied (rig layer)
+
+Jest calls `testResultsProcessor(results)` from `processResults()` **after**
+`results.success` is finalized, and the plugin reads back exactly the object the
+processor returns (`runJest` → `processResults` → `onComplete(runResults)` →
+`runCLI` return). `$.testResultsProcessor` is already in the plugin's module-path
+resolution list, so a rig-relative module reference resolves correctly.
+
+New rig files:
+
+- `rigs/heft-dual-rig/profiles/default/config/coverageResultsProcessor.js` — the
+  hook. When jest deems the run a failure (`success === false`) but no test or
+  suite failure was recorded (`numFailedTests === 0 && numFailedTestSuites === 0`
+  — i.e. the failure is a coverage-threshold miss), it bumps `numFailedTestSuites`
+  so the plugin's existing check fires and fails the task. Restores the
+  `results.success` semantics the plugin drops. Pure CommonJS (rig has no build).
+- `rigs/heft-dual-rig/profiles/default/config/jest.config.json` — extends the
+  node-rig shared jest config (preserving all existing behavior) and adds
+  `testResultsProcessor: "<packageDir:@fgv/heft-dual-rig>/profiles/default/config/coverageResultsProcessor.js"`.
+
+Consumer wiring: each library's `config/jest.config.json` now `extends`
+`@fgv/heft-dual-rig/.../jest.config.json` instead of the node-rig file directly
+(one-line change × 21 packages). The dual-rig config still extends node-rig, so
+current behavior is unchanged except for the added enforcement. Future packages
+that extend the rig inherit the gate for free.
+
+## Verification (after fix)
+
+- `ts-utils` at its declared threshold (98): **exit 0**, no warning — no false positive.
+- `ts-utils` with `statements: 101` probe: **exit 1**, plus
+  `Jest: "global" coverage threshold for statements (101%) not met: 99.2%` and
+  `[test:jest] Error: 1 Jest test suite failed` / `Exit code: 1`.
+
+## Full-suite result (post-fix)
+
+`rush test` halts on dependency order at an **environmental** failure in
+`ts-json-base` (`mutableFsTree.test.ts` "returns permission-denied for read-only
+file" — the sandbox runs as uid 0, so `chmod 0o444` is ignored by root and the
+write-access probe returns writable). This is pre-existing and unrelated to the
+coverage gate (0 coverage warnings). It blocked 25 downstream packages, so each
+migrated library was run individually after a full `rush build`.
+
+Per-package results (21 migrated node-rig libraries):
+
+- **20 pass** at their declared thresholds (exit 0, no coverage warning):
+  ts-utils, ts-utils-jest, ts-json, ts-bcp47, ts-extras, ts-extras-argon2,
+  ts-extras-mcp, ts-extras-ollama, ts-extras-webauthn, ts-extras-transformers,
+  ts-web-extras, ts-web-extras-argon2, ts-web-extras-webauthn,
+  ts-web-extras-transformers, ts-app-shell, ts-agent-memory, ts-prompt-assist,
+  ts-res, ts-sudoku-lib. (ts-json-base's coverage passes; its only failure is the
+  environmental root test above.)
+
+- **1 genuinely flagged by the now-live gate — `ts-random`** (declares 100% on
+  all four metrics; actual):
+
+  | metric | declared | actual |
+  |---|---|---|
+  | statements | 100 | **20.32%** |
+  | lines | 100 | **20.32%** |
+  | functions | 100 | **66.66%** |
+  | branches | 100 | **81.39%** |
+
+  Cause: the `src/generator` packlet is fully covered (100%), but the entire
+  `src/generator-data` packlet (word lists — adjectives, animals, cities,
+  colors, countries, domains, gerunds, jobs, names, …, plus `charClasses.ts`)
+  and `src/index.ts` are **0% covered** and not excluded via
+  `coveragePathIgnorePatterns`. Tests pass (127 tests); the code is simply
+  untested/uncollected. This is real, previously-invisible debt surfaced by the
+  now-enforced gate.
+
+Per the brief, this was **not** papered over — no threshold lowered, no
+`c8 ignore` added. The disposition for `ts-random` (add tests for the data
+packlet, exclude the data files from collection, or accept an explicit justified
+threshold) is a separate decision for the orchestrator, not part of this fix.
+
+## Scope boundary (not covered by this fix)
+
+- **Web-rig packages** `ts-res-ui-components` and `ts-sudoku-ui` extend
+  `@rushstack/heft-web-rig` (not the dual-rig) and were **not** migrated — they
+  retain the unenforced behavior. Enforcing them needs either the same
+  `testResultsProcessor` field added to their configs (they'd need a devDependency
+  on the rig) or a parallel web profile. `ts-sudoku-ui` is out of scope
+  (slated to move to its own monorepo); `ts-res-ui-components` is a candidate for
+  a follow-up. Flagged for the orchestrator.
+- **Tools** (`ks`, `ts-res-cli`, `ts-res-browser`, …) are not dual-rig consumers
+  (`ks` uses the `ts-jest` preset directly with no coverage gate; the `ts-res-*`
+  tools use `@rushstack/rig`). Out of scope for this rig fix.

--- a/.ai/tasks/active/heft-rig-coverage-gate/findings.md
+++ b/.ai/tasks/active/heft-rig-coverage-gate/findings.md
@@ -129,3 +129,47 @@ threshold) is a separate decision for the orchestrator, not part of this fix.
 - **Tools** (`ks`, `ts-res-cli`, `ts-res-browser`, …) are not dual-rig consumers
   (`ks` uses the `ts-jest` preset directly with no coverage gate; the `ts-res-*`
   tools use `@rushstack/rig`). Out of scope for this rig fix.
+
+## Resolution — ts-random brought to a true 100% (exclusion + 2 branch tests)
+
+Orchestrator disposition: exclude ts-random's pure-data + barrel files from
+coverage (matching the ts-utils convention); do not lower the threshold; fill any
+remaining *real* logic gaps with tests.
+
+1. **Exclusion applied** to `libraries/ts-random/config/jest.config.json`:
+   `"coveragePathIgnorePatterns": ["index.js", "generator-data"]`. `src/generator-data/`
+   is pure static data (word lists, `charClasses` string constants) and the
+   `index.ts` files are barrels — no logic to cover. Threshold left at 100 on all
+   four metrics. After the exclusion, statements/functions/lines reached 100% but
+   **branches were 95.89%** — three genuine uncovered branches remained in the
+   real generator logic (`generators.ts:88`, `randomSource.ts:116`, `:117`).
+
+2. **Precise diagnosis (from lcov, not the coverage summary's line column).** The
+   originally-hypothesized gaps (`{ global: true }`, custom `step`, no-seed) were
+   already covered by existing tests. The actually-uncovered branches were the
+   **optional-chaining null-guard paths** — `params?.global`, `init?.step`,
+   `init?.seed` — whose "argument is null/undefined" branch was never exercised.
+   These are reachable (not dead code): because `typeof null === 'object'`, a
+   `create(null)` call flows into the object-form path with `init === null`, so
+   the `?.` guards fall back to defaults instead of throwing. The guards are
+   load-bearing — removing them would make `create(null)` throw a TypeError
+   before `captureResult` wraps construction — so the honest fix is to test the
+   null path, not delete the guard.
+
+3. **Two targeted tests added** (129 tests total, up from 127), following existing
+   conventions with `@fgv/ts-utils-jest` Result matchers and `Date.now` spies:
+   - `randomSource.test.ts` — `SeededRandomSource.create(null as unknown as number)`
+     succeeds with the default (mulberry) step and a `Date.now`-derived seed
+     (covers `init?.step` @116 and `init?.seed` @117 null-guard branches).
+   - `generators.test.ts` — `PseudoRandomGenerator.create(null as unknown as IPseudoRandomGeneratorCreateParams)`
+     succeeds and leaves the global rng unset (covers `params?.global` @88).
+
+**Result:** `heft test` for ts-random now **exits 0 at 100% on statements,
+branches, functions, and lines**, no coverage warning. No threshold lowered, no
+`c8 ignore` added — the exclusion removed only pure-data/barrel files, and the
+two tests cover real, reachable defensive branches.
+
+**Final tally:** all 21 migrated node-rig libraries pass at their declared
+thresholds under the now-live gate. (The web-rig packages and tools remain out of
+scope as noted above; the `rush test` CI-step wiring is a separate phase-2
+follow-up and `ci.yml` was intentionally not touched.)

--- a/common/changes/@fgv/heft-dual-rig/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/heft-dual-rig/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/heft-dual-rig"
+    }
+  ],
+  "packageName": "@fgv/heft-dual-rig",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-agent-memory/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-agent-memory/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-agent-memory"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-app-shell/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-app-shell/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-app-shell"
+    }
+  ],
+  "packageName": "@fgv/ts-app-shell",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-bcp47/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-bcp47/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-bcp47"
+    }
+  ],
+  "packageName": "@fgv/ts-bcp47",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-extras-argon2/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-extras-argon2/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-extras-argon2"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-argon2",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-extras-mcp/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-extras-mcp/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-extras-mcp"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-mcp",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-extras-ollama/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-extras-ollama/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-extras-ollama"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-ollama",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-extras-transformers/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-extras-transformers/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-extras-transformers"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-transformers",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-extras-webauthn/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-extras-webauthn/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-extras-webauthn"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-webauthn",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-extras/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-extras/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-json-base/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-json-base/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-json-base"
+    }
+  ],
+  "packageName": "@fgv/ts-json-base",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-json/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-json/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-json"
+    }
+  ],
+  "packageName": "@fgv/ts-json",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-prompt-assist/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-prompt-assist/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-prompt-assist"
+    }
+  ],
+  "packageName": "@fgv/ts-prompt-assist",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-random/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-random/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-random"
+    }
+  ],
+  "packageName": "@fgv/ts-random",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-res/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-res/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-res"
+    }
+  ],
+  "packageName": "@fgv/ts-res",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-sudoku-lib/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-sudoku-lib/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-sudoku-lib"
+    }
+  ],
+  "packageName": "@fgv/ts-sudoku-lib",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-utils-jest/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-utils-jest/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-utils-jest"
+    }
+  ],
+  "packageName": "@fgv/ts-utils-jest",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-utils/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-utils/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-utils"
+    }
+  ],
+  "packageName": "@fgv/ts-utils",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-web-extras-argon2/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-web-extras-argon2/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-web-extras-argon2"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras-argon2",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-web-extras-transformers/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-web-extras-transformers/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-web-extras-transformers"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras-transformers",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-web-extras-webauthn/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-web-extras-webauthn/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-web-extras-webauthn"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras-webauthn",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-web-extras/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
+++ b/common/changes/@fgv/ts-web-extras/claude-heft-rig-coverage-gate_2026-07-06-20-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Enforce jest coverage-threshold misses as build failures (heft-dual-rig testResultsProcessor); consuming packages repoint their jest config at the @fgv/heft-dual-rig profile to inherit the gate. Build-tooling only; no runtime/API change.",
+      "type": "none",
+      "packageName": "@fgv/ts-web-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-agent-memory/config/jest.config.json
+++ b/libraries/ts-agent-memory/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": ["index.js"],
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-app-shell/config/jest.config.json
+++ b/libraries/ts-app-shell/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": ["index.js", "public.js", "internal.js"],
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-bcp47/config/jest.config.json
+++ b/libraries/ts-bcp47/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": [
     "index.js",
     "index.browser.js",

--- a/libraries/ts-extras-argon2/config/jest.config.json
+++ b/libraries/ts-extras-argon2/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": ["index.js"],
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-extras-mcp/config/jest.config.json
+++ b/libraries/ts-extras-mcp/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coverageThreshold": {
     "global": {
       "branches": 100,

--- a/libraries/ts-extras-ollama/config/jest.config.json
+++ b/libraries/ts-extras-ollama/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coverageThreshold": {
     "global": {
       "branches": 100,

--- a/libraries/ts-extras-transformers/config/jest.config.json
+++ b/libraries/ts-extras-transformers/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coverageThreshold": {
     "global": {
       "branches": 100,

--- a/libraries/ts-extras-webauthn/config/jest.config.json
+++ b/libraries/ts-extras-webauthn/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coverageThreshold": {
     "global": {
       "branches": 100,

--- a/libraries/ts-extras/config/jest.config.json
+++ b/libraries/ts-extras/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": ["index.js", "public.js", "internal.js", "index.browser.js", "index.node.js"],
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-json-base/config/jest.config.json
+++ b/libraries/ts-json-base/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": ["index.js", "public.js", "index.browser.js"],
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-json/config/jest.config.json
+++ b/libraries/ts-json/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": ["index.js", "index.browser.js", "public.js"],
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-prompt-assist/config/jest.config.json
+++ b/libraries/ts-prompt-assist/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": ["index.js"],
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-random/config/jest.config.json
+++ b/libraries/ts-random/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coverageThreshold": {
     "global": {
       "branches": 100,

--- a/libraries/ts-random/config/jest.config.json
+++ b/libraries/ts-random/config/jest.config.json
@@ -1,5 +1,6 @@
 {
   "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
+  "coveragePathIgnorePatterns": ["index.js", "generator-data"],
   "coverageThreshold": {
     "global": {
       "branches": 100,

--- a/libraries/ts-random/src/test/unit/generators.test.ts
+++ b/libraries/ts-random/src/test/unit/generators.test.ts
@@ -1,6 +1,11 @@
 import '@fgv/ts-utils-jest';
 
-import { IRandomSequencePickParams, ISequentialPickParams, PseudoRandomGenerator } from '../../generator';
+import {
+  IPseudoRandomGeneratorCreateParams,
+  IRandomSequencePickParams,
+  ISequentialPickParams,
+  PseudoRandomGenerator
+} from '../../generator';
 
 function createGenerator(seed: number | string = 42): PseudoRandomGenerator {
   return PseudoRandomGenerator.create({ seed }).orThrow();
@@ -63,6 +68,19 @@ describe('PseudoRandomGenerator', () => {
     test('does not set global rng when global is omitted', () => {
       PseudoRandomGenerator.create({ seed: 1 }).orThrow();
       expect(PseudoRandomGenerator.getGlobalRng()).toBeUndefined();
+    });
+
+    test('tolerates a null params argument and does not set the global rng', () => {
+      // `typeof null === 'object'`, so a null argument reaches the object-form
+      // branch; the `params?.global` guard must fall through rather than throw,
+      // leaving the global rng unset.
+      expect(PseudoRandomGenerator.getGlobalRng()).toBeUndefined();
+      expect(
+        PseudoRandomGenerator.create(null as unknown as IPseudoRandomGeneratorCreateParams)
+      ).toSucceedAndSatisfy((gen) => {
+        expect(gen.rng).toBeDefined();
+        expect(PseudoRandomGenerator.getGlobalRng()).toBeUndefined();
+      });
     });
   });
 

--- a/libraries/ts-random/src/test/unit/randomSource.test.ts
+++ b/libraries/ts-random/src/test/unit/randomSource.test.ts
@@ -93,6 +93,25 @@ describe('SeededRandomSource', () => {
         nowSpy.mockRestore();
       }
     });
+
+    test('tolerates a null argument, using the default step and Date.now seed', () => {
+      // `typeof null === 'object'`, so a null argument reaches the object-form
+      // branch where `init` itself is null; the `init?.step` / `init?.seed`
+      // guards must fall back to their defaults rather than throw.
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(777);
+      try {
+        expect(SeededRandomSource.create(null as unknown as number)).toSucceedAndSatisfy((source) => {
+          expect(source.seed).toBe('777');
+          expect(source.counter).toBe(0);
+          // The default (mulberry) step is in effect, producing values in [0, 1).
+          const value = source.next();
+          expect(value).toBeGreaterThanOrEqual(0);
+          expect(value).toBeLessThan(1);
+        });
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
   });
 
   describe('deterministic sequences', () => {

--- a/libraries/ts-res/config/jest.config.json
+++ b/libraries/ts-res/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": [
     "index.js",
     "index.browser.js",

--- a/libraries/ts-sudoku-lib/config/jest.config.json
+++ b/libraries/ts-sudoku-lib/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": ["index.js", "index.browser.js", "public.js", "internal.js", "Types.ts"],
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-utils-jest/config/jest.config.json
+++ b/libraries/ts-utils-jest/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": ["index.js"],
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-utils/config/jest.config.json
+++ b/libraries/ts-utils/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": ["index.js", "public.js", "internal.js"],
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-web-extras-argon2/config/jest.config.json
+++ b/libraries/ts-web-extras-argon2/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "coveragePathIgnorePatterns": ["index.js"],
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-web-extras-transformers/config/jest.config.json
+++ b/libraries/ts-web-extras-transformers/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "testEnvironment": "jsdom",
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-web-extras-webauthn/config/jest.config.json
+++ b/libraries/ts-web-extras-webauthn/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "testEnvironment": "jsdom",
   "coverageThreshold": {
     "global": {

--- a/libraries/ts-web-extras/config/jest.config.json
+++ b/libraries/ts-web-extras/config/jest.config.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  "extends": "@fgv/heft-dual-rig/profiles/default/config/jest.config.json",
   "setupFilesAfterEnv": ["<rootDir>/lib/test/setupTests.js"],
   "testEnvironment": "jsdom",
   "coveragePathIgnorePatterns": ["index.js", "index.browser.js", "public.js", "internal.js"],

--- a/rigs/heft-dual-rig/profiles/default/config/coverageResultsProcessor.js
+++ b/rigs/heft-dual-rig/profiles/default/config/coverageResultsProcessor.js
@@ -1,0 +1,46 @@
+// Jest `testResultsProcessor` hook that makes a coverage-threshold miss cause the
+// Heft "test" task to exit non-zero, so CI actually blocks on the repo's coverage gate.
+//
+// Why this exists:
+//   `@rushstack/heft-jest-plugin` inspects `results.numFailedTests` and
+//   `results.numFailedTestSuites` after `runCLI()` returns and only emits a Heft
+//   error (which fails the task) for those two counters. Jest reflects a
+//   coverage-*threshold* failure in `results.success === false` (the coverage
+//   reporter records an error, which flips `success` in TestScheduler) but does
+//   NOT increment the failed-test/suite counters. The plugin therefore prints the
+//   `Jest: "global" coverage threshold ... not met` warning and still exits 0.
+//
+// Jest invokes `testResultsProcessor(results)` from `processResults()` AFTER
+// `results.success` has been finalized, and the plugin reads back exactly the
+// object this function returns. So when jest considers the run a failure but no
+// test or suite failure was recorded (i.e. the failure is a coverage-threshold
+// miss, or another run-level failure such as an obsolete snapshot under CI), we
+// surface it as a failed test suite. That makes the plugin's existing
+// `numFailedTestSuites > 0` check fire and fail the task, restoring
+// `results.success` semantics that the plugin otherwise drops.
+//
+// This is a plain CommonJS module (the rig has no build step); it is referenced
+// from the sibling `jest.config.json` via `testResultsProcessor`.
+
+'use strict';
+
+/**
+ * @param {import('@jest/test-result').AggregatedResult} results
+ * @returns {import('@jest/test-result').AggregatedResult}
+ */
+function coverageResultsProcessor(results) {
+  if (
+    results &&
+    results.success === false &&
+    results.numFailedTests === 0 &&
+    results.numFailedTestSuites === 0
+  ) {
+    // No individual test/suite failed, yet jest deemed the run a failure. The
+    // dominant cause is an unmet `coverageThreshold`. Surface it through the
+    // counter the Heft jest plugin actually inspects.
+    results.numFailedTestSuites += 1;
+  }
+  return results;
+}
+
+module.exports = coverageResultsProcessor;

--- a/rigs/heft-dual-rig/profiles/default/config/jest.config.json
+++ b/rigs/heft-dual-rig/profiles/default/config/jest.config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/rushstack/main/apps/heft/src/schemas/heft-jest-plugin.schema.json",
+
+  // Inherit the node-rig shared Jest configuration, then add the coverage-gate
+  // enforcement that the upstream heft-jest-plugin omits. Consuming packages
+  // should `extends` THIS file (not the node-rig file directly) so they inherit
+  // the fix; see coverageResultsProcessor.js for the rationale.
+  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+
+  "testResultsProcessor": "<packageDir:@fgv/heft-dual-rig>/profiles/default/config/coverageResultsProcessor.js"
+}


### PR DESCRIPTION
## Summary

The repo's "100% coverage to merge" rule was **unenforced**: with an unmeetable `coverageThreshold` (e.g. `statements: 101`) in a package, `rushx test` printed the `Jest: "global" coverage threshold … not met` warning but **exited 0**. Test *failures* failed the command; coverage-*threshold* misses did not. This PR makes a threshold miss fail the build.

**Phase 1 of 2.** This is the plugin fix + consumer migration + resolving the one real coverage gap it exposed. **Phase 2** (adding a `rush test` step to `ci.yml`) is a deliberate follow-up — see "The other half" below.

## Root cause

Upstream `@rushstack/heft-jest-plugin@1.2.7` only fails the Heft test task on `results.numFailedTests` / `results.numFailedTestSuites`. Jest records a coverage-threshold miss in `results.success === false` (never in the failed-test counters), so the plugin printed the warning and exited 0.

## The fix (rig layer, no fork)

- `rigs/heft-dual-rig/profiles/default/config/coverageResultsProcessor.js` — a Jest-native `testResultsProcessor` hook. Jest calls it after `results.success` is finalized and the plugin reads back its return value. When jest deems the run a failure but **no** test/suite failed (i.e. a coverage-threshold miss, or another run-level failure such as an obsolete snapshot under CI), it surfaces that as a failed suite so the plugin's existing `numFailedTestSuites > 0` check fires. Narrow by construction — never double-counts real test failures, never touches passing runs.
- `rigs/heft-dual-rig/profiles/default/config/jest.config.json` — extends the node-rig profile + wires the processor.
- **21 node-rig libraries** repoint their `config/jest.config.json` `extends` at `@fgv/heft-dual-rig/...` (one line each) to inherit the gate. **No thresholds changed.**

## The gap the now-live gate exposed — `ts-random` (resolved, not papered over)

`ts-random` declared 100% but actually sat at ~20% statements: its `src/generator-data/` (pure static word lists + `charClasses` string constants) and barrel `index.ts` files were 0% covered and had no `coveragePathIgnorePatterns`. Resolution:
- **Exclude the pure-data + barrels** via `coveragePathIgnorePatterns: ["index.js", "generator-data"]` (matching `ts-utils`' existing convention) — no logic to cover there.
- That surfaced **3 genuinely-uncovered branches in the real generator logic** (the optional-chaining null-guard paths `params?.global` / `init?.step` / `init?.seed`, reachable via `create(null)` since `typeof null === 'object'`). **Added 2 targeted tests** (`create(null)` on each class) — `ts-random` now hits a true **100% on all four metrics**.
- **No threshold lowered, no `c8 ignore` added.**

## Scope boundary

`ts-res-ui-components` and `ts-sudoku-ui` use `@rushstack/heft-web-rig` (not the dual-rig) and are **not** migrated here — they retain the unenforced behavior (`ts-sudoku-ui` is out of scope / moving out; `ts-res-ui-components` is a follow-up candidate). Tools are not dual-rig consumers.

## The other half (Phase 2, deliberately not in this PR)

`ci.yml` currently runs `rush change --verify` → `rush install` → `rush rebuild` — **there is no `rush test` step**, so coverage is not run in CI at all. This plugin fix makes the gate bite for local/manual `rushx test`; **making it CI-enforced requires adding a `rush test` step to `ci.yml`**, which lands as a separate follow-up **only once the tree is green** (i.e. after this merges). Tracked.

## Verification (local; CI here is build-only)

- **Before:** `statements: 101` probe → warning + exit `0`.
- **After:** same probe → `Error: 1 Jest test suite failed` + exit `1`; a real at-threshold package still exits `0` (no false positive).
- All **21 migrated libraries pass** at their declared thresholds under the now-live gate.
- `rush change` descriptions added for all changed projects (`type: none` — build-tooling only).

(Note: a `ts-json-base` fs-permission test fails only under this sandbox's uid-0 environment — `chmod 0o444` is ignored by root; GitHub runners run non-root, so it's unaffected. Not a coverage gap.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_