### PR TITLE
feat(crypto-utils): base64url-no-pad helpers + branded MultibaseSpkiPublicKey

### DIFF
--- a/.ai/tasks/active/crypto-utils-base64url-hardening/brief.md
+++ b/.ai/tasks/active/crypto-utils-base64url-hardening/brief.md
@@ -1,0 +1,54 @@
+# Brief — crypto-utils base64url + branded multibase SPKI hardening (items 2 + 3)
+
+**Branch:** `claude/crypto-utils-base64url-hardening` (off `release`).
+**Surface:** `@fgv/ts-extras` → `src/packlets/crypto-utils` (**active** surface — additive/breaking OK per `.ai/instructions/ACTIVE_DEVELOPMENT.md`).
+**Consumer:** PersonAIlity V2 identity/signing (RFC 9421 signatures + WebAuthn). Two V2 asks bundled — both additive on crypto-utils, tightly coupled (base64url + multibase).
+**Ships under the now-enforced coverage gate** (item 4, #517/#518) — 100% coverage is real now; hit it for real.
+
+## Item 3 — bare base64url-no-pad encode/decode (extract + refactor)
+
+crypto-utils exposes `multibaseBase64UrlEncode`/`Decode` (multibase-`m`-prefixed) and `toBase64`/`fromBase64` (standard alphabet), but **nothing for plain base64url-no-pad** — RFC 9421 signatures and WebAuthn payloads both need it. The current V2 workaround (reviewer-flagged) is `multibaseBase64UrlEncode(bytes).slice(1)` with a prefix-strip comment.
+
+**The primitive already exists inside `spkiHelpers.ts`:** `multibaseBase64UrlEncode` computes base64 → base64url-no-pad (`+→-`, `/→_`, strip `=`) then prepends `'m'`; `multibaseBase64UrlDecode` checks the `'m'` prefix then decodes the body with a shape guard (`/^[A-Za-z0-9_-]*$/` + `length % 4 !== 1`).
+
+**Do:**
+1. Add `base64UrlNoPadEncode(data: Uint8Array): string` and `base64UrlNoPadDecode(encoded: string): Result<Uint8Array>` — the base64url-no-pad body logic, **no** `'m'` prefix.
+2. **Refactor the existing multibase functions to delegate** so there's one implementation, not two: `multibaseBase64UrlEncode(d) === 'm' + base64UrlNoPadEncode(d)`; `multibaseBase64UrlDecode(e)` = `'m'`-prefix check → `base64UrlNoPadDecode(e.slice(1))`. Preserve the existing multibase error messages/behavior exactly (they're the established public surface). Keep the `/* c8 ignore */` on the genuine browser-only `btoa`/`atob` branches.
+3. Export both new helpers from `crypto-utils/index.ts` **and** `index.browser.ts` (the multibase siblings are exported from both).
+
+## Item 2 — branded `MultibaseSpkiPublicKey` + validating converter + tightened signatures
+
+`exportPublicKeyAsMultibaseSpki` / `importPublicKeyFromMultibaseSpki` traffic in plain `string`. PersonAIlity's keystore already declares this exact brand (`MultibaseSpkiPublicKey`, `isValidMultibaseSpkiPublicKey`) locally and would migrate to the ts-extras export (a separate V1-track consumer change — not in this stream, but match the shape so the migration is a drop-in).
+
+**Do:**
+1. **Brand type** `MultibaseSpkiPublicKey = Brand<string, 'MultibaseSpkiPublicKey'>` (use `Brand` from `@fgv/ts-utils`), placed with the other crypto-utils types (`model.ts`).
+2. **Type guard** `isValidMultibaseSpkiPublicKey(v: unknown): v is MultibaseSpkiPublicKey` — validates: is a string, starts with `'m'`, and the body matches the base64url-no-pad shape (`/^[A-Za-z0-9_-]*$/` and `body.length % 4 !== 1`). Reuse the same shape rule the decoder uses — do NOT duplicate a divergent regex; factor the body-shape check so the guard and `base64UrlNoPadDecode` agree.
+3. **Validating converter** `multibaseSpkiPublicKey: Converter<MultibaseSpkiPublicKey>` in `converters.ts` (follow the existing `Converter<T>` export pattern there), failing with context on a non-string / bad-prefix / malformed-body input, succeeding with the branded value otherwise.
+4. **Tighten the helper signatures:**
+   - `exportPublicKeyAsMultibaseSpki(...) : Promise<Result<MultibaseSpkiPublicKey>>` — its output is a freshly-built valid multibase SPKI string, so brand it on the way out (no re-validation needed; assert the brand at the construction site with a comment, or route through the guard).
+   - `importPublicKeyFromMultibaseSpki(encoded: MultibaseSpkiPublicKey, algorithm, provider)` — accept the brand so validation-before-import is enforced by the type system. Callers obtain the brand via the converter / guard at their boundary. (Internal decode still runs; the brand narrows the contract.)
+5. Export the brand type, guard, and converter from `index.ts` + `index.browser.ts` (the converter likely rides the existing `Converters` namespace export — match how `encryptionAlgorithm` etc. are surfaced).
+
+## Item 5 — file the RFC 9421 heads-up (docs only, no code)
+
+Add a `docs/FUTURE.md` entry: **"RFC 9421 HTTP-message-signature packlet (prospective `@fgv/ts-extras`)"** — a strict Ed25519-only RFC 9421 profile (signer/verifier/signature-base over `ICryptoProvider`, framework-free, Result-shaped) that the V2 track is proving out in its own `signing` packlet and intends to propose upstream once Phase 0 lands. Note that this stream's `base64UrlNoPadEncode/Decode` (item 3) is the primitive it depends on. No action beyond the entry.
+
+## Constraints
+
+- No `any`; `Result<T>` for fallible ops; Converters/guards for validation (no manual-typeof-then-cast); `Brand<T>` for the branded id; `__`-prefix unused params (lint-mandated).
+- Additive + the intentional signature tightenings (active surface). Don't remove/rename existing exports except the two tightened return/param types.
+- Regenerate `etc/ts-extras.api.md`. **100% coverage — actually enforced now.**
+
+## Tests
+
+- `base64UrlNoPadEncode`/`Decode`: round-trip a range of byte lengths (incl. lengths that produce 0/1/2 `=` pads pre-strip, and empty); decode rejects malformed bodies (bad chars, `length % 4 === 1`); **cross-check** that `multibaseBase64UrlEncode(x) === 'm' + base64UrlNoPadEncode(x)` and the decode delegation round-trips, so the refactor is behavior-preserving.
+- `isValidMultibaseSpkiPublicKey` / `multibaseSpkiPublicKey` converter: accepts a real exported key blob + valid synthetic values; rejects non-string, missing/wrong prefix, malformed body.
+- `exportPublicKeyAsMultibaseSpki` returns a value the guard/converter accepts; `importPublicKeyFromMultibaseSpki` round-trips an exported branded key back to a usable `CryptoKey` (export → import → verify usable). Use `NodeCryptoProvider` in tests.
+
+## Sequence
+
+Implement → `code-reviewer` on the diff **before** coverage-chasing → `rushx build && lint` + `rushx test` @ 100% (the gate is live) + api-extractor regen → `rushx fixlint` → `rush change` (`--bulk --bump-type minor --target-branch origin/release`) → commit + push + open PR onto `release`.
+
+## Proof of work
+
+`git log --oneline -3`; build/lint/test tails (100%); the `etc/ts-extras.api.md` diff (new base64url helpers, brand, guard, converter, tightened signatures); the delegation-equivalence test output; `code-reviewer` findings + dispositions; the `docs/FUTURE.md` entry.

--- a/common/changes/@fgv/ts-extras/claude-crypto-utils-base64url-hardening_2026-07-07-08-34.json
+++ b/common/changes/@fgv/ts-extras/claude-crypto-utils-base64url-hardening_2026-07-07-08-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add base64url-no-pad encode/decode helpers and branded MultibaseSpkiPublicKey (guard + converter); tighten SPKI multibase export/import signatures to the brand",
+      "type": "none",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -302,3 +302,29 @@ prioritized; the fleshed design lets it start cold.
 (design-space note + §9 refinement + §10 unified-substrate / L3 contract) and
 `design.md` (moderate-detail platform design). Floated package name
 `@fgv/ts-agent-memory`.
+
+## RFC 9421 HTTP-message-signature packlet (prospective `@fgv/ts-extras`)
+
+A strict, Ed25519-only [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421) HTTP
+Message Signatures profile as a new `@fgv/ts-extras` packlet: a signer/verifier
+pair plus a signature-base builder, all built over the crypto-utils
+`ICryptoProvider` (`sign`/`verify`), framework-free (no Express/Fetch coupling —
+the caller supplies the covered-component values) and `Result`-shaped throughout.
+The PersonAIlity V2 identity/signing track is proving this out inside its own
+`signing` packlet against real request/response signing and intends to propose it
+upstream to `@fgv/ts-extras` once its Phase 0 lands and the profile has settled.
+
+**Why deferred**: still being proven against a live consumer's request-signing
+surface; the covered-component set, canonicalization edge cases, and the
+Ed25519-only scoping want to settle in the consumer before being frozen as a
+published primitive.
+
+**Dependencies**: this stream's `base64UrlNoPadEncode` / `base64UrlNoPadDecode`
+(`@fgv/ts-extras/crypto-utils`, the base64url-no-pad primitives) — the RFC 9421
+signature-base and signature encoding both traffic in base64url-no-pad, so the
+packlet builds directly on them rather than re-deriving the codec. Also
+`ICryptoProvider.sign`/`verify` (already shipped).
+
+**Reference**: PersonAIlity V2 identity/signing track (`signing` packlet, Phase 0);
+crypto-utils base64url + branded multibase SPKI hardening stream
+(`.ai/tasks/active/crypto-utils-base64url-hardening/`).

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Brand } from '@fgv/ts-utils';
 import { Conversion } from '@fgv/ts-utils';
 import { Converter } from '@fgv/ts-utils';
 import { DateTime } from 'luxon';
@@ -301,6 +302,16 @@ const argon2idKeyDerivationParams: Converter<IArgon2idKeyDerivationParams>;
 // @public
 const base64String: Converter<string>;
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+function base64UrlNoPadDecode(encoded: string): Result<Uint8Array>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+function base64UrlNoPadEncode(data: Uint8Array): string;
+
 // @public
 function callProviderCompletion(params: IProviderCompletionParams): Promise<Result<IAiCompletionResponse>>;
 
@@ -397,6 +408,7 @@ declare namespace Converters_3 {
         argon2idKeyDerivationParams,
         keyDerivationParams,
         base64String,
+        multibaseSpkiPublicKey,
         uint8ArrayFromBase64,
         namedSecret,
         encryptedFile
@@ -433,13 +445,17 @@ declare namespace CryptoUtils {
         ICreateEncryptedFileParams,
         toBase64,
         tryDecryptFile,
+        base64UrlNoPadDecode,
+        base64UrlNoPadEncode,
         exportPublicKeyAsMultibaseSpki,
         importPublicKeyFromMultibaseSpki,
+        isValidMultibaseSpkiPublicKey,
         multibaseBase64UrlDecode,
         multibaseBase64UrlEncode,
         HpkeProvider,
         IHpkeSealResult,
         isEncryptedFile,
+        MultibaseSpkiPublicKey,
         EncryptionAlgorithm,
         EncryptedFileFormat,
         INamedSecret,
@@ -595,7 +611,7 @@ export { Experimental }
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-function exportPublicKeyAsMultibaseSpki(key: CryptoKey, provider: ICryptoProvider): Promise<Result<string>>;
+function exportPublicKeyAsMultibaseSpki(key: CryptoKey, provider: ICryptoProvider): Promise<Result<MultibaseSpkiPublicKey>>;
 
 // @beta
 class ExtendedArray<T> extends Array<T> {
@@ -1556,7 +1572,7 @@ interface IModelSpecMap {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-function importPublicKeyFromMultibaseSpki(encoded: string, algorithm: KeyPairAlgorithm, provider: ICryptoProvider): Promise<Result<CryptoKey>>;
+function importPublicKeyFromMultibaseSpki(encoded: MultibaseSpkiPublicKey, algorithm: KeyPairAlgorithm, provider: ICryptoProvider): Promise<Result<CryptoKey>>;
 
 // @public
 interface IMustacheTemplateOptions {
@@ -1745,6 +1761,12 @@ const isoDate: Converter<Date, unknown>;
 
 // @public
 const isoDateTime: Converter<DateTime, unknown>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+function isValidMultibaseSpkiPublicKey(value: unknown): value is MultibaseSpkiPublicKey;
 
 // @public
 interface IThinkingConfig {
@@ -2079,6 +2101,19 @@ function multibaseBase64UrlDecode(encoded: string): Result<Uint8Array>;
 
 // @public
 function multibaseBase64UrlEncode(data: Uint8Array): string;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+type MultibaseSpkiPublicKey = Brand<string, 'MultibaseSpkiPublicKey'>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+const multibaseSpkiPublicKey: Converter<MultibaseSpkiPublicKey>;
 
 declare namespace Mustache {
     export {

--- a/libraries/ts-extras/src/packlets/crypto-utils/converters.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/converters.ts
@@ -30,8 +30,10 @@ import {
   IKeyDerivationParams,
   INamedSecret,
   IPbkdf2KeyDerivationParams,
-  KeyDerivationFunction
+  KeyDerivationFunction,
+  MultibaseSpkiPublicKey
 } from './model';
+import { isValidMultibaseSpkiPublicKey } from './spkiHelpers';
 
 // ============================================================================
 // Base Converters
@@ -111,6 +113,25 @@ export const base64String: Converter<string> = Converters.string.withConstraint(
     return fail('Invalid base64 encoding');
   }
   return succeed(value);
+});
+
+/**
+ * Converter for {@link CryptoUtils.MultibaseSpkiPublicKey | multibase SPKI public key} strings.
+ * Validates that the value is a string with the `'m'` multibase prefix and a well-formed
+ * base64url-no-pad body, and yields the branded value. Fails with context on a non-string,
+ * bad-prefix, or malformed-body input.
+ * @public
+ */
+export const multibaseSpkiPublicKey: Converter<MultibaseSpkiPublicKey> = Converters.string.map((value) => {
+  if (isValidMultibaseSpkiPublicKey(value)) {
+    return succeed(value);
+  }
+  if (!value.startsWith('m')) {
+    return fail(
+      `multibaseSpkiPublicKey: invalid multibase prefix '${value[0] ?? '(empty)'}' — expected 'm' (base64url)`
+    );
+  }
+  return fail(`multibaseSpkiPublicKey: malformed base64url body`);
 });
 
 // ============================================================================

--- a/libraries/ts-extras/src/packlets/crypto-utils/index.browser.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/index.browser.ts
@@ -64,10 +64,13 @@ export {
   tryDecryptFile
 } from './encryptedFile';
 
-// Multibase/SPKI helpers
+// Multibase/SPKI + base64url helpers
 export {
+  base64UrlNoPadDecode,
+  base64UrlNoPadEncode,
   exportPublicKeyAsMultibaseSpki,
   importPublicKeyFromMultibaseSpki,
+  isValidMultibaseSpkiPublicKey,
   multibaseBase64UrlDecode,
   multibaseBase64UrlEncode
 } from './spkiHelpers';

--- a/libraries/ts-extras/src/packlets/crypto-utils/index.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/index.ts
@@ -57,10 +57,13 @@ export {
   tryDecryptFile
 } from './encryptedFile';
 
-// Multibase/SPKI helpers
+// Multibase/SPKI + base64url helpers
 export {
+  base64UrlNoPadDecode,
+  base64UrlNoPadEncode,
   exportPublicKeyAsMultibaseSpki,
   importPublicKeyFromMultibaseSpki,
+  isValidMultibaseSpkiPublicKey,
   multibaseBase64UrlDecode,
   multibaseBase64UrlEncode
 } from './spkiHelpers';

--- a/libraries/ts-extras/src/packlets/crypto-utils/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/model.ts
@@ -19,10 +19,25 @@
 // SOFTWARE.
 
 import { JsonValue } from '@fgv/ts-json-base';
-import { Result, Uuid } from '@fgv/ts-utils';
+import { Brand, Result, Uuid } from '@fgv/ts-utils';
 
 import * as Constants from './constants';
 export { Constants };
+
+// ============================================================================
+// Public Key Types
+// ============================================================================
+
+/**
+ * A multibase base64url-encoded SPKI (SubjectPublicKeyInfo) public key string —
+ * a `'m'` multibase prefix followed by a base64url-no-pad body. Produced by
+ * {@link CryptoUtils.exportPublicKeyAsMultibaseSpki} and consumed by
+ * {@link CryptoUtils.importPublicKeyFromMultibaseSpki}. Obtain the brand at a
+ * boundary via {@link CryptoUtils.isValidMultibaseSpkiPublicKey} or the
+ * {@link CryptoUtils.Converters.multibaseSpkiPublicKey} converter.
+ * @public
+ */
+export type MultibaseSpkiPublicKey = Brand<string, 'MultibaseSpkiPublicKey'>;
 
 // ============================================================================
 // Encryption Types

--- a/libraries/ts-extras/src/packlets/crypto-utils/spkiHelpers.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/spkiHelpers.ts
@@ -19,20 +19,30 @@
 // SOFTWARE.
 
 import { Result, fail, succeed } from '@fgv/ts-utils';
-import { ICryptoProvider, KeyPairAlgorithm } from './model';
+import { ICryptoProvider, KeyPairAlgorithm, MultibaseSpkiPublicKey } from './model';
 
 /**
- * Encodes a `Uint8Array` as a multibase base64url (no-padding) string.
+ * Shared shape check for a base64url (no-padding) body: only base64url alphabet
+ * characters (`A-Z`, `a-z`, `0-9`, `-`, `_`) and a length that is never `% 4 === 1`
+ * (an impossible base64 remainder). Factored so the decoder and the
+ * {@link isValidMultibaseSpkiPublicKey} guard agree on exactly one rule.
+ */
+function isBase64UrlNoPadBody(body: string): boolean {
+  return /^[A-Za-z0-9_-]*$/.test(body) && body.length % 4 !== 1;
+}
+
+/**
+ * Encodes a `Uint8Array` as a base64url (no-padding) string (RFC 4648 §5).
  *
- * The multibase prefix `'m'` identifies the encoding as RFC 4648 base64url
- * without padding. The body uses base64url alphabet: `+` → `-`, `/` → `_`,
- * and trailing `=` padding is stripped.
+ * The body uses the base64url alphabet (`+` → `-`, `/` → `_`) and trailing `=`
+ * padding is stripped. This is the bare primitive with no multibase prefix; use
+ * {@link CryptoUtils.multibaseBase64UrlEncode} when a multibase-`'m'`-prefixed value is required.
  *
  * @param data - The binary data to encode.
- * @returns A multibase-prefixed base64url string (`'m' + base64url-no-pad`).
+ * @returns The base64url-no-pad string.
  * @public
  */
-export function multibaseBase64UrlEncode(data: Uint8Array): string {
+export function base64UrlNoPadEncode(data: Uint8Array): string {
   let base64: string;
   if (typeof Buffer !== 'undefined') {
     base64 = Buffer.from(data).toString('base64');
@@ -46,8 +56,72 @@ export function multibaseBase64UrlEncode(data: Uint8Array): string {
   }
   /* c8 ignore stop */
   // Convert to base64url: + → -, / → _, strip = padding
-  const base64url = base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-  return 'm' + base64url;
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Decodes a base64url (no-padding) string (RFC 4648 §5) back to a `Uint8Array`.
+ *
+ * This is the bare primitive with no multibase prefix; use
+ * {@link CryptoUtils.multibaseBase64UrlDecode} to decode a multibase-`'m'`-prefixed value.
+ *
+ * @param encoded - The base64url-no-pad body to decode.
+ * @returns `Success` with the decoded bytes, or `Failure` with error context.
+ * @public
+ */
+export function base64UrlNoPadDecode(encoded: string): Result<Uint8Array> {
+  if (!isBase64UrlNoPadBody(encoded)) {
+    return fail(`base64UrlNoPadDecode: malformed base64url body`);
+  }
+  // Convert base64url back to standard base64 and restore padding
+  const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+  try {
+    let bytes: Uint8Array;
+    if (typeof Buffer !== 'undefined') {
+      bytes = new Uint8Array(Buffer.from(padded, 'base64'));
+      /* c8 ignore start - browser-only: atob path not available in Node tests */
+    } else {
+      const binary = atob(padded);
+      bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+    }
+    /* c8 ignore stop */
+    return succeed(bytes);
+    /* c8 ignore next 3 - defensive: shape check above prevents invalid chars from reaching here */
+  } catch {
+    return fail(`base64UrlNoPadDecode: malformed base64url body`);
+  }
+}
+
+/**
+ * Type guard for {@link CryptoUtils.MultibaseSpkiPublicKey}: a string that starts
+ * with the multibase `'m'` prefix and whose body matches the base64url-no-pad shape.
+ * Shares the exact body-shape rule used by {@link CryptoUtils.base64UrlNoPadDecode}.
+ *
+ * @param value - The value to test.
+ * @returns `true` if `value` is a well-formed multibase SPKI public key string.
+ * @public
+ */
+export function isValidMultibaseSpkiPublicKey(value: unknown): value is MultibaseSpkiPublicKey {
+  return typeof value === 'string' && value.startsWith('m') && isBase64UrlNoPadBody(value.slice(1));
+}
+
+/**
+ * Encodes a `Uint8Array` as a multibase base64url (no-padding) string.
+ *
+ * The multibase prefix `'m'` identifies the encoding as RFC 4648 base64url
+ * without padding. The body uses base64url alphabet: `+` → `-`, `/` → `_`,
+ * and trailing `=` padding is stripped.
+ *
+ * @param data - The binary data to encode.
+ * @returns A multibase-prefixed base64url string (`'m' + base64url-no-pad`).
+ * @public
+ */
+export function multibaseBase64UrlEncode(data: Uint8Array): string {
+  return 'm' + base64UrlNoPadEncode(data);
 }
 
 /**
@@ -68,31 +142,13 @@ export function multibaseBase64UrlDecode(encoded: string): Result<Uint8Array> {
       }' — expected 'm' (base64url)`
     );
   }
-  const body = encoded.slice(1);
-  if (!/^[A-Za-z0-9_-]*$/.test(body) || body.length % 4 === 1) {
-    return fail(`multibaseBase64UrlDecode: malformed base64url body`);
-  }
-  // Convert base64url back to standard base64 and restore padding
-  const base64 = body.replace(/-/g, '+').replace(/_/g, '/');
-  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
-  try {
-    let bytes: Uint8Array;
-    if (typeof Buffer !== 'undefined') {
-      bytes = new Uint8Array(Buffer.from(padded, 'base64'));
-      /* c8 ignore start - browser-only: atob path not available in Node tests */
-    } else {
-      const binary = atob(padded);
-      bytes = new Uint8Array(binary.length);
-      for (let i = 0; i < binary.length; i++) {
-        bytes[i] = binary.charCodeAt(i);
-      }
-    }
-    /* c8 ignore stop */
-    return succeed(bytes);
-    /* c8 ignore next 3 - defensive: regex validation above prevents invalid chars from reaching here */
-  } catch {
-    return fail(`multibaseBase64UrlDecode: malformed base64url body`);
-  }
+  // Intentionally pin the exact original message (the delegate has a single failure
+  // mode) to keep this established public function byte-for-byte behavior-preserving
+  // after the extract-and-delegate refactor — do not "fix" this into composing the
+  // delegate's message without updating the delegation-equivalence tests.
+  return base64UrlNoPadDecode(encoded.slice(1)).withErrorFormat(
+    () => `multibaseBase64UrlDecode: malformed base64url body`
+  );
 }
 
 /**
@@ -110,10 +166,14 @@ export function multibaseBase64UrlDecode(encoded: string): Result<Uint8Array> {
 export async function exportPublicKeyAsMultibaseSpki(
   key: CryptoKey,
   provider: ICryptoProvider
-): Promise<Result<string>> {
+): Promise<Result<MultibaseSpkiPublicKey>> {
   return (await provider.exportPublicKeySpki(key))
     .withErrorFormat((e) => `exportPublicKeyAsMultibaseSpki: ${e}`)
-    .onSuccess((buf) => succeed(multibaseBase64UrlEncode(buf)));
+    .onSuccess((buf) =>
+      // The output is a freshly-built valid multibase SPKI string (`'m'` prefix +
+      // base64url-no-pad body), so brand it at the construction site — no re-validation needed.
+      succeed(multibaseBase64UrlEncode(buf) as MultibaseSpkiPublicKey)
+    );
 }
 
 /**
@@ -130,7 +190,7 @@ export async function exportPublicKeyAsMultibaseSpki(
  * @public
  */
 export async function importPublicKeyFromMultibaseSpki(
-  encoded: string,
+  encoded: MultibaseSpkiPublicKey,
   algorithm: KeyPairAlgorithm,
   provider: ICryptoProvider
 ): Promise<Result<CryptoKey>> {

--- a/libraries/ts-extras/src/test/unit/crypto/spkiHelpers.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/spkiHelpers.test.ts
@@ -21,7 +21,7 @@
 import '@fgv/ts-utils-jest';
 
 import * as CryptoUtils from '../../../packlets/crypto-utils';
-import type { KeyPairAlgorithm } from '../../../packlets/crypto-utils';
+import type { KeyPairAlgorithm, MultibaseSpkiPublicKey } from '../../../packlets/crypto-utils';
 
 const provider = CryptoUtils.nodeCryptoProvider;
 
@@ -115,15 +115,15 @@ describe('exportPublicKeyAsMultibaseSpki / importPublicKeyFromMultibaseSpki', ()
       // Use a valid base64url body but wrong prefix
       const pair = (await provider.generateKeyPair('ed25519', true)).orThrow();
       const encoded = (await CryptoUtils.exportPublicKeyAsMultibaseSpki(pair.publicKey, provider)).orThrow();
-      // Replace the 'm' prefix with 'z'
-      const badPrefixed = 'z' + encoded.slice(1);
+      // Replace the 'm' prefix with 'z' (intentionally invalid — cast the test brand)
+      const badPrefixed = ('z' + encoded.slice(1)) as MultibaseSpkiPublicKey;
       const result = await CryptoUtils.importPublicKeyFromMultibaseSpki(badPrefixed, 'ed25519', provider);
       expect(result).toFailWith(/invalid multibase prefix/i);
     });
 
     test('fails on malformed base64url body', async () => {
       const result = await CryptoUtils.importPublicKeyFromMultibaseSpki(
-        'm!@#invalid!!!',
+        'm!@#invalid!!!' as MultibaseSpkiPublicKey,
         'ed25519',
         provider
       );
@@ -139,5 +139,148 @@ describe('exportPublicKeyAsMultibaseSpki / importPublicKeyFromMultibaseSpki', ()
       const result = await CryptoUtils.importPublicKeyFromMultibaseSpki(encoded, 'ecdsa-p256', provider);
       expect(result).toFail();
     });
+
+    test('accepts a value produced by exportPublicKeyAsMultibaseSpki via the guard and converter', async () => {
+      const pair = (await provider.generateKeyPair('ed25519', true)).orThrow();
+      const encoded = (await CryptoUtils.exportPublicKeyAsMultibaseSpki(pair.publicKey, provider)).orThrow();
+      expect(CryptoUtils.isValidMultibaseSpkiPublicKey(encoded)).toBe(true);
+      expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert(encoded)).toSucceedWith(encoded);
+    });
+  });
+});
+
+describe('base64UrlNoPadEncode / base64UrlNoPadDecode', () => {
+  test('round-trips the empty array', () => {
+    const data = new Uint8Array(0);
+    const encoded = CryptoUtils.base64UrlNoPadEncode(data);
+    expect(encoded).toBe('');
+    expect(CryptoUtils.base64UrlNoPadDecode(encoded)).toSucceedWith(data);
+  });
+
+  // 1 byte -> 2 pad chars pre-strip; 2 bytes -> 1 pad char; 3 bytes -> 0 pads.
+  test.each([1, 2, 3, 4, 5, 15, 16, 31, 32, 64])(
+    'round-trips %d bytes across all pad-count boundaries',
+    (length) => {
+      const data = new Uint8Array(Array.from({ length }, (__unused, i) => (i * 37 + 11) % 256));
+      const encoded = CryptoUtils.base64UrlNoPadEncode(data);
+      // no padding, no standard-base64-only characters
+      expect(encoded).not.toMatch(/[+/=]/);
+      expect(CryptoUtils.base64UrlNoPadDecode(encoded)).toSucceedWith(data);
+    }
+  );
+
+  test('uses the base64url alphabet for bytes that produce + and / in standard base64', () => {
+    const data = new Uint8Array([0xfb, 0xff, 0xfe]); // '+//+' territory in base64
+    const encoded = CryptoUtils.base64UrlNoPadEncode(data);
+    expect(encoded).not.toMatch(/[+/=]/);
+    expect(encoded).toMatch(/[-_]/);
+    expect(CryptoUtils.base64UrlNoPadDecode(encoded)).toSucceedWith(data);
+  });
+
+  test('decode rejects bodies with non-base64url characters', () => {
+    expect(CryptoUtils.base64UrlNoPadDecode('!@#$')).toFailWith(/malformed base64url/i);
+    expect(CryptoUtils.base64UrlNoPadDecode('ab cd')).toFailWith(/malformed base64url/i);
+    expect(CryptoUtils.base64UrlNoPadDecode('has=pad')).toFailWith(/malformed base64url/i);
+  });
+
+  test('decode rejects a body whose length is % 4 === 1 (impossible base64 remainder)', () => {
+    expect(CryptoUtils.base64UrlNoPadDecode('A')).toFailWith(/malformed base64url/i);
+    expect(CryptoUtils.base64UrlNoPadDecode('AAAAA')).toFailWith(/malformed base64url/i);
+  });
+});
+
+describe('multibase delegation equivalence (behavior-preserving refactor)', () => {
+  const samples: Uint8Array[] = [
+    new Uint8Array(0),
+    new Uint8Array([0]),
+    new Uint8Array([0xfb, 0xff, 0xfe]),
+    new Uint8Array([...Array(32).keys()]),
+    new Uint8Array(Array.from({ length: 65 }, (__unused, i) => (i * 53 + 7) % 256))
+  ];
+
+  test.each(samples.map((s, i) => [i, s] as const))(
+    'sample %d: multibaseBase64UrlEncode(x) === "m" + base64UrlNoPadEncode(x)',
+    (__i, data) => {
+      expect(CryptoUtils.multibaseBase64UrlEncode(data)).toBe('m' + CryptoUtils.base64UrlNoPadEncode(data));
+    }
+  );
+
+  test.each(samples.map((s, i) => [i, s] as const))(
+    'sample %d: multibase decode delegates to base64UrlNoPadDecode of the body',
+    (__i, data) => {
+      const multibase = CryptoUtils.multibaseBase64UrlEncode(data);
+      const bare = CryptoUtils.base64UrlNoPadEncode(data);
+      expect(CryptoUtils.multibaseBase64UrlDecode(multibase)).toSucceedWith(data);
+      expect(CryptoUtils.base64UrlNoPadDecode(bare)).toSucceedWith(data);
+      // The multibase body is exactly the bare encoding.
+      expect(multibase.slice(1)).toBe(bare);
+    }
+  );
+
+  test('multibase decode preserves its own malformed-body error message after delegation', () => {
+    expect(CryptoUtils.multibaseBase64UrlDecode('m!@#$%')).toFailWith(
+      /multibaseBase64UrlDecode: malformed base64url body/
+    );
+  });
+});
+
+describe('isValidMultibaseSpkiPublicKey', () => {
+  test('accepts well-formed multibase base64url-no-pad values', () => {
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey('m')).toBe(true); // 'm' + empty body
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey('mSGVsbG8')).toBe(true);
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey('mAAAA')).toBe(true);
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey('mabc-_ABC')).toBe(true);
+  });
+
+  test('rejects non-string values', () => {
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey(undefined)).toBe(false);
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey(null)).toBe(false);
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey(42)).toBe(false);
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey(new Uint8Array([1, 2, 3]))).toBe(false);
+  });
+
+  test('rejects missing or wrong multibase prefix', () => {
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey('')).toBe(false);
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey('zSGVsbG8')).toBe(false);
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey('SGVsbG8')).toBe(false);
+  });
+
+  test('rejects malformed base64url body', () => {
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey('m!@#$%')).toBe(false);
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey('mA')).toBe(false); // body length % 4 === 1
+  });
+});
+
+describe('Converters.multibaseSpkiPublicKey', () => {
+  test('succeeds with the branded value for valid input', () => {
+    expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert('mSGVsbG8')).toSucceedWith(
+      'mSGVsbG8' as MultibaseSpkiPublicKey
+    );
+    expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert('m')).toSucceedWith(
+      'm' as MultibaseSpkiPublicKey
+    );
+  });
+
+  test('fails on a non-string input', () => {
+    expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert(42)).toFail();
+    expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert(undefined)).toFail();
+  });
+
+  test('fails with prefix context on a bad multibase prefix', () => {
+    expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert('zSGVsbG8')).toFailWith(
+      /invalid multibase prefix 'z'/i
+    );
+    expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert('')).toFailWith(
+      /invalid multibase prefix '\(empty\)'/i
+    );
+  });
+
+  test('fails with malformed-body context on a bad base64url body', () => {
+    expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert('m!@#$%')).toFailWith(
+      /malformed base64url body/i
+    );
+    expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert('mA')).toFailWith(
+      /malformed base64url body/i
+    );
   });
 });


### PR DESCRIPTION
## Summary

Additive hardening of the **active** `@fgv/ts-extras/crypto-utils` surface for the PersonAIlity V2 identity/signing track (RFC 9421 + WebAuthn). Two coupled asks (base64url + multibase SPKI).

### Item 3 — bare base64url-no-pad primitives (extract + delegate)
- New `base64UrlNoPadEncode(data: Uint8Array): string` and `base64UrlNoPadDecode(encoded: string): Result<Uint8Array>` — RFC 4648 §5 base64url, no padding, **no** multibase `'m'` prefix.
- Extracted the body logic out of the existing `multibaseBase64UrlEncode/Decode`; those now **delegate** to the bare primitives (`multibaseBase64UrlEncode(d) === 'm' + base64UrlNoPadEncode(d)`; decode = `'m'`-prefix check → `base64UrlNoPadDecode(body)`). One implementation, not two. Existing multibase error messages/behavior are byte-for-byte preserved and the genuine browser-only `btoa`/`atob` `c8 ignore` branches are retained.

### Item 2 — branded `MultibaseSpkiPublicKey`
- Brand `MultibaseSpkiPublicKey = Brand<string, 'MultibaseSpkiPublicKey'>` (model.ts).
- Type guard `isValidMultibaseSpkiPublicKey` + validating `Converters.multibaseSpkiPublicKey`. Guard and decoder share **one** private shape rule (`isBase64UrlNoPadBody`) — no divergent regex.
- Tightened signatures (active surface): `exportPublicKeyAsMultibaseSpki → Promise<Result<MultibaseSpkiPublicKey>>` (brands the freshly-built output at the single construction site) and `importPublicKeyFromMultibaseSpki(encoded: MultibaseSpkiPublicKey, ...)`.
- New helpers/guard/type/converter exported from both `index.ts` and `index.browser.ts`.

### Item 5 — docs only
- `docs/FUTURE.md`: **"RFC 9421 HTTP-message-signature packlet (prospective @fgv/ts-extras)"** entry noting it depends on this stream's `base64UrlNoPadEncode/Decode`.

## api.md additive diff
```
+ function base64UrlNoPadEncode(data: Uint8Array): string;
+ function base64UrlNoPadDecode(encoded: string): Result<Uint8Array>;
+ function isValidMultibaseSpkiPublicKey(value: unknown): value is MultibaseSpkiPublicKey;
+ type MultibaseSpkiPublicKey = Brand<string, 'MultibaseSpkiPublicKey'>;
+ const multibaseSpkiPublicKey: Converter<MultibaseSpkiPublicKey>;
- function exportPublicKeyAsMultibaseSpki(...): Promise<Result<string>>;
+ function exportPublicKeyAsMultibaseSpki(...): Promise<Result<MultibaseSpkiPublicKey>>;
- function importPublicKeyFromMultibaseSpki(encoded: string, ...): Promise<Result<CryptoKey>>;
+ function importPublicKeyFromMultibaseSpki(encoded: MultibaseSpkiPublicKey, ...): Promise<Result<CryptoKey>>;
```
The only removed/changed lines are the two intentional signature tightenings; everything else is additive.

## Delegation-equivalence proof
A dedicated `multibase delegation equivalence (behavior-preserving refactor)` test block asserts, across 5 byte-length samples:
- `multibaseBase64UrlEncode(x) === 'm' + base64UrlNoPadEncode(x)` ✓
- multibase decode round-trips and its body equals the bare encoding ✓
- `multibaseBase64UrlDecode('m!@#$%')` still fails with the exact original `multibaseBase64UrlDecode: malformed base64url body` message ✓

All 52 tests in `spkiHelpers.test.ts` pass.

## Gates
- `rushx build` ✓ (api-extractor regenerated `etc/ts-extras.api.md`)
- `rushx lint` ✓ (`rushx fixlint` run before final commit)
- `rushx test` ✓ — **100% coverage** (statements/branches/functions/lines) across ts-extras, incl. `spkiHelpers.ts`, `model.ts`, `converters.ts` at 100%.

## Code-reviewer (layer 1) findings + dispositions
Ran the `code-reviewer` agent on the diff before coverage confirmation.
- **P1:** none.
- **P2:** one judgment call — `multibaseBase64UrlDecode`'s `.withErrorFormat(() => ...)` discards the delegate's message. **Disposition: intentional** (the delegate has a single failure mode; pinning the exact original string is what makes the refactor behavior-preserving). Added an explanatory comment at the call site warning future editors not to "fix" it into composing the message without updating the equivalence tests.
- **P3 (noted):** the new `{@link CryptoUtils.X}` TSDoc refs produce `ae-unresolved-link` api-extractor warnings — a pre-existing, pervasive convention in this file (namespace-qualified `@link` isn't resolved by the repo's api-extractor config), not a regression. Left consistent with existing convention.

Recommendation: **Approved**, no blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new base64url encoding and decoding support for unpadded values.
  * Strengthened public-key handling with validated, branded SPKI key values for safer use across the app.

* **Bug Fixes**
  * Improved key encoding/decoding consistency while preserving existing error behavior.
  * Tightened validation so malformed or incorrectly prefixed values are rejected earlier and more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->