### PR TITLE
fix(ai-assist): surface Gemini image-generation refusals cleanly

### DIFF
--- a/.ai/tasks/active/ai-assist-gemini-image-refusal/brief.md
+++ b/.ai/tasks/active/ai-assist-gemini-image-refusal/brief.md
@@ -1,0 +1,61 @@
+# Brief — ai-assist: surface Gemini image-generation refusals cleanly
+
+**Branch:** `claude/ai-assist-gemini-image-refusal` (off `release`).
+**Surface:** `@fgv/ts-extras` → `src/packlets/ai-assist` (**active** surface — additive OK per `.ai/instructions/ACTIVE_DEVELOPMENT.md`).
+**Ships under the enforced coverage gate** (#517/#518) — 100% coverage is real; hit it for real.
+
+## Problem (real consumer bug report)
+
+A PersonAIlity avatar render using a character-reference image failed. Gemini's `:generateContent` returned a **refusal candidate** — a candidate carrying `finishReason: "IMAGE_OTHER"` + a `finishMessage` ("Unable to show the generated image. The model could not generate the image based on the prompt provided… Try rephrasing…") and **no `content`**. Our adapter surfaced this as:
+
+```
+Gemini image API response: candidates[0].content: Field not found
+```
+
+That is a mis-signal: a well-behaved Gemini *refusal* is reported as if **we** couldn't parse the response (a wire-shape mismatch). The consumer can't distinguish "our integration broke" from "the model declined; rephrase and retry."
+
+**Root cause** in `libraries/ts-extras/src/packlets/ai-assist/apiClient.ts` (the `gemini-image-out` path, function `callGeminiImageOutGeneration`, ~line 1160):
+
+- `IGeminiImageOutCandidate` (line 877) declares `content` **required**; the validator `geminiImageOutCandidate` (line 899) has `content: geminiImageOutContent` with no `.optional()`. A content-less refusal candidate fails validation at the missing `content` field → the cryptic error.
+- `finishReason` is captured (optional, line 900) but **never read**. `finishMessage` **isn't modeled at all**.
+- The `images.length === 0` fallback (line 1210) `'no image parts in response'` can't tell "empty" from "refused" either.
+
+## Do (additive, minimal, one file + tests)
+
+In `apiClient.ts`:
+
+1. **Model the refusal fields.** Add `finishMessage?: string` to `IGeminiImageOutCandidate` (line 877-880) and its validator (line 897-901): `finishMessage: Validators.string.optional()`.
+2. **Make `content` optional.** `IGeminiImageOutContent` on the candidate becomes `content?: IGeminiImageOutContent` (interface) and `content: geminiImageOutContent.optional()` (validator). A refusal candidate now validates instead of erroring.
+3. **Relax the `parts` non-empty constraint** on `geminiImageOutContent` (line 894-896) — drop `.withConstraint((arr) => arr.length > 0)`. Emptiness is now handled uniformly in the extraction loop's `images.length === 0` branch (below), so a `content`-present-but-empty-`parts` candidate also degrades to the clean refusal/empty error rather than a cryptic validation failure.
+4. **Guard the content deref + build a legible refusal error.** In the extraction loop (line 1197-1213):
+   - Iterate `candidate.content?.parts ?? []` so a content-less candidate is skipped safely (no more unconditional `candidate.content.parts`).
+   - When `images.length === 0`, before failing, scan `response.candidates` for any `finishReason`. If one is present, fail with a message that surfaces it, e.g.:
+     `Gemini image generation declined: <finishReason>[ — <finishMessage>]` (include the ` — <finishMessage>` segment only when `finishMessage` is present). If **no** candidate carries a `finishReason`, keep the existing `Gemini image API response: no image parts in response` message.
+   - Keep the outer `.withErrorFormat((msg) => \`Gemini image API response: ${msg}\`)` for the validation stage. The refusal message is returned from inside `.onSuccess`, so decide the final wording deliberately — the declined-message should read cleanly on its own (it's fine for it to NOT carry the `Gemini image API response:` prefix, or to carry it — pick one and be consistent; prefer a form a consumer can substring-match, e.g. stable leading text `Gemini image generation declined:`).
+
+Keep it surgical. Do not touch the other provider image paths (OpenAI/xAI), the completion/streaming paths, or the dispatcher.
+
+## Constraints
+
+- No `any`; `Result<T>` for fallible ops; Validators for shape validation (no manual-typeof-then-cast). `__`-prefix unused params (lint-mandated).
+- Additive only — no removed/renamed exports (these interfaces are `@internal`). The two behavior changes (content optional, parts constraint dropped) only *widen* what validates; every previously-valid response still validates and still yields the same images.
+- Regenerate `etc/ts-extras.api.md` if anything public shifts (these are `@internal`, so likely no api.md change — confirm the diff is empty or additive).
+- **100% coverage — actually enforced now.**
+
+## Tests
+
+Add to the existing ai-assist image-generation test suite (find the current `callProviderImageGeneration` / gemini-image-out tests and colocate). Drive through the public `callProviderImageGeneration` entry with a mocked/fixtured Gemini response body where possible; if the suite already fixtures `fetchJson`/wire JSON, follow that pattern.
+
+- **Refusal candidate** (`finishReason: 'IMAGE_OTHER'`, `finishMessage: '...'`, **no `content`**) → `toFailWith(/Gemini image generation declined: IMAGE_OTHER/)` and assert the `finishMessage` text is included.
+- **Refusal candidate with `finishReason` but no `finishMessage`** → fails with the reason, no dangling ` — `.
+- **Empty-parts candidate** (`content.parts: []`, no image, with a `finishReason`) → same clean declined error (proves the dropped `parts` constraint routes through the refusal branch).
+- **No-finishReason empty** (candidate with content but zero inlineData parts and no finishReason) → preserves the existing `no image parts in response` message.
+- **Happy path unchanged** — a normal `content.parts[].inlineData` response still yields the image(s). Confirm the existing success test still passes untouched.
+
+## Sequence
+
+Implement → `code-reviewer` on the diff **before** coverage-chasing → `rushx build && rushx lint` (fixlint first) + `rushx test` @ 100% + api-extractor regen (confirm no/additive api.md diff) → `rush change` (`--bulk --bump-type patch --target-branch origin/release` — this is a bugfix) → commit + push + open PR onto `release`.
+
+## Proof of work
+
+`git log --oneline -3`; build/lint/test tails (100%); the refusal-path test output (declined message with finishReason + finishMessage); confirmation the happy-path test is unchanged; `code-reviewer` findings + dispositions; api.md diff (expected empty/additive since the touched interfaces are `@internal`).

--- a/common/changes/@fgv/ts-extras/claude-ai-assist-gemini-image-refusal_2026-07-07-09-31.json
+++ b/common/changes/@fgv/ts-extras/claude-ai-assist-gemini-image-refusal_2026-07-07-09-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Surface Gemini image-generation refusals (finishReason/finishMessage) as a clean declined error instead of a cryptic content-missing validation failure; treat benign STOP/MAX_TOKENS terminal reasons as no-image rather than a decline",
+      "type": "none",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/apiClient.ts
@@ -875,8 +875,9 @@ interface IGeminiImageOutContent {
 }
 /** @internal */
 interface IGeminiImageOutCandidate {
-  content: IGeminiImageOutContent;
+  content?: IGeminiImageOutContent;
   finishReason?: string;
+  finishMessage?: string;
 }
 /** @internal */
 interface IGeminiImageOutResponse {
@@ -892,12 +893,13 @@ const geminiImageOutPart: Validator<IGeminiImageOutPart> = Validators.object<IGe
   inlineData: geminiImageInlineData.optional()
 });
 const geminiImageOutContent: Validator<IGeminiImageOutContent> = Validators.object<IGeminiImageOutContent>({
-  parts: Validators.arrayOf(geminiImageOutPart).withConstraint((arr) => arr.length > 0)
+  parts: Validators.arrayOf(geminiImageOutPart)
 });
 const geminiImageOutCandidate: Validator<IGeminiImageOutCandidate> =
   Validators.object<IGeminiImageOutCandidate>({
-    content: geminiImageOutContent,
-    finishReason: Validators.string.optional()
+    content: geminiImageOutContent.optional(),
+    finishReason: Validators.string.optional(),
+    finishMessage: Validators.string.optional()
   });
 const geminiImageOutResponse: Validator<IGeminiImageOutResponse> = Validators.object<IGeminiImageOutResponse>(
   {
@@ -1157,6 +1159,15 @@ async function callXaiImageGeneration(
   );
 }
 
+/**
+ * Gemini `finishReason` values that indicate a normal terminal completion rather
+ * than a refusal. `STOP` is set on every successful generation (and on completions
+ * that return a text part instead of an image); `MAX_TOKENS` is a benign truncation.
+ * A candidate carrying only one of these is NOT a decline — treating it as one would
+ * mislabel an ordinary no-image outcome as a policy refusal. @internal
+ */
+const benignGeminiImageFinishReasons: ReadonlySet<string> = new Set(['STOP', 'MAX_TOKENS']);
+
 /** Calls Gemini :generateContent for image output; accepts ref images as inlineData. @internal */
 async function callGeminiImageOutGeneration(
   config: IAiApiConfig,
@@ -1197,7 +1208,7 @@ async function callGeminiImageOutGeneration(
       .onSuccess((response) => {
         const images: IAiGeneratedImage[] = [];
         for (const candidate of response.candidates) {
-          for (const part of candidate.content.parts) {
+          for (const part of candidate.content?.parts ?? []) {
             if (part.inlineData) {
               images.push({
                 mimeType: part.inlineData.mimeType,
@@ -1207,6 +1218,21 @@ async function callGeminiImageOutGeneration(
           }
         }
         if (images.length === 0) {
+          // A candidate with no image parts is a *decline* only when it carries a
+          // refusal-shaped finishReason — i.e. present and not a benign terminal reason
+          // (`STOP`/`MAX_TOKENS`). A normal completion that emitted text-instead-of-image
+          // carries `finishReason: 'STOP'` and must fall through to the no-image message.
+          const declined = response.candidates.find(
+            (candidate) =>
+              candidate.finishReason !== undefined &&
+              !benignGeminiImageFinishReasons.has(candidate.finishReason)
+          );
+          if (declined?.finishReason !== undefined) {
+            // Truthiness (not `!== undefined`) so an empty-string finishMessage is treated
+            // as "no message" and produces no dangling ` — ` separator.
+            const suffix = declined.finishMessage ? ` — ${declined.finishMessage}` : '';
+            return fail(`Gemini image generation declined: ${declined.finishReason}${suffix}`);
+          }
           return fail('Gemini image API response: no image parts in response');
         }
         return succeed({ images });

--- a/libraries/ts-extras/src/test/unit/ai-assist/apiClient.imageGeneration.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/apiClient.imageGeneration.test.ts
@@ -744,6 +744,126 @@ describe('callProviderImageGeneration', () => {
       const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
       expect(body.generationConfig).toEqual({ responseModalities: ['IMAGE'] });
     });
+
+    test('extracts image parts on the happy path', async () => {
+      mockFetchResponse(
+        geminiImageOutBody([
+          { mimeType: 'image/png', data: 'PPPP' },
+          { mimeType: 'image/jpeg', data: 'JJJJ' }
+        ])
+      );
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor: geminiImageOutDescriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a robot' }
+      });
+
+      expect(result).toSucceedAndSatisfy((response) => {
+        expect(response.images).toEqual([
+          { mimeType: 'image/png', base64: 'PPPP' },
+          { mimeType: 'image/jpeg', base64: 'JJJJ' }
+        ]);
+      });
+    });
+
+    test('surfaces a content-less refusal candidate as a clean declined error including finishMessage', async () => {
+      mockFetchResponse({
+        candidates: [
+          {
+            finishReason: 'IMAGE_OTHER',
+            finishMessage:
+              'Unable to show the generated image. The model could not generate the image based on the prompt provided. Try rephrasing.'
+          }
+        ]
+      });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor: geminiImageOutDescriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a robot' }
+      });
+
+      expect(result).toFailWith(/Gemini image generation declined: IMAGE_OTHER/);
+      expect(result).toFailWith(/Try rephrasing\./);
+    });
+
+    test('surfaces a refusal with finishReason but no finishMessage without a dangling separator', async () => {
+      mockFetchResponse({
+        candidates: [{ finishReason: 'IMAGE_OTHER' }]
+      });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor: geminiImageOutDescriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a robot' }
+      });
+
+      expect(result).toFailWith(/Gemini image generation declined: IMAGE_OTHER$/);
+      expect(result).toFailWith(/^(?!.* — ).*$/);
+    });
+
+    test('routes an empty-parts candidate carrying a finishReason through the declined branch', async () => {
+      mockFetchResponse({
+        candidates: [{ content: { parts: [] }, finishReason: 'SAFETY' }]
+      });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor: geminiImageOutDescriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a robot' }
+      });
+
+      expect(result).toFailWith(/Gemini image generation declined: SAFETY/);
+    });
+
+    test('preserves the no-image-parts message when no candidate carries a finishReason', async () => {
+      mockFetchResponse({
+        candidates: [{ content: { parts: [{ text: 'here is a description instead' }] } }]
+      });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor: geminiImageOutDescriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a robot' }
+      });
+
+      expect(result).toFailWith(/Gemini image API response: no image parts in response/);
+    });
+
+    test('treats a benign STOP finishReason with no image parts as no-image, not a decline', async () => {
+      // A normal completion that emitted a text part instead of an image carries
+      // finishReason: 'STOP' — this is not a refusal and must not be reported as declined.
+      mockFetchResponse({
+        candidates: [
+          { content: { parts: [{ text: 'sorry, I cannot generate that image' }] }, finishReason: 'STOP' }
+        ]
+      });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor: geminiImageOutDescriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a robot' }
+      });
+
+      expect(result).toFailWith(/Gemini image API response: no image parts in response/);
+      expect(result).toFailWith(/^(?!.*declined).*$/);
+    });
+
+    test('treats an empty-string finishMessage as no message, producing no dangling separator', async () => {
+      mockFetchResponse({
+        candidates: [{ finishReason: 'IMAGE_OTHER', finishMessage: '' }]
+      });
+
+      const result = await AiAssist.callProviderImageGeneration({
+        descriptor: geminiImageOutDescriptor,
+        apiKey: 'test-key',
+        params: { prompt: 'a robot' }
+      });
+
+      expect(result).toFailWith(/Gemini image generation declined: IMAGE_OTHER$/);
+      expect(result).toFailWith(/^(?!.* — ).*$/);
+    });
   });
 });
 


### PR DESCRIPTION
## Problem (consumer bug report)

A PersonAIlity avatar render using a character-reference image failed with:

```
hub-config POST /hub/decorate/mood-set returned 422 [generation_failed]:
Gemini image API response: candidates: "content": Field not found in
"{"finishReason":"IMAGE_OTHER","finishMessage":"Unable to show the generated image..."}"
```

Gemini's `:generateContent` returns a **content-less candidate** carrying a `finishReason` (`IMAGE_OTHER`) + `finishMessage` when it *declines* to render an image. Our `gemini-image-out` adapter required `content` and never inspected `finishReason`, so a well-behaved Gemini refusal surfaced as a cryptic `candidates[0].content: Field not found` — mis-signalling an integration/parse bug when the actual cause was a model-side decline the consumer should retry/rephrase on.

## Fix (`libraries/ts-extras/src/packlets/ai-assist/apiClient.ts`, `gemini-image-out` path only)

- Make candidate `content` optional; add `finishMessage` to `IGeminiImageOutCandidate` + validator; drop the `parts` non-empty constraint (emptiness now handled uniformly in the extraction loop).
- Guard the content deref (`candidate.content?.parts ?? []`) and, when no image parts are present, surface a stable, consumer-substring-matchable error: `Gemini image generation declined: <finishReason> — <finishMessage>` (the ` — <finishMessage>` segment omitted when absent/empty).
- **Exclude benign terminal reasons (`STOP`/`MAX_TOKENS`)** from the decline path so a normal completion that emitted text instead of an image still falls through to the existing `no image parts in response` message.

The touched interfaces are `@internal` — **no public API change** (`etc/ts-extras.api.md` diff is empty).

## Review — code-reviewer (layer 1), findings resolved

- **P1 (fixed):** the initial predicate `finishReason !== undefined` treated *any* finishReason as a decline, but Gemini sets `finishReason: 'STOP'` on **successful** completions too — this mislabeled a normal text-instead-of-image outcome as `declined: STOP` and regressed a pre-existing passing test in `apiClient.refImages.test.ts`. Fixed by excluding benign terminal reasons via a `benignGeminiImageFinishReasons` set; regression test now passes.
- **P2 (fixed):** empty-string `finishMessage` produced a dangling ` — ` separator (the `!== undefined` guard missed `''`). Switched to a truthiness guard (the one place `||`-style is semantically correct — `''` should mean "no message") + added a covering test.
- **P3 (dispositioned):** the `declined?.finishReason !== undefined` check reads as redundant after the `find`, but is **required for TypeScript to narrow `finishReason` to `string`** in the template literal — kept intentionally. The `{}`-candidate path is covered transitively by the no-finishReason test.

## Tests

New cases in `apiClient.imageGeneration.test.ts`: happy path unchanged; content-less refusal → declined error incl. `finishMessage`; refusal with no `finishMessage` → no dangling separator; empty-`parts` + `finishReason` → declined branch; benign `STOP` no-image → falls through to `no image parts in response` (regression guard); empty-string `finishMessage` → no dangling separator; no-finishReason empty → existing message preserved.

## Gates (local, `libraries/ts-extras`)

- `rushx build` ✅ (api-extractor clean — no api.md drift)
- `rushx lint` ✅ clean
- `rushx test` ✅ — **100% coverage** on `apiClient.ts` (statements/branch/funcs/lines), enforced gate; full ai-assist suite green including the previously-failing `apiClient.refImages.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini image-generation handling so refusal responses now surface as a clearer declined error instead of a generic missing-content message.
  * Better distinguishes between true refusals and benign stop/truncation outcomes, avoiding false decline errors.
  * Preserves image results as before when generation succeeds.

* **Tests**
  * Added coverage for refusal responses, empty image parts, missing finish messages, and successful multi-image outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->