### PR TITLE
docs(agent-memory): speculative platform briefs for the three v1 fast-follows

### DIFF
--- a/.ai/tasks/active/agent-memory-l2-tools/brief.md
+++ b/.ai/tasks/active/agent-memory-l2-tools/brief.md
@@ -1,9 +1,31 @@
 # Brief — `@fgv/ts-agent-memory`: L2 agent-tool surface (`IAiClientTool` memory tools)
 
-> **STATUS: DRAFT / SPECULATIVE — not commissioned.** Platform fast-follow, consumer-gated
-> (commission when PersonAIlity wants the agent to curate its own memory via tool-use). One of
+> **STATUS: DRAFT — not commissioned, but consumer-validated.** Platform fast-follow. One of
 > three agent-memory fast-follow briefs. **Independent of the other two** — depends only on the
-> shipped v1 L1 substrate; can slot first if the tool loop is wanted before temporal/L3.
+> shipped v1 L1 substrate. **PersonAIlity's nearest-term consumer** (three `FileTreeMemoryStore`
+> adoptions in; they want L2 first or in parallel with temporal, not strictly last). Consumer
+> feedback (2026-07-07) is folded in below and has **locked several previously-open decisions**.
+
+## Consumer requirements (PersonAIlity, 2026-07-07 — LOCKED)
+
+From the nearest-term adopter (knowledge vault + durable MTM + durable LTM live, agent-facing
+mnemonic-deref `recall` tool shipped). These are adoption gates, not suggestions:
+
+1. **Scope isolation is constructor-fixed, never argument-reachable (make-or-break).** The factory
+   takes a **pre-scoped store** (the actor's own memory root). **No tool argument may name or widen
+   scope** — these tools face an LLM, so a steerable `scope` parameter is a cross-actor read
+   primitive. This *removes* `scope` from every tool arg shape (resolves the arg→key open question
+   in that direction) and makes the injected store the sole scope authority.
+2. **Per-tool granularity, not just `readOnly?`.** Ship a `tools?` subset / per-tool enable set.
+   PersonAIlity's v1 posture: `memory_search` + `memory_context` **on**; `memory_write` +
+   `memory_delete` **off** (writes stay curation-mediated); `memory_read` likely **skipped** in
+   favor of their existing mnemonic deref. A single all-or-`readOnly` flag is too coarse.
+3. **Host-suppliable result handle on `memory_search` (design consideration).** Their agent-facing
+   handles are **evocative mnemonic tags, not entity ids** — prompts teach agents to deref by the
+   short tag shown in context. Let `memory_search` results carry a **host-suppliable handle**
+   (they'd feed mnemonics) instead of / alongside raw ids, so a host's search→deref loop speaks one
+   vocabulary to the agent. Design the result shape to accept a `handleFor?(record) => string`-style
+   host hook rather than hard-coding raw `MemoryId` as the agent-visible key.
 
 **Surface:** `@fgv/ts-agent-memory` (new `tools/` packlet) + consumes `@fgv/ts-extras` ai-assist `IAiClientTool` and `@fgv/ts-json-base` `JsonSchema`. **Active** library.
 **Ships under the enforced coverage gate** — 100% real.
@@ -31,28 +53,33 @@ L2 is explicitly OUT of the v1 build (`design-lock.md:16`, `README.md:33`, `brie
 - **Package location** — a `tools/` packlet inside `@fgv/ts-agent-memory` (`:919-920`): the `IAiClientTool` factory set + a tool-suite factory returning the tool array for `executeClientToolTurn`.
 - **MCP dual-path** — the same schemas pass `JsonSchema.fromJson` in `adaptMcpTools` (§8.3:757-759), so one authoring serves both direct and MCP exposure.
 
-**OPEN — this brief's decisions at commission:**
-- **Tool-arg → domain-key mapping (must resolve).** The design's flat `{scope, id}` schemas don't map to the shipped signatures: `delete(kind, entityId)` needs a `kind`; `get(kind, entityId)` needs the per-kind `EntityId`, and the **MTM composite `<conversationId>:<turnIndex>`** doesn't fit a single flat `id`. Decide the tool arg shape (likely `{kind, entityId}` with per-kind entityId documented, using the codec to validate) and reconcile `memory_read`'s `getById({scope, id})` vs `get({kind, entityId})` split.
-- **Tool-suite factory signature (named deliverable, unspecified).** How the consumer injects its store + retriever(s) + registry into the `tools/` factory. Recommend: `createMemoryTools({ store, retriever, registry, kinds?, readOnly? }): ReadonlyArray<IAiClientTool>` — `kinds?` whitelists toolable kinds (default = `registry.has`-backed enumeration), `readOnly?` omits `memory_write`/`memory_delete`.
-- **Safety at the tool boundary (under-specified).** Validation IS settled (schema `.validate` + registry `.convert`). NOT settled: whether/how a tool surfaces `IWritePolicy.admit` rejections vs. dedup no-ops to the agent, and behavior hints (`destructiveHint`/`idempotentHint`/`readOnlyHint`/`openWorldHint` exist only as inline comments today — no typed structure). Decide: (a) map `admit` reject → tool `Result.fail` with the reason; dedup no-op → success with a "already present" note; (b) whether to ship a typed behavior-hint field now or defer.
-- **Tool granularity (OQ-8).** Five is a proof set (basic-memory ships ~15). Final count "depends on personaility's agent design" — ship the five, note the extension seam.
+**LOCKED by consumer feedback (see Consumer requirements above):**
+- **Tool-arg → domain-key mapping.** **No `scope` in any tool arg** — scope is fixed by the injected pre-scoped store (requirement 1). Tool args are `{kind, entityId}` (per-kind `EntityId`, codec-validated; the MTM composite `<conversationId>:<turnIndex>` rides `entityId`, not a flat `id`). `memory_read`/`memory_delete` therefore never take a `scope`; `memory_search`/`memory_context` never accept a scope-widening axis.
+- **Factory signature.** `createMemoryTools({ store, retriever, registry, tools?, kinds? }): ReadonlyArray<IAiClientTool>` — `store` is **pre-scoped** (sole scope authority); `tools?` selects the per-tool subset (requirement 2; default = the safe read set `['memory_search','memory_context']`, NOT all five — writes opt in explicitly); `kinds?` whitelists toolable kinds (default = `registry.has`-backed enumeration). The coarse `readOnly?` flag is dropped in favor of the `tools?` subset.
+- **`memory_search` result handle.** Accept a host `handleFor?(record) => string` hook; when supplied, the agent-visible key in search results is the host handle (mnemonic), not raw `MemoryId` (requirement 3).
+
+**Still OPEN — decide at commission:**
+- **Safety at the tool boundary.** Validation IS settled (schema `.validate` + registry `.convert`). Decide: (a) map `IWritePolicy.admit` reject → tool `Result.fail` with the reason; dedup no-op → success with an "already present" note; (b) whether to ship a typed behavior-hint field (`destructiveHint`/`idempotentHint`/`readOnlyHint`/`openWorldHint`, comments-only today) now or defer.
+- **Tool granularity (OQ-8).** Five is a proof set (basic-memory ships ~15). Final count depends on the consumer's agent design — ship the five, note the extension seam.
 
 ## Scope (do)
 
-1. New `tools/` packlet: `createMemoryTools(params)` factory (signature per the open-decision above) returning the five `IAiClientTool`s, each authored with a `JsonSchema.object(...)` `parametersSchema` and an `execute` that mirrors the ts-extras-mcp idiom (validate/narrow → delegate to store/retriever → return `Result`, never swallow).
-2. Resolve the tool-arg→domain-key mapping (per-kind `entityId`; MTM composite handled by routing through the codec, not a flat `id`).
-3. Wire write-safety: `memory_write` deserializes `body` string → the store's `put` runs `registry.convert`; surface `admit` rejections as tool failures; `readOnly?` gate on the mutating tools.
-4. Prove the loop in a `samples/testbed` scenario (design anchor `:985-987`, exploration Scenario A `:317-356`): the five tools wired through `executeClientToolTurn`, agent curates the substrate end-to-end. (STOP-FLAG if it needs a live model call — build ready, principal runs keyed.)
-5. **Do NOT** add new L1/store capability; do NOT touch temporal or ingest.
+1. New `tools/` packlet: `createMemoryTools({ store, retriever, registry, tools?, kinds? })` factory (locked signature above) returning the selected `IAiClientTool`s, each authored with a `JsonSchema.object(...)` `parametersSchema` and an `execute` that mirrors the ts-extras-mcp idiom (validate/narrow → delegate to store/retriever → return `Result`, never swallow).
+2. **Enforce scope isolation structurally:** the factory closes over the pre-scoped `store`; NO tool's `parametersSchema` declares a `scope` (or any scope-widening) property. Add a test that asserts no tool schema carries a scope arg — this is the adoption gate.
+3. Tool-arg→domain-key mapping: `{kind, entityId}` (per-kind `EntityId`, codec-validated; MTM composite via `entityId`, never a flat `id`).
+4. `memory_search` result shape accepts the host `handleFor?(record)` hook; when present the agent-visible key is the host handle (mnemonic), else raw `MemoryId`.
+5. Wire write-safety: `memory_write` deserializes `body` string → the store's `put` runs `registry.convert`; surface `admit` rejections as tool failures. Mutating tools (`memory_write`/`memory_delete`) are **off by default** — included only when named in `tools?`.
+6. Prove the loop in a `samples/testbed` scenario (design anchor `:985-987`, exploration Scenario A `:317-356`): the selected tools wired through `executeClientToolTurn`, agent curates the substrate end-to-end. (STOP-FLAG if it needs a live model call — build ready, principal runs keyed.)
+7. **Do NOT** add new L1/store capability; do NOT touch temporal or ingest.
 
 ## Interdependencies
 
-- **Independent of temporal and L3.** Depends only on shipped L1. Can be commissioned first for early consumer value (the agent-curates-memory loop is the most demoable of the three).
+- **Independent of temporal and L3.** Depends only on shipped L1. **Recommended to commission first, or in parallel with temporal** (consumer's stated preference — L2 changes what consuming agents can *do* soonest; the agent-curates-memory loop is the most demoable of the three).
 - Shares the substrate L3 will later write *automatically* — L2 is the *manual* writer of the same graph.
 
 ## Constraints / tests / sequence / proof
 
 - No `any`; `Result<T>`; `JsonSchema.object` for every param schema (no hand-authored wire schema); `execute` returns `Result`, failures never swallowed; `__`-prefix unused. **100% coverage enforced.**
-- **Tests:** each tool's `parametersSchema.validate` accept/reject; each `execute` happy + failure (store/retriever `Result.fail` propagates, incl. loud-degrade on an unwired retrieval axis); the arg→domain-key mapping incl. MTM composite; `readOnly` omits mutating tools; `memory_write` body-deserialize + registry-convert reject; the testbed scenario wiring (mocked). Mirror `@fgv/ts-extras-mcp` adapter tests for the tool-construction idiom.
+- **Tests:** **no tool schema declares a `scope` arg** (the scope-isolation adoption gate — assert structurally across the returned suite); `tools?` subset selection (default excludes `memory_write`/`memory_delete`; naming them includes them); `kinds?` whitelist; each tool's `parametersSchema.validate` accept/reject; each `execute` happy + failure (store/retriever `Result.fail` propagates, incl. loud-degrade on an unwired retrieval axis); the arg→domain-key mapping incl. MTM composite; `memory_search` `handleFor` hook (agent-visible key is the mnemonic when supplied, raw id when not); `memory_write` body-deserialize + registry-convert reject; the testbed scenario wiring (mocked). Mirror `@fgv/ts-extras-mcp` adapter tests for the tool-construction idiom.
 - **Sequence:** implement → `code-reviewer` SYNCHRONOUSLY before coverage-chasing → gates @100% → `rush change --bulk --bump-type minor --target-branch origin/release` (committed) → PR onto `release`.
 - **Proof:** git log; gate tails (100%); the five tool descriptors + their `JsonSchema.object` schemas; the factory signature; the testbed-scenario wiring; code-reviewer findings + dispositions; STOP-FLAG note if the scenario needs a live run.

--- a/.ai/tasks/active/agent-memory-l2-tools/brief.md
+++ b/.ai/tasks/active/agent-memory-l2-tools/brief.md
@@ -1,0 +1,58 @@
+# Brief — `@fgv/ts-agent-memory`: L2 agent-tool surface (`IAiClientTool` memory tools)
+
+> **STATUS: DRAFT / SPECULATIVE — not commissioned.** Platform fast-follow, consumer-gated
+> (commission when PersonAIlity wants the agent to curate its own memory via tool-use). One of
+> three agent-memory fast-follow briefs. **Independent of the other two** — depends only on the
+> shipped v1 L1 substrate; can slot first if the tool loop is wanted before temporal/L3.
+
+**Surface:** `@fgv/ts-agent-memory` (new `tools/` packlet) + consumes `@fgv/ts-extras` ai-assist `IAiClientTool` and `@fgv/ts-json-base` `JsonSchema`. **Active** library.
+**Ships under the enforced coverage gate** — 100% real.
+
+## Goal
+
+Expose memory operations as a suite of `AiAssist.IAiClientTool`s so an LLM agent can read/write/search its own memory substrate through `AiAssist.executeClientToolTurn` (and, for free, through `@fgv/ts-extras-mcp` since the same `JsonSchema.object` schemas pass `JsonSchema.fromJson`). L2 is a **consumer of L1 that must not gate it** — it adds no new envelope/store capability; the design confirmed the envelope did not have to change to support it.
+
+## Status: not shipped; seams stable
+
+L2 is explicitly OUT of the v1 build (`design-lock.md:16`, `README.md:33`, `brief.md:20`, `state.md:23`). Everything it sits on is shipped:
+
+- **Store API** (`packlets/store/fileTreeMemoryStore.ts:60-92`, `IMemoryStore`): `get(kind, entityId)`, `getById(scope, MemoryId)`, `list(filter?)`, `put(record)`, `delete(kind, entityId)`. Filter `{scope?, kind?, tag?, asOf?}` (`:42-54`).
+- **Retrievers:** `HybridRetriever` (`hybridRetriever.ts:97,122,141`) fans one `IMemoryQuery` across all wired retrievers + score-union — natural backing for `memory_search`. `LinkTraversalRetriever` backs `memory_context` (`linkedFrom`/`hops`). `IMemoryQuery` axes all-optional (`retriever.ts:32-63`). Loud-degrade on unwired axes (`guardRetrieverCapabilities:127`) — surface as tool failures.
+- **Body registry** (`bodyConverterRegistry.ts:16-45`, `IBodyConverterRegistry`): `register/registerSchema/has/getConverter/convert`. **This is the tool write-safety gate** — the store already runs `registry.convert(kind, body)` on every `put`; `has(kind)` lets the factory whitelist toolable kinds.
+- **Identity codecs** (`identityCodec.ts:33-51`): `KnowledgeIdentityCodec` (single-id stem), `LtmIdentityCodec` (conversationId), `MtmIdentityCodec` (composite `<conversationId>:<turnIndex>`). The domain `EntityId` shape is **per-kind, codec-specific**.
+- **`IAiClientTool` machinery** (`@fgv/ts-extras` `ai-assist/model.ts`): `IAiClientToolConfig<TParams>` (`:264-276`, `type:'client_tool'`, `name`, `description`, `parametersSchema: JsonSchema.ISchemaValidator<TParams>`); `IAiClientTool<TParams>` (`:288-297`, `execute: (args: TParams) => Promise<Result<unknown>>` — **receives already-validated typed `TParams`**). Runner `executeClientToolTurn` (`streamingClient.ts:73`).
+- **Mirror idiom** — `@fgv/ts-extras-mcp` `adapter.ts:57-67,91-101` constructs an `IAiClientTool` exactly the way each `memory_*` tool should: build `config` with a `JsonSchema.object(...)` `parametersSchema`, `execute` narrows/validates args → delegates → returns the `Result` (never swallowed).
+
+## Design: settled vs. open
+
+**Settled (design.md §8:659-766):**
+- **Five-tool proof set** — `memory_write`→`store.put`, `memory_read`→`store.get`/`getById`, `memory_search`→`HybridRetriever.retrieve`, `memory_context`→`LinkTraversalRetriever`, `memory_delete`→`store.delete`. Full descriptors at `:679-745`.
+- **Param schemas authored via `JsonSchema.object(...)`** — the schema IS the validator (`schema.validate(args)` is the round-trip verify), and `JsonSchema.Static<typeof schema>` derives `TParams`. Body passed as a **serialized string**, validated by the kind's Converter via the registry (`:686`).
+- **Package location** — a `tools/` packlet inside `@fgv/ts-agent-memory` (`:919-920`): the `IAiClientTool` factory set + a tool-suite factory returning the tool array for `executeClientToolTurn`.
+- **MCP dual-path** — the same schemas pass `JsonSchema.fromJson` in `adaptMcpTools` (§8.3:757-759), so one authoring serves both direct and MCP exposure.
+
+**OPEN — this brief's decisions at commission:**
+- **Tool-arg → domain-key mapping (must resolve).** The design's flat `{scope, id}` schemas don't map to the shipped signatures: `delete(kind, entityId)` needs a `kind`; `get(kind, entityId)` needs the per-kind `EntityId`, and the **MTM composite `<conversationId>:<turnIndex>`** doesn't fit a single flat `id`. Decide the tool arg shape (likely `{kind, entityId}` with per-kind entityId documented, using the codec to validate) and reconcile `memory_read`'s `getById({scope, id})` vs `get({kind, entityId})` split.
+- **Tool-suite factory signature (named deliverable, unspecified).** How the consumer injects its store + retriever(s) + registry into the `tools/` factory. Recommend: `createMemoryTools({ store, retriever, registry, kinds?, readOnly? }): ReadonlyArray<IAiClientTool>` — `kinds?` whitelists toolable kinds (default = `registry.has`-backed enumeration), `readOnly?` omits `memory_write`/`memory_delete`.
+- **Safety at the tool boundary (under-specified).** Validation IS settled (schema `.validate` + registry `.convert`). NOT settled: whether/how a tool surfaces `IWritePolicy.admit` rejections vs. dedup no-ops to the agent, and behavior hints (`destructiveHint`/`idempotentHint`/`readOnlyHint`/`openWorldHint` exist only as inline comments today — no typed structure). Decide: (a) map `admit` reject → tool `Result.fail` with the reason; dedup no-op → success with a "already present" note; (b) whether to ship a typed behavior-hint field now or defer.
+- **Tool granularity (OQ-8).** Five is a proof set (basic-memory ships ~15). Final count "depends on personaility's agent design" — ship the five, note the extension seam.
+
+## Scope (do)
+
+1. New `tools/` packlet: `createMemoryTools(params)` factory (signature per the open-decision above) returning the five `IAiClientTool`s, each authored with a `JsonSchema.object(...)` `parametersSchema` and an `execute` that mirrors the ts-extras-mcp idiom (validate/narrow → delegate to store/retriever → return `Result`, never swallow).
+2. Resolve the tool-arg→domain-key mapping (per-kind `entityId`; MTM composite handled by routing through the codec, not a flat `id`).
+3. Wire write-safety: `memory_write` deserializes `body` string → the store's `put` runs `registry.convert`; surface `admit` rejections as tool failures; `readOnly?` gate on the mutating tools.
+4. Prove the loop in a `samples/testbed` scenario (design anchor `:985-987`, exploration Scenario A `:317-356`): the five tools wired through `executeClientToolTurn`, agent curates the substrate end-to-end. (STOP-FLAG if it needs a live model call — build ready, principal runs keyed.)
+5. **Do NOT** add new L1/store capability; do NOT touch temporal or ingest.
+
+## Interdependencies
+
+- **Independent of temporal and L3.** Depends only on shipped L1. Can be commissioned first for early consumer value (the agent-curates-memory loop is the most demoable of the three).
+- Shares the substrate L3 will later write *automatically* — L2 is the *manual* writer of the same graph.
+
+## Constraints / tests / sequence / proof
+
+- No `any`; `Result<T>`; `JsonSchema.object` for every param schema (no hand-authored wire schema); `execute` returns `Result`, failures never swallowed; `__`-prefix unused. **100% coverage enforced.**
+- **Tests:** each tool's `parametersSchema.validate` accept/reject; each `execute` happy + failure (store/retriever `Result.fail` propagates, incl. loud-degrade on an unwired retrieval axis); the arg→domain-key mapping incl. MTM composite; `readOnly` omits mutating tools; `memory_write` body-deserialize + registry-convert reject; the testbed scenario wiring (mocked). Mirror `@fgv/ts-extras-mcp` adapter tests for the tool-construction idiom.
+- **Sequence:** implement → `code-reviewer` SYNCHRONOUSLY before coverage-chasing → gates @100% → `rush change --bulk --bump-type minor --target-branch origin/release` (committed) → PR onto `release`.
+- **Proof:** git log; gate tails (100%); the five tool descriptors + their `JsonSchema.object` schemas; the factory signature; the testbed-scenario wiring; code-reviewer findings + dispositions; STOP-FLAG note if the scenario needs a live run.

--- a/.ai/tasks/active/agent-memory-l3-ingest/brief.md
+++ b/.ai/tasks/active/agent-memory-l3-ingest/brief.md
@@ -8,6 +8,15 @@
 **Surface:** `@fgv/ts-agent-memory` (new `ingest/` packlet); reads `retrieve` + `vector`; writes via `store`. **Active** library.
 **Ships under the enforced coverage gate** — 100% real.
 
+## Consumer feedback (PersonAIlity, 2026-07-07 — folded in)
+
+Furthest-out of the three for them ("L3 furthest out"), but they gave four shaping inputs that **lock two open questions** and add two requirements:
+
+1. **OQ-10 → staged host interface (LOCKED).** They already own classifiers/extractors (their curator framework) and would plug into the classify/extract/relate stages. An opaque "hand me items" ingestor would force them to abandon working machinery. → Ship the staged split, not the opaque `IMemoryIngestor`.
+2. **Single-item incremental ingest is first-class (new requirement).** Their writes are per-turn and streaming; a batch-only orchestrator that only pays off at batch N can't serve their main pipeline (only the smaller knowledge-vault document path). The orchestrator API must accept and be efficient for a **single `IIngestItem`**, not just an array.
+3. **OQ-13 → `IEntityResolver` stays optional (LOCKED).** Their entity keys are deterministic composites (`<conversationId>:<turnIndex>`, `<conversationId>`); a mandatory resolver is dead weight for deterministic-identity hosts.
+4. **Additive/optional provenance guarantee (new).** The provenance fields (`by`/`model`/`confidence`/`derivedFrom` — the memory-lineage substrate they want but don't stamp today) must land **additive/optional**, so already-persisted `mtm`/`ltm` records stay valid with **no migration**. (Already true of the shipped envelope; make it an explicit non-regression the stream must preserve and test.)
+
 ## Goal
 
 The fgv-side ingestion target for a consumer's own extract/relate pipeline. **The host brings classify/extract/relate judgment; fgv owns the typed validation boundary, dedup, edge/cycle safety, provenance stamping, and the `contradicts`→temporal interlock.** Cognee-ECL-shaped six-stage pipeline (design §9).
@@ -33,16 +42,19 @@ The fgv-side ingestion target for a consumer's own extract/relate pipeline. **Th
 - **Body validation boundary**: every `ICandidateRecord.body` validated against the kind's registered Converter before the store (design:829-832).
 - **Attributed edges + structured provenance (not bare strings)** — "firmest Phase-A recommendation," already shipped.
 
-**OPEN — this brief's decisions at commission:**
-- **OQ-10 — host-interface granularity (the central fork).** Staged split (`IMemoryClassifier` + `IFactExtractor` + `IEntityResolver?` + `IRelationExtractor`) — *recommended*, because fgv's stage-4-6 machinery is the value-add and a single opaque `IMemoryIngestor` pushes it back onto the host — vs. one opaque `IMemoryIngestor`. Decide at commission.
-- **OQ-13 — `IEntityResolver` optional (default) vs. required.** Without it, layer-2 near-dup dedup falls back to exact-hash-only. `IEntityResolver` returns `new | duplicate-of | supersede | merge-into`. Not defined anywhere in v1.
+**LOCKED by consumer feedback:**
+- **OQ-10 — staged host interface.** Ship the staged split (`IMemoryClassifier` + `IFactExtractor` + `IEntityResolver?` + `IRelationExtractor`), NOT the opaque `IMemoryIngestor` — the consumer plugs its existing classifier/extractor machinery into the stages (fgv's stage-4-6 machinery is the value-add).
+- **OQ-13 — `IEntityResolver` optional.** Optional, not required — deterministic-identity hosts (composite keys) skip it; without it, layer-2 near-dup dedup falls back to exact-hash-only. Returns `new | duplicate-of | supersede | merge-into`.
+- **Single-item incremental ingest is first-class.** The orchestrator accepts and is efficient for a single `IIngestItem` (per-turn streaming writes), not just a batch array. Batch is a convenience over the single-item path, not the only path.
+
+**Still OPEN — decide at commission:**
 - **Similarity-dedup layer is entirely new.** V1 has exact content-hash dedup only; the vector packlet provides cosine *search* but nothing wires similarity into the write/dedup path. L3 layer-2 = vector candidate-gen + threshold (default unspecified — decide) + optional `IEntityResolver`.
 - **Hash-key discrepancy to reconcile:** store content-hash is over `{kind,body,links}` (`:864`); design stage-4 exact dedup specifies `canonicalize({kind,body})` (design:836). L3 must decide whether to reuse the store's `links`-inclusive hash or compute its own `{kind,body}` key — they differ.
 - **OQ-3 — home:** in-package `ingest/` packlet (recommended default); own-package split deferred.
 
-## Scope (do) — at commission, after OQ-10/OQ-13 decided
+## Scope (do) — OQ-10/OQ-13 locked (see Consumer feedback)
 
-1. New `ingest/` packlet: the four host interfaces (per the OQ-10 decision) + `ICandidateRecord` + `IIngestItem` + the fgv-owned `IMemoryIngestOrchestrator`.
+1. New `ingest/` packlet: the **four staged host interfaces** (`IMemoryClassifier` + `IFactExtractor` + `IEntityResolver?` + `IRelationExtractor`) + `ICandidateRecord` + `IIngestItem` + the fgv-owned `IMemoryIngestOrchestrator`. The orchestrator's entry point takes a **single `IIngestItem`** as the first-class path (a batch overload/loop composes over it) — per-turn streaming ingest must not be second-class. Provenance fields land **additive/optional** (no migration of persisted `mtm`/`ltm`).
 2. **Stage 4 (fgv):** exact dedup (reconcile the hash key) + layer-2 similarity candidate-gen (vector) + threshold + optional `IEntityResolver` dispatch (`new|duplicate-of|supersede|merge-into`).
 3. **Stage 5 (fgv):** write-time edge validation + edge write + **write-time cycle guard** (new — the design's `buildCycleKey`, not the read-time BFS).
 4. **Stage 6 (fgv):** stamp `IProvenance` (`source:'host-ingest'`, `by`/`model`/`confidence` from the host) + `derivedFrom` back-link; admit through the per-kind `IWritePolicy`; `put`.
@@ -62,6 +74,6 @@ The fgv-side ingestion target for a consumer's own extract/relate pipeline. **Th
 ## Constraints / tests / sequence / proof
 
 - No `any`; `Result<T>`; Converters/`JsonSchema` for the validation boundary (host bodies validated against registered converters — no unchecked host data reaches the store); attributed edges + structured provenance only. **100% coverage enforced.**
-- **Tests:** each host-interface contract via a mocked host; stage-4 exact + similarity dedup (incl. the `IEntityResolver` verdicts and the fall-back-to-exact when absent); stage-5 edge validation + write-time cycle guard (reject a cycle-inducing edge); stage-6 provenance/`derivedFrom` stamping + policy admission; the `contradicts` interlock (only if temporal is present — else assert it's deferred/fails-loud); testbed end-to-end.
-- **Sequence:** decide OQ-10/OQ-13 → implement → `code-reviewer` SYNCHRONOUSLY before coverage-chasing → gates @100% → `rush change --bulk --bump-type minor --target-branch origin/release` (committed) → PR onto `release`.
+- **Tests:** each staged host-interface contract via a mocked host; **single-item ingest path** (one `IIngestItem` end-to-end, not just a batch); **additive-provenance non-regression** (a pre-existing `mtm`/`ltm` record with no provenance fields still loads/validates after the stream); stage-4 exact + similarity dedup (incl. the `IEntityResolver` verdicts and the fall-back-to-exact when absent — the deterministic-key host path); stage-5 edge validation + write-time cycle guard (reject a cycle-inducing edge); stage-6 provenance/`derivedFrom` stamping + policy admission; the `contradicts` interlock (only if temporal is present — else assert it's deferred/fails-loud); testbed end-to-end.
+- **Sequence:** implement (OQ-10/OQ-13 locked) → `code-reviewer` SYNCHRONOUSLY before coverage-chasing → gates @100% → `rush change --bulk --bump-type minor --target-branch origin/release` (committed) → PR onto `release`.
 - **Proof:** git log; gate tails (100%); the OQ-10/OQ-13 decision note; the six-stage orchestrator + four host interfaces; dedup (both layers) + cycle-guard + provenance test output; the interlock status (delivered vs. deferred-pending-temporal); code-reviewer findings + dispositions.

--- a/.ai/tasks/active/agent-memory-l3-ingest/brief.md
+++ b/.ai/tasks/active/agent-memory-l3-ingest/brief.md
@@ -1,0 +1,67 @@
+# Brief — `@fgv/ts-agent-memory`: L3 ingest orchestrator
+
+> **STATUS: DRAFT / SPECULATIVE — not commissioned.** Platform fast-follow, consumer-gated
+> (commission when PersonAIlity is ready to wire extractors into an ingestion pipeline). One of
+> three agent-memory fast-follow briefs. **Largest of the three, and dependency-blocked:** its
+> `contradicts`→temporal interlock requires the `agent-memory-temporal` stream shipped first.
+
+**Surface:** `@fgv/ts-agent-memory` (new `ingest/` packlet); reads `retrieve` + `vector`; writes via `store`. **Active** library.
+**Ships under the enforced coverage gate** — 100% real.
+
+## Goal
+
+The fgv-side ingestion target for a consumer's own extract/relate pipeline. **The host brings classify/extract/relate judgment; fgv owns the typed validation boundary, dedup, edge/cycle safety, provenance stamping, and the `contradicts`→temporal interlock.** Cognee-ECL-shaped six-stage pipeline (design §9).
+
+## Status: green-field packlet
+
+**Nothing L3-shaped exists in v1** — no `ingest/` packlet, no `IMemoryIngestor`, no `IMemoryClassifier`/`IFactExtractor`/`IEntityResolver`/`IRelationExtractor`, not even a stub. `src/index.ts` re-exports exactly seven packlets (`types, converters, store, index, retrieve, observe, vector`). The only "ingest" token in shipped source is the `'host-ingest'` arm of `ProvenanceSource`. L3 **composes** existing seams and adds the orchestrator + four host interfaces.
+
+## Shipped seams L3 composes (verified)
+
+- **Write path** (`fileTreeMemoryStore.put`): already delivers body-validate (`registry.convert` `:486`), content-hash over `{kind,body,links}` (`_contentHash:863-865`), per-kind dedup (`dedupScope` content/entity `:535-544`), policy `admit` (`:558`), seq/created/updated/contentHash stamp (`_buildRecord:722`), persist + index-patch. **It persists whatever `provenance` it's handed but never *stamps* provenance** — that stamping is L3's job.
+- **Write policy** (`IWritePolicy` `writePolicy.ts:56-103`): `admit → accept|reject|cull-oldest`, `applyUpdate` (RFC-7386 merge). L3 admits through the per-kind policy; never bypasses `admit`.
+- **Provenance + edges** (`envelope.ts:23-36,45-62`): `IProvenance` structured + extensible (`source`, `by?`, `model?`, `confidence?`, `derivedFrom?`, open `[key]`); `IEdge` attributed (`type`, `provenance?`, `confidence?`, `valid_at?`, `invalid_at?`). `derivedFrom` is exactly the field L3 stage-6 stamps.
+- **Backlink index** (`memoryIndex.ts:203-205`): derived, patched per put/delete, keyed by `(scope,id)`.
+- **Cycle safety TODAY is read-time only** (`linkTraversalRetriever.ts:92-107`, bounded BFS + `Set<string>` visited). The design specified a **write-time** cycle key via `Crc32Normalizer`/RFC-8785 `buildCycleKey` (design.md:860-862) — that does not exist. L3 must add write-time edge validation + a write-time cycle guard.
+- **Retrieve + vector** (`IMemoryRetriever`, `IVectorIndex`/`InMemoryCosineIndex`, `SemanticRetriever`): L3 stages 4-5 *read* the graph (similarity candidate-gen for dedup; neighborhood for relation context) before writing.
+
+## Design: settled vs. open (design.md §9-§10, exploration §10)
+
+**Settled:**
+- **Responsibility split** (design §9.1:774-776): host owns classification/extraction/entity-resolution judgment; **fgv owns** typed validation boundary, content-hash dedup, edge/cycle safety, provenance stamping, `contradicts`→temporal interlock.
+- **Six-stage pipeline** (design §9.2:781-873): (1) Intake — host hands `IIngestItem[]`; (2) Classify — host `IMemoryClassifier`; (3) Extract — host `IFactExtractor` → `ICandidateRecord[]`; (4) Resolve/dedup — **fgv-owned**, two-layer (exact hash + similarity), optional host `IEntityResolver`; (5) Relate — host `IRelationExtractor`, **fgv owns edge validation + write + cycle guard**; (6) Load-with-provenance — **fgv-owned** (stamp `IProvenance` + `derivedFrom`, call `put`). `ICandidateRecord.envelope` = `Omit<IMemoryEnvelope, 'id'|'contentHash'|'created'|'updated'>` (design:825) — host supplies all but the four store-stamped fields.
+- **Body validation boundary**: every `ICandidateRecord.body` validated against the kind's registered Converter before the store (design:829-832).
+- **Attributed edges + structured provenance (not bare strings)** — "firmest Phase-A recommendation," already shipped.
+
+**OPEN — this brief's decisions at commission:**
+- **OQ-10 — host-interface granularity (the central fork).** Staged split (`IMemoryClassifier` + `IFactExtractor` + `IEntityResolver?` + `IRelationExtractor`) — *recommended*, because fgv's stage-4-6 machinery is the value-add and a single opaque `IMemoryIngestor` pushes it back onto the host — vs. one opaque `IMemoryIngestor`. Decide at commission.
+- **OQ-13 — `IEntityResolver` optional (default) vs. required.** Without it, layer-2 near-dup dedup falls back to exact-hash-only. `IEntityResolver` returns `new | duplicate-of | supersede | merge-into`. Not defined anywhere in v1.
+- **Similarity-dedup layer is entirely new.** V1 has exact content-hash dedup only; the vector packlet provides cosine *search* but nothing wires similarity into the write/dedup path. L3 layer-2 = vector candidate-gen + threshold (default unspecified — decide) + optional `IEntityResolver`.
+- **Hash-key discrepancy to reconcile:** store content-hash is over `{kind,body,links}` (`:864`); design stage-4 exact dedup specifies `canonicalize({kind,body})` (design:836). L3 must decide whether to reuse the store's `links`-inclusive hash or compute its own `{kind,body}` key — they differ.
+- **OQ-3 — home:** in-package `ingest/` packlet (recommended default); own-package split deferred.
+
+## Scope (do) — at commission, after OQ-10/OQ-13 decided
+
+1. New `ingest/` packlet: the four host interfaces (per the OQ-10 decision) + `ICandidateRecord` + `IIngestItem` + the fgv-owned `IMemoryIngestOrchestrator`.
+2. **Stage 4 (fgv):** exact dedup (reconcile the hash key) + layer-2 similarity candidate-gen (vector) + threshold + optional `IEntityResolver` dispatch (`new|duplicate-of|supersede|merge-into`).
+3. **Stage 5 (fgv):** write-time edge validation + edge write + **write-time cycle guard** (new — the design's `buildCycleKey`, not the read-time BFS).
+4. **Stage 6 (fgv):** stamp `IProvenance` (`source:'host-ingest'`, `by`/`model`/`confidence` from the host) + `derivedFrom` back-link; admit through the per-kind `IWritePolicy`; `put`.
+5. **`contradicts`→temporal interlock (design §6.4):** a `contradicts` edge on a temporal kind triggers the `temporal-versioned` policy (set `invalid_at`, write new version) instead of plain upsert. **⚠ HARD-BLOCKED on `agent-memory-temporal`** — the policy it calls does not exist until temporal ships. See sequencing.
+6. Prove end-to-end in `samples/testbed` (mocked host stages; STOP-FLAG if a live model is needed for a realistic extractor demo).
+
+## Interdependencies (load-bearing)
+
+- **L3 ↔ temporal (HARD BLOCK):** the `contradicts` interlock's invalidate-don't-delete behavior requires the `temporal-versioned` write path + versioned layout — **not in v1** (three `isVersioned` fail-stops). **Sequence temporal FIRST.** A partial L3 *could* stamp `contradicts` edges (they persist as plain `links`) that a later temporal layer consumes, but the interlock proper cannot ship before temporal. If commissioned before temporal, scope item 5 is explicitly deferred and called out.
+- **L3 ↔ L2:** both consume L1 and must not gate it. L3 is the *automated* writer of the same substrate L2 curates *manually* — the `memory_write` tool and L3 stage-6 both bottom out in `store.put`.
+- **L3 ↔ retrieve/vector:** stages 4-5 read the graph — "extraction quality is bounded by search quality," a reason substrate + search shipped before L3.
+
+## Recommended sequencing across the three fast-follows
+
+**temporal → L2 → L3** (or **L2 → temporal → L3** if the tool loop is wanted first — L2 is independent). L3 is always last: it is the largest, is hard-blocked on temporal for the interlock, and reads the vector/retrieve layers. Do not commission L3 before temporal unless deliberately shipping it interlock-deferred.
+
+## Constraints / tests / sequence / proof
+
+- No `any`; `Result<T>`; Converters/`JsonSchema` for the validation boundary (host bodies validated against registered converters — no unchecked host data reaches the store); attributed edges + structured provenance only. **100% coverage enforced.**
+- **Tests:** each host-interface contract via a mocked host; stage-4 exact + similarity dedup (incl. the `IEntityResolver` verdicts and the fall-back-to-exact when absent); stage-5 edge validation + write-time cycle guard (reject a cycle-inducing edge); stage-6 provenance/`derivedFrom` stamping + policy admission; the `contradicts` interlock (only if temporal is present — else assert it's deferred/fails-loud); testbed end-to-end.
+- **Sequence:** decide OQ-10/OQ-13 → implement → `code-reviewer` SYNCHRONOUSLY before coverage-chasing → gates @100% → `rush change --bulk --bump-type minor --target-branch origin/release` (committed) → PR onto `release`.
+- **Proof:** git log; gate tails (100%); the OQ-10/OQ-13 decision note; the six-stage orchestrator + four host interfaces; dedup (both layers) + cycle-guard + provenance test output; the interlock status (delivered vs. deferred-pending-temporal); code-reviewer findings + dispositions.

--- a/.ai/tasks/active/agent-memory-temporal/brief.md
+++ b/.ai/tasks/active/agent-memory-temporal/brief.md
@@ -9,6 +9,14 @@
 **Surface:** `@fgv/ts-agent-memory` (**active** — new library, no external consumers; additive/breaking OK).
 **Ships under the enforced coverage gate** — 100% real.
 
+## Consumer feedback (PersonAIlity, 2026-07-07 — folded in)
+
+From the nearest-term adopter (three `FileTreeMemoryStore` adoptions live, in-place revision via `put()` merge-patch). Timed for "when we get to epistemics / contradiction handling" — after L2.
+
+1. **Pin the merge-patch-under-versioning contract (added to scope item 3).** For a `temporal-versioned` kind, a merge-patch `put()` on an existing entity must produce **a new version + `invalid_at` on the prior** — i.e. merge-patch *composes with* versioning rather than mutating the current version in place. This is the semantics their re-curation path relies on. The brief implied it; it is now pinned against the merge-patch path specifically.
+2. **OQ-11 → subtree-per-entity (consumer-backed).** They back the recommendation; flat+sidecar is "two sources of truth, exactly what bites during crash recovery." Treat subtree-per-entity as the default unless a hard reason emerges.
+3. **Keep the flat / `isVersioned:false` guarantee prominent (load-bearing for them).** Knowledge/LTM/MTM staying flat with **zero impact on shipped stores until a kind opts in** is an explicit adoption guarantee — see scope item 6, elevated.
+
 ## Why this is real work, not plumbing
 
 Every temporal seam is **already present and typed** in v1, but the enforcement is **stubbed to fail loudly**. Nothing about serialization needs to change — the converters already round-trip `temporal?`, `valid_at`, `invalid_at` (`packlets/converters/envelopeConverter.ts:74-77,84-89,109`). What's missing is the write/read *logic*:
@@ -37,7 +45,8 @@ Every temporal seam is **already present and typed** in v1, but the enforcement 
 **OPEN — must be resolved at commission (this brief's first decisions):**
 - **OQ-11 — versioned identity/layout model is NOT locked** (design §6.2:574-577, §12:1124-1136). Two candidates:
   - *Recommended default:* subtree-per-entity — `<scope>/entities/<entityId>/<entityId>-v<seq>.md`; current version = latest with `invalid_at` null/absent.
-  - *Pivot:* keep flat layout + a sidecar version-index file (`<entityId>.index.json`).
+  - *Pivot:* keep flat layout + a sidecar version-index file (`<entityId>.index.json`). **Consumer counsel against this** — "two sources of truth, exactly what bites during crash recovery."
+  - **Consumer-backed default: subtree-per-entity.** PersonAIlity backs the recommendation; treat subtree-per-entity as the default and only revisit for a hard reason.
   - **Non-negotiable:** do NOT bake `id == filename == single current value` as a global assumption.
   - **→ Decide this FIRST.** It drives the codec, the store read/write/delete branches, and the `_verifyLoaded` relaxation.
 - **OQ-9 — temporal query depth** (design §12:1099-1107). Ship point-in-time (`asOf`) + current-valid + history. **Defer** full bi-temporal reasoning (state-transition timelines, "what did the agent believe about X between A and B", LongMemEval-class) — additive later; the capture is already in the envelope.
@@ -46,10 +55,10 @@ Every temporal seam is **already present and typed** in v1, but the enforcement 
 
 1. **Resolve OQ-11** (layout) — recommend subtree-per-entity unless a concrete reason favors the sidecar index; document the choice at the top of the stream's design note.
 2. **Temporal `IIdentityCodec`** returning `isVersioned: true` + the chosen versioned path layout (encode/decode/verifyRoundTrip for `<entityId>-v<seq>` stems).
-3. **`temporal-versioned` `IWritePolicy`** implementing invalidate-don't-delete: `admit` accepts; on a superseding write, set `invalid_at` on the current version and write the new version. Declare `mutableFields`/`dedupScope` consistent with the versioned semantics. (No existing policy to extend — this is a new sibling in `writePolicy.ts`.)
+3. **`temporal-versioned` `IWritePolicy`** implementing invalidate-don't-delete: `admit` accepts; on a superseding write, set `invalid_at` on the current version and write the new version. Declare `mutableFields`/`dedupScope` consistent with the versioned semantics. (No existing policy to extend — this is a new sibling in `writePolicy.ts`.) **Merge-patch-under-versioning contract (consumer-pinned):** a merge-patch `put()` on an existing temporal-versioned entity must compose with versioning — apply the RFC-7386 merge to the current version's content to form the new version's content, write that as **a new version, and set `invalid_at` on the prior** — NOT mutate the current version in place. Test this explicitly (a merge-patch re-`put` yields two persisted versions, prior carrying `invalid_at`).
 4. **Store branches** — replace the three `if (addr.isVersioned) return fail(...)` fail-stops (`:304,:493,:780`) with real versioned read (resolve current or `asOf` version), write (new version + invalidate prior), and delete (invalidate-don't-delete, or hard-delete-all-versions — decide + document). Relax the `id === stem` verify (`:911`) for versioned kinds. Wire `IMemoryStoreListFilter.asOf` (`:53`) to select the version valid at that instant. Extend `_mutableFieldAccessors` if `invalid_at` rides the update path.
 5. **Retrievers** — `AsOfRetriever` / `CurrentValidRetriever` / `HistoryRetriever` declaring `supportsTemporalQuery: true`. The loud-degrade guard (`retriever.ts:134`) and Hybrid `asOf` projection (`hybridRetriever.ts:171`) already accommodate a temporal child — verify they light up the composite.
-6. **Do NOT** touch the non-temporal path (Knowledge/LTM/MTM stay `isVersioned: false`, flat) beyond what the shared code requires; do NOT build the `contradicts` interlock here (that's L3 — see below).
+6. **Preserve the flat-path guarantee (consumer adoption gate).** Knowledge/LTM/MTM stay `isVersioned: false`, flat, with **zero behavioral impact until a kind explicitly opts into a temporal codec** — no shipped store migrates, no persisted record changes shape. Touch the non-temporal path only as the shared code strictly requires, and assert this guarantee in the regression tests. Do NOT build the `contradicts` interlock here (that's L3 — see below).
 
 ## Interdependencies
 

--- a/.ai/tasks/active/agent-memory-temporal/brief.md
+++ b/.ai/tasks/active/agent-memory-temporal/brief.md
@@ -1,0 +1,64 @@
+# Brief — `@fgv/ts-agent-memory`: temporal versioned write path + temporal retrievers
+
+> **STATUS: DRAFT / SPECULATIVE — not commissioned.** Platform fast-follow, consumer-gated
+> (commission when PersonAIlity's episodic pipeline needs point-in-time recall). One of three
+> agent-memory fast-follow briefs (see `agent-memory-l2-tools`, `agent-memory-l3-ingest`).
+> **This is the keystone of the three** — L3's `contradicts`→invalidate interlock hard-depends
+> on the versioned write path this stream builds.
+
+**Surface:** `@fgv/ts-agent-memory` (**active** — new library, no external consumers; additive/breaking OK).
+**Ships under the enforced coverage gate** — 100% real.
+
+## Why this is real work, not plumbing
+
+Every temporal seam is **already present and typed** in v1, but the enforcement is **stubbed to fail loudly**. Nothing about serialization needs to change — the converters already round-trip `temporal?`, `valid_at`, `invalid_at` (`packlets/converters/envelopeConverter.ts:74-77,84-89,109`). What's missing is the write/read *logic*:
+
+- **Three fail-stops** in the store on a versioned codec: `fileTreeMemoryStore.ts:304-305` (`get`), `:493-494` (`put`), `:780-782` (`delete`) — all `if (addr.isVersioned) return fail('versioned/temporal layout not yet supported')`.
+- **Every retriever declares `supportsTemporalQuery: false`** (`recencyRetriever`/`tag`/`structuredFilter` via `NON_SEMANTIC_CAPABILITIES` `retriever.ts:104-108`; `linkTraversalRetriever.ts:22`; `semanticRetriever.ts:81`). No retriever answers `asOf`.
+- **All three shipped codecs hardcode `isVersioned: false`** (`identityCodec.ts:73,127,204`). No codec emits `true`.
+- **No `temporal-versioned` `IWritePolicy` exists** (`writePolicy.ts` ships only `KnowledgeLwwPolicy` + `MemoryCapCullPolicy`).
+
+## Shipped seams to build on (verified)
+
+- **Envelope:** `ITemporalBlock` fully defined — `packlets/types/envelope.ts:64-75` (`valid_at?: number`, `invalid_at?: number | null` where `null` = still valid). `IMemoryEnvelope.temporal?` `:114-116`. `IEdge.valid_at?/invalid_at?` `:53-61`. `entityId` already distinguished from `id` (`:86` "Equals id for non-temporal kinds").
+- **Codec:** `IIdentityCodecResult.isVersioned` `identityCodec.ts:14-25` (docstring: "versioned layout: multiple files per entity vs flat: one file per entity"). `IIdentityCodec` owns "flat-vs-versioned layout dispatch" (`:32-33`).
+- **Query:** `IMemoryQuery.asOf?` `retriever.ts:53-58`. Capability `supportsTemporalQuery` `retriever.ts:16-23`. Loud-degrade centralized in `guardRetrieverCapabilities` `retriever.ts:127-143` (`asOf` + `!supportsTemporalQuery` → `fail`). `HybridRetriever` already **strips `asOf` from sub-queries for non-temporal children** (`hybridRetriever.ts:171-172`) — the exact dispatch point where a temporal child lights up the composite.
+- **List filter:** `IMemoryStoreListFilter.asOf?` present but no-op (`fileTreeMemoryStore.ts:49-53`; `list` never reads it `:327-343`).
+- **Write path insert point:** `_putLocked` `fileTreeMemoryStore.ts:491-504` — the `if (addr.isVersioned)` fail-stop is where the versioned branch inserts. `_buildRecord` (`:722-762`) stamps `created/updated/seq/contentHash` and passes `temporal?` through untouched via `{ ...incoming.envelope }` (`:733`); `_mutableFieldAccessors` (`:241-250`) has **no `temporal` entry** — an `invalid_at` update path extends this map.
+- **Persistence layout today:** flat single-file `<scope>/<idStem>.md` (`_writeFile:978-981`, `MEMORY_FILE_EXTENSION:36`); `_readRecord`/`_verifyLoaded` (`:884,:906-911`) enforce `envelope.id === filename stem` — the `id == filename == single current value` assumption the design says temporal must break. `delete` physically removes the file (`:776`).
+
+## Design: settled vs. open (from `.ai/tasks/completed/2026-06/ts-agent-memory/`)
+
+**Settled (design.md §6):**
+- **Bi-temporal, transaction-time free / valid-time opt-in** (exploration §9.4:634-636). `created/updated/seq` always present; only `temporal?` (world-truth valid-time) is the opt-in axis.
+- **Write model = invalidate-don't-delete / versioned** (design §3.6 policy table:361): set `invalid_at` on current, write a new version; never `deleteFile`.
+- **Initial retriever set** (design §6.3:583-585): `AsOfRetriever` (version valid at `asOf` ms), `CurrentValidRetriever` (`invalid_at` null/absent), `HistoryRetriever` (all versions ascending by `valid_at`). All degrade loudly for non-temporal kinds.
+
+**OPEN — must be resolved at commission (this brief's first decisions):**
+- **OQ-11 — versioned identity/layout model is NOT locked** (design §6.2:574-577, §12:1124-1136). Two candidates:
+  - *Recommended default:* subtree-per-entity — `<scope>/entities/<entityId>/<entityId>-v<seq>.md`; current version = latest with `invalid_at` null/absent.
+  - *Pivot:* keep flat layout + a sidecar version-index file (`<entityId>.index.json`).
+  - **Non-negotiable:** do NOT bake `id == filename == single current value` as a global assumption.
+  - **→ Decide this FIRST.** It drives the codec, the store read/write/delete branches, and the `_verifyLoaded` relaxation.
+- **OQ-9 — temporal query depth** (design §12:1099-1107). Ship point-in-time (`asOf`) + current-valid + history. **Defer** full bi-temporal reasoning (state-transition timelines, "what did the agent believe about X between A and B", LongMemEval-class) — additive later; the capture is already in the envelope.
+
+## Scope (do)
+
+1. **Resolve OQ-11** (layout) — recommend subtree-per-entity unless a concrete reason favors the sidecar index; document the choice at the top of the stream's design note.
+2. **Temporal `IIdentityCodec`** returning `isVersioned: true` + the chosen versioned path layout (encode/decode/verifyRoundTrip for `<entityId>-v<seq>` stems).
+3. **`temporal-versioned` `IWritePolicy`** implementing invalidate-don't-delete: `admit` accepts; on a superseding write, set `invalid_at` on the current version and write the new version. Declare `mutableFields`/`dedupScope` consistent with the versioned semantics. (No existing policy to extend — this is a new sibling in `writePolicy.ts`.)
+4. **Store branches** — replace the three `if (addr.isVersioned) return fail(...)` fail-stops (`:304,:493,:780`) with real versioned read (resolve current or `asOf` version), write (new version + invalidate prior), and delete (invalidate-don't-delete, or hard-delete-all-versions — decide + document). Relax the `id === stem` verify (`:911`) for versioned kinds. Wire `IMemoryStoreListFilter.asOf` (`:53`) to select the version valid at that instant. Extend `_mutableFieldAccessors` if `invalid_at` rides the update path.
+5. **Retrievers** — `AsOfRetriever` / `CurrentValidRetriever` / `HistoryRetriever` declaring `supportsTemporalQuery: true`. The loud-degrade guard (`retriever.ts:134`) and Hybrid `asOf` projection (`hybridRetriever.ts:171`) already accommodate a temporal child — verify they light up the composite.
+6. **Do NOT** touch the non-temporal path (Knowledge/LTM/MTM stay `isVersioned: false`, flat) beyond what the shared code requires; do NOT build the `contradicts` interlock here (that's L3 — see below).
+
+## Interdependencies
+
+- **L3 depends on THIS.** L3's `contradicts`→temporal-invalidate interlock (design §6.4) *calls* the `temporal-versioned` policy built in scope item 3. L3 cannot deliver that interlock until this ships. Sequence temporal **before** L3.
+- **Independent of L2.** L2 (agent-tool surface) does not need temporal.
+
+## Constraints / tests / sequence / proof
+
+- No `any`; `Result<T>` for fallible ops; Converters/guards for validation; `__`-prefix unused params. Additive on the new library; **100% coverage enforced.**
+- **Tests:** versioned codec round-trip (`<entityId>-v<seq>` ⇄ address); `temporal-versioned` policy invalidate-don't-delete (write v2 → v1 gets `invalid_at`, both persist); store versioned put/get/delete + `list({asOf})` + `get` current-vs-asOf resolution; each temporal retriever (`asOf`/current/history) incl. the loud-degrade on a non-temporal kind and the Hybrid composite lighting up; regression: all non-temporal (flat) paths unchanged.
+- **Sequence:** implement → `code-reviewer` SYNCHRONOUSLY on the diff **before** coverage-chasing → `rushx fixlint`/`lint`/`build`/`test` @100% → `rush change --bulk --bump-type minor --target-branch origin/release` (committed) → PR onto `release`.
+- **Proof:** git log; gate tails (100%); the layout-decision note (OQ-11); versioned round-trip + invalidate-don't-delete test output; the three retrievers passing incl. loud-degrade; confirmation flat-path regression-free; code-reviewer findings + dispositions.

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -202,6 +202,41 @@ Design-triage-implement shape is likely; new public API has real consequences.
 
 ---
 
+### `agent-memory-temporal` 🟡
+
+**Status:** 🟡 drafted, not commissioned — consumer-gated (commission when PersonAIlity's episodic pipeline needs point-in-time recall). Keystone of the three agent-memory fast-follows.
+**Branch base:** `release` HEAD; reference `.ai/tasks/completed/2026-06/ts-agent-memory/` (README/exploration/design).
+**Package surface:** `@fgv/ts-agent-memory` (types/envelope, identityCodec, store/fileTreeMemoryStore, writePolicy, retrieve).
+**Brief:** `.ai/tasks/active/agent-memory-temporal/brief.md`.
+
+**Mission.** Build the temporal versioned write path + temporal retrievers. All seams ship in v1 but are stubbed to fail loudly (three `if (addr.isVersioned) return fail(...)` fail-stops; every retriever `supportsTemporalQuery:false`; no `temporal-versioned` policy). Adds a versioned codec, the invalidate-don't-delete policy, versioned store branches, and `AsOfRetriever`/`CurrentValidRetriever`/`HistoryRetriever`. **First decision: OQ-11** (subtree-per-entity vs. flat+sidecar-index layout). Converters already round-trip `temporal?`/`valid_at`/`invalid_at` — no serialization work.
+
+---
+
+### `agent-memory-l2-tools` 🟡
+
+**Status:** 🟡 drafted, not commissioned — consumer-gated (commission when PersonAIlity wants the agent to curate its own memory via tool-use). **Independent** of temporal/L3; can slot first for early demoable value.
+**Branch base:** `release` HEAD; reference the ts-agent-memory completion bundle + `@fgv/ts-extras-mcp` `adapter.ts` (the `IAiClientTool` construction idiom).
+**Package surface:** new `@fgv/ts-agent-memory/tools` packlet; consumes `@fgv/ts-extras` ai-assist `IAiClientTool` + `@fgv/ts-json-base` `JsonSchema`.
+**Brief:** `.ai/tasks/active/agent-memory-l2-tools/brief.md`.
+
+**Mission.** Expose memory ops as an `IAiClientTool` suite (design-settled five-tool proof set: `memory_write/read/search/context/delete`) via `createMemoryTools({ store, retriever, registry, ... })`, authored with `JsonSchema.object` schemas that also pass `JsonSchema.fromJson` (MCP dual-path). Open decisions: tool-arg→domain-key mapping (flat `{scope,id}` doesn't fit `delete(kind,entityId)` or the MTM composite), the factory signature, and tool-boundary safety (admit-reject surfacing, behavior hints).
+
+---
+
+### `agent-memory-l3-ingest` 🟡
+
+**Status:** 🟡 drafted, not commissioned — consumer-gated (commission when PersonAIlity wires extractors). **🔴 hard-blocked on `agent-memory-temporal`** for the `contradicts`→invalidate interlock; ship interlock-deferred only if commissioned earlier. Largest of the three.
+**Branch base:** `release` HEAD (with temporal shipped for the full interlock); reference the ts-agent-memory completion bundle (design §9-§10).
+**Package surface:** new `@fgv/ts-agent-memory/ingest` packlet; reads `retrieve`+`vector`, writes via `store`.
+**Brief:** `.ai/tasks/active/agent-memory-l3-ingest/brief.md`.
+
+**Mission.** The fgv-side ingest orchestrator — host brings classify/extract/relate judgment; fgv owns the typed validation boundary, dedup (exact + new similarity layer), write-time edge/cycle safety, provenance stamping, and the `contradicts`→temporal interlock. Green-field packlet composing shipped seams. **Central fork: OQ-10** (staged host interfaces vs. one opaque `IMemoryIngestor`) + OQ-13 (`IEntityResolver` optional vs. required).
+
+**Recommended sequencing across the three:** temporal → L2 → L3 (or L2 → temporal → L3; L2 is independent). L3 always last — largest, hard-blocked on temporal, reads vector/retrieve.
+
+---
+
 ## Completed workstreams
 
 ### `ai-assist-model-tiers` ✅

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -204,36 +204,36 @@ Design-triage-implement shape is likely; new public API has real consequences.
 
 ### `agent-memory-temporal` 🟡
 
-**Status:** 🟡 drafted, not commissioned — consumer-gated (commission when PersonAIlity's episodic pipeline needs point-in-time recall). Keystone of the three agent-memory fast-follows.
+**Status:** 🟡 drafted, **consumer-validated** (PersonAIlity 2026-07-07, PR #521), not commissioned — gated on their epistemics/contradiction-handling work (after L2). Keystone of the three (L3 hard-depends on it).
 **Branch base:** `release` HEAD; reference `.ai/tasks/completed/2026-06/ts-agent-memory/` (README/exploration/design).
 **Package surface:** `@fgv/ts-agent-memory` (types/envelope, identityCodec, store/fileTreeMemoryStore, writePolicy, retrieve).
 **Brief:** `.ai/tasks/active/agent-memory-temporal/brief.md`.
 
-**Mission.** Build the temporal versioned write path + temporal retrievers. All seams ship in v1 but are stubbed to fail loudly (three `if (addr.isVersioned) return fail(...)` fail-stops; every retriever `supportsTemporalQuery:false`; no `temporal-versioned` policy). Adds a versioned codec, the invalidate-don't-delete policy, versioned store branches, and `AsOfRetriever`/`CurrentValidRetriever`/`HistoryRetriever`. **First decision: OQ-11** (subtree-per-entity vs. flat+sidecar-index layout). Converters already round-trip `temporal?`/`valid_at`/`invalid_at` — no serialization work.
+**Mission.** Build the temporal versioned write path + temporal retrievers. All seams ship in v1 but are stubbed to fail loudly (three `if (addr.isVersioned) return fail(...)` fail-stops; every retriever `supportsTemporalQuery:false`; no `temporal-versioned` policy). Adds a versioned codec, the invalidate-don't-delete policy, versioned store branches, and `AsOfRetriever`/`CurrentValidRetriever`/`HistoryRetriever`. **OQ-11 → subtree-per-entity (consumer-backed).** Consumer-pinned: merge-patch `put()` on a temporal-versioned kind = new version + `invalid_at` on prior (composes with versioning); flat/`isVersioned:false` guarantee for Knowledge/LTM/MTM preserved (zero impact until a kind opts in). Converters already round-trip `temporal?`/`valid_at`/`invalid_at` — no serialization work.
 
 ---
 
 ### `agent-memory-l2-tools` 🟡
 
-**Status:** 🟡 drafted, not commissioned — consumer-gated (commission when PersonAIlity wants the agent to curate its own memory via tool-use). **Independent** of temporal/L3; can slot first for early demoable value.
+**Status:** 🟡 drafted, **consumer-validated** (PersonAIlity 2026-07-07, PR #521), not commissioned — **nearest-term consumer**; recommended first or in parallel with temporal. **Independent** of temporal/L3.
 **Branch base:** `release` HEAD; reference the ts-agent-memory completion bundle + `@fgv/ts-extras-mcp` `adapter.ts` (the `IAiClientTool` construction idiom).
 **Package surface:** new `@fgv/ts-agent-memory/tools` packlet; consumes `@fgv/ts-extras` ai-assist `IAiClientTool` + `@fgv/ts-json-base` `JsonSchema`.
 **Brief:** `.ai/tasks/active/agent-memory-l2-tools/brief.md`.
 
-**Mission.** Expose memory ops as an `IAiClientTool` suite (design-settled five-tool proof set: `memory_write/read/search/context/delete`) via `createMemoryTools({ store, retriever, registry, ... })`, authored with `JsonSchema.object` schemas that also pass `JsonSchema.fromJson` (MCP dual-path). Open decisions: tool-arg→domain-key mapping (flat `{scope,id}` doesn't fit `delete(kind,entityId)` or the MTM composite), the factory signature, and tool-boundary safety (admit-reject surfacing, behavior hints).
+**Mission.** Expose memory ops as an `IAiClientTool` suite via `createMemoryTools({ store, retriever, registry, tools?, kinds? })`, `JsonSchema.object` schemas (MCP dual-path via `JsonSchema.fromJson`). **Consumer-locked:** scope isolation is constructor-fixed via a **pre-scoped store** — no tool arg carries `scope` (adoption make-or-break); **per-tool `tools?` subset** (default = read-only `search`+`context`; writes opt in) replaces the coarse `readOnly?`; `memory_search` results carry a host-suppliable **mnemonic handle** (`handleFor?`). Still open: tool-boundary safety (admit-reject surfacing, behavior hints); tool count beyond the five.
 
 ---
 
 ### `agent-memory-l3-ingest` 🟡
 
-**Status:** 🟡 drafted, not commissioned — consumer-gated (commission when PersonAIlity wires extractors). **🔴 hard-blocked on `agent-memory-temporal`** for the `contradicts`→invalidate interlock; ship interlock-deferred only if commissioned earlier. Largest of the three.
+**Status:** 🟡 drafted, **consumer-validated** (PersonAIlity 2026-07-07, PR #521), not commissioned — furthest-out for them. **🔴 hard-blocked on `agent-memory-temporal`** for the `contradicts`→invalidate interlock; ship interlock-deferred only if commissioned earlier. Largest of the three.
 **Branch base:** `release` HEAD (with temporal shipped for the full interlock); reference the ts-agent-memory completion bundle (design §9-§10).
 **Package surface:** new `@fgv/ts-agent-memory/ingest` packlet; reads `retrieve`+`vector`, writes via `store`.
 **Brief:** `.ai/tasks/active/agent-memory-l3-ingest/brief.md`.
 
-**Mission.** The fgv-side ingest orchestrator — host brings classify/extract/relate judgment; fgv owns the typed validation boundary, dedup (exact + new similarity layer), write-time edge/cycle safety, provenance stamping, and the `contradicts`→temporal interlock. Green-field packlet composing shipped seams. **Central fork: OQ-10** (staged host interfaces vs. one opaque `IMemoryIngestor`) + OQ-13 (`IEntityResolver` optional vs. required).
+**Mission.** The fgv-side ingest orchestrator — host brings classify/extract/relate judgment; fgv owns the typed validation boundary, dedup (exact + new similarity layer), write-time edge/cycle safety, provenance stamping, and the `contradicts`→temporal interlock. Green-field packlet composing shipped seams. **Consumer-locked:** OQ-10 → **staged host interfaces** (consumer plugs its own classifiers/extractors); OQ-13 → `IEntityResolver` **optional** (deterministic-key hosts skip it); **single-item incremental ingest first-class** (per-turn streaming, not batch-only); provenance fields land **additive/optional** (no migration of persisted `mtm`/`ltm`).
 
-**Recommended sequencing across the three:** temporal → L2 → L3 (or L2 → temporal → L3; L2 is independent). L3 always last — largest, hard-blocked on temporal, reads vector/retrieve.
+**Recommended sequencing across the three:** **L2 first or in parallel with temporal** (consumer preference — L2 is independent and changes what agents can do soonest), then temporal, then L3. L3 always last — largest, hard-blocked on temporal, reads vector/retrieve.
 
 ---
 


### PR DESCRIPTION
Drafted (not commissioned) implementation briefs for the three deferred `@fgv/ts-agent-memory` v1 fast-follows, each grounded in a fresh seam-map of the **shipped substrate** cross-referenced against the **completed design bundle** (`.ai/tasks/completed/2026-06/ts-agent-memory/`). Docs-only — no code, no package changes (no `rush change` needed).

## What's here

- `.ai/tasks/active/agent-memory-temporal/brief.md` — **temporal versioned write path + temporal retrievers** (the keystone). All seams ship in v1 but are stubbed to fail loudly (three `if (addr.isVersioned) return fail(...)` fail-stops; every retriever `supportsTemporalQuery:false`; no `temporal-versioned` policy; converters already round-trip `temporal?`). First decision: **OQ-11** (subtree-per-entity vs. flat+sidecar-index layout).
- `.ai/tasks/active/agent-memory-l2-tools/brief.md` — **L2 agent-tool surface**. Design-settled five-tool proof set (`memory_write/read/search/context/delete`) via a `createMemoryTools({ store, retriever, registry, ... })` factory, `JsonSchema.object` schemas (MCP dual-path via `JsonSchema.fromJson`). Open: tool-arg→domain-key mapping (flat `{scope,id}` doesn't fit `delete(kind,entityId)`/MTM composite), factory signature, tool-boundary safety. **Independent** of the other two.
- `.ai/tasks/active/agent-memory-l3-ingest/brief.md` — **L3 ingest orchestrator** (largest, green-field `ingest/` packlet). Host brings classify/extract/relate; fgv owns validation boundary, dedup (exact + new similarity layer), write-time edge/cycle safety, provenance stamping, and the `contradicts`→temporal interlock. Central fork: **OQ-10** (staged host interfaces vs. one opaque `IMemoryIngestor`) + OQ-13.
- `docs/WORKSTREAMS.md` — three staged 🟡 entries (drafted/not-commissioned, consumer-gated) with the sequencing and dependency calls.

## Load-bearing findings

- **These are logic streams, not plumbing** — the v1 substrate deliberately shipped the seams (envelope `temporal?`, codec `isVersioned`, query `asOf`, `IProvenance`/`IEdge`, `IBodyConverterRegistry`) with loud-fail stubs, so each fast-follow fills in real behavior.
- **Sequencing: temporal → L2 → L3** (or L2 → temporal → L3; L2 is independent). **L3 is hard-blocked on temporal** for the `contradicts`→invalidate interlock (the `temporal-versioned` policy it calls doesn't exist until temporal ships) — it can only ship interlock-deferred if commissioned earlier.
- All three are **consumer-gated** — commission when PersonAIlity actually needs each (episodic recall → temporal; agent self-curation → L2; extractor pipeline → L3).

Prep only; nothing here changes runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_