### PR TITLE
docs(ai-assist): client-tool annotations + before-execute gate brief; wire L2 to consume it

### DIFF
--- a/.ai/tasks/active/agent-memory-l2-tools/brief.md
+++ b/.ai/tasks/active/agent-memory-l2-tools/brief.md
@@ -58,8 +58,12 @@ L2 is explicitly OUT of the v1 build (`design-lock.md:16`, `README.md:33`, `brie
 - **Factory signature.** `createMemoryTools({ store, retriever, registry, tools?, kinds? }): ReadonlyArray<IAiClientTool>` — `store` is **pre-scoped** (sole scope authority); `tools?` selects the per-tool subset (requirement 2; default = the safe read set `['memory_search','memory_context']`, NOT all five — writes opt in explicitly); `kinds?` whitelists toolable kinds (default = `registry.has`-backed enumeration). The coarse `readOnly?` flag is dropped in favor of the `tools?` subset.
 - **`memory_search` result handle.** Accept a host `handleFor?(record) => string` hook; when supplied, the agent-visible key in search results is the host handle (mnemonic), not raw `MemoryId` (requirement 3).
 
+**Tool-boundary safety — RESOLVED (via the `ai-assist-tool-annotations` precursor stream, 2026-07-07 spike):**
+- **Behavior annotations ship as typed data**, not comments. `IAiClientToolConfig` gains an `annotations?: IAiToolAnnotations` field (MCP-native names: `readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`/`title`) — built in `ai-assist-tool-annotations` (commission **before** this stream). This stream populates it per tool (Component 4 below).
+- **Write-outcome surfacing:** map `IWritePolicy.admit` reject → tool `Result.fail` with the reason; a dedup no-op → success with an "already present" note (discriminate `written`/`deduped`/`culled` on the success value so the agent can reason about it).
+- **In-turn write gating:** `executeClientToolTurn` gains an `onBeforeToolExecute?` gate hook (also in `ai-assist-tool-annotations`), so a consumer can mediate `memory_write`/`memory_delete` (deny → synthesized denial tool-result, turn continues). This stream wires it as an example for the mutating tools.
+
 **Still OPEN — decide at commission:**
-- **Safety at the tool boundary.** Validation IS settled (schema `.validate` + registry `.convert`). Decide: (a) map `IWritePolicy.admit` reject → tool `Result.fail` with the reason; dedup no-op → success with an "already present" note; (b) whether to ship a typed behavior-hint field (`destructiveHint`/`idempotentHint`/`readOnlyHint`/`openWorldHint`, comments-only today) now or defer.
 - **Tool granularity (OQ-8).** Five is a proof set (basic-memory ships ~15). Final count depends on the consumer's agent design — ship the five, note the extension seam.
 
 ## Scope (do)
@@ -68,13 +72,16 @@ L2 is explicitly OUT of the v1 build (`design-lock.md:16`, `README.md:33`, `brie
 2. **Enforce scope isolation structurally:** the factory closes over the pre-scoped `store`; NO tool's `parametersSchema` declares a `scope` (or any scope-widening) property. Add a test that asserts no tool schema carries a scope arg — this is the adoption gate.
 3. Tool-arg→domain-key mapping: `{kind, entityId}` (per-kind `EntityId`, codec-validated; MTM composite via `entityId`, never a flat `id`).
 4. `memory_search` result shape accepts the host `handleFor?(record)` hook; when present the agent-visible key is the host handle (mnemonic), else raw `MemoryId`.
-5. Wire write-safety: `memory_write` deserializes `body` string → the store's `put` runs `registry.convert`; surface `admit` rejections as tool failures. Mutating tools (`memory_write`/`memory_delete`) are **off by default** — included only when named in `tools?`.
-6. Prove the loop in a `samples/testbed` scenario (design anchor `:985-987`, exploration Scenario A `:317-356`): the selected tools wired through `executeClientToolTurn`, agent curates the substrate end-to-end. (STOP-FLAG if it needs a live model call — build ready, principal runs keyed.)
-7. **Do NOT** add new L1/store capability; do NOT touch temporal or ingest.
+5. Wire write-safety: `memory_write` deserializes `body` string → the store's `put` runs `registry.convert`; surface `admit` rejections as tool `Result.fail`, dedup no-op as success-with-note. Mutating tools (`memory_write`/`memory_delete`) are **off by default** — included only when named in `tools?`.
+6. **Populate behavior annotations (Component 4 — needs `ai-assist-tool-annotations` shipped).** Set `config.annotations` on each tool: `memory_search`/`memory_context`/`memory_read` → `readOnlyHint: true`; `memory_write` → `destructiveHint: false, idempotentHint: false`; `memory_delete` → `destructiveHint: true, idempotentHint: true`; `openWorldHint: false` throughout (closed store). Test the values per tool.
+7. **Demonstrate the write-gate** in the testbed scenario: wire `onBeforeToolExecute` to mediate `memory_write`/`memory_delete` (e.g. deny a write pending confirmation), proving the mediated-writes path end-to-end.
+8. Prove the loop in a `samples/testbed` scenario (design anchor `:985-987`, exploration Scenario A `:317-356`): the selected tools wired through `executeClientToolTurn`, agent curates the substrate end-to-end. (STOP-FLAG if it needs a live model call — build ready, principal runs keyed.)
+9. **Do NOT** add new L1/store capability; do NOT touch temporal or ingest; do NOT define the annotations field or the gate hook here (they belong to `ai-assist-tool-annotations`).
 
 ## Interdependencies
 
-- **Independent of temporal and L3.** Depends only on shipped L1. **Recommended to commission first, or in parallel with temporal** (consumer's stated preference — L2 changes what consuming agents can *do* soonest; the agent-curates-memory loop is the most demoable of the three).
+- **Depends on `ai-assist-tool-annotations`** (the `IAiClientToolConfig.annotations` field + the `onBeforeToolExecute` gate hook). Commission that precursor first; scope items 6–7 consume it.
+- **Independent of temporal and L3.** Otherwise depends only on shipped L1. **Recommended to commission first, or in parallel with temporal** (consumer's stated preference — L2 changes what consuming agents can *do* soonest; the agent-curates-memory loop is the most demoable of the three).
 - Shares the substrate L3 will later write *automatically* — L2 is the *manual* writer of the same graph.
 
 ## Constraints / tests / sequence / proof

--- a/.ai/tasks/active/ai-assist-tool-annotations/brief.md
+++ b/.ai/tasks/active/ai-assist-tool-annotations/brief.md
@@ -1,0 +1,72 @@
+# Brief — `@fgv/ts-extras/ai-assist` + `@fgv/ts-extras-mcp`: client-tool behavior annotations + before-execute gate
+
+> **STATUS: 🟢 ready to commission.** Precursor to the `agent-memory-l2-tools` stream (L2's `memory_write`/`memory_delete` tools consume this for annotations + write-gating). Design fully spiked 2026-07-07 (two read-only spikes over the ai-assist tool surface + the MCP adapter). Consumer: PersonAIlity (mediated agent writes).
+>
+> **Surface:** `@fgv/ts-extras/ai-assist` + `@fgv/ts-extras-mcp` — both **active** (additive/breaking OK). Additive throughout; no breaking change.
+> **Ships under the enforced coverage gate** — 100% real.
+
+## Why this stream exists
+
+The `agent-memory-l2-tools` stream exposes `memory_write`/`memory_delete` as agent-callable `IAiClientTool`s. A consumer with a **mediated-writes** posture (PersonAIlity) needs (a) per-tool **behavior annotations** (readOnly/destructive/idempotent/openWorld) so a host can reason about a tool's side effects, and (b) a **before-execute seam** so a host can gate/deny a destructive call inside the tool-turn loop. Neither exists today, and the annotation home is a shared ai-assist concept (not memory-specific), so it lands here as a precursor rather than inside L2.
+
+## Spike findings (the design rests on these — verified 2026-07-07)
+
+**F1 — Hints are host-advisory-only; they never reach the model.** All three provider wire tool-schemas are strictly `{name, description, parameters}` — no annotation slot:
+- OpenAI/xAI Responses: `toolFormats.ts:108-115` (`clientToolToResponsesApi`)
+- Anthropic: `toolFormats.ts:171-177` (`clientToolToAnthropic`)
+- Gemini: `toolFormats.ts:278-284`
+
+MCP's SDK says the same explicitly (`@modelcontextprotocol/sdk` `types.d.ts:2351-2367`): *"all properties in ToolAnnotations are hints… clients should never make tool-use decisions based on ToolAnnotations received from untrusted servers."* → Annotations are consumed by the **host's tool loop**, never serialized to the LLM. Adding an `annotations` field is invisible to the (field-whitelisting) serializers.
+
+**F2 — MCP `ToolAnnotations` shape** (`types.d.ts` `ToolAnnotationsSchema`, on `Tool.annotations`): five optional fields — `title?: string`, `readOnlyHint?: boolean`, `destructiveHint?: boolean`, `idempotentHint?: boolean`, `openWorldHint?: boolean`. (Note: the display title lives at `annotations.title`, distinct from the separate top-level `Tool.title`.)
+
+**F3 — Canonical home = `IAiClientToolConfig`** (`ai-assist/model.ts:264-276`) — the declarative tool-definition half, reachable as `tool.config.annotations`, parallel to MCP's `Tool.annotations`. Client-tool-only: server tools (`IAiWebSearchToolConfig`, `model.ts:205-244`) are provider-executed and have no host-gating semantics, so do NOT hoist annotations to a shared base.
+
+**F4 — MCP currently DROPS annotations at 3 stacked layers** (real data loss today): local `ISdkToolDescriptor` omits the field (`ts-extras-mcp/sdk.ts:71-75`); `_toDescriptor` doesn't copy it (`operations.ts:41-47`); `IMcpToolDescriptor` has no slot (`model.ts:131-143`); so `_adaptOne` can't propagate it (`adapter.ts:73-100`).
+
+**F5 — `executeClientToolTurn` has NO pre-execute hook.** The full `IAiClientTool` (config incl. annotations) IS in scope at the execute site (`clientToolContinuationBuilder.ts:547-552` builds `toolsByName`; execute at `:683-719` already reads `tool.config.parametersSchema`), but there is no host callback between the `client-tool-call-done` event and `tool.execute(...)`. A gate must be added as a new param on `IExecuteClientToolTurnParams` (`:413-470`).
+
+## Scope (do) — Components 1 + 2 + 3
+
+### Component 1 — annotations data model (`@fgv/ts-extras/ai-assist`)
+- Add `IAiToolAnnotations` (all optional, **MCP-native names** for 1:1 passthrough): `title?`, `readOnlyHint?`, `destructiveHint?`, `idempotentHint?`, `openWorldHint?`.
+- Add `readonly annotations?: IAiToolAnnotations` to `IAiClientToolConfig` (`model.ts:264`). Export both from `index.ts`. **Additive, non-breaking** — the three serializers whitelist fields, so they ignore it (no serializer change; add a test asserting annotations never appear in any provider's wire tool schema).
+
+### Component 2 — MCP passthrough (`@fgv/ts-extras-mcp`)
+Thread MCP `Tool.annotations` → `IAiClientToolConfig.annotations` through the four hops (each stays optional; no behavior change to existing tools):
+1. `ISdkToolDescriptor` (`sdk.ts:71`) — declare `readonly annotations?: {...}` so the SDK field survives narrowing.
+2. `_toDescriptor` (`operations.ts:41`) — copy it through. **Validate/normalize, do NOT trust raw** (per the untrusted-server warning): run the raw annotations through a Converter/validator that keeps only the five known boolean/string fields and drops anything malformed.
+3. `IMcpToolDescriptor` (`model.ts:131`) + a local `IMcpToolAnnotations` interface — add the slot.
+4. `_adaptOne` (`adapter.ts:91`) — set `annotations: descriptor.annotations` on the `config` literal.
+- A tool with no annotations stays exactly as today (field absent). Add a test: an MCP tool declaring `destructiveHint`/`readOnlyHint` round-trips onto the adapted `IAiClientTool.config.annotations`; a malformed annotations blob is dropped/normalized, not propagated raw.
+
+### Component 3 — before-execute gate hook (`@fgv/ts-extras/ai-assist`)
+- Add an optional `onBeforeToolExecute?` callback to `IExecuteClientToolTurnParams` (`clientToolContinuationBuilder.ts:413`):
+  `onBeforeToolExecute?(tool: IAiClientTool, args: unknown) => Promise<Result<IToolExecutionDecision>>`
+  where `IToolExecutionDecision = { action: 'proceed' } | { action: 'deny'; reason: string }`.
+- Invoke it in the execute path (`:683-719`) **after** arg validation, **before** `tool.execute(...)`. The full `tool` (with `.config.annotations`) is passed so host gate logic can key off annotations (e.g. deny a `destructiveHint` call pending confirmation).
+- **Deny-semantics (LOCKED):** on `{ action: 'deny', reason }`, do NOT run `execute`; **synthesize a tool-result carrying the reason and continue the turn** — ride the exact same result→`continuation.messages` path a normal/failed execute result already uses (the model sees "that call was denied because <reason>" and can react). Emit a `client-tool-result` event for the denied call so the event stream stays coherent. A callback that itself returns `Result.fail` (or rejects) is caught like `execute` failures and treated as a hard error (not a deny) — `deny` must be explicit.
+- `proceed` (or an absent callback) → unchanged behavior.
+
+## Constraints
+
+- No `any`; `Result<T>` for fallible ops; Converters/validators for the MCP annotation normalization (no manual-typeof-then-cast); `__`-prefix unused params. Additive on both active surfaces. Regenerate `etc/ts-extras.api.md` and `etc/ts-extras-mcp.api.md`. **100% coverage enforced.**
+
+## Tests
+
+- **C1:** annotations field present/absent on a client tool; **annotations never appear in any provider wire tool schema** (Anthropic/OpenAI-Responses/Gemini) — the host-advisory-only guarantee.
+- **C2:** MCP tool with hints → adapted `config.annotations` (all five fields); tool without annotations → field absent; malformed/partial annotations → normalized (known fields kept, junk dropped), never raw-propagated; the graceful-degradation path (skipped tools) unaffected.
+- **C3:** `proceed` → tool runs (unchanged); **`deny` → execute NOT called, a synthesized denial tool-result lands in `continuation.messages`, turn continues, `client-tool-result` event emitted with the reason**; callback `fail`/reject → hard error (not a silent deny); absent callback → unchanged; a host gate that keys off `tool.config.annotations.destructiveHint` denies a destructive tool and proceeds a readOnly one (the end-to-end annotations→gate composition).
+- **Testbed:** extend/author a `samples/testbed` client-tools scenario that exercises the deny path (a gate that denies one tool call and proves the continuation stays coherent). STOP-FLAG if a live model turn is needed — build ready, principal runs keyed.
+
+## Sequence
+
+Implement (C1 → C2 → C3) → `code-reviewer` SYNCHRONOUSLY on the diff **before** coverage-chasing → `rushx fixlint`/`lint`/`build`/`test` @100% in both `ts-extras` and `ts-extras-mcp` + api-extractor regen (both `.api.md`) → `rush change --bulk --bump-type minor --target-branch origin/release` (both packages; committed) → PR onto `release`.
+
+## Proof of work
+
+`git log --oneline -3`; build/lint/test tails (100%, both packages); both `.api.md` diffs (new `IAiToolAnnotations` + `annotations?` field + `onBeforeToolExecute` param + `IToolExecutionDecision`; MCP `IMcpToolAnnotations` + descriptor field); the C3 deny-path test output (synthesized tool-result in continuation); the MCP round-trip + malformed-normalization test output; the annotations-never-on-the-wire test; `code-reviewer` findings + dispositions; STOP-FLAG note if the testbed scenario needs a live run.
+
+## Downstream
+
+`agent-memory-l2-tools` consumes this: its five tools populate `config.annotations` (`memory_search`/`memory_context`/`memory_read` → `readOnlyHint: true`; `memory_write` → `destructiveHint: false, idempotentHint: false`; `memory_delete` → `destructiveHint: true, idempotentHint: true`; `openWorldHint: false` throughout — closed store), and a consumer wires `onBeforeToolExecute` to mediate `memory_write`/`memory_delete`. Commission this stream **before** L2.

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -202,6 +202,17 @@ Design-triage-implement shape is likely; new public API has real consequences.
 
 ---
 
+### `ai-assist-tool-annotations` 🟢
+
+**Status:** 🟢 ready to commission — precursor to `agent-memory-l2-tools` (L2's write tools consume it). Fully spiked 2026-07-07 (ai-assist tool surface + MCP adapter). Consumer: PersonAIlity (mediated agent writes).
+**Branch base:** `release` HEAD.
+**Package surface:** `@fgv/ts-extras/ai-assist` (`model.ts`, `clientToolContinuationBuilder.ts`, `index.ts`) + `@fgv/ts-extras-mcp` (`sdk.ts`, `operations.ts`, `model.ts`, `adapter.ts`).
+**Brief:** `.ai/tasks/active/ai-assist-tool-annotations/brief.md`.
+
+**Mission.** Add client-tool **behavior annotations** + a **before-execute gate hook** to the ai-assist client-tool surface. Three components: (1) `IAiToolAnnotations` + `IAiClientToolConfig.annotations?` (MCP-native names; host-advisory-only — no provider wire slot, so serialization is unaffected); (2) thread MCP `Tool.annotations` → the field through `adaptMcpTools` (validated, per the untrusted-server warning — currently dropped at 3 layers); (3) `onBeforeToolExecute?` gate on `executeClientToolTurn` (deny → synthesized denial tool-result, turn continues — reuses the tested failure→continuation path). Additive on both active surfaces. **Full design (incl. deny-semantics, locked) is in the brief** — built up front because it's well-understood, low-medium effort, and ships *with* the write tools it protects (avoiding the shovel-ready-then-forgotten carrying cost).
+
+---
+
 ### `agent-memory-temporal` 🟡
 
 **Status:** 🟡 drafted, **consumer-validated** (PersonAIlity 2026-07-07, PR #521), not commissioned — gated on their epistemics/contradiction-handling work (after L2). Keystone of the three (L3 hard-depends on it).
@@ -215,7 +226,7 @@ Design-triage-implement shape is likely; new public API has real consequences.
 
 ### `agent-memory-l2-tools` 🟡
 
-**Status:** 🟡 drafted, **consumer-validated** (PersonAIlity 2026-07-07, PR #521), not commissioned — **nearest-term consumer**; recommended first or in parallel with temporal. **Independent** of temporal/L3.
+**Status:** 🟡 drafted, **consumer-validated** (PersonAIlity 2026-07-07, PR #521), not commissioned — **nearest-term consumer**; recommended first or in parallel with temporal. **Depends on `ai-assist-tool-annotations`** (annotations field + gate hook); independent of temporal/L3.
 **Branch base:** `release` HEAD; reference the ts-agent-memory completion bundle + `@fgv/ts-extras-mcp` `adapter.ts` (the `IAiClientTool` construction idiom).
 **Package surface:** new `@fgv/ts-agent-memory/tools` packlet; consumes `@fgv/ts-extras` ai-assist `IAiClientTool` + `@fgv/ts-json-base` `JsonSchema`.
 **Brief:** `.ai/tasks/active/agent-memory-l2-tools/brief.md`.


### PR DESCRIPTION
Docs-only. A design spike (2026-07-07, two read-only passes over the ai-assist client-tool surface + the `ts-extras-mcp` adapter) resolved the tool-boundary-safety open question in the `agent-memory-l2-tools` brief, and factored the shared piece into a precursor stream.

## New: `ai-assist-tool-annotations` stream brief (🟢 ready to commission)

Three additive components on the active ai-assist + ts-extras-mcp surfaces:
- **C1** — `IAiToolAnnotations` + `IAiClientToolConfig.annotations?` (MCP-native names: `readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`/`title`). **Host-advisory-only** — the spike confirmed no provider wire tool-schema (Anthropic/OpenAI-Responses/Gemini) has an annotation slot, so this is invisible to serialization.
- **C2** — thread MCP `Tool.annotations` → the field through `adaptMcpTools` (validated, per the SDK's untrusted-server warning). **Currently dropped at 3 stacked layers** — this stops real data loss.
- **C3** — `onBeforeToolExecute?` gate hook on `executeClientToolTurn`. **Deny-semantics locked:** deny → synthesized denial tool-result, turn continues (reuses the tested failure→`continuation.messages` path); `{ action: 'proceed' } | { action: 'deny', reason }`.

The full design (file:line anchors, deny-path, tests incl. a testbed deny-path exercise) is in the brief — built up front rather than deferred because it's well-understood + low-medium effort and ships *with* the `memory_write`/`memory_delete` tools it protects, for a consumer (PersonAIlity) whose posture is mediated writes.

## Updated: `agent-memory-l2-tools` brief
- Tool-boundary-safety open item → **resolved** (annotations = typed data; write-outcome surfacing = fail-on-reject / success-with-note; in-turn gating = the `onBeforeToolExecute` hook).
- Scope gains **Component 4** (populate annotations per tool) + a testbed write-gate demonstration; dependency on `ai-assist-tool-annotations` recorded (commission it first).

## Ledger
- New 🟢 `ai-assist-tool-annotations` entry in `docs/WORKSTREAMS.md`; L2 entry notes the dependency.

Prep only — no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_