### PR TITLE
feat(ai-assist): client-tool behavior annotations + before-execute gate hook

### DIFF
--- a/common/changes/@fgv/ts-extras-mcp/claude-ai-assist-tool-annotations_2026-07-07-17-18.json
+++ b/common/changes/@fgv/ts-extras-mcp/claude-ai-assist-tool-annotations_2026-07-07-17-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Client-tool behavior annotations (IAiClientToolConfig.annotations), MCP annotation passthrough in adaptMcpTools, and an onBeforeToolExecute gate hook on executeClientToolTurn",
+      "type": "none",
+      "packageName": "@fgv/ts-extras-mcp"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-mcp",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-extras/claude-ai-assist-tool-annotations_2026-07-07-17-18.json
+++ b/common/changes/@fgv/ts-extras/claude-ai-assist-tool-annotations_2026-07-07-17-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Client-tool behavior annotations (IAiClientToolConfig.annotations), MCP annotation passthrough in adaptMcpTools, and an onBeforeToolExecute gate hook on executeClientToolTurn",
+      "type": "none",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras-mcp/etc/ts-extras-mcp.api.md
+++ b/libraries/ts-extras-mcp/etc/ts-extras-mcp.api.md
@@ -82,12 +82,22 @@ export interface IMcpStdioTransportParams {
 }
 
 // @public
+export interface IMcpToolAnnotations {
+    readonly destructiveHint?: boolean;
+    readonly idempotentHint?: boolean;
+    readonly openWorldHint?: boolean;
+    readonly readOnlyHint?: boolean;
+    readonly title?: string;
+}
+
+// @public
 export interface IMcpToolCallResult {
     readonly content: string;
 }
 
 // @public
 export interface IMcpToolDescriptor {
+    readonly annotations?: IMcpToolAnnotations;
     readonly description: string | undefined;
     readonly inputSchema: JsonValue;
     readonly name: string;

--- a/libraries/ts-extras-mcp/src/packlets/mcp/adapter.ts
+++ b/libraries/ts-extras-mcp/src/packlets/mcp/adapter.ts
@@ -71,7 +71,7 @@ function _makeExecute(session: IMcpSession, name: string): (args: unknown) => Pr
  * tool's `inputSchema` is not a JSON object or is outside the `JsonSchema.fromJson` subset.
  */
 function _adaptOne(session: IMcpSession, descriptor: IMcpToolDescriptor): IAdaptOutcome {
-  const { name, description, inputSchema } = descriptor;
+  const { name, description, inputSchema, annotations } = descriptor;
 
   const skip = (reason: string, schema: JsonValue): IAdaptOutcome => ({
     kind: 'skipped',
@@ -92,7 +92,10 @@ function _adaptOne(session: IMcpSession, descriptor: IMcpToolDescriptor): IAdapt
     type: 'client_tool',
     name,
     description: description ?? name,
-    parametersSchema: schemaResult.value
+    parametersSchema: schemaResult.value,
+    // IMcpToolAnnotations maps 1:1 onto AiAssist.IAiToolAnnotations. Only set the field when the
+    // server provided usable annotations, so a tool without them stays exactly as before.
+    ...(annotations !== undefined ? { annotations } : {})
   };
   return {
     kind: 'tool',

--- a/libraries/ts-extras-mcp/src/packlets/mcp/model.ts
+++ b/libraries/ts-extras-mcp/src/packlets/mcp/model.ts
@@ -125,6 +125,31 @@ export interface IMcpSession {
 // ============================================================================
 
 /**
+ * Normalized MCP `Tool.annotations` — the five known host-advisory behavior hints.
+ *
+ * @remarks
+ * Field names mirror MCP's `ToolAnnotations` 1:1 (and map straight onto
+ * `AiAssist.IAiToolAnnotations`). Per the MCP spec these are hints only, and per the
+ * untrusted-server warning they are validated/normalized (known fields kept, malformed
+ * or unknown fields dropped) before they reach {@link IMcpToolDescriptor} — the raw
+ * server blob is never propagated.
+ *
+ * @public
+ */
+export interface IMcpToolAnnotations {
+  /** Optional human-readable display title for the tool. */
+  readonly title?: string;
+  /** Hint: the tool does not modify its environment (read-only). */
+  readonly readOnlyHint?: boolean;
+  /** Hint: the tool may perform destructive updates (only meaningful when not read-only). */
+  readonly destructiveHint?: boolean;
+  /** Hint: repeated calls with the same arguments have no additional effect. */
+  readonly idempotentHint?: boolean;
+  /** Hint: the tool interacts with an open world of external entities. */
+  readonly openWorldHint?: boolean;
+}
+
+/**
  * A tool descriptor discovered from an MCP server via {@link listMcpTools}.
  * @public
  */
@@ -140,6 +165,12 @@ export interface IMcpToolDescriptor {
    * supported subset).
    */
   readonly inputSchema: JsonValue;
+  /**
+   * The tool's normalized behavior annotations, when the server provided any usable ones.
+   * Absent when the server declared no annotations (or only malformed/unknown fields).
+   * See {@link IMcpToolAnnotations}.
+   */
+  readonly annotations?: IMcpToolAnnotations;
 }
 
 /**

--- a/libraries/ts-extras-mcp/src/packlets/mcp/operations.ts
+++ b/libraries/ts-extras-mcp/src/packlets/mcp/operations.ts
@@ -26,23 +26,66 @@
  * @packageDocumentation
  */
 
-import { type Result, captureAsyncResult, fail, succeed } from '@fgv/ts-utils';
+import { Converters as UtilsConverters, type Result, captureAsyncResult, fail, succeed } from '@fgv/ts-utils';
 import { Converters, type JsonObject } from '@fgv/ts-json-base';
 
-import { type IMcpSession, type IMcpToolCallResult, type IMcpToolDescriptor } from './model';
+import {
+  type IMcpSession,
+  type IMcpToolAnnotations,
+  type IMcpToolCallResult,
+  type IMcpToolDescriptor
+} from './model';
 import { type ISdkContentBlock, type ISdkToolDescriptor } from './sdk';
 import { McpSession } from './session';
+
+/**
+ * Validates/normalizes a raw (untrusted) MCP `Tool.annotations` blob into an
+ * {@link IMcpToolAnnotations}, keeping only the five known fields that convert cleanly.
+ *
+ * @remarks
+ * Each known field is converted independently with its own Converter, so a present-but-malformed
+ * field is dropped (never failing the whole blob) and unknown keys are ignored. Returns
+ * `undefined` when the blob is absent, not a JSON object, or normalizes to no usable known
+ * fields — so a tool with no (usable) annotations leaves {@link IMcpToolDescriptor.annotations}
+ * absent. The raw server value is never propagated verbatim (per the MCP untrusted-server
+ * warning).
+ */
+function _normalizeAnnotations(raw: unknown): IMcpToolAnnotations | undefined {
+  const objResult = Converters.jsonObject.convert(raw);
+  if (objResult.isFailure()) {
+    return undefined;
+  }
+  const obj = objResult.value;
+  const title = UtilsConverters.string.convert(obj.title).orDefault();
+  const readOnlyHint = UtilsConverters.boolean.convert(obj.readOnlyHint).orDefault();
+  const destructiveHint = UtilsConverters.boolean.convert(obj.destructiveHint).orDefault();
+  const idempotentHint = UtilsConverters.boolean.convert(obj.idempotentHint).orDefault();
+  const openWorldHint = UtilsConverters.boolean.convert(obj.openWorldHint).orDefault();
+
+  const normalized: IMcpToolAnnotations = {
+    ...(title !== undefined ? { title } : {}),
+    ...(readOnlyHint !== undefined ? { readOnlyHint } : {}),
+    ...(destructiveHint !== undefined ? { destructiveHint } : {}),
+    ...(idempotentHint !== undefined ? { idempotentHint } : {}),
+    ...(openWorldHint !== undefined ? { openWorldHint } : {})
+  };
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
 
 /**
  * Projects a single SDK tool descriptor into a public {@link IMcpToolDescriptor}. The
  * `inputSchema` field is validated as a `JsonValue`; an absent/non-JSON schema becomes `null`
  * (which {@link adaptMcpTools} then reports as un-adaptable rather than offering it to the model).
+ * The raw `annotations` blob is validated/normalized (never propagated raw) per the MCP
+ * untrusted-server warning.
  */
 function _toDescriptor(tool: ISdkToolDescriptor): IMcpToolDescriptor {
+  const annotations = _normalizeAnnotations(tool.annotations);
   return {
     name: tool.name,
     description: tool.description,
-    inputSchema: Converters.jsonValue.convert(tool.inputSchema).orDefault(null)
+    inputSchema: Converters.jsonValue.convert(tool.inputSchema).orDefault(null),
+    ...(annotations !== undefined ? { annotations } : {})
   };
 }
 

--- a/libraries/ts-extras-mcp/src/packlets/mcp/sdk.ts
+++ b/libraries/ts-extras-mcp/src/packlets/mcp/sdk.ts
@@ -72,6 +72,12 @@ export interface ISdkToolDescriptor {
   readonly name: string;
   readonly description?: string;
   readonly inputSchema?: unknown;
+  /**
+   * Raw MCP `Tool.annotations` (untrusted). Declared as `unknown` so the SDK field survives
+   * narrowing; the operations layer validates/normalizes it (never propagates raw) per the MCP
+   * spec's untrusted-server warning.
+   */
+  readonly annotations?: unknown;
 }
 
 /**

--- a/libraries/ts-extras-mcp/src/test/unit/mcp.test.ts
+++ b/libraries/ts-extras-mcp/src/test/unit/mcp.test.ts
@@ -470,4 +470,132 @@ describe('adaptMcpTools', () => {
       expect(await execute({ q: 'hello' })).toFailWith(/denied/);
     });
   });
+
+  // ==========================================================================
+  // C2 — MCP Tool.annotations passthrough (normalized, never raw)
+  // ==========================================================================
+
+  describe('annotations passthrough (C2)', () => {
+    const goodSchema2: JsonValue = { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] };
+
+    test('all five hints round-trip onto descriptor.annotations and config.annotations', async () => {
+      const annotations = {
+        title: 'Recall Memory',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
+      };
+      const fake = makeFakeClient({
+        listTools: jest.fn(async () => ({
+          tools: [{ name: 'recall', description: 'r', inputSchema: goodSchema2, annotations }]
+        }))
+      });
+      const session = await connectWith(fake);
+
+      expect(await listMcpTools(session)).toSucceedAndSatisfy((tools: ReadonlyArray<IMcpToolDescriptor>) => {
+        expect(tools[0].annotations).toEqual(annotations);
+      });
+
+      const session2 = await connectWith(
+        makeFakeClient({
+          listTools: jest.fn(async () => ({
+            tools: [{ name: 'recall', description: 'r', inputSchema: goodSchema2, annotations }]
+          }))
+        })
+      );
+      expect(await adaptMcpTools(session2)).toSucceedAndSatisfy((result: IAdaptMcpToolsResult) => {
+        expect(result.tools[0].config.annotations).toEqual(annotations);
+      });
+    });
+
+    test('a tool with no annotations leaves the field absent', async () => {
+      const fake = makeFakeClient({
+        listTools: jest.fn(async () => ({ tools: [{ name: 'plain', inputSchema: goodSchema2 }] }))
+      });
+      const session = await connectWith(fake);
+      expect(await listMcpTools(session)).toSucceedAndSatisfy((tools: ReadonlyArray<IMcpToolDescriptor>) => {
+        expect(tools[0]).not.toHaveProperty('annotations');
+      });
+
+      const session2 = await connectWith(
+        makeFakeClient({
+          listTools: jest.fn(async () => ({ tools: [{ name: 'plain', inputSchema: goodSchema2 }] }))
+        })
+      );
+      expect(await adaptMcpTools(session2)).toSucceedAndSatisfy((result: IAdaptMcpToolsResult) => {
+        expect(result.tools[0].config).not.toHaveProperty('annotations');
+      });
+    });
+
+    test('a malformed annotations blob is normalized (known fields kept, junk dropped), never raw-propagated', async () => {
+      // readOnlyHint is the wrong type (dropped); bogusField is unknown (dropped); title is valid (kept).
+      const rawAnnotations = {
+        title: 'Keep Me',
+        readOnlyHint: 'yes-please',
+        destructiveHint: true,
+        bogusField: { nested: 42 }
+      };
+      const fake = makeFakeClient({
+        listTools: jest.fn(async () => ({
+          tools: [{ name: 'messy', inputSchema: goodSchema2, annotations: rawAnnotations }]
+        }))
+      });
+      const session = await connectWith(fake);
+      expect(await listMcpTools(session)).toSucceedAndSatisfy((tools: ReadonlyArray<IMcpToolDescriptor>) => {
+        // Only the well-typed known fields survive; the malformed readOnlyHint and unknown
+        // bogusField are dropped; the raw blob is never propagated.
+        expect(tools[0].annotations).toEqual({ title: 'Keep Me', destructiveHint: true });
+        expect(tools[0].annotations).not.toHaveProperty('readOnlyHint');
+        expect(tools[0].annotations).not.toHaveProperty('bogusField');
+      });
+    });
+
+    test('an all-junk annotations blob normalizes to an absent field (not an empty object)', async () => {
+      const fake = makeFakeClient({
+        listTools: jest.fn(async () => ({
+          tools: [
+            { name: 'junk', inputSchema: goodSchema2, annotations: { unknownOnly: 1, readOnlyHint: 3 } }
+          ]
+        }))
+      });
+      const session = await connectWith(fake);
+      expect(await listMcpTools(session)).toSucceedAndSatisfy((tools: ReadonlyArray<IMcpToolDescriptor>) => {
+        expect(tools[0]).not.toHaveProperty('annotations');
+      });
+    });
+
+    test('a non-object annotations value is dropped', async () => {
+      const fake = makeFakeClient({
+        listTools: jest.fn(async () => ({
+          tools: [{ name: 'weird', inputSchema: goodSchema2, annotations: 'not-an-object' }]
+        }))
+      });
+      const session = await connectWith(fake);
+      expect(await listMcpTools(session)).toSucceedAndSatisfy((tools: ReadonlyArray<IMcpToolDescriptor>) => {
+        expect(tools[0]).not.toHaveProperty('annotations');
+      });
+    });
+
+    test('the skipped-tool path is unaffected by annotations', async () => {
+      // A tool with annotations but an unsupported inputSchema is still skipped; annotations do
+      // not rescue it or leak onto the skip record.
+      const forbidden: JsonValue = {
+        type: 'object',
+        properties: { name: { type: 'string', pattern: '^a' } }
+      };
+      const fake = makeFakeClient({
+        listTools: jest.fn(async () => ({
+          tools: [{ name: 'blocked', inputSchema: forbidden, annotations: { destructiveHint: true } }]
+        }))
+      });
+      const session = await connectWith(fake);
+      expect(await adaptMcpTools(session)).toSucceedAndSatisfy((result: IAdaptMcpToolsResult) => {
+        expect(result.tools).toHaveLength(0);
+        expect(result.skipped).toHaveLength(1);
+        expect(result.skipped[0].name).toBe('blocked');
+        expect(result.skipped[0]).not.toHaveProperty('annotations');
+      });
+    });
+  });
 });

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -35,6 +35,7 @@ declare namespace AiAssist {
         AiToolConfig,
         IAiWebSearchToolConfig,
         IAiClientToolConfig,
+        IAiToolAnnotations,
         IAiClientTool,
         IAiClientToolCallSummary,
         IAiClientToolContinuation,
@@ -146,6 +147,7 @@ declare namespace AiAssist {
         executeClientToolTurn,
         IExecuteClientToolTurnParams,
         IExecuteClientToolTurnResult,
+        IToolExecutionDecision,
         aiProviderId,
         aiServerToolType,
         aiWebSearchToolConfig,
@@ -838,6 +840,8 @@ interface IAiClientToolCallSummary {
 
 // @public
 interface IAiClientToolConfig<TParams = unknown> {
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiToolAnnotations"
+    readonly annotations?: IAiToolAnnotations;
     readonly description: string;
     readonly name: string;
     readonly parametersSchema: JsonSchema.ISchemaValidator<TParams>;
@@ -1073,6 +1077,15 @@ interface IAiStreamToolUseStart {
 }
 
 // @public
+interface IAiToolAnnotations {
+    readonly destructiveHint?: boolean;
+    readonly idempotentHint?: boolean;
+    readonly openWorldHint?: boolean;
+    readonly readOnlyHint?: boolean;
+    readonly title?: string;
+}
+
+// @public
 interface IAiToolEnablement {
     readonly config?: AiServerToolConfig;
     readonly enabled: boolean;
@@ -1279,6 +1292,7 @@ interface IExecuteClientToolTurnParams extends IChatRequest {
     readonly endpoint?: string;
     readonly logger?: Logging.ILogger;
     readonly model?: string;
+    readonly onBeforeToolExecute?: (tool: IAiClientTool, args: unknown) => Promise<Result<IToolExecutionDecision>>;
     readonly resolvedThinking?: IResolvedThinkingConfig;
     readonly signal?: AbortSignal;
     readonly temperature?: number;
@@ -1784,6 +1798,16 @@ interface IThinkingConfig {
 
 // @public
 type IThinkingProviderConfig = IAnthropicThinkingOptions | IOpenAiThinkingOptions | IGeminiThinkingOptions | IXAiThinkingOptions | IOtherThinkingOptions;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IExecuteClientToolTurnParams"
+//
+// @public
+type IToolExecutionDecision = {
+    readonly action: 'proceed';
+} | {
+    readonly action: 'deny';
+    readonly reason: string;
+};
 
 // @public
 interface IVariableRef {

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -152,6 +152,7 @@ declare namespace AiAssist {
         aiServerToolType,
         aiWebSearchToolConfig,
         aiServerToolConfig,
+        aiToolAnnotations,
         aiClientToolConfig,
         aiToolEnablement,
         aiAssistProviderConfig,
@@ -248,6 +249,11 @@ const aiServerToolType: Converter<AiServerToolType>;
 
 // @public
 type AiThinkingMode = 'optional' | 'required' | 'unsupported';
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+const aiToolAnnotations: Converter<IAiToolAnnotations>;
 
 // @public
 type AiToolConfig = AiServerToolConfig | IAiClientToolConfig;

--- a/libraries/ts-extras/src/packlets/ai-assist/converters.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/converters.ts
@@ -33,6 +33,7 @@ import {
   type IAiAssistProviderConfig,
   type IAiAssistSettings,
   type IAiClientToolConfig,
+  type IAiToolAnnotations,
   type IAiToolEnablement,
   type IAiWebSearchToolConfig,
   type ModelSpec,
@@ -114,8 +115,21 @@ const parametersSchemaValidator: Validator<JsonSchema.ISchemaValidator<unknown>>
 );
 
 /**
+ * Converter for {@link AiAssist.IAiToolAnnotations} — the five optional host-advisory hints.
+ * @public
+ */
+export const aiToolAnnotations: Converter<IAiToolAnnotations> = Converters.strictObject<IAiToolAnnotations>({
+  title: Converters.string.optional(),
+  readOnlyHint: Converters.boolean.optional(),
+  destructiveHint: Converters.boolean.optional(),
+  idempotentHint: Converters.boolean.optional(),
+  openWorldHint: Converters.boolean.optional()
+});
+
+/**
  * Converter for {@link AiAssist.IAiClientToolConfig}. Validates the wrapper shape: `type`,
- * `name`, `description`, and the presence of a usable `parametersSchema`.
+ * `name`, `description`, the presence of a usable `parametersSchema`, and optional
+ * host-advisory `annotations`.
  * Does not inspect the inner JSON Schema structure — `JsonSchema.object(...)` already
  * guarantees the schema is valid.
  * @public
@@ -126,7 +140,8 @@ export const aiClientToolConfig: Converter<IAiClientToolConfig> = Converters.obj
     description: 'name must be a non-empty string'
   }),
   description: Converters.string,
-  parametersSchema: parametersSchemaValidator
+  parametersSchema: parametersSchemaValidator,
+  annotations: aiToolAnnotations.optional()
 });
 
 /**

--- a/libraries/ts-extras/src/packlets/ai-assist/index.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/index.ts
@@ -148,6 +148,7 @@ export {
   aiServerToolType,
   aiWebSearchToolConfig,
   aiServerToolConfig,
+  aiToolAnnotations,
   aiClientToolConfig,
   aiToolEnablement,
   aiAssistProviderConfig,

--- a/libraries/ts-extras/src/packlets/ai-assist/index.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/index.ts
@@ -13,6 +13,7 @@ export {
   type AiToolConfig,
   type IAiWebSearchToolConfig,
   type IAiClientToolConfig,
+  type IAiToolAnnotations,
   type IAiClientTool,
   type IAiClientToolCallSummary,
   type IAiClientToolContinuation,
@@ -138,7 +139,8 @@ export {
   type IProviderCompletionStreamParams,
   executeClientToolTurn,
   type IExecuteClientToolTurnParams,
-  type IExecuteClientToolTurnResult
+  type IExecuteClientToolTurnResult,
+  type IToolExecutionDecision
 } from './streamingClient';
 
 export {

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -249,6 +249,35 @@ export interface IAiToolEnablement {
 // ============================================================================
 
 /**
+ * Behavior annotations for a client-defined tool.
+ *
+ * @remarks
+ * These are **host-advisory-only hints** describing a tool's side-effect profile.
+ * They are consumed by the host's tool loop (e.g. a before-execute gate) and are
+ * **never serialized to the model** — the provider wire tool-schemas whitelist
+ * `{name, description, parameters}` and ignore this field.
+ *
+ * Field names mirror MCP's `ToolAnnotations` (`@modelcontextprotocol/sdk`) 1:1 so
+ * an MCP tool's annotations pass through unchanged. Per the MCP spec, all fields
+ * are hints — a host should never make tool-use decisions based on annotations
+ * received from an untrusted server without its own validation.
+ *
+ * @public
+ */
+export interface IAiToolAnnotations {
+  /** Optional human-readable display title for the tool. */
+  readonly title?: string;
+  /** Hint: the tool does not modify its environment (read-only). */
+  readonly readOnlyHint?: boolean;
+  /** Hint: the tool may perform destructive updates (only meaningful when not read-only). */
+  readonly destructiveHint?: boolean;
+  /** Hint: repeated calls with the same arguments have no additional effect. */
+  readonly idempotentHint?: boolean;
+  /** Hint: the tool interacts with an open world of external entities. */
+  readonly openWorldHint?: boolean;
+}
+
+/**
  * Configuration for a client-defined (harness-supplied) tool.
  *
  * @remarks
@@ -273,6 +302,12 @@ export interface IAiClientToolConfig<TParams = unknown> {
    * `.toJson()` and validates model-returned args via `.validate(rawArgs)`.
    */
   readonly parametersSchema: JsonSchema.ISchemaValidator<TParams>;
+  /**
+   * Optional host-advisory behavior annotations (read-only / destructive /
+   * idempotent / open-world hints + display title). Consumed by the host's
+   * tool loop; never serialized to the model. See {@link IAiToolAnnotations}.
+   */
+  readonly annotations?: IAiToolAnnotations;
 }
 
 /**

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
@@ -399,6 +399,27 @@ export function buildGeminiContinuation(
 // ============================================================================
 
 /**
+ * Decision returned by an {@link IExecuteClientToolTurnParams.onBeforeToolExecute}
+ * gate for a single client-tool call.
+ *
+ * @remarks
+ * - `{ action: 'proceed' }` — run the tool's `execute` normally.
+ * - `{ action: 'deny', reason }` — do NOT run `execute`; a synthesized tool-result
+ *   carrying `reason` is fed into the continuation exactly like a normal result so
+ *   the model can react, and a `client-tool-result` event is emitted for the call.
+ *   The turn continues.
+ *
+ * A gate that wants to signal a hard error (as opposed to a deliberate deny) should
+ * return `Result.fail` (or reject) from the callback — that is treated like an
+ * `execute` failure, not a silent deny.
+ *
+ * @public
+ */
+export type IToolExecutionDecision =
+  | { readonly action: 'proceed' }
+  | { readonly action: 'deny'; readonly reason: string };
+
+/**
  * Parameters for {@link AiAssist.executeClientToolTurn}.
  *
  * @remarks
@@ -467,6 +488,24 @@ export interface IExecuteClientToolTurnParams extends IChatRequest {
   readonly resolvedThinking?: IResolvedThinkingConfig;
   /** Resolved model string (pre-resolved by the caller). When omitted, uses the descriptor's default model. */
   readonly model?: string;
+  /**
+   * Optional host gate invoked for each client-tool call **after** the model's raw
+   * args have been validated against the tool's `parametersSchema` and **before**
+   * `tool.execute(...)` runs. The full `tool` (including `tool.config.annotations`)
+   * and the validated `args` are passed so gate logic can key off a tool's behavior
+   * annotations (e.g. deny a `destructiveHint` call pending confirmation).
+   *
+   * Returning `{ action: 'proceed' }` (or omitting the callback) runs `execute`
+   * normally. Returning `{ action: 'deny', reason }` skips `execute` and synthesizes
+   * a denial tool-result carrying `reason` into the continuation (the model sees the
+   * denial and can react); the turn continues. A callback that returns `Result.fail`
+   * or rejects is treated as a hard error, exactly like an `execute` failure — a deny
+   * must be explicit.
+   */
+  readonly onBeforeToolExecute?: (
+    tool: IAiClientTool,
+    args: unknown
+  ) => Promise<Result<IToolExecutionDecision>>;
 }
 
 /**
@@ -529,7 +568,8 @@ export function executeClientToolTurn(
     logger,
     resolvedThinking,
     model,
-    endpoint
+    endpoint,
+    onBeforeToolExecute
   } = params;
 
   const splitResult = splitChatRequest(system, messages);
@@ -714,6 +754,50 @@ export function executeClientToolTurn(
           yield resultEvent;
           toolResults.push({ toolName, callId, args, result: errMsg, isError: true });
           continue;
+        }
+
+        // Host gate: run after arg-validation, before execute. A `deny` decision
+        // synthesizes a denial tool-result and continues the turn; a `fail`/reject
+        // from the gate itself is a hard error (mirrors an execute failure), never
+        // a silent deny.
+        if (onBeforeToolExecute !== undefined) {
+          const decisionResult: Result<IToolExecutionDecision> = (
+            await captureAsyncResult(async () => onBeforeToolExecute(tool, validationResult.value))
+          ).onSuccess((decision) => decision);
+
+          if (decisionResult.isFailure()) {
+            const errMsg = `${toolName} (callId=${callId}): ${decisionResult.message}`;
+            const resultEvent: IAiStreamEvent = {
+              type: 'client-tool-result',
+              toolName,
+              callId,
+              result: errMsg,
+              isError: true
+            };
+            yield resultEvent;
+            // Gate-fail is a hard, turn-terminating error (unlike a non-fatal `deny`, whose
+            // generator continues). Emit an explicit `error` event so a consumer watching only
+            // `events` sees the fatal failure inline and can distinguish it from a deny — matching
+            // the stream-open / continuation hard-error paths.
+            yield { type: 'error', message: errMsg };
+            toolResults.push({ toolName, callId, args, result: errMsg, isError: true });
+            resolveNextTurn(fail(errMsg));
+            return;
+          }
+
+          if (decisionResult.value.action === 'deny') {
+            const denialMsg = `${toolName} (callId=${callId}): tool execution denied: ${decisionResult.value.reason}`;
+            const resultEvent: IAiStreamEvent = {
+              type: 'client-tool-result',
+              toolName,
+              callId,
+              result: denialMsg,
+              isError: true
+            };
+            yield resultEvent;
+            toolResults.push({ toolName, callId, args, result: denialMsg, isError: true });
+            continue;
+          }
         }
 
         const executeResult = await captureAsyncResult(async () => tool.execute(validationResult.value));

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder.ts
@@ -410,8 +410,10 @@ export function buildGeminiContinuation(
  *   The turn continues.
  *
  * A gate that wants to signal a hard error (as opposed to a deliberate deny) should
- * return `Result.fail` (or reject) from the callback — that is treated like an
- * `execute` failure, not a silent deny.
+ * return `Result.fail` (or reject) from the callback. Note this is NOT the same as a
+ * `tool.execute` failure: an `execute` failure yields an `isError` tool-result and the
+ * **turn continues**, whereas a gate `fail`/reject **terminates the turn** — it fails
+ * `nextTurn` (and emits an inline `error` event) rather than synthesizing a deny.
  *
  * @public
  */
@@ -498,9 +500,10 @@ export interface IExecuteClientToolTurnParams extends IChatRequest {
    * Returning `{ action: 'proceed' }` (or omitting the callback) runs `execute`
    * normally. Returning `{ action: 'deny', reason }` skips `execute` and synthesizes
    * a denial tool-result carrying `reason` into the continuation (the model sees the
-   * denial and can react); the turn continues. A callback that returns `Result.fail`
-   * or rejects is treated as a hard error, exactly like an `execute` failure — a deny
-   * must be explicit.
+   * denial and can react); **the turn continues**. A callback that returns `Result.fail`
+   * or rejects is a hard error that **terminates the turn** (fails `nextTurn` + emits an
+   * inline `error` event) — distinct from a `tool.execute` failure, which continues the
+   * turn with an `isError` result. A deny must therefore be explicit.
    */
   readonly onBeforeToolExecute?: (
     tool: IAiClientTool,

--- a/libraries/ts-extras/src/packlets/ai-assist/streamingClient.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/streamingClient.ts
@@ -67,7 +67,8 @@ export type { IProviderCompletionStreamParams } from './streamingAdapters/common
 export {
   executeClientToolTurn,
   type IExecuteClientToolTurnParams,
-  type IExecuteClientToolTurnResult
+  type IExecuteClientToolTurnResult,
+  type IToolExecutionDecision
 } from './streamingAdapters/clientToolContinuationBuilder';
 
 /**

--- a/libraries/ts-extras/src/test/unit/ai-assist/clientToolTurnGate.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/clientToolTurnGate.test.ts
@@ -1,0 +1,346 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * Tests for C3: the `onBeforeToolExecute` before-execute gate hook on
+ * `executeClientToolTurn` (deny-semantics LOCKED — see the stream brief).
+ */
+
+import '@fgv/ts-utils-jest';
+
+import { fail, type Result, succeed } from '@fgv/ts-utils';
+import { JsonSchema } from '@fgv/ts-json-base';
+// eslint-disable-next-line @rushstack/packlets/mechanics
+import {
+  executeClientToolTurn,
+  type IToolExecutionDecision
+} from '../../../packlets/ai-assist/streamingAdapters/clientToolContinuationBuilder';
+// eslint-disable-next-line @rushstack/packlets/mechanics
+import type { IAiClientTool, IAiProviderDescriptor, IAiStreamEvent } from '../../../packlets/ai-assist/model';
+// eslint-disable-next-line @rushstack/packlets/mechanics
+import { AiPrompt } from '../../../packlets/ai-assist/model';
+
+// ============================================================================
+// Test helpers (self-contained: mirror the minimal harness the sibling suite uses)
+// ============================================================================
+
+function makeReadable(chunks: ReadonlyArray<string>): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller: ReadableStreamDefaultController<Uint8Array>): void {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[i++]));
+      } else {
+        controller.close();
+      }
+    }
+  });
+}
+
+function mockSseResponse(chunks: ReadonlyArray<string>): void {
+  const body = makeReadable(chunks);
+  const response = {
+    ok: true,
+    status: 200,
+    body,
+    text: jest.fn().mockResolvedValue(''),
+    headers: new Map([['content-type', 'text/event-stream']])
+  };
+  (global.fetch as jest.Mock).mockResolvedValue(response);
+}
+
+async function collect(iter: AsyncIterable<IAiStreamEvent>): Promise<IAiStreamEvent[]> {
+  const out: IAiStreamEvent[] = [];
+  for await (const event of iter) {
+    out.push(event);
+  }
+  return out;
+}
+
+const testPrompt = new AiPrompt('hello', 'system');
+
+function makeAnthropicDescriptor(): IAiProviderDescriptor {
+  return {
+    id: 'anthropic',
+    label: 'Anthropic',
+    buttonLabel: 'Anthropic',
+    needsSecret: true,
+    apiFormat: 'anthropic',
+    baseUrl: 'https://api.anthropic.com/v1',
+    defaultModel: 'claude-sonnet-4-6',
+    supportedTools: ['web_search'],
+    corsRestricted: false,
+    streamingCorsRestricted: false,
+    acceptsImageInput: false,
+    thinkingMode: 'optional'
+  };
+}
+
+function anthropicToolUseSse(toolId: string, toolName: string, argsJson: string): string[] {
+  return [
+    `event: content_block_start\ndata: ${JSON.stringify({
+      index: 0,
+      content_block: { type: 'tool_use', id: toolId, name: toolName }
+    })}\n\n`,
+    `event: content_block_delta\ndata: ${JSON.stringify({
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: argsJson }
+    })}\n\n`,
+    `event: content_block_stop\ndata: ${JSON.stringify({ index: 0 })}\n\n`,
+    `event: message_delta\ndata: ${JSON.stringify({ delta: { stop_reason: 'tool_use' } })}\n\n`,
+    `event: message_stop\ndata: {}\n\n`
+  ];
+}
+
+const recallSchema = JsonSchema.object({ query: JsonSchema.string() });
+type RecallParams = JsonSchema.Static<typeof recallSchema>;
+
+// A memory tool whose execute is a spy, so tests can assert it was / was not run.
+function makeSpyTool(
+  spy: jest.Mock,
+  annotations?: IAiClientTool['config']['annotations']
+): IAiClientTool<RecallParams> {
+  return {
+    config: {
+      type: 'client_tool',
+      name: 'recall_memory',
+      description: 'Recall stored context',
+      parametersSchema: recallSchema,
+      ...(annotations !== undefined ? { annotations } : {})
+    },
+    execute: async (args) => {
+      spy(args);
+      return succeed(`User prefers ${args.query}`);
+    }
+  };
+}
+
+// ============================================================================
+// onBeforeToolExecute gate (C3)
+// ============================================================================
+
+describe('onBeforeToolExecute gate (C3)', () => {
+  beforeEach(() => {
+    jest.spyOn(global, 'fetch').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('proceed → tool runs (unchanged behavior)', async () => {
+    mockSseResponse(anthropicToolUseSse('toolu_01', 'recall_memory', '{"query":"user prefs"}'));
+    const spy = jest.fn();
+    const tool = makeSpyTool(spy);
+
+    const result = executeClientToolTurn({
+      descriptor: makeAnthropicDescriptor(),
+      apiKey: 'test-key',
+      ...testPrompt.toRequest(),
+      clientTools: [tool] as IAiClientTool[],
+      model: 'claude-sonnet-4-6',
+      onBeforeToolExecute: async () => succeed({ action: 'proceed' })
+    });
+    expect(result).toSucceed();
+    if (result.isFailure()) return;
+
+    const events = await collect(result.value.events);
+    const turnResult = await result.value.nextTurn;
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const resultEvent = events.find((e) => e.type === 'client-tool-result');
+    expect(resultEvent?.type === 'client-tool-result' && resultEvent.isError).toBe(false);
+    expect(turnResult).toSucceedAndSatisfy((r) => {
+      expect(r.continuation?.toolCallsSummary[0].isError).toBe(false);
+    });
+  });
+
+  test('deny → execute NOT called, synthesized denial result in continuation, event emitted, turn continues', async () => {
+    mockSseResponse(anthropicToolUseSse('toolu_01', 'recall_memory', '{"query":"user prefs"}'));
+    const spy = jest.fn();
+    const tool = makeSpyTool(spy);
+
+    const result = executeClientToolTurn({
+      descriptor: makeAnthropicDescriptor(),
+      apiKey: 'test-key',
+      ...testPrompt.toRequest(),
+      clientTools: [tool] as IAiClientTool[],
+      model: 'claude-sonnet-4-6',
+      onBeforeToolExecute: async () => succeed({ action: 'deny', reason: 'pending user confirmation' })
+    });
+    expect(result).toSucceed();
+    if (result.isFailure()) return;
+
+    const events = await collect(result.value.events);
+    const turnResult = await result.value.nextTurn;
+
+    // execute never ran.
+    expect(spy).not.toHaveBeenCalled();
+
+    // a client-tool-result event was emitted for the denied call, carrying the reason.
+    const resultEvent = events.find((e) => e.type === 'client-tool-result');
+    expect(resultEvent).toBeDefined();
+    if (resultEvent?.type === 'client-tool-result') {
+      expect(resultEvent.isError).toBe(true);
+      expect(resultEvent.toolName).toBe('recall_memory');
+      expect(resultEvent.result).toMatch(/denied.*pending user confirmation/i);
+    }
+
+    // the turn continues: nextTurn succeeds with a continuation carrying the denial as
+    // a normal (isError) tool-result the model will see and can react to.
+    expect(turnResult).toSucceedAndSatisfy((r) => {
+      expect(r.continuation).toBeDefined();
+      expect(r.continuation?.toolCallsSummary).toHaveLength(1);
+      expect(r.continuation?.toolCallsSummary[0].isError).toBe(true);
+      expect(JSON.stringify(r.continuation?.messages)).toMatch(/pending user confirmation/i);
+    });
+  });
+
+  test('callback returning Result.fail → hard error (not a silent deny), execute NOT called', async () => {
+    mockSseResponse(anthropicToolUseSse('toolu_01', 'recall_memory', '{"query":"user prefs"}'));
+    const spy = jest.fn();
+    const tool = makeSpyTool(spy);
+
+    const result = executeClientToolTurn({
+      descriptor: makeAnthropicDescriptor(),
+      apiKey: 'test-key',
+      ...testPrompt.toRequest(),
+      clientTools: [tool] as IAiClientTool[],
+      model: 'claude-sonnet-4-6',
+      onBeforeToolExecute: async () => fail('gate backend unavailable')
+    });
+    expect(result).toSucceed();
+    if (result.isFailure()) return;
+
+    const events = await collect(result.value.events);
+    const turnResult = await result.value.nextTurn;
+
+    expect(spy).not.toHaveBeenCalled();
+    const resultEvent = events.find((e) => e.type === 'client-tool-result');
+    expect(resultEvent?.type === 'client-tool-result' && resultEvent.isError).toBe(true);
+    // Gate-fail is turn-terminating: an explicit `error` event is emitted inline so an
+    // events-only consumer sees the fatal failure (and can distinguish it from a non-fatal deny).
+    const errorEvent = events.find((e) => e.type === 'error');
+    expect(errorEvent?.type === 'error' && /gate backend unavailable/i.test(errorEvent.message)).toBe(true);
+    expect(turnResult).toFailWith(/gate backend unavailable/i);
+  });
+
+  test('callback that rejects → hard error (caught like an execute failure), execute NOT called', async () => {
+    mockSseResponse(anthropicToolUseSse('toolu_01', 'recall_memory', '{"query":"user prefs"}'));
+    const spy = jest.fn();
+    const tool = makeSpyTool(spy);
+
+    const result = executeClientToolTurn({
+      descriptor: makeAnthropicDescriptor(),
+      apiKey: 'test-key',
+      ...testPrompt.toRequest(),
+      clientTools: [tool] as IAiClientTool[],
+      model: 'claude-sonnet-4-6',
+      onBeforeToolExecute: async () => {
+        throw new Error('gate threw');
+      }
+    });
+    expect(result).toSucceed();
+    if (result.isFailure()) return;
+
+    await collect(result.value.events);
+    const turnResult = await result.value.nextTurn;
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(turnResult).toFailWith(/gate threw/i);
+  });
+
+  test('absent callback → unchanged behavior', async () => {
+    mockSseResponse(anthropicToolUseSse('toolu_01', 'recall_memory', '{"query":"user prefs"}'));
+    const spy = jest.fn();
+    const tool = makeSpyTool(spy);
+
+    const result = executeClientToolTurn({
+      descriptor: makeAnthropicDescriptor(),
+      apiKey: 'test-key',
+      ...testPrompt.toRequest(),
+      clientTools: [tool] as IAiClientTool[],
+      model: 'claude-sonnet-4-6'
+    });
+    expect(result).toSucceed();
+    if (result.isFailure()) return;
+
+    await collect(result.value.events);
+    const turnResult = await result.value.nextTurn;
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(turnResult).toSucceedAndSatisfy((r) => {
+      expect(r.continuation?.toolCallsSummary[0].isError).toBe(false);
+    });
+  });
+
+  test('end-to-end: an annotations-keyed gate denies a destructive tool and proceeds a readOnly one', async () => {
+    // One gate keyed off tool.config.annotations.destructiveHint, applied across two turns.
+    const gate: (tool: IAiClientTool, args: unknown) => Promise<Result<IToolExecutionDecision>> = async (
+      tool
+    ) =>
+      tool.config.annotations?.destructiveHint === true
+        ? succeed({ action: 'deny', reason: 'destructive tool blocked by policy' })
+        : succeed({ action: 'proceed' });
+
+    // Turn 1: the destructive tool is denied.
+    mockSseResponse(anthropicToolUseSse('toolu_01', 'recall_memory', '{"query":"x"}'));
+    const destructiveSpy = jest.fn();
+    const destructiveTool = makeSpyTool(destructiveSpy, { destructiveHint: true });
+    const denyRun = executeClientToolTurn({
+      descriptor: makeAnthropicDescriptor(),
+      apiKey: 'test-key',
+      ...testPrompt.toRequest(),
+      clientTools: [destructiveTool] as IAiClientTool[],
+      model: 'claude-sonnet-4-6',
+      onBeforeToolExecute: gate
+    });
+    expect(denyRun).toSucceed();
+    if (denyRun.isFailure()) return;
+    await collect(denyRun.value.events);
+    const denyResult = await denyRun.value.nextTurn;
+    expect(destructiveSpy).not.toHaveBeenCalled();
+    expect(denyResult).toSucceedAndSatisfy((r) => {
+      expect(r.continuation?.toolCallsSummary[0].isError).toBe(true);
+      expect(JSON.stringify(r.continuation?.messages)).toMatch(/destructive tool blocked by policy/i);
+    });
+
+    // Turn 2: the read-only tool proceeds under the same gate.
+    mockSseResponse(anthropicToolUseSse('toolu_02', 'recall_memory', '{"query":"y"}'));
+    const readOnlySpy = jest.fn();
+    const readOnlyTool = makeSpyTool(readOnlySpy, { readOnlyHint: true });
+    const proceedRun = executeClientToolTurn({
+      descriptor: makeAnthropicDescriptor(),
+      apiKey: 'test-key',
+      ...testPrompt.toRequest(),
+      clientTools: [readOnlyTool] as IAiClientTool[],
+      model: 'claude-sonnet-4-6',
+      onBeforeToolExecute: gate
+    });
+    expect(proceedRun).toSucceed();
+    if (proceedRun.isFailure()) return;
+    await collect(proceedRun.value.events);
+    const proceedResult = await proceedRun.value.nextTurn;
+    expect(readOnlySpy).toHaveBeenCalledTimes(1);
+    expect(proceedResult).toSucceedAndSatisfy((r) => {
+      expect(r.continuation?.toolCallsSummary[0].isError).toBe(false);
+    });
+  });
+});

--- a/libraries/ts-extras/src/test/unit/ai-assist/converters.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/converters.test.ts
@@ -23,7 +23,7 @@ import '@fgv/ts-utils-jest';
 import { JsonSchema } from '@fgv/ts-json-base';
 
 // eslint-disable-next-line @rushstack/packlets/mechanics
-import { aiClientToolConfig } from '../../../packlets/ai-assist/converters';
+import { aiClientToolConfig, aiToolAnnotations } from '../../../packlets/ai-assist/converters';
 
 // ============================================================================
 // aiClientToolConfig converter
@@ -79,6 +79,51 @@ describe('aiClientToolConfig', () => {
       expect(aiClientToolConfig.convert(validConfig)).toSucceedAndSatisfy((config) => {
         expect(config.parametersSchema.validate({ query: 'test' })).toSucceed();
       });
+    });
+
+    test('projects annotations when present (not dropped)', () => {
+      const withAnnotations = {
+        ...validConfig,
+        annotations: { destructiveHint: true, idempotentHint: true, title: 'Delete Memory' }
+      };
+      expect(aiClientToolConfig.convert(withAnnotations)).toSucceedAndSatisfy((config) => {
+        expect(config.annotations).toEqual({
+          destructiveHint: true,
+          idempotentHint: true,
+          title: 'Delete Memory'
+        });
+      });
+    });
+
+    test('leaves annotations undefined when absent', () => {
+      expect(aiClientToolConfig.convert(validConfig)).toSucceedAndSatisfy((config) => {
+        expect(config.annotations).toBeUndefined();
+      });
+    });
+  });
+
+  describe('aiToolAnnotations converter', () => {
+    test('accepts a partial set of hints', () => {
+      expect(aiToolAnnotations.convert({ readOnlyHint: true })).toSucceedWith({ readOnlyHint: true });
+    });
+
+    test('accepts all five fields', () => {
+      const all = {
+        title: 'Search',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
+      };
+      expect(aiToolAnnotations.convert(all)).toSucceedWith(all);
+    });
+
+    test('accepts an empty object (all hints optional)', () => {
+      expect(aiToolAnnotations.convert({})).toSucceedWith({});
+    });
+
+    test('rejects a wrong-typed hint', () => {
+      expect(aiToolAnnotations.convert({ readOnlyHint: 'yes' })).toFail();
     });
   });
 

--- a/libraries/ts-extras/src/test/unit/ai-assist/toolFormats.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/toolFormats.test.ts
@@ -557,3 +557,78 @@ describe('toGeminiParameterSchema', () => {
     expect(toGeminiParameterSchema(null)).toBeNull();
   });
 });
+
+// ============================================================================
+// Host-advisory-only guarantee: annotations NEVER reach any provider wire schema
+// ============================================================================
+
+describe('client-tool annotations are host-advisory-only (never serialized to the model)', () => {
+  // A client tool carrying every annotation field. The wire serializers whitelist
+  // {name, description, parameters}, so none of these must appear on any provider format.
+  const annotatedTool: IAiClientToolConfig = {
+    type: 'client_tool',
+    name: 'recall_memory',
+    description: 'Recall stored user context',
+    parametersSchema: memorySchema,
+    annotations: {
+      title: 'Recall Memory',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    }
+  };
+
+  test('OpenAI/xAI Responses wire tool omits annotations entirely', () => {
+    expect(toResponsesApiTools([annotatedTool])).toEqual([
+      {
+        type: 'function',
+        name: 'recall_memory',
+        description: 'Recall stored user context',
+        parameters: memoryWireSchema
+      }
+    ]);
+  });
+
+  test('Anthropic wire tool omits annotations entirely', () => {
+    expect(toAnthropicTools([annotatedTool])).toEqual([
+      {
+        name: 'recall_memory',
+        description: 'Recall stored user context',
+        input_schema: memoryWireSchema
+      }
+    ]);
+  });
+
+  test('Gemini wire tool omits annotations entirely', () => {
+    expect(toGeminiTools([annotatedTool])).toEqual([
+      {
+        function_declarations: [
+          {
+            name: 'recall_memory',
+            description: 'Recall stored user context',
+            parameters: memoryGeminiParams
+          }
+        ]
+      }
+    ]);
+  });
+
+  test('no provider wire schema mentions any annotation key', () => {
+    const serialized = JSON.stringify([
+      toResponsesApiTools([annotatedTool]),
+      toAnthropicTools([annotatedTool]),
+      toGeminiTools([annotatedTool])
+    ]);
+    for (const key of [
+      'annotations',
+      'readOnlyHint',
+      'destructiveHint',
+      'idempotentHint',
+      'openWorldHint',
+      'Recall Memory'
+    ]) {
+      expect(serialized).not.toContain(key);
+    }
+  });
+});

--- a/samples/testbed/src/scenarios/gateDenyClientTools/index.ts
+++ b/samples/testbed/src/scenarios/gateDenyClientTools/index.ts
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * Client-tool before-execute gate (deny path) scenario — `onBeforeToolExecute`.
+ *
+ * Demonstrates the C3 gate hook end-to-end WITHOUT a live model. The provider stream is
+ * **mocked** (a canned Anthropic tool_use SSE stream substituted for `global.fetch`), so the
+ * scenario is deterministic and requires no API key. It proves the LOCKED deny-semantics:
+ *
+ * - The model "calls" a `delete_all_memories` tool (a destructive tool, annotated
+ *   `destructiveHint: true`).
+ * - The host gate keys off `tool.config.annotations.destructiveHint` and returns
+ *   `{ action: 'deny', reason }`.
+ * - The tool's `execute` is NEVER run; a synthesized denial tool-result is emitted as a
+ *   `client-tool-result` event AND fed into `continuation.messages`, so the turn stays
+ *   coherent and the model would see "that call was denied because <reason>".
+ *
+ * A second run with a `recall_memory` tool (annotated `readOnlyHint: true`) proves the same
+ * gate proceeds a read-only call — the annotations→gate composition.
+ *
+ * This scenario is CLI-only and self-contained (mocked stream, no live API), matching the
+ * `*ClientTools/` coverage-exclusion convention used by the sibling live client-tool scenarios.
+ *
+ * @packageDocumentation
+ */
+
+import { fail, succeed } from '@fgv/ts-utils';
+import type { Result } from '@fgv/ts-utils';
+import { JsonSchema } from '@fgv/ts-json-base';
+import { AiAssist } from '@fgv/ts-extras';
+
+import type { IScenario, ICliScenarioImpl, IScenarioContext } from '../../shell';
+
+// ---------------------------------------------------------------------------
+// Mocked provider stream (Anthropic tool_use SSE) — no live API
+// ---------------------------------------------------------------------------
+
+/** Builds a canned Anthropic SSE stream in which the model calls `toolName` with `argsJson`. */
+function anthropicToolUseSse(toolId: string, toolName: string, argsJson: string): string[] {
+  return [
+    `event: content_block_start\ndata: ${JSON.stringify({
+      index: 0,
+      content_block: { type: 'tool_use', id: toolId, name: toolName }
+    })}\n\n`,
+    `event: content_block_delta\ndata: ${JSON.stringify({
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: argsJson }
+    })}\n\n`,
+    `event: content_block_stop\ndata: ${JSON.stringify({ index: 0 })}\n\n`,
+    `event: message_delta\ndata: ${JSON.stringify({ delta: { stop_reason: 'tool_use' } })}\n\n`,
+    `event: message_stop\ndata: {}\n\n`
+  ];
+}
+
+/** Installs a mocked `global.fetch` returning the given SSE chunks; returns a restore fn. */
+function installMockFetch(chunks: ReadonlyArray<string>): () => void {
+  const original = global.fetch;
+  const encoder = new TextEncoder();
+  let i = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller: ReadableStreamDefaultController<Uint8Array>): void {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[i++]));
+      } else {
+        controller.close();
+      }
+    }
+  });
+  const response = {
+    ok: true,
+    status: 200,
+    body,
+    text: async (): Promise<string> => '',
+    headers: new Map([['content-type', 'text/event-stream']])
+  };
+  global.fetch = (async () => response) as unknown as typeof global.fetch;
+  return () => {
+    global.fetch = original;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tools + gate
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @rushstack/typedef-var
+const memorySchema = JsonSchema.object({
+  key: JsonSchema.string({ description: 'The preference key' })
+});
+
+/** A destructive tool the gate must deny. Its `execute` throws if ever reached. */
+const deleteTool: AiAssist.IAiClientTool = {
+  config: {
+    type: 'client_tool',
+    name: 'delete_all_memories',
+    description: 'Permanently delete all stored user memories.',
+    parametersSchema: memorySchema,
+    annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false }
+  },
+  execute: async (): Promise<Result<unknown>> => fail('BUG: destructive execute ran despite a deny decision')
+};
+
+/** A read-only tool the gate must allow. */
+const recallTool: AiAssist.IAiClientTool = {
+  config: {
+    type: 'client_tool',
+    name: 'recall_memory',
+    description: 'Recall a stored user preference.',
+    parametersSchema: memorySchema,
+    annotations: { readOnlyHint: true, openWorldHint: false }
+  },
+  execute: async (): Promise<Result<unknown>> => succeed({ found: true, value: 'dark mode' })
+};
+
+/** The host gate: deny anything annotated destructive; proceed otherwise. */
+const gate: (
+  tool: AiAssist.IAiClientTool,
+  args: unknown
+) => Promise<Result<AiAssist.IToolExecutionDecision>> = async (tool) =>
+  tool.config.annotations?.destructiveHint === true
+    ? succeed({ action: 'deny', reason: 'destructive tool blocked by host policy pending confirmation' })
+    : succeed({ action: 'proceed' });
+
+// ---------------------------------------------------------------------------
+// CLI implementation
+// ---------------------------------------------------------------------------
+
+const cliImpl: ICliScenarioImpl = {
+  async run(context: IScenarioContext): Promise<Result<string>> {
+    const descriptorResult = AiAssist.getProviderDescriptor('anthropic');
+    if (descriptorResult.isFailure()) {
+      return fail(`Failed to get Anthropic descriptor: ${descriptorResult.message}`);
+    }
+    const descriptor = descriptorResult.value;
+    const request: AiAssist.IChatRequest = {
+      system: 'You manage user memories.',
+      messages: [{ role: 'user', content: 'Delete all my memories.' }]
+    };
+    const summary: string[] = ['client-tool gate deny-path scenario (mocked stream, no live API)', ''];
+
+    // --- Run 1: destructive tool → DENIED --------------------------------
+    const restore1 = installMockFetch(
+      anthropicToolUseSse('toolu_del', 'delete_all_memories', '{"key":"all"}')
+    );
+    let denyEventSeen = false;
+    let denyResultText = '';
+    try {
+      const turn = AiAssist.executeClientToolTurn({
+        descriptor,
+        apiKey: 'mock-key',
+        ...request,
+        clientTools: [deleteTool],
+        model: 'claude-sonnet-4-6',
+        onBeforeToolExecute: gate
+      });
+      if (turn.isFailure()) {
+        return fail(`deny-run executeClientToolTurn failed: ${turn.message}`);
+      }
+      for await (const event of turn.value.events) {
+        if (event.type === 'client-tool-result') {
+          denyEventSeen = true;
+          denyResultText = event.result;
+        } else if (event.type === 'error') {
+          return fail(`deny-run stream error: ${event.message}`);
+        }
+      }
+      const outcome = await turn.value.nextTurn;
+      if (outcome.isFailure()) {
+        return fail(`deny-run nextTurn failed (should continue, not hard-fail): ${outcome.message}`);
+      }
+      const cont = outcome.value.continuation;
+      const denialInContinuation =
+        cont !== undefined && JSON.stringify(cont.messages).includes('destructive tool blocked');
+      const denialSummarized = cont?.toolCallsSummary[0]?.isError === true;
+
+      if (!denyEventSeen || !denialInContinuation || !denialSummarized) {
+        return fail(
+          `deny-path assertion failed: event=${String(denyEventSeen)} ` +
+            `continuation=${String(denialInContinuation)} summary=${String(denialSummarized)}`
+        );
+      }
+      context.logger.info(
+        `[run 1] destructive tool DENIED — execute skipped; denial result: ${denyResultText}`
+      );
+      summary.push('Run 1 (destructive delete_all_memories): DENIED');
+      summary.push(`  - execute() never ran (tool.execute would have failed the run if reached)`);
+      summary.push(`  - client-tool-result event emitted: ${denyResultText}`);
+      summary.push('  - synthesized denial fed into continuation.messages; turn continued (nextTurn ok)');
+    } finally {
+      restore1();
+    }
+
+    // --- Run 2: read-only tool → PROCEEDS --------------------------------
+    const restore2 = installMockFetch(anthropicToolUseSse('toolu_recall', 'recall_memory', '{"key":"mode"}'));
+    try {
+      const turn = AiAssist.executeClientToolTurn({
+        descriptor,
+        apiKey: 'mock-key',
+        ...request,
+        clientTools: [recallTool],
+        model: 'claude-sonnet-4-6',
+        onBeforeToolExecute: gate
+      });
+      if (turn.isFailure()) {
+        return fail(`proceed-run executeClientToolTurn failed: ${turn.message}`);
+      }
+      let proceedIsError = true;
+      for await (const event of turn.value.events) {
+        if (event.type === 'client-tool-result') {
+          proceedIsError = event.isError;
+        } else if (event.type === 'error') {
+          return fail(`proceed-run stream error: ${event.message}`);
+        }
+      }
+      const outcome = await turn.value.nextTurn;
+      if (outcome.isFailure()) {
+        return fail(`proceed-run nextTurn failed: ${outcome.message}`);
+      }
+      if (proceedIsError) {
+        return fail('proceed-path assertion failed: read-only tool result was flagged isError');
+      }
+      context.logger.info('[run 2] read-only tool PROCEEDED under the same gate');
+      summary.push('');
+      summary.push('Run 2 (read-only recall_memory): PROCEEDED (same gate, keyed off annotations)');
+    } finally {
+      restore2();
+    }
+
+    summary.push('');
+    summary.push('gate-deny-client-tools scenario: PASS');
+    return succeed(summary.join('\n'));
+  }
+};
+
+/**
+ * Client-tool before-execute gate (deny path) scenario.
+ *
+ * Self-contained (mocked provider stream; no live API / key) demonstration of the C3
+ * `onBeforeToolExecute` deny-semantics and the annotations→gate composition.
+ *
+ * @public
+ */
+export const gateDenyClientToolsScenario: IScenario = {
+  id: 'gate-deny-client-tools',
+  title: 'Client-Tool Gate — Deny Path',
+  description:
+    'Self-contained (mocked stream, no live API) demonstration of the onBeforeToolExecute gate: ' +
+    'a host gate keyed off tool.config.annotations.destructiveHint denies a destructive tool ' +
+    '(execute skipped, synthesized denial in the continuation, turn continues) and proceeds a ' +
+    'read-only one.',
+  category: 'ai',
+  tags: ['client-tools', 'tool-use', 'annotations', 'gate', 'deny', 'mocked'],
+  cli: cliImpl
+};

--- a/samples/testbed/src/scenarios/index.ts
+++ b/samples/testbed/src/scenarios/index.ts
@@ -12,6 +12,7 @@
 import type { IScenario } from '../shell';
 import { anthropicClientToolsScenario } from './anthropicClientTools';
 import { crossProviderEmbeddingSearchScenario } from './crossProviderEmbeddingSearch';
+import { gateDenyClientToolsScenario } from './gateDenyClientTools';
 import { geminiClientToolsScenario } from './geminiClientTools';
 import { localClassifierSafetyScenario } from './localClassifierSafety';
 import { localEmbeddingSearchScenario } from './localEmbeddingSearch';
@@ -34,6 +35,7 @@ export const scenarios: readonly IScenario[] = [
   openaiClientToolsScenario,
   geminiClientToolsScenario,
   xaiClientToolsScenario,
+  gateDenyClientToolsScenario,
   localClassifierSafetyScenario,
   localEmbeddingSearchScenario,
   localSummarizationScenario,

--- a/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
+++ b/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
@@ -6,6 +6,7 @@ Array [
   "openai-client-tools",
   "gemini-client-tools",
   "xai-client-tools",
+  "gate-deny-client-tools",
   "local-classifier-safety",
   "local-embedding-search",
   "local-summarization",


### PR DESCRIPTION
Implements the `ai-assist-tool-annotations` stream (brief: `.ai/tasks/active/ai-assist-tool-annotations/brief.md`) — the precursor `agent-memory-l2-tools` depends on. Three additive components across the active ai-assist + ts-extras-mcp surfaces.

## What shipped

- **C1 — annotations data model** (`@fgv/ts-extras/ai-assist`): `IAiToolAnnotations` (MCP-native names: `readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`/`title`) + `IAiClientToolConfig.annotations?`. **Host-advisory-only** — no provider wire tool-schema has an annotation slot, so annotations are *never serialized to the model*. The three serializers in `toolFormats.ts` are untouched, and a test asserts annotation keys never appear in any provider's wire payload.
- **C2 — MCP passthrough** (`@fgv/ts-extras-mcp`): thread MCP `Tool.annotations` → the field through all four hops (`sdk.ts` → `_toDescriptor` → `IMcpToolDescriptor` → `_adaptOne`). `_normalizeAnnotations` validates each field independently via Converters (malformed fields dropped, unknown keys never copied, `undefined` when nothing usable — never `{}`, never raw). Fixes the prior 3-layer silent data loss.
- **C3 — before-execute gate** (`executeClientToolTurn`): `onBeforeToolExecute?(tool, args) => Promise<Result<IToolExecutionDecision>>`, `{ action: 'proceed' } | { action: 'deny', reason }`. Runs after arg-validation, before execute; the full tool (incl. `config.annotations`) is passed so a gate can key off hints. **Deny** → synthesized denial tool-result pushed into `continuation.messages` (uniform across all providers), `client-tool-result` event emitted, turn continues. **Gate fail/reject** → hard error that terminates the turn with an explicit inline `error` event (so events-only consumers see the fatal signal and can distinguish it from a non-fatal deny).

## Review — layer 1 (two independent code-reviewer passes, both Approved)

No P1s. Deny-path double-`Result` flatten, per-provider continuation wire-validity, execute-skip, event ordering, C2 normalization, and C1 wire-invisibility all verified correct by trace. Dispositions:
- **P2 (fixed): gate-fail visibility.** Original hard-error path emitted only an `isError` tool-result, indistinguishable to an events-only consumer from a non-fatal deny. Added an explicit `error` event on gate-fail (matching the stream-open/continuation hard-error convention) + a test asserting it.
- **P2 (dispositioned): testbed `global.fetch` save/restore** in `gateDenyClientTools` — the named anti-pattern, but runs as a **CLI scenario outside Jest** (so `jest.spyOn` is unavailable) and is `try/finally`-scoped; no fgv primitive covers non-Jest global mocking. Accepted for the sample scenario; the sibling unit test uses `jest.spyOn` correctly.
- **P3 (fixed):** added `readonly` to `IToolExecutionDecision` fields (consistency with sibling unions).
- **P3 (dispositioned):** 2 new `ae-unresolved-link` api-extractor warnings on the new `@link`s — inherited from the `AiAssist` namespace-re-export pattern (241 pre-existing, `logLevel: none`), not a regression.

## Gates

- `rushx build`/`lint`/`test` @ **100%** in `libraries/ts-extras` AND `libraries/ts-extras-mcp`; `samples/testbed` build + tests green. Both `.api.md` regenerated (additive: `IAiToolAnnotations`, `annotations?`, `onBeforeToolExecute`, `IToolExecutionDecision`; MCP `IMcpToolAnnotations` + descriptor field).
- No live run needed — the deny path is harness-side logic; the testbed scenario exercises it offline.

## Downstream
`agent-memory-l2-tools` consumes this (populate `config.annotations` per memory tool + wire `onBeforeToolExecute` for mediated `memory_write`/`memory_delete`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tool annotations in AI assist and MCP tool metadata, including read-only, destructive, idempotent, open-world, and title hints.
  * Added a before-execution gate for client tools, allowing tool runs to proceed or be denied with a reason.
  * Expanded the testbed with a new scenario demonstrating deny/allow behavior for annotated tools.

* **Bug Fixes**
  * Tool annotations are now normalized and handled safely, with invalid or unknown values ignored instead of passed through.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->