### PR TITLE
feat(ts-agent-memory): L2 agent-tool surface (createMemoryTools)

### DIFF
--- a/common/changes/@fgv/ts-agent-memory/claude-agent-memory-l2-tools_2026-07-07-20-51.json
+++ b/common/changes/@fgv/ts-agent-memory/claude-agent-memory-l2-tools_2026-07-07-20-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "L2 agent-tool surface: createMemoryTools exposes memory ops as ai-assist client tools (scope-isolated via pre-scoped store, per-tool subset, mnemonic handle, behavior annotations, mediated-write gate)",
+      "type": "minor",
+      "packageName": "@fgv/ts-agent-memory"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory",
+  "email": "noreply@anthropic.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2517,6 +2517,9 @@ importers:
 
   ../../samples/testbed:
     dependencies:
+      '@fgv/ts-agent-memory':
+        specifier: workspace:*
+        version: link:../../libraries/ts-agent-memory
       '@fgv/ts-app-shell':
         specifier: workspace:*
         version: link:../../libraries/ts-app-shell

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -35,6 +35,17 @@ opportunistically when the right surface area is touched.
 
 ## P2 — Fix before next major feature in affected area
 
+- **[P3] `ts-agent-memory` L2 `createMemoryTools` duplicates the store's codec wiring instead of delegating.**
+  `createMemoryTools({ codecs?, defaultCodec? })` (`libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts`) accepts the per-kind identity codecs a second time, in addition to `FileTreeMemoryStore.create({ codecs })`. `memory_write` needs them because `IMemoryStore.put` (`fileTreeMemoryStore.ts:496-502`) validates `envelope.id === codec-derived idStem` and does not derive/stamp the id itself — so a caller building a new `IMemoryRecord` must compute the same `idStem` up front, which requires the same codec the store was constructed with. The testbed scenario passes the same `codecs` map to both constructors, illustrating the drift risk: a host that re-wires the store's codecs but forgets the mirrored `createMemoryTools` config gets a confusing "envelope id does not match codec-derived stem" failure at `put()` time. Scope isolation is NOT compromised (codec `scope` is derived deterministically from `kind`, not from agent input; a mismatch loudly rejects the write rather than writing cross-scope), so this is a DX/robustness smell, not a security gap.
+
+  **Trigger**: when the temporal write path lands (it touches the same `IMemoryStore` write surface) or the next time `createMemoryTools` is extended.
+
+  **Scope sketch**: add an additive method to `IMemoryStore` — e.g. `resolveWriteAddress(kind, entityId): Result<IIdentityCodecResult>` delegating to the store's already-configured `codecs`/`defaultCodec` — and have `memory_write` call it, dropping the `codecs?`/`defaultCodec?` params from `ICreateMemoryToolsParams`. Purely additive on the active `ts-agent-memory` surface; removes the duplicate config and the drift failure mode.
+
+  **Not a P2**: the current shape ships correctly and the failure mode on host misconfiguration is loud (a `put`-time reject), not silent; scope isolation holds structurally.
+
+  **Reference**: `agent-memory-l2-tools` stream; code-reviewer pass on the L2 diff (2026-07-07).
+
 - **[P2] `ts-prompt-assist` (and adjacent `ts-res` qualifier surface) needs an API documentation pass once the v0.1 surface settles.**
   PR #380 review surfaced that the recently-extended `ts-prompt-assist` surface — `PromptLibrary` + `IPromptLibraryCreateParams` + `IPromptResolveRequest` + the related fixture / resource-binding / resolve-output types — carries minimal TSDoc on individual methods, parameters, and return shapes. The v0.1 surface has been moving fast (Phase B sub-phases + post-merge cleanups + surface-tidy + round-1 ergonomics absorption), so documenting heavily during churn was the right call; with v0.1 effectively settled now, the next concern is consumer-facing TSDoc quality on the public surface.
 

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -35,17 +35,6 @@ opportunistically when the right surface area is touched.
 
 ## P2 — Fix before next major feature in affected area
 
-- **[P3] `ts-agent-memory` L2 `createMemoryTools` duplicates the store's codec wiring instead of delegating.**
-  `createMemoryTools({ codecs?, defaultCodec? })` (`libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts`) accepts the per-kind identity codecs a second time, in addition to `FileTreeMemoryStore.create({ codecs })`. `memory_write` needs them because `IMemoryStore.put` (`fileTreeMemoryStore.ts:496-502`) validates `envelope.id === codec-derived idStem` and does not derive/stamp the id itself — so a caller building a new `IMemoryRecord` must compute the same `idStem` up front, which requires the same codec the store was constructed with. The testbed scenario passes the same `codecs` map to both constructors, illustrating the drift risk: a host that re-wires the store's codecs but forgets the mirrored `createMemoryTools` config gets a confusing "envelope id does not match codec-derived stem" failure at `put()` time. Scope isolation is NOT compromised (codec `scope` is derived deterministically from `kind`, not from agent input; a mismatch loudly rejects the write rather than writing cross-scope), so this is a DX/robustness smell, not a security gap.
-
-  **Trigger**: when the temporal write path lands (it touches the same `IMemoryStore` write surface) or the next time `createMemoryTools` is extended.
-
-  **Scope sketch**: add an additive method to `IMemoryStore` — e.g. `resolveWriteAddress(kind, entityId): Result<IIdentityCodecResult>` delegating to the store's already-configured `codecs`/`defaultCodec` — and have `memory_write` call it, dropping the `codecs?`/`defaultCodec?` params from `ICreateMemoryToolsParams`. Purely additive on the active `ts-agent-memory` surface; removes the duplicate config and the drift failure mode.
-
-  **Not a P2**: the current shape ships correctly and the failure mode on host misconfiguration is loud (a `put`-time reject), not silent; scope isolation holds structurally.
-
-  **Reference**: `agent-memory-l2-tools` stream; code-reviewer pass on the L2 diff (2026-07-07).
-
 - **[P2] `ts-prompt-assist` (and adjacent `ts-res` qualifier surface) needs an API documentation pass once the v0.1 surface settles.**
   PR #380 review surfaced that the recently-extended `ts-prompt-assist` surface — `PromptLibrary` + `IPromptLibraryCreateParams` + `IPromptResolveRequest` + the related fixture / resource-binding / resolve-output types — carries minimal TSDoc on individual methods, parameters, and return shapes. The v0.1 surface has been moving fast (Phase B sub-phases + post-merge cleanups + surface-tidy + round-1 ergonomics absorption), so documenting heavily during churn was the right call; with v0.1 effectively settled now, the next concern is consumer-facing TSDoc quality on the public surface.
 
@@ -126,6 +115,15 @@ opportunistically when the right surface area is touched.
   **Reference**: PR #377 (ts-extras Yaml fix + micro-test pattern landed); original L13 lessons-pending entry; earlier ts-extras `Crypto` bug.
 
 ## P3 — Opportunistic cleanup
+
+- **[P3] `ts-agent-memory` L2 `createMemoryTools` duplicates the store's codec wiring instead of delegating.**
+  `createMemoryTools({ codecs?, defaultCodec? })` (`libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts`) accepts the per-kind identity codecs a second time, in addition to `FileTreeMemoryStore.create({ codecs })`. `memory_write` needs them because `IMemoryStore.put` (`fileTreeMemoryStore.ts:496-502`) validates `envelope.id === codec-derived idStem` and does not derive/stamp the id itself — so a caller building a new `IMemoryRecord` must compute the same `idStem` up front, which requires the same codec the store was constructed with. The testbed scenario passes the same `codecs` map to both constructors, illustrating the drift risk: a host that re-wires the store's codecs but forgets the mirrored `createMemoryTools` config gets a confusing "envelope id does not match codec-derived stem" failure at `put()` time. Scope isolation is NOT compromised (codec `scope` is derived deterministically from `kind`, not from agent input; a mismatch loudly rejects the write rather than writing cross-scope), so this is a DX/robustness smell, not a security gap.
+
+  **Trigger**: when the temporal write path lands (it touches the same `IMemoryStore` write surface) or the next time `createMemoryTools` is extended.
+
+  **Scope sketch**: add an additive method to `IMemoryStore` — e.g. `resolveWriteAddress(kind, entityId): Result<IIdentityCodecResult>` delegating to the store's already-configured `codecs`/`defaultCodec` — and have `memory_write` call it, dropping the `codecs?`/`defaultCodec?` params from `ICreateMemoryToolsParams`. Purely additive on the active `ts-agent-memory` surface; removes the duplicate config and the drift failure mode.
+
+  **Reference**: `agent-memory-l2-tools` stream; code-reviewer pass on the L2 diff (2026-07-07).
 
 - **[P3] ai-assist model-alias layer does NOT cover capability-detection or the typed `*ModelNames` unions — both stay manual on a provider line rotation.**
   The `@<provider>:<role>` alias layer (`ai-assist-model-aliases` stream) fixes model *selection/default* churn: a line rotation is one edit to a descriptor's `aliases` map plus a testbed run. It deliberately does **not** touch two adjacent axes, which still need a manual bump (design §3):

--- a/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
+++ b/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AiAssist } from '@fgv/ts-extras';
 import { Brand } from '@fgv/ts-utils';
 import { Converter } from '@fgv/ts-utils';
 import { FileTree } from '@fgv/ts-json-base';
@@ -46,10 +47,16 @@ export const Convert: {
 };
 
 // @public
+export function createMemoryTools(params: ICreateMemoryToolsParams): ReadonlyArray<AiAssist.IAiClientTool>;
+
+// @public
 export type DedupScope = 'content' | 'entity';
 
 // @public
 export const DEFAULT_DEDUP_SCOPE: DedupScope;
+
+// @public
+export const DEFAULT_MEMORY_TOOLS: ReadonlyArray<MemoryToolName>;
 
 // @public
 export function defaultMemoryScopeEncoding(scope: MemoryScopeKey): Result<string>;
@@ -93,6 +100,18 @@ export interface IBodyConverterRegistry {
     has(kind: Kind): boolean;
     register<T>(kind: Kind, converter: Converter<T>): void;
     registerSchema<T>(kind: Kind, schema: JsonSchema.ISchemaValidator<T>): void;
+}
+
+// @public
+export interface ICreateMemoryToolsParams {
+    readonly codecs?: ReadonlyMap<Kind, IIdentityCodec>;
+    readonly defaultCodec?: IIdentityCodec;
+    readonly handleFor?: (record: IMemoryRecord<unknown>) => string;
+    readonly kinds?: ReadonlyArray<Kind>;
+    readonly registry: IBodyConverterRegistry;
+    readonly retriever: IMemoryRetriever;
+    readonly store: IMemoryStore;
+    readonly tools?: ReadonlyArray<MemoryToolName>;
 }
 
 // @public
@@ -273,6 +292,23 @@ export interface IMemoryStoreListFilter {
 }
 
 // @public
+export interface IMemoryToolResultItem {
+    readonly body: unknown;
+    readonly entityId: EntityId;
+    readonly handle: string;
+    readonly kind: Kind;
+    readonly tags: ReadonlyArray<string>;
+}
+
+// @public
+export interface IMemoryWriteResult {
+    readonly entityId: EntityId;
+    readonly id: MemoryId;
+    readonly kind: Kind;
+    readonly outcome: MemoryWriteOutcome;
+}
+
+// @public
 export interface IMergeStrategy {
     merge(resultSets: ReadonlyArray<ReadonlyArray<IMemoryRecord<unknown>>>): Result<ReadonlyArray<IMemoryRecord<unknown>>>;
 }
@@ -437,6 +473,12 @@ export class MemoryObservationStore implements IMemoryObserver {
 
 // @public
 export type MemoryScopeKey = Brand<string, 'MemoryScopeKey'>;
+
+// @public
+export type MemoryToolName = 'memory_write' | 'memory_read' | 'memory_search' | 'memory_context' | 'memory_delete';
+
+// @public
+export type MemoryWriteOutcome = 'written' | 'deduped';
 
 // @public
 export class MtmIdentityCodec implements IIdentityCodec {

--- a/libraries/ts-agent-memory/src/index.ts
+++ b/libraries/ts-agent-memory/src/index.ts
@@ -10,3 +10,4 @@ export * from './packlets/index';
 export * from './packlets/retrieve';
 export * from './packlets/observe';
 export * from './packlets/vector';
+export * from './packlets/tools';

--- a/libraries/ts-agent-memory/src/packlets/tools/index.ts
+++ b/libraries/ts-agent-memory/src/packlets/tools/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+export * from './memoryTools';

--- a/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
+++ b/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
@@ -1,0 +1,573 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import { JsonSchema } from '@fgv/ts-json-base';
+import { AiAssist } from '@fgv/ts-extras';
+import { Convert, EntityId, IIdentityCodec, IMemoryRecord, Kind, MemoryId, Tag } from '../types';
+import { IBodyConverterRegistry, envelopeConverter } from '../converters';
+import { IMemoryStore } from '../store';
+import { IMemoryQuery, IMemoryRetriever } from '../retrieve';
+
+/**
+ * The names of the five proof-set memory tools. A caller selects a subset via
+ * {@link ICreateMemoryToolsParams.tools | tools}.
+ * @public
+ */
+export type MemoryToolName =
+  | 'memory_write'
+  | 'memory_read'
+  | 'memory_search'
+  | 'memory_context'
+  | 'memory_delete';
+
+/**
+ * The default tool subset when {@link ICreateMemoryToolsParams.tools | tools} is
+ * omitted: the read-only set. Mutating tools (`memory_write` / `memory_delete`)
+ * are **off by default** and must be named explicitly — writes stay
+ * curation-mediated unless the host opts in.
+ * @public
+ */
+export const DEFAULT_MEMORY_TOOLS: ReadonlyArray<MemoryToolName> = ['memory_search', 'memory_context'];
+
+/**
+ * Discriminates the outcome of a {@link createMemoryTools | memory_write} call so
+ * the agent can reason about what its write actually did.
+ *
+ * @remarks
+ * - `written` — a new record was persisted, or an existing entity was updated.
+ * - `deduped` — the content already existed (content-hash dedup no-op); the
+ *   store returned the existing record unchanged.
+ *
+ * The store's public `put` return does not surface cap-cull evictions, so a
+ * `culled` outcome is not distinguishable at this layer without an L1 change or
+ * observer wiring (both out of scope for L2). The writer's own record is always
+ * `written` even when the write triggers a cull of older siblings.
+ * @public
+ */
+export type MemoryWriteOutcome = 'written' | 'deduped';
+
+/**
+ * The success value returned by `memory_write.execute`.
+ * @public
+ */
+export interface IMemoryWriteResult {
+  /** What the write did — see {@link MemoryWriteOutcome}. */
+  readonly outcome: MemoryWriteOutcome;
+  /** The stored record's {@link MemoryId}. */
+  readonly id: MemoryId;
+  /** The domain {@link EntityId} the write targeted. */
+  readonly entityId: EntityId;
+  /** The record's {@link Kind}. */
+  readonly kind: Kind;
+}
+
+/**
+ * A single agent-visible search / context result item. The agent-facing key is
+ * {@link IMemoryToolResultItem.handle | handle}: the host mnemonic when a
+ * {@link ICreateMemoryToolsParams.handleFor | handleFor} hook is supplied, else
+ * the raw {@link MemoryId}.
+ * @public
+ */
+export interface IMemoryToolResultItem {
+  /** The agent-visible key (host handle when supplied, raw {@link MemoryId} otherwise). */
+  readonly handle: string;
+  /** The record's {@link Kind}. */
+  readonly kind: Kind;
+  /** The record's domain {@link EntityId}. */
+  readonly entityId: EntityId;
+  /** The record's tags. */
+  readonly tags: ReadonlyArray<string>;
+  /** The record body (a markdown string in B1). */
+  readonly body: unknown;
+}
+
+/**
+ * Parameters for {@link createMemoryTools}.
+ *
+ * @remarks
+ * **Scope isolation is constructor-fixed.** The {@link
+ * ICreateMemoryToolsParams.store | store} is the sole scope authority — it is the
+ * actor's own, pre-scoped memory root. No tool's `parametersSchema` declares a
+ * `scope` (or any scope-widening) property, so an LLM cannot steer a tool at
+ * another actor's memory.
+ * @public
+ */
+export interface ICreateMemoryToolsParams {
+  /**
+   * The pre-scoped memory store (the actor's own memory root). Sole scope
+   * authority — backs `memory_write` / `memory_read` / `memory_delete`.
+   */
+  readonly store: IMemoryStore;
+  /** Retriever backing `memory_search` (and `memory_context` via link traversal). */
+  readonly retriever: IMemoryRetriever;
+  /** Body converter registry — gates the toolable kinds via `has(kind)`. */
+  readonly registry: IBodyConverterRegistry;
+  /**
+   * The per-tool enable subset. Defaults to {@link DEFAULT_MEMORY_TOOLS} (the
+   * read-only set). Name `memory_write` / `memory_delete` here to opt into the
+   * mutating tools.
+   */
+  readonly tools?: ReadonlyArray<MemoryToolName>;
+  /**
+   * Optional whitelist of toolable kinds. When present, a tool `kind` argument
+   * outside this set is rejected. When absent, {@link
+   * IBodyConverterRegistry.has | registry.has} is the sole kind gate.
+   */
+  readonly kinds?: ReadonlyArray<Kind>;
+  /**
+   * Per-kind identity codecs, used by `memory_write` to map the domain
+   * {@link EntityId} to the record's storage id (the store resolves codecs
+   * internally for `get` / `delete`, so read / delete do not need them). Absent
+   * → `memory_write` uses {@link ICreateMemoryToolsParams.defaultCodec |
+   * defaultCodec}, and fails loudly for a kind with no resolvable codec. The
+   * read-only default tool set needs no codecs.
+   */
+  readonly codecs?: ReadonlyMap<Kind, IIdentityCodec>;
+  /** Default identity codec for kinds without an explicit {@link ICreateMemoryToolsParams.codecs | codecs} entry. */
+  readonly defaultCodec?: IIdentityCodec;
+  /**
+   * Optional host hook mapping a record to its agent-visible handle (an evocative
+   * mnemonic tag). When supplied, `memory_search` / `memory_context` results use
+   * the returned handle as the agent-visible key; when absent the raw
+   * {@link MemoryId} is used.
+   */
+  readonly handleFor?: (record: IMemoryRecord<unknown>) => string;
+}
+
+/** The resolved factory context threaded into each tool's `execute`. */
+interface IToolContext {
+  readonly store: IMemoryStore;
+  readonly retriever: IMemoryRetriever;
+  readonly registry: IBodyConverterRegistry;
+  readonly kinds?: ReadonlyArray<Kind>;
+  readonly codecs?: ReadonlyMap<Kind, IIdentityCodec>;
+  readonly defaultCodec?: IIdentityCodec;
+  readonly handleFor?: (record: IMemoryRecord<unknown>) => string;
+}
+
+// ---------------------------------------------------------------------------
+// Parameter schemas — authored once via JsonSchema.object(...); the schema IS
+// both the wire schema (.toJson()) and the runtime validator (.convert()).
+// NONE of these declare a `scope` (or scope-widening) property — the adoption
+// gate is enforced structurally and asserted in the tests.
+// ---------------------------------------------------------------------------
+
+/** A single attributed link edge as authored by the agent on a write. */
+// eslint-disable-next-line @rushstack/typedef-var
+const linkEdgeSchema = JsonSchema.object({
+  type: JsonSchema.string({ description: 'The relation type of the link.' }),
+  target: JsonSchema.string({ description: 'The MemoryId this edge points at.' }),
+  confidence: JsonSchema.optional(JsonSchema.number({ description: 'Optional confidence in [0, 1].' }))
+});
+
+// eslint-disable-next-line @rushstack/typedef-var
+const writeSchema = JsonSchema.object({
+  kind: JsonSchema.string({ description: 'The record kind (must be an enabled, registered kind).' }),
+  entityId: JsonSchema.string({
+    description:
+      'The domain entity id. For composite (e.g. medium-term) kinds this is the full composite key.'
+  }),
+  body: JsonSchema.string({ description: "The serialized record body; validated by the kind's converter." }),
+  tags: JsonSchema.optional(JsonSchema.array(JsonSchema.string({ description: 'A tag label.' }))),
+  links: JsonSchema.optional(JsonSchema.array(linkEdgeSchema))
+});
+type WriteArgs = JsonSchema.Static<typeof writeSchema>;
+
+// eslint-disable-next-line @rushstack/typedef-var
+const readSchema = JsonSchema.object({
+  kind: JsonSchema.string({ description: 'The record kind.' }),
+  entityId: JsonSchema.string({ description: 'The domain entity id to read.' })
+});
+
+// eslint-disable-next-line @rushstack/typedef-var
+const deleteSchema = JsonSchema.object({
+  kind: JsonSchema.string({ description: 'The record kind.' }),
+  entityId: JsonSchema.string({ description: 'The domain entity id to delete.' })
+});
+
+// eslint-disable-next-line @rushstack/typedef-var
+const searchSchema = JsonSchema.object({
+  kind: JsonSchema.optional(JsonSchema.string({ description: 'Restrict to this kind.' })),
+  tag: JsonSchema.optional(JsonSchema.string({ description: 'Restrict to records carrying this tag.' })),
+  semantic: JsonSchema.optional(
+    JsonSchema.string({ description: 'Semantic query text (requires a semantic-capable retriever).' })
+  ),
+  limit: JsonSchema.optional(JsonSchema.integer({ description: 'Maximum number of results to return.' }))
+});
+
+// eslint-disable-next-line @rushstack/typedef-var
+const contextSchema = JsonSchema.object({
+  from: JsonSchema.string({ description: 'The seed MemoryId to traverse links from.' }),
+  kind: JsonSchema.optional(JsonSchema.string({ description: 'Restrict reached records to this kind.' })),
+  tag: JsonSchema.optional(JsonSchema.string({ description: 'Restrict reached records carrying this tag.' })),
+  hops: JsonSchema.optional(JsonSchema.integer({ description: 'BFS hop count (default 1).' })),
+  limit: JsonSchema.optional(JsonSchema.integer({ description: 'Maximum number of results to return.' }))
+});
+
+// ---------------------------------------------------------------------------
+// Behavior annotations (Component 4) — host-advisory hints; never serialized to
+// the model. openWorldHint is false throughout (a closed, local store).
+// ---------------------------------------------------------------------------
+
+const READ_ONLY_ANNOTATIONS: AiAssist.IAiToolAnnotations = {
+  readOnlyHint: true,
+  openWorldHint: false
+};
+
+const WRITE_ANNOTATIONS: AiAssist.IAiToolAnnotations = {
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: false
+};
+
+const DELETE_ANNOTATIONS: AiAssist.IAiToolAnnotations = {
+  destructiveHint: true,
+  idempotentHint: true,
+  openWorldHint: false
+};
+
+// ---------------------------------------------------------------------------
+// Shared validation / projection helpers
+// ---------------------------------------------------------------------------
+
+/** Validate a `kind` string and assert it is an enabled, registered toolable kind. */
+function assertKindEnabled(ctx: IToolContext, kindStr: string): Result<Kind> {
+  return Convert.kind.convert(kindStr).onSuccess((kind) => {
+    if (!ctx.registry.has(kind)) {
+      return fail(`memory tools: kind '${kind}' has no registered body converter`);
+    }
+    if (ctx.kinds !== undefined && !ctx.kinds.includes(kind)) {
+      return fail(`memory tools: kind '${kind}' is not enabled for memory tools`);
+    }
+    return succeed(kind);
+  });
+}
+
+/** Validate an optional `kind` string (enabled when present; `undefined` passes through). */
+function resolveOptionalKind(ctx: IToolContext, kindStr?: string): Result<Kind | undefined> {
+  if (kindStr === undefined) {
+    return succeed(undefined);
+  }
+  return assertKindEnabled(ctx, kindStr);
+}
+
+/** Project a record into an agent-visible result item, applying the host handle hook when present. */
+function projectItem(ctx: IToolContext, record: IMemoryRecord<unknown>): IMemoryToolResultItem {
+  return {
+    handle: ctx.handleFor !== undefined ? ctx.handleFor(record) : record.envelope.id,
+    kind: record.envelope.kind,
+    entityId: record.envelope.entityId,
+    tags: record.envelope.tags,
+    body: record.body
+  };
+}
+
+/** Resolve the identity codec used by `memory_write` to derive the storage id. */
+function codecForWrite(ctx: IToolContext, kind: Kind): Result<IIdentityCodec> {
+  const codec: IIdentityCodec | undefined = ctx.codecs?.get(kind) ?? ctx.defaultCodec;
+  if (codec === undefined) {
+    return fail(`memory_write: no identity codec available for kind '${kind}'`);
+  }
+  return succeed(codec);
+}
+
+/** Build the record to persist from validated write args (store stamps txn-time metadata). */
+function buildWriteRecord(
+  typed: WriteArgs,
+  kind: Kind,
+  entityId: EntityId,
+  idStem: string
+): Result<IMemoryRecord<unknown>> {
+  // Plain shapes handed to `envelopeConverter`, which validates each field
+  // (type → LinkType, target → MemoryId) and produces the branded IEdge[].
+  const links: ReadonlyArray<Record<string, unknown>> = (typed.links ?? []).map((link) => ({
+    type: link.type,
+    target: link.target,
+    ...(link.confidence !== undefined ? { confidence: link.confidence } : {})
+  }));
+  return envelopeConverter
+    .convert({
+      id: idStem,
+      entityId,
+      kind,
+      tags: typed.tags ?? [],
+      links,
+      created: 0,
+      updated: 0,
+      seq: 0,
+      contentHash: '',
+      provenance: { source: 'agent' }
+    })
+    .withErrorFormat((msg) => `memory_write: invalid record: ${msg}`)
+    .onSuccess((envelope) => succeed({ envelope, body: typed.body }));
+}
+
+/** Resolve the validated write args into the storage id + record (all synchronous). */
+function prepareWrite(
+  ctx: IToolContext,
+  typed: WriteArgs
+): Result<{ readonly kind: Kind; readonly entityId: EntityId; readonly record: IMemoryRecord<unknown> }> {
+  return assertKindEnabled(ctx, typed.kind).onSuccess((kind) =>
+    Convert.entityId.convert(typed.entityId).onSuccess((entityId) =>
+      codecForWrite(ctx, kind).onSuccess((codec) =>
+        codec.encode(entityId).onSuccess((addr) => {
+          if (addr.isVersioned) {
+            return fail(`memory_write: versioned/temporal kind '${kind}' is not supported`);
+          }
+          return buildWriteRecord(typed, kind, entityId, addr.idStem).onSuccess((record) =>
+            succeed({ kind, entityId, record })
+          );
+        })
+      )
+    )
+  );
+}
+
+/**
+ * Discriminate the write outcome from a pre-put snapshot and the returned record.
+ * A dedup no-op returns either a different entity (content-scope dedup) or the
+ * same-id record with an unchanged `seq` (entity-scope re-put); a fresh write or
+ * update advances `seq`.
+ */
+function writeOutcome(
+  before: IMemoryRecord<unknown> | undefined,
+  written: IMemoryRecord<unknown>,
+  entityId: EntityId
+): MemoryWriteOutcome {
+  if (written.envelope.entityId !== entityId) {
+    return 'deduped';
+  }
+  if (before !== undefined && written.envelope.seq === before.envelope.seq) {
+    return 'deduped';
+  }
+  return 'written';
+}
+
+// ---------------------------------------------------------------------------
+// Tool builders — config with a JsonSchema.object(...) parametersSchema; execute
+// validates/narrows → delegates to store/retriever → returns the Result (never
+// swallowed), following the ts-extras-mcp adapter shape.
+//
+// Each `execute` re-runs its own `parametersSchema.convert(args)` even though the
+// `executeClientToolTurn` harness already validates against the same schema. This
+// is deliberate: the factory returns a heterogeneous `ReadonlyArray<IAiClientTool>`
+// (TParams erased to `unknown`, since the members carry different param shapes), so
+// `execute` receives `unknown` and must narrow it back to the typed args. The
+// re-validation is also the narrowing step exercised by the direct-call tests (which
+// invoke `execute` with raw args, bypassing the harness). Re-validating an
+// already-conforming shape is a cheap, side-effect-free identity.
+// ---------------------------------------------------------------------------
+
+function buildWriteTool(ctx: IToolContext): AiAssist.IAiClientTool {
+  return {
+    config: {
+      type: 'client_tool',
+      name: 'memory_write',
+      description:
+        'Store a new memory record or update an existing one by (kind, entityId). ' +
+        'Identical content is a no-op that returns the existing record.',
+      parametersSchema: writeSchema,
+      annotations: WRITE_ANNOTATIONS
+    },
+    execute: async (args: unknown): Promise<Result<unknown>> =>
+      writeSchema
+        .convert(args)
+        .withErrorFormat((msg) => `memory_write: invalid arguments: ${msg}`)
+        .onSuccess((typed) => prepareWrite(ctx, typed))
+        .thenOnSuccess(async ({ kind, entityId, record }) =>
+          // Read the prior record to discriminate written-vs-deduped. A `Failure`
+          // here (corrupt file, I/O error, codec round-trip failure) is a real
+          // condition distinct from the "not found" success (`undefined`); propagate
+          // it rather than defaulting it away, so a genuine store fault surfaces
+          // instead of being masked as a normal write.
+          (await ctx.store.get(kind, entityId)).thenOnSuccess(async (before) =>
+            (await ctx.store.put(record)).onSuccess((persisted) =>
+              succeed<IMemoryWriteResult>({
+                outcome: writeOutcome(before, persisted, entityId),
+                id: persisted.envelope.id,
+                entityId,
+                kind
+              })
+            )
+          )
+        )
+  };
+}
+
+function buildReadTool(ctx: IToolContext): AiAssist.IAiClientTool {
+  return {
+    config: {
+      type: 'client_tool',
+      name: 'memory_read',
+      description: 'Read a specific memory record by (kind, entityId).',
+      parametersSchema: readSchema,
+      annotations: READ_ONLY_ANNOTATIONS
+    },
+    execute: async (args: unknown): Promise<Result<unknown>> =>
+      readSchema
+        .convert(args)
+        .withErrorFormat((msg) => `memory_read: invalid arguments: ${msg}`)
+        .onSuccess((typed) =>
+          assertKindEnabled(ctx, typed.kind).onSuccess((kind) =>
+            Convert.entityId.convert(typed.entityId).onSuccess((entityId) => succeed({ kind, entityId }))
+          )
+        )
+        .thenOnSuccess(async ({ kind, entityId }) =>
+          (await ctx.store.get(kind, entityId)).onSuccess((record) =>
+            record === undefined
+              ? succeed({ found: false })
+              : succeed({ found: true, item: projectItem(ctx, record) })
+          )
+        )
+  };
+}
+
+function buildSearchTool(ctx: IToolContext): AiAssist.IAiClientTool {
+  return {
+    config: {
+      type: 'client_tool',
+      name: 'memory_search',
+      description: 'Search memories by tag, kind, or semantic text. Returns ranked results.',
+      parametersSchema: searchSchema,
+      annotations: READ_ONLY_ANNOTATIONS
+    },
+    execute: async (args: unknown): Promise<Result<unknown>> =>
+      searchSchema
+        .convert(args)
+        .withErrorFormat((msg) => `memory_search: invalid arguments: ${msg}`)
+        .onSuccess((typed) =>
+          resolveOptionalKind(ctx, typed.kind).onSuccess((kind) =>
+            resolveOptionalTag(typed.tag).onSuccess((tag) => succeed({ typed, kind, tag }))
+          )
+        )
+        .thenOnSuccess(async ({ typed, kind, tag }) => {
+          const query: IMemoryQuery = {
+            ...(kind !== undefined ? { kind } : {}),
+            ...(tag !== undefined ? { tag } : {}),
+            ...(typed.semantic !== undefined ? { semantic: typed.semantic } : {}),
+            ...(typed.limit !== undefined ? { limit: typed.limit } : {})
+          };
+          return (await ctx.retriever.retrieve(query)).onSuccess((records) =>
+            succeed({ count: records.length, results: records.map((r) => projectItem(ctx, r)) })
+          );
+        })
+  };
+}
+
+function buildContextTool(ctx: IToolContext): AiAssist.IAiClientTool {
+  return {
+    config: {
+      type: 'client_tool',
+      name: 'memory_context',
+      description:
+        'Build a context graph from a seed memory: returns the records linked from the seed, up to `hops` hops.',
+      parametersSchema: contextSchema,
+      annotations: READ_ONLY_ANNOTATIONS
+    },
+    execute: async (args: unknown): Promise<Result<unknown>> =>
+      contextSchema
+        .convert(args)
+        .withErrorFormat((msg) => `memory_context: invalid arguments: ${msg}`)
+        .onSuccess((typed) =>
+          Convert.memoryId
+            .convert(typed.from)
+            .onSuccess((from) =>
+              resolveOptionalKind(ctx, typed.kind).onSuccess((kind) =>
+                resolveOptionalTag(typed.tag).onSuccess((tag) => succeed({ typed, from, kind, tag }))
+              )
+            )
+        )
+        .thenOnSuccess(async ({ typed, from, kind, tag }) => {
+          const query: IMemoryQuery = {
+            linkedFrom: from,
+            ...(kind !== undefined ? { kind } : {}),
+            ...(tag !== undefined ? { tag } : {}),
+            ...(typed.hops !== undefined ? { hops: typed.hops } : {}),
+            ...(typed.limit !== undefined ? { limit: typed.limit } : {})
+          };
+          return (await ctx.retriever.retrieve(query)).onSuccess((records) =>
+            succeed({ seed: from, count: records.length, results: records.map((r) => projectItem(ctx, r)) })
+          );
+        })
+  };
+}
+
+function buildDeleteTool(ctx: IToolContext): AiAssist.IAiClientTool {
+  return {
+    config: {
+      type: 'client_tool',
+      name: 'memory_delete',
+      description: 'Delete a memory record by (kind, entityId). Destructive for non-temporal kinds.',
+      parametersSchema: deleteSchema,
+      annotations: DELETE_ANNOTATIONS
+    },
+    execute: async (args: unknown): Promise<Result<unknown>> =>
+      deleteSchema
+        .convert(args)
+        .withErrorFormat((msg) => `memory_delete: invalid arguments: ${msg}`)
+        .onSuccess((typed) =>
+          assertKindEnabled(ctx, typed.kind).onSuccess((kind) =>
+            Convert.entityId.convert(typed.entityId).onSuccess((entityId) => succeed({ kind, entityId }))
+          )
+        )
+        .thenOnSuccess(async ({ kind, entityId }) =>
+          (await ctx.store.delete(kind, entityId)).onSuccess((id) =>
+            succeed({ deleted: true, id, entityId, kind })
+          )
+        )
+  };
+}
+
+/** Validate an optional `tag` string (`undefined` passes through). */
+function resolveOptionalTag(tagStr?: string): Result<Tag | undefined> {
+  if (tagStr === undefined) {
+    return succeed(undefined);
+  }
+  return Convert.tag.convert(tagStr);
+}
+
+/** Ordered registry of the five tool builders, keyed by name. */
+const TOOL_BUILDERS: ReadonlyArray<{
+  readonly name: MemoryToolName;
+  readonly build: (ctx: IToolContext) => AiAssist.IAiClientTool;
+}> = [
+  { name: 'memory_write', build: buildWriteTool },
+  { name: 'memory_read', build: buildReadTool },
+  { name: 'memory_search', build: buildSearchTool },
+  { name: 'memory_context', build: buildContextTool },
+  { name: 'memory_delete', build: buildDeleteTool }
+];
+
+/**
+ * Build the selected suite of memory `AiAssist.IAiClientTool`s over a
+ * pre-scoped store — ready to hand to `AiAssist.executeClientToolTurn` (and, via
+ * the shared `JsonSchema.object(...)` schemas, `@fgv/ts-extras-mcp`).
+ *
+ * @remarks
+ * **Scope isolation is make-or-break.** The returned tools close over the
+ * pre-scoped {@link ICreateMemoryToolsParams.store | store}; no tool's
+ * `parametersSchema` declares a `scope` (or any scope-widening) property, so an
+ * LLM cannot steer a tool at another actor's memory. The store instance is the
+ * sole scope authority.
+ *
+ * The default selection is {@link DEFAULT_MEMORY_TOOLS} (the read-only set) —
+ * `memory_write` / `memory_delete` are included only when named in
+ * {@link ICreateMemoryToolsParams.tools | tools}.
+ * @public
+ */
+export function createMemoryTools(params: ICreateMemoryToolsParams): ReadonlyArray<AiAssist.IAiClientTool> {
+  const ctx: IToolContext = {
+    store: params.store,
+    retriever: params.retriever,
+    registry: params.registry,
+    kinds: params.kinds,
+    codecs: params.codecs,
+    defaultCodec: params.defaultCodec,
+    handleFor: params.handleFor
+  };
+  const selected: ReadonlySet<MemoryToolName> = new Set<MemoryToolName>(params.tools ?? DEFAULT_MEMORY_TOOLS);
+  return TOOL_BUILDERS.filter((builder) => selected.has(builder.name)).map((builder) => builder.build(ctx));
+}

--- a/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
+++ b/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Result, fail, succeed } from '@fgv/ts-utils';
+import { Result, captureResult, fail, succeed } from '@fgv/ts-utils';
 import { JsonSchema } from '@fgv/ts-json-base';
 import { AiAssist } from '@fgv/ts-extras';
 import { Convert, EntityId, IIdentityCodec, IMemoryRecord, Kind, MemoryId, Tag } from '../types';
@@ -256,8 +256,14 @@ function resolveOptionalKind(ctx: IToolContext, kindStr?: string): Result<Kind |
 
 /** Project a record into an agent-visible result item, applying the host handle hook when present. */
 function projectItem(ctx: IToolContext, record: IMemoryRecord<unknown>): IMemoryToolResultItem {
+  // `handleFor` is a host callback; guard it so a throw degrades to the raw id rather than
+  // escaping the Result chain (and crashing the whole search/context call).
+  const handle =
+    ctx.handleFor !== undefined
+      ? captureResult(() => ctx.handleFor!(record)).orDefault(record.envelope.id)
+      : record.envelope.id;
   return {
-    handle: ctx.handleFor !== undefined ? ctx.handleFor(record) : record.envelope.id,
+    handle,
     kind: record.envelope.kind,
     entityId: record.envelope.entityId,
     tags: record.envelope.tags,

--- a/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
@@ -605,6 +605,26 @@ describe('createMemoryTools', () => {
       });
     });
 
+    test('falls back to the raw id when a throwing handleFor would otherwise escape', async () => {
+      const retriever = makeRetriever([{ id: 'doc-1', tags: ['topic'] }]);
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever,
+          registry: registryWith([{ kind: knowledgeKind }]),
+          handleFor: () => {
+            throw new Error('host handle hook blew up');
+          }
+        }),
+        'memory_search'
+      );
+      // A throwing host callback must not crash the search; the item degrades to the raw id.
+      expect(await tool.execute({ tag: 'topic', limit: 5 })).toSucceedAndSatisfy((value) => {
+        const out = value as { results: ReadonlyArray<IMemoryToolResultItem> };
+        expect(out.results[0].handle).toBe('doc-1');
+      });
+    });
+
     test('loud-degrades on the unwired semantic axis', async () => {
       const retriever = makeRetriever([{ id: 'doc-1' }]);
       const tool = toolByName(

--- a/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
@@ -1,0 +1,751 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converter, Converters, Result, fail, succeed } from '@fgv/ts-utils';
+import { FileTree, JsonObject } from '@fgv/ts-json-base';
+import { AiAssist } from '@fgv/ts-extras';
+import {
+  AdmissionDecision,
+  BodyConverterRegistry,
+  DEFAULT_MEMORY_TOOLS,
+  FileTreeMemoryStore,
+  HybridRetriever,
+  IBodyConverterRegistry,
+  IIdentityCodec,
+  IIndexedMemoryRecord,
+  IMemoryRecord,
+  IMemoryStore,
+  IMemoryToolResultItem,
+  IMemoryWriteResult,
+  IWritePolicy,
+  Kind,
+  KnowledgeIdentityCodec,
+  LinkTraversalRetriever,
+  MemoryIndex,
+  IIdentityCodecResult,
+  MemoryScopeKey,
+  MemoryToolName,
+  MtmIdentityCodec,
+  RecencyRetriever,
+  ScoreUnionMergeStrategy,
+  StructuredFilterRetriever,
+  TagRetriever,
+  createMemoryTools,
+  envelopeConverter
+} from '../../../index';
+
+const knowledgeKind: Kind = 'knowledge' as Kind;
+const mtmKind: Kind = 'mtm' as Kind;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function mutableRoot(): FileTree.IMutableFileTreeDirectoryItem {
+  const tree = FileTree.inMemory([], { mutable: true }).orThrow();
+  const root = tree.getDirectory('/').orThrow();
+  if (!FileTree.isMutableDirectoryItem(root)) {
+    throw new Error('expected a mutable root directory');
+  }
+  return root;
+}
+
+function registryWith(
+  entries: ReadonlyArray<{ kind: Kind; converter?: Converter<string> }>
+): IBodyConverterRegistry {
+  const registry = BodyConverterRegistry.create().orThrow();
+  for (const entry of entries) {
+    registry.register(entry.kind, entry.converter ?? Converters.string);
+  }
+  return registry;
+}
+
+const codecs: ReadonlyMap<Kind, IIdentityCodec> = new Map<Kind, IIdentityCodec>([
+  [knowledgeKind, new KnowledgeIdentityCodec()],
+  [mtmKind, new MtmIdentityCodec()]
+]);
+
+/** A write policy that always rejects — exercises the admit-reject → fail path. */
+class RejectingPolicy implements IWritePolicy {
+  public readonly mutableFields: ReadonlyArray<string> = ['body'];
+  public admit(): Result<AdmissionDecision> {
+    return succeed({ decision: 'reject', reason: 'blocked by test policy' });
+  }
+  public applyUpdate(existing: IMemoryRecord<unknown>): Result<IMemoryRecord<unknown>> {
+    return succeed(existing);
+  }
+}
+
+function makeStore(
+  params: {
+    registry?: IBodyConverterRegistry;
+    writePolicies?: ReadonlyMap<Kind, IWritePolicy>;
+  } = {}
+): FileTreeMemoryStore {
+  return FileTreeMemoryStore.create({
+    root: mutableRoot(),
+    registry: params.registry ?? registryWith([{ kind: knowledgeKind }, { kind: mtmKind }]),
+    codecs,
+    writePolicies: params.writePolicies
+  }).orThrow();
+}
+
+interface IEntrySpec {
+  readonly id: string;
+  readonly scope?: string;
+  readonly kind?: string;
+  readonly entityId?: string;
+  readonly tags?: ReadonlyArray<string>;
+  readonly updated?: number;
+  readonly links?: ReadonlyArray<string>;
+}
+
+function makeEntry(spec: IEntrySpec): IIndexedMemoryRecord {
+  const record: IMemoryRecord<unknown> = {
+    envelope: envelopeConverter
+      .convert({
+        id: spec.id,
+        entityId: spec.entityId ?? spec.id,
+        kind: spec.kind ?? 'knowledge',
+        tags: spec.tags ?? [],
+        links: (spec.links ?? []).map((target) => ({ type: 'rel', target })),
+        created: 0,
+        updated: spec.updated ?? 0,
+        seq: 0,
+        contentHash: 'h',
+        provenance: { source: 'agent' }
+      })
+      .orThrow(),
+    body: `body-${spec.id}`
+  };
+  return { scope: (spec.scope ?? 'knowledge') as MemoryScopeKey, record };
+}
+
+function makeIndex(specs: ReadonlyArray<IEntrySpec>): MemoryIndex {
+  const index = MemoryIndex.create().orThrow();
+  index.rebuild(specs.map(makeEntry)).orThrow();
+  return index;
+}
+
+/**
+ * A HybridRetriever (structured + tag) over the given entries — the seedless
+ * `memory_search` backing. A bare `LinkTraversalRetriever` is intentionally NOT
+ * composed here: it hard-fails a seedless query, so link traversal is the
+ * separate `memory_context` retriever.
+ */
+function makeRetriever(specs: ReadonlyArray<IEntrySpec>): HybridRetriever {
+  const index = makeIndex(specs);
+  return HybridRetriever.create(
+    [
+      RecencyRetriever.create(index).orThrow(),
+      StructuredFilterRetriever.create(index).orThrow(),
+      TagRetriever.create(index).orThrow()
+    ],
+    ScoreUnionMergeStrategy.create().orThrow()
+  ).orThrow();
+}
+
+/** A LinkTraversalRetriever over the given entries — the `memory_context` backing. */
+function makeLinkRetriever(specs: ReadonlyArray<IEntrySpec>): LinkTraversalRetriever {
+  return LinkTraversalRetriever.create(makeIndex(specs)).orThrow();
+}
+
+/** Build the full five-tool suite for structural / annotation inspection. */
+function allTools(
+  overrides: Partial<Parameters<typeof createMemoryTools>[0]> = {}
+): ReadonlyArray<AiAssist.IAiClientTool> {
+  return createMemoryTools({
+    store: overrides.store ?? makeStore(),
+    retriever: overrides.retriever ?? makeRetriever([]),
+    registry: overrides.registry ?? registryWith([{ kind: knowledgeKind }, { kind: mtmKind }]),
+    codecs,
+    tools: ['memory_write', 'memory_read', 'memory_search', 'memory_context', 'memory_delete'],
+    ...overrides
+  });
+}
+
+function toolByName(
+  tools: ReadonlyArray<AiAssist.IAiClientTool>,
+  name: MemoryToolName
+): AiAssist.IAiClientTool {
+  const tool = tools.find((t) => t.config.name === name);
+  if (tool === undefined) {
+    throw new Error(`tool '${name}' not found`);
+  }
+  return tool;
+}
+
+/** The property names declared by a tool's JSON-schema. */
+function schemaProperties(tool: AiAssist.IAiClientTool): string[] {
+  const json = tool.config.parametersSchema.toJson() as JsonObject;
+  return Object.keys((json.properties as JsonObject) ?? {});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createMemoryTools', () => {
+  describe('tool subset selection', () => {
+    test('defaults to the read-only set (excludes memory_write / memory_delete)', () => {
+      const tools = createMemoryTools({
+        store: makeStore(),
+        retriever: makeRetriever([]),
+        registry: registryWith([{ kind: knowledgeKind }])
+      });
+      expect(tools.map((t) => t.config.name)).toEqual(['memory_search', 'memory_context']);
+      expect(DEFAULT_MEMORY_TOOLS).toEqual(['memory_search', 'memory_context']);
+    });
+
+    test('includes memory_write / memory_delete only when named', () => {
+      const tools = createMemoryTools({
+        store: makeStore(),
+        retriever: makeRetriever([]),
+        registry: registryWith([{ kind: knowledgeKind }]),
+        codecs,
+        tools: ['memory_write', 'memory_delete']
+      });
+      expect(tools.map((t) => t.config.name)).toEqual(['memory_write', 'memory_delete']);
+    });
+
+    test('returns tools in a stable builder order regardless of selection order', () => {
+      const tools = createMemoryTools({
+        store: makeStore(),
+        retriever: makeRetriever([]),
+        registry: registryWith([{ kind: knowledgeKind }]),
+        codecs,
+        tools: ['memory_delete', 'memory_search', 'memory_write']
+      });
+      expect(tools.map((t) => t.config.name)).toEqual(['memory_write', 'memory_search', 'memory_delete']);
+    });
+
+    test('an empty selection yields no tools', () => {
+      const tools = createMemoryTools({
+        store: makeStore(),
+        retriever: makeRetriever([]),
+        registry: registryWith([{ kind: knowledgeKind }]),
+        tools: []
+      });
+      expect(tools).toEqual([]);
+    });
+  });
+
+  describe('scope isolation (adoption gate)', () => {
+    test('NO tool schema declares a scope (or scope-widening) property', () => {
+      const tools = allTools();
+      expect(tools).toHaveLength(5);
+      for (const tool of tools) {
+        const props = schemaProperties(tool);
+        expect(props.length).toBeGreaterThan(0);
+        for (const prop of props) {
+          expect(prop.toLowerCase()).not.toContain('scope');
+        }
+      }
+    });
+  });
+
+  describe('behavior annotations (Component 4)', () => {
+    test('read-only tools are readOnlyHint with openWorldHint false', () => {
+      const tools = allTools();
+      for (const name of ['memory_search', 'memory_context', 'memory_read'] as const) {
+        expect(toolByName(tools, name).config.annotations).toEqual({
+          readOnlyHint: true,
+          openWorldHint: false
+        });
+      }
+    });
+
+    test('memory_write is non-destructive, non-idempotent, closed-world', () => {
+      expect(toolByName(allTools(), 'memory_write').config.annotations).toEqual({
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false
+      });
+    });
+
+    test('memory_delete is destructive, idempotent, closed-world', () => {
+      expect(toolByName(allTools(), 'memory_delete').config.annotations).toEqual({
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false
+      });
+    });
+  });
+
+  describe('parametersSchema validation', () => {
+    test('memory_write accepts a well-formed record and rejects a missing body', () => {
+      const schema = toolByName(allTools(), 'memory_write').config.parametersSchema;
+      expect(schema.convert({ kind: 'knowledge', entityId: 'doc-1', body: 'hello' })).toSucceed();
+      expect(
+        schema.convert({
+          kind: 'knowledge',
+          entityId: 'doc-1',
+          body: 'hello',
+          tags: ['a'],
+          links: [{ type: 'rel', target: 'doc-2', confidence: 0.5 }]
+        })
+      ).toSucceed();
+      expect(schema.convert({ kind: 'knowledge', entityId: 'doc-1' })).toFail();
+    });
+
+    test('memory_read / memory_delete require kind and entityId', () => {
+      for (const name of ['memory_read', 'memory_delete'] as const) {
+        const schema = toolByName(allTools(), name).config.parametersSchema;
+        expect(schema.convert({ kind: 'knowledge', entityId: 'doc-1' })).toSucceed();
+        expect(schema.convert({ kind: 'knowledge' })).toFail();
+      }
+    });
+
+    test('memory_search rejects a non-integer limit and accepts an all-optional query', () => {
+      const schema = toolByName(allTools(), 'memory_search').config.parametersSchema;
+      expect(schema.convert({})).toSucceed();
+      expect(schema.convert({ tag: 'x', limit: 3 })).toSucceed();
+      expect(schema.convert({ limit: 'three' })).toFail();
+    });
+
+    test('memory_context requires a from seed', () => {
+      const schema = toolByName(allTools(), 'memory_context').config.parametersSchema;
+      expect(schema.convert({ from: 'doc-1' })).toSucceed();
+      expect(schema.convert({ hops: 2 })).toFail();
+    });
+  });
+
+  describe('memory_write', () => {
+    async function write(
+      tool: AiAssist.IAiClientTool,
+      args: Record<string, unknown>
+    ): Promise<Result<unknown>> {
+      return tool.execute(args);
+    }
+
+    test('writes a new record (outcome: written) and round-trips through memory_read', async () => {
+      const store = makeStore();
+      const tools = createMemoryTools({
+        store,
+        retriever: makeRetriever([]),
+        registry: registryWith([{ kind: knowledgeKind }]),
+        codecs,
+        tools: ['memory_write', 'memory_read']
+      });
+      const writeTool = toolByName(tools, 'memory_write');
+      expect(
+        await write(writeTool, { kind: 'knowledge', entityId: 'doc-1', body: 'first', tags: ['t'] })
+      ).toSucceedAndSatisfy((value) => {
+        const result = value as IMemoryWriteResult;
+        expect(result.outcome).toBe('written');
+        expect(result.id).toBe('doc-1');
+        expect(result.entityId).toBe('doc-1');
+      });
+      expect(
+        await toolByName(tools, 'memory_read').execute({ kind: 'knowledge', entityId: 'doc-1' })
+      ).toSucceedAndSatisfy((value) => {
+        const read = value as { found: boolean; item: IMemoryToolResultItem };
+        expect(read.found).toBe(true);
+        expect(read.item.body).toBe('first');
+        expect(read.item.tags).toEqual(['t']);
+      });
+    });
+
+    test('persists authored links (with confidence) on the written record', async () => {
+      const store = makeStore();
+      const tools = createMemoryTools({
+        store,
+        retriever: makeRetriever([]),
+        registry: registryWith([{ kind: knowledgeKind }]),
+        codecs,
+        tools: ['memory_write', 'memory_read']
+      });
+      expect(
+        await toolByName(tools, 'memory_write').execute({
+          kind: 'knowledge',
+          entityId: 'doc-1',
+          body: 'linked',
+          links: [
+            { type: 'rel', target: 'doc-2', confidence: 0.9 },
+            { type: 'rel', target: 'doc-3' }
+          ]
+        })
+      ).toSucceedAndSatisfy((v) => expect((v as IMemoryWriteResult).outcome).toBe('written'));
+      expect(
+        await toolByName(tools, 'memory_read').execute({ kind: 'knowledge', entityId: 'doc-1' })
+      ).toSucceedAndSatisfy(() => undefined);
+    });
+
+    test('an identical re-put of the same entity is a dedup no-op (outcome: deduped)', async () => {
+      const store = makeStore();
+      const tool = toolByName(allTools({ store }), 'memory_write');
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-1', body: 'same' })).toSucceedAndSatisfy(
+        (v) => expect((v as IMemoryWriteResult).outcome).toBe('written')
+      );
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-1', body: 'same' })).toSucceedAndSatisfy(
+        (v) => expect((v as IMemoryWriteResult).outcome).toBe('deduped')
+      );
+    });
+
+    test('content-scope dedup under a different entity reports deduped', async () => {
+      const store = makeStore();
+      const tool = toolByName(allTools({ store }), 'memory_write');
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-a', body: 'shared' })).toSucceed();
+      // Knowledge dedups scope-wide: identical body under a different docId is a no-op
+      // that returns the existing (different-entity) record.
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-b', body: 'shared' })).toSucceedAndSatisfy(
+        (v) => expect((v as IMemoryWriteResult).outcome).toBe('deduped')
+      );
+    });
+
+    test('an update with new content reports written', async () => {
+      const store = makeStore();
+      const tool = toolByName(allTools({ store }), 'memory_write');
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-1', body: 'v1' })).toSucceed();
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-1', body: 'v2' })).toSucceedAndSatisfy(
+        (v) => expect((v as IMemoryWriteResult).outcome).toBe('written')
+      );
+    });
+
+    test('maps an MTM composite entityId to its turn stem', async () => {
+      const store = makeStore();
+      const tools = createMemoryTools({
+        store,
+        retriever: makeRetriever([]),
+        registry: registryWith([{ kind: knowledgeKind }, { kind: mtmKind }]),
+        codecs,
+        tools: ['memory_write', 'memory_read']
+      });
+      expect(
+        await toolByName(tools, 'memory_write').execute({
+          kind: 'mtm',
+          entityId: 'conv-1:7',
+          body: 'turn body'
+        })
+      ).toSucceedAndSatisfy((value) => {
+        const result = value as IMemoryWriteResult;
+        expect(result.id).toBe('turn-7');
+        expect(result.entityId).toBe('conv-1:7');
+      });
+      // Read back via the same composite entityId.
+      expect(
+        await toolByName(tools, 'memory_read').execute({ kind: 'mtm', entityId: 'conv-1:7' })
+      ).toSucceedAndSatisfy((value) => {
+        expect((value as { found: boolean }).found).toBe(true);
+      });
+    });
+
+    test('a body the kind converter rejects fails the write', async () => {
+      const rejectBad: Converter<string> = Converters.string.map((s) =>
+        s === 'BAD' ? fail('body not allowed') : succeed(s)
+      );
+      const registry = registryWith([{ kind: knowledgeKind, converter: rejectBad }]);
+      const store = makeStore({ registry });
+      const tool = toolByName(allTools({ store, registry }), 'memory_write');
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-1', body: 'BAD' })).toFailWith(
+        /invalid body|body not allowed/i
+      );
+    });
+
+    test('a policy admit-reject surfaces as a failure', async () => {
+      const store = makeStore({
+        writePolicies: new Map<Kind, IWritePolicy>([[knowledgeKind, new RejectingPolicy()]])
+      });
+      const tool = toolByName(allTools({ store }), 'memory_write');
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-1', body: 'x' })).toFailWith(
+        /rejected by policy|blocked by test policy/i
+      );
+    });
+
+    test('fails when no codec is available for the kind', async () => {
+      const store = makeStore();
+      const tool = toolByName(
+        createMemoryTools({
+          store,
+          retriever: makeRetriever([]),
+          registry: registryWith([{ kind: knowledgeKind }]),
+          tools: ['memory_write'] // no codecs / defaultCodec supplied
+        }),
+        'memory_write'
+      );
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-1', body: 'x' })).toFailWith(
+        /no identity codec available/i
+      );
+    });
+
+    test('rejects a kind with no registered converter', async () => {
+      const tool = toolByName(allTools(), 'memory_write');
+      expect(await write(tool, { kind: 'unregistered', entityId: 'doc-1', body: 'x' })).toFailWith(
+        /no registered body converter/i
+      );
+    });
+
+    test('rejects a kind outside the kinds whitelist', async () => {
+      const tool = toolByName(allTools({ kinds: [mtmKind] }), 'memory_write');
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-1', body: 'x' })).toFailWith(
+        /not enabled for memory tools/i
+      );
+    });
+
+    test('propagates a store.get failure (does not mask a real fault as a fresh write)', async () => {
+      const failingStore: IMemoryStore = {
+        get: async () => fail('disk fault'),
+        getById: async () => fail('unused'),
+        list: async () => succeed([]),
+        put: async (record) => succeed(record),
+        delete: async () => fail('unused')
+      };
+      const tool = toolByName(
+        createMemoryTools({
+          store: failingStore,
+          retriever: makeRetriever([]),
+          registry: registryWith([{ kind: knowledgeKind }]),
+          codecs,
+          tools: ['memory_write']
+        }),
+        'memory_write'
+      );
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-1', body: 'x' })).toFailWith(
+        /disk fault/i
+      );
+    });
+
+    test('rejects a versioned/temporal kind', async () => {
+      const versionedCodec: IIdentityCodec = {
+        encode: (entityId): Result<IIdentityCodecResult> =>
+          succeed({ scope: 'knowledge' as MemoryScopeKey, idStem: entityId as string, isVersioned: true }),
+        decode: (): Result<never> => fail('unused'),
+        verifyRoundTrip: (): Result<true> => succeed(true)
+      };
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever: makeRetriever([]),
+          registry: registryWith([{ kind: knowledgeKind }]),
+          codecs: new Map<Kind, IIdentityCodec>([[knowledgeKind, versionedCodec]]),
+          tools: ['memory_write']
+        }),
+        'memory_write'
+      );
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-1', body: 'x' })).toFailWith(
+        /versioned\/temporal kind .* is not supported/i
+      );
+    });
+
+    test('rejects malformed arguments', async () => {
+      const tool = toolByName(allTools(), 'memory_write');
+      expect(await write(tool, { kind: 'knowledge', entityId: 'doc-1' })).toFailWith(/invalid arguments/i);
+    });
+  });
+
+  describe('memory_read', () => {
+    test('returns found:false when the record is absent', async () => {
+      const tool = toolByName(allTools(), 'memory_read');
+      expect(await tool.execute({ kind: 'knowledge', entityId: 'missing' })).toSucceedWith({ found: false });
+    });
+
+    test('applies the handleFor hook to the returned item', async () => {
+      const store = makeStore();
+      const tools = createMemoryTools({
+        store,
+        retriever: makeRetriever([]),
+        registry: registryWith([{ kind: knowledgeKind }]),
+        codecs,
+        tools: ['memory_write', 'memory_read'],
+        handleFor: (r) => `mnemonic:${r.envelope.id}`
+      });
+      await toolByName(tools, 'memory_write').execute({ kind: 'knowledge', entityId: 'doc-1', body: 'b' });
+      expect(
+        await toolByName(tools, 'memory_read').execute({ kind: 'knowledge', entityId: 'doc-1' })
+      ).toSucceedAndSatisfy((value) => {
+        const read = value as { found: boolean; item: IMemoryToolResultItem };
+        expect(read.item.handle).toBe('mnemonic:doc-1');
+      });
+    });
+
+    test('propagates a store failure (bad entityId)', async () => {
+      const tool = toolByName(allTools(), 'memory_read');
+      expect(await tool.execute({ kind: 'knowledge', entityId: '   ' })).toFail();
+    });
+  });
+
+  describe('memory_search', () => {
+    test('returns projected results keyed by raw MemoryId when no handleFor is supplied', async () => {
+      const retriever = makeRetriever([
+        { id: 'doc-1', tags: ['topic'] },
+        { id: 'doc-2', tags: ['topic'] }
+      ]);
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever,
+          registry: registryWith([{ kind: knowledgeKind }])
+        }),
+        'memory_search'
+      );
+      expect(await tool.execute({ tag: 'topic' })).toSucceedAndSatisfy((value) => {
+        const out = value as { count: number; results: ReadonlyArray<IMemoryToolResultItem> };
+        expect(out.count).toBe(2);
+        expect(out.results.map((r) => r.handle).sort()).toEqual(['doc-1', 'doc-2']);
+      });
+    });
+
+    test('uses the host handle (mnemonic) as the agent-visible key when handleFor is supplied', async () => {
+      const retriever = makeRetriever([{ id: 'doc-1', tags: ['topic'] }]);
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever,
+          registry: registryWith([{ kind: knowledgeKind }]),
+          handleFor: (r) => `@${r.envelope.id}`
+        }),
+        'memory_search'
+      );
+      expect(await tool.execute({ tag: 'topic', limit: 5 })).toSucceedAndSatisfy((value) => {
+        const out = value as { results: ReadonlyArray<IMemoryToolResultItem> };
+        expect(out.results[0].handle).toBe('@doc-1');
+      });
+    });
+
+    test('loud-degrades on the unwired semantic axis', async () => {
+      const retriever = makeRetriever([{ id: 'doc-1' }]);
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever,
+          registry: registryWith([{ kind: knowledgeKind }])
+        }),
+        'memory_search'
+      );
+      expect(await tool.execute({ semantic: 'find me' })).toFailWith(
+        /semantic recall requires a vector index/i
+      );
+    });
+
+    test('rejects a kind outside the kinds whitelist', async () => {
+      const retriever = makeRetriever([{ id: 'doc-1' }]);
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever,
+          registry: registryWith([{ kind: knowledgeKind }]),
+          kinds: [knowledgeKind]
+        }),
+        'memory_search'
+      );
+      expect(await tool.execute({ kind: 'mtm' })).toFailWith(/no registered body converter|not enabled/i);
+    });
+
+    test('filters by a validated kind', async () => {
+      const retriever = makeRetriever([
+        { id: 'doc-1', kind: 'knowledge' },
+        { id: 'turn-0', kind: 'mtm', scope: 'conversations/conv-1' }
+      ]);
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever,
+          registry: registryWith([{ kind: knowledgeKind }, { kind: mtmKind }])
+        }),
+        'memory_search'
+      );
+      expect(await tool.execute({ kind: 'knowledge' })).toSucceedAndSatisfy((value) => {
+        const out = value as { results: ReadonlyArray<IMemoryToolResultItem> };
+        expect(out.results.map((r) => r.handle)).toEqual(['doc-1']);
+      });
+    });
+
+    test('rejects malformed arguments', async () => {
+      const tool = toolByName(allTools(), 'memory_search');
+      expect(await tool.execute({ limit: 'nope' })).toFailWith(/invalid arguments/i);
+    });
+  });
+
+  describe('memory_context', () => {
+    test('returns the neighbors reachable from a seed', async () => {
+      const retriever = makeLinkRetriever([
+        { id: 'a', links: ['b', 'c'] },
+        { id: 'b', updated: 20 },
+        { id: 'c', updated: 10 }
+      ]);
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever,
+          registry: registryWith([{ kind: knowledgeKind }])
+        }),
+        'memory_context'
+      );
+      expect(await tool.execute({ from: 'a' })).toSucceedAndSatisfy((value) => {
+        const out = value as { seed: string; count: number; results: ReadonlyArray<IMemoryToolResultItem> };
+        expect(out.seed).toBe('a');
+        expect(out.results.map((r) => r.handle)).toEqual(['b', 'c']);
+      });
+    });
+
+    test('honors hops, kind, tag, and limit filters', async () => {
+      const retriever = makeLinkRetriever([
+        { id: 'a', links: ['b'] },
+        { id: 'b', links: ['c'], tags: ['keep'] },
+        { id: 'c', tags: ['keep'] }
+      ]);
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever,
+          registry: registryWith([{ kind: knowledgeKind }])
+        }),
+        'memory_context'
+      );
+      expect(
+        await tool.execute({ from: 'a', hops: 2, tag: 'keep', kind: 'knowledge', limit: 5 })
+      ).toSucceedAndSatisfy((value) => {
+        const out = value as { results: ReadonlyArray<IMemoryToolResultItem> };
+        expect(out.results.map((r) => r.handle).sort()).toEqual(['b', 'c']);
+      });
+    });
+
+    test('rejects an invalid seed id', async () => {
+      const tool = toolByName(allTools(), 'memory_context');
+      expect(await tool.execute({ from: 'a/b' })).toFail();
+    });
+
+    test('rejects malformed arguments', async () => {
+      const tool = toolByName(allTools(), 'memory_context');
+      expect(await tool.execute({ hops: 1 })).toFailWith(/invalid arguments/i);
+    });
+  });
+
+  describe('memory_delete', () => {
+    test('deletes an existing record', async () => {
+      const store = makeStore();
+      const tools = createMemoryTools({
+        store,
+        retriever: makeRetriever([]),
+        registry: registryWith([{ kind: knowledgeKind }]),
+        codecs,
+        tools: ['memory_write', 'memory_delete', 'memory_read']
+      });
+      await toolByName(tools, 'memory_write').execute({ kind: 'knowledge', entityId: 'doc-1', body: 'b' });
+      expect(
+        await toolByName(tools, 'memory_delete').execute({ kind: 'knowledge', entityId: 'doc-1' })
+      ).toSucceedWith({ deleted: true, id: 'doc-1', entityId: 'doc-1', kind: 'knowledge' });
+      expect(
+        await toolByName(tools, 'memory_read').execute({ kind: 'knowledge', entityId: 'doc-1' })
+      ).toSucceedWith({ found: false });
+    });
+
+    test('propagates a store failure when the record is absent', async () => {
+      const tool = toolByName(allTools(), 'memory_delete');
+      expect(await tool.execute({ kind: 'knowledge', entityId: 'missing' })).toFailWith(/no record found/i);
+    });
+
+    test('rejects a kind outside the whitelist', async () => {
+      const tool = toolByName(allTools({ kinds: [knowledgeKind] }), 'memory_delete');
+      expect(await tool.execute({ kind: 'mtm', entityId: 'conv-1:0' })).toFailWith(/not enabled/i);
+    });
+
+    test('rejects malformed arguments', async () => {
+      const tool = toolByName(allTools(), 'memory_delete');
+      expect(await tool.execute({ kind: 'knowledge' })).toFailWith(/invalid arguments/i);
+    });
+  });
+});

--- a/samples/testbed/config/jest.config.json
+++ b/samples/testbed/config/jest.config.json
@@ -13,7 +13,8 @@
     "/node_modules/",
     "<rootDir>/lib/web/index.js",
     "<rootDir>/lib/generated/",
-    "<rootDir>/lib/scenarios/[a-zA-Z]+ClientTools/"
+    "<rootDir>/lib/scenarios/[a-zA-Z]+ClientTools/",
+    "<rootDir>/lib/scenarios/memoryToolsGate/"
   ],
   "collectCoverage": true,
   "coverageReporters": ["text", "lcov", "html"],

--- a/samples/testbed/package.json
+++ b/samples/testbed/package.json
@@ -45,7 +45,8 @@
     "@fgv/ts-prompt-assist": "workspace:*",
     "@fgv/ts-extras-transformers": "workspace:*",
     "@fgv/ts-web-extras-transformers": "workspace:*",
-    "@fgv/ts-extras-mcp": "workspace:*"
+    "@fgv/ts-extras-mcp": "workspace:*",
+    "@fgv/ts-agent-memory": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "~7.29.0",

--- a/samples/testbed/src/scenarios/index.ts
+++ b/samples/testbed/src/scenarios/index.ts
@@ -18,6 +18,7 @@ import { localClassifierSafetyScenario } from './localClassifierSafety';
 import { localEmbeddingSearchScenario } from './localEmbeddingSearch';
 import { localSummarizationScenario } from './localSummarization';
 import { mcpProbeScenario } from './mcpProbe';
+import { memoryToolsGateScenario } from './memoryToolsGate';
 import {
   anthropicModelTiersScenario,
   geminiModelTiersScenario,
@@ -40,6 +41,7 @@ export const scenarios: readonly IScenario[] = [
   localEmbeddingSearchScenario,
   localSummarizationScenario,
   mcpProbeScenario,
+  memoryToolsGateScenario,
   crossProviderEmbeddingSearchScenario,
   openaiModelTiersScenario,
   anthropicModelTiersScenario,

--- a/samples/testbed/src/scenarios/memoryToolsGate/index.ts
+++ b/samples/testbed/src/scenarios/memoryToolsGate/index.ts
@@ -43,7 +43,7 @@
  * @packageDocumentation
  */
 
-import { Converters, fail, succeed } from '@fgv/ts-utils';
+import { Converters, captureResult, fail, succeed } from '@fgv/ts-utils';
 import type { Result } from '@fgv/ts-utils';
 import { FileTree } from '@fgv/ts-json-base';
 import { AiAssist } from '@fgv/ts-extras';
@@ -122,15 +122,18 @@ function buildMemory(): Result<{
   store: FileTreeMemoryStore;
   tools: ReadonlyArray<AiAssist.IAiClientTool>;
 }> {
-  const tree = FileTree.inMemory([], { mutable: true }).orThrow();
-  const root = tree.getDirectory('/').orThrow();
-  if (!FileTree.isMutableDirectoryItem(root)) {
-    return fail('expected a mutable root directory');
-  }
-  const registry = BodyConverterRegistry.create().orThrow();
-  registry.register(KNOWLEDGE_KIND, Converters.string);
-  const codecs = new Map<Kind, IIdentityCodec>([[KNOWLEDGE_KIND, new KnowledgeIdentityCodec()]]);
-  return FileTreeMemoryStore.create({ root, registry, codecs }).onSuccess((store) => {
+  // Wrap the whole setup so the `.orThrow()` calls convert to a `Failure` instead of
+  // escaping as an unhandled rejection through the async `run` (which must return a Result).
+  return captureResult(() => {
+    const tree = FileTree.inMemory([], { mutable: true }).orThrow();
+    const root = tree.getDirectory('/').orThrow();
+    if (!FileTree.isMutableDirectoryItem(root)) {
+      throw new Error('expected a mutable root directory');
+    }
+    const registry = BodyConverterRegistry.create().orThrow();
+    registry.register(KNOWLEDGE_KIND, Converters.string);
+    const codecs = new Map<Kind, IIdentityCodec>([[KNOWLEDGE_KIND, new KnowledgeIdentityCodec()]]);
+    const store = FileTreeMemoryStore.create({ root, registry, codecs }).orThrow();
     const retriever = HybridRetriever.create(
       [StructuredFilterRetriever.create(MemoryIndex.create().orThrow()).orThrow()],
       ScoreUnionMergeStrategy.create().orThrow()
@@ -145,7 +148,7 @@ function buildMemory(): Result<{
       // Host handle vocabulary: the agent sees mnemonics, not raw ids.
       handleFor: (record) => `@${record.envelope.id}`
     });
-    return succeed({ store, tools });
+    return { store, tools };
   });
 }
 

--- a/samples/testbed/src/scenarios/memoryToolsGate/index.ts
+++ b/samples/testbed/src/scenarios/memoryToolsGate/index.ts
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * `@fgv/ts-agent-memory` L2 agent-tool surface — the mediated-write gate, end-to-end.
+ *
+ * Demonstrates {@link createMemoryTools} wired through `AiAssist.executeClientToolTurn` WITHOUT a
+ * live model. The provider stream is **mocked** (a canned Anthropic tool_use SSE stream substituted
+ * for `global.fetch`), so the scenario is deterministic and requires no API key.
+ *
+ * The agent "calls" `memory_write` on a real (in-memory) `FileTreeMemoryStore`; a host
+ * `onBeforeToolExecute` gate keeps writes curation-mediated:
+ *
+ * - **Run 1 (mediated deny):** the gate denies the mutating `memory_write` call pending
+ *   confirmation. `execute` never runs; a synthesized denial tool-result is fed into the
+ *   continuation (the model sees the denial). The store is left untouched (verified via `store.get`).
+ * - **Run 2 (confirmed):** the same gate proceeds the call; `memory_write` runs and the record is
+ *   durably persisted (verified via `store.get`).
+ *
+ * Scope isolation is structural: the tools close over a pre-scoped store and no tool argument
+ * names a scope — the agent cannot steer at another actor's memory.
+ *
+ * CLI-only and self-contained (mocked stream, no live API), matching the `gateDenyClientTools`
+ * convention.
+ *
+ * @packageDocumentation
+ */
+
+import { Converters, fail, succeed } from '@fgv/ts-utils';
+import type { Result } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
+import { AiAssist } from '@fgv/ts-extras';
+import {
+  BodyConverterRegistry,
+  EntityId,
+  FileTreeMemoryStore,
+  HybridRetriever,
+  IIdentityCodec,
+  Kind,
+  KnowledgeIdentityCodec,
+  MemoryIndex,
+  ScoreUnionMergeStrategy,
+  StructuredFilterRetriever,
+  createMemoryTools
+} from '@fgv/ts-agent-memory';
+
+import type { IScenario, ICliScenarioImpl, IScenarioContext } from '../../shell';
+
+const KNOWLEDGE_KIND: Kind = 'knowledge' as Kind;
+
+// ---------------------------------------------------------------------------
+// Mocked provider stream (Anthropic tool_use SSE) — no live API
+// ---------------------------------------------------------------------------
+
+/** Builds a canned Anthropic SSE stream in which the model calls `toolName` with `argsJson`. */
+function anthropicToolUseSse(toolId: string, toolName: string, argsJson: string): string[] {
+  return [
+    `event: content_block_start\ndata: ${JSON.stringify({
+      index: 0,
+      content_block: { type: 'tool_use', id: toolId, name: toolName }
+    })}\n\n`,
+    `event: content_block_delta\ndata: ${JSON.stringify({
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: argsJson }
+    })}\n\n`,
+    `event: content_block_stop\ndata: ${JSON.stringify({ index: 0 })}\n\n`,
+    `event: message_delta\ndata: ${JSON.stringify({ delta: { stop_reason: 'tool_use' } })}\n\n`,
+    `event: message_stop\ndata: {}\n\n`
+  ];
+}
+
+/** Installs a mocked `global.fetch` returning the given SSE chunks; returns a restore fn. */
+function installMockFetch(chunks: ReadonlyArray<string>): () => void {
+  const original = global.fetch;
+  const encoder = new TextEncoder();
+  let i = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller: ReadableStreamDefaultController<Uint8Array>): void {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[i++]));
+      } else {
+        controller.close();
+      }
+    }
+  });
+  const response = {
+    ok: true,
+    status: 200,
+    body,
+    text: async (): Promise<string> => '',
+    headers: new Map([['content-type', 'text/event-stream']])
+  };
+  global.fetch = (async () => response) as unknown as typeof global.fetch;
+  return () => {
+    global.fetch = original;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Memory substrate + tools
+// ---------------------------------------------------------------------------
+
+/** Build a fresh in-memory knowledge store and the selected memory tools over it. */
+function buildMemory(): Result<{
+  store: FileTreeMemoryStore;
+  tools: ReadonlyArray<AiAssist.IAiClientTool>;
+}> {
+  const tree = FileTree.inMemory([], { mutable: true }).orThrow();
+  const root = tree.getDirectory('/').orThrow();
+  if (!FileTree.isMutableDirectoryItem(root)) {
+    return fail('expected a mutable root directory');
+  }
+  const registry = BodyConverterRegistry.create().orThrow();
+  registry.register(KNOWLEDGE_KIND, Converters.string);
+  const codecs = new Map<Kind, IIdentityCodec>([[KNOWLEDGE_KIND, new KnowledgeIdentityCodec()]]);
+  return FileTreeMemoryStore.create({ root, registry, codecs }).onSuccess((store) => {
+    const retriever = HybridRetriever.create(
+      [StructuredFilterRetriever.create(MemoryIndex.create().orThrow()).orThrow()],
+      ScoreUnionMergeStrategy.create().orThrow()
+    ).orThrow();
+    const tools = createMemoryTools({
+      store,
+      retriever,
+      registry,
+      codecs,
+      // Writes are opt-in; enable memory_write to demonstrate the mediated-write gate.
+      tools: ['memory_write', 'memory_search'],
+      // Host handle vocabulary: the agent sees mnemonics, not raw ids.
+      handleFor: (record) => `@${record.envelope.id}`
+    });
+    return succeed({ store, tools });
+  });
+}
+
+/** The host gate: deny mutating memory tools pending confirmation; proceed everything else. */
+function makeGate(
+  confirmed: boolean
+): (tool: AiAssist.IAiClientTool, args: unknown) => Promise<Result<AiAssist.IToolExecutionDecision>> {
+  const mutating = new Set<string>(['memory_write', 'memory_delete']);
+  return async (tool) =>
+    !confirmed && mutating.has(tool.config.name)
+      ? succeed({ action: 'deny', reason: 'memory write requires host confirmation (curation-mediated)' })
+      : succeed({ action: 'proceed' });
+}
+
+// ---------------------------------------------------------------------------
+// CLI implementation
+// ---------------------------------------------------------------------------
+
+const WRITE_ARGS: string = JSON.stringify({
+  kind: 'knowledge',
+  entityId: 'note-1',
+  body: 'the user prefers dark mode'
+});
+
+const cliImpl: ICliScenarioImpl = {
+  async run(context: IScenarioContext): Promise<Result<string>> {
+    const descriptorResult = AiAssist.getProviderDescriptor('anthropic');
+    if (descriptorResult.isFailure()) {
+      return fail(`Failed to get Anthropic descriptor: ${descriptorResult.message}`);
+    }
+    const descriptor = descriptorResult.value;
+    const request: AiAssist.IChatRequest = {
+      system: 'You curate the user’s long-lived memory.',
+      messages: [{ role: 'user', content: 'Remember that I prefer dark mode.' }]
+    };
+    const summary: string[] = ['memory-tools mediated-write gate (mocked stream, no live API)', ''];
+
+    // --- Run 1: memory_write DENIED (curation-mediated) ------------------
+    const denied = await buildMemory();
+    if (denied.isFailure()) {
+      return fail(`run 1 setup failed: ${denied.message}`);
+    }
+    const restore1 = installMockFetch(anthropicToolUseSse('toolu_w1', 'memory_write', WRITE_ARGS));
+    try {
+      const turn = AiAssist.executeClientToolTurn({
+        descriptor,
+        apiKey: 'mock-key',
+        ...request,
+        clientTools: denied.value.tools,
+        model: 'claude-sonnet-4-6',
+        onBeforeToolExecute: makeGate(false)
+      });
+      if (turn.isFailure()) {
+        return fail(`deny-run executeClientToolTurn failed: ${turn.message}`);
+      }
+      let denyResult = '';
+      for await (const event of turn.value.events) {
+        if (event.type === 'client-tool-result') {
+          denyResult = event.result;
+        } else if (event.type === 'error') {
+          return fail(`deny-run stream error: ${event.message}`);
+        }
+      }
+      const outcome = await turn.value.nextTurn;
+      if (outcome.isFailure()) {
+        return fail(`deny-run nextTurn failed (should continue): ${outcome.message}`);
+      }
+      const persisted = await denied.value.store.get(KNOWLEDGE_KIND, 'note-1' as EntityId);
+      if (persisted.isFailure()) {
+        return fail(`deny-run store.get failed: ${persisted.message}`);
+      }
+      if (persisted.value !== undefined) {
+        return fail('deny-path assertion failed: a record was persisted despite the deny gate');
+      }
+      context.logger.info(`[run 1] memory_write DENIED — store untouched; denial: ${denyResult}`);
+      summary.push('Run 1 (memory_write): DENIED by host gate');
+      summary.push(`  - execute() never ran; synthesized denial fed into the continuation`);
+      summary.push('  - store.get(note-1) === undefined (nothing persisted)');
+    } finally {
+      restore1();
+    }
+
+    // --- Run 2: memory_write CONFIRMED → persisted -----------------------
+    const confirmed = await buildMemory();
+    if (confirmed.isFailure()) {
+      return fail(`run 2 setup failed: ${confirmed.message}`);
+    }
+    const restore2 = installMockFetch(anthropicToolUseSse('toolu_w2', 'memory_write', WRITE_ARGS));
+    try {
+      const turn = AiAssist.executeClientToolTurn({
+        descriptor,
+        apiKey: 'mock-key',
+        ...request,
+        clientTools: confirmed.value.tools,
+        model: 'claude-sonnet-4-6',
+        onBeforeToolExecute: makeGate(true)
+      });
+      if (turn.isFailure()) {
+        return fail(`confirm-run executeClientToolTurn failed: ${turn.message}`);
+      }
+      let writeIsError = true;
+      for await (const event of turn.value.events) {
+        if (event.type === 'client-tool-result') {
+          writeIsError = event.isError;
+        } else if (event.type === 'error') {
+          return fail(`confirm-run stream error: ${event.message}`);
+        }
+      }
+      const outcome = await turn.value.nextTurn;
+      if (outcome.isFailure()) {
+        return fail(`confirm-run nextTurn failed: ${outcome.message}`);
+      }
+      if (writeIsError) {
+        return fail('confirm-path assertion failed: memory_write result was flagged isError');
+      }
+      const persisted = await confirmed.value.store.get(KNOWLEDGE_KIND, 'note-1' as EntityId);
+      if (persisted.isFailure() || persisted.value === undefined) {
+        return fail('confirm-path assertion failed: record was not persisted after a proceed decision');
+      }
+      context.logger.info(
+        `[run 2] memory_write CONFIRMED — persisted note-1: "${String(persisted.value.body)}"`
+      );
+      summary.push('');
+      summary.push('Run 2 (memory_write): PROCEEDED under host confirmation');
+      summary.push(
+        `  - record durably persisted: store.get(note-1).body = "${String(persisted.value.body)}"`
+      );
+    } finally {
+      restore2();
+    }
+
+    summary.push('');
+    summary.push('memory-tools-gate scenario: PASS');
+    return succeed(summary.join('\n'));
+  }
+};
+
+/**
+ * `@fgv/ts-agent-memory` L2 mediated-write gate scenario.
+ *
+ * Self-contained (mocked provider stream; no live API / key) demonstration of `createMemoryTools`
+ * driven through `AiAssist.executeClientToolTurn`, with an `onBeforeToolExecute` gate keeping
+ * `memory_write` curation-mediated.
+ *
+ * @public
+ */
+export const memoryToolsGateScenario: IScenario = {
+  id: 'memory-tools-gate',
+  title: 'Agent Memory Tools — Mediated Write Gate',
+  description:
+    'Self-contained (mocked stream, no live API) demonstration of @fgv/ts-agent-memory createMemoryTools ' +
+    'wired through executeClientToolTurn: a host onBeforeToolExecute gate denies a memory_write pending ' +
+    'confirmation (store untouched), then proceeds it (record durably persisted).',
+  category: 'ai',
+  tags: ['agent-memory', 'client-tools', 'tool-use', 'gate', 'memory', 'mocked'],
+  cli: cliImpl
+};

--- a/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
+++ b/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
@@ -11,6 +11,7 @@ Array [
   "local-embedding-search",
   "local-summarization",
   "mcp-probe",
+  "memory-tools-gate",
   "cross-provider-embedding-search",
   "openai-model-tiers",
   "anthropic-model-tiers",

--- a/samples/testbed/src/test/unit/scenarios/memoryToolsGate.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/memoryToolsGate.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import '@fgv/ts-utils-jest';
+import { ReadableStream as NodeReadableStream } from 'node:stream/web';
+import { Logging } from '@fgv/ts-utils';
+
+import { memoryToolsGateScenario } from '../../../scenarios/memoryToolsGate';
+import type { IScenarioContext } from '../../../shell';
+
+// The scenario builds a mocked SSE response body with the WHATWG `ReadableStream`
+// (present in browsers and the Node CLI runtime). jsdom does not expose it as a
+// global, so polyfill from `node:stream/web` for the duration of this suite.
+const NEEDS_READABLE_STREAM_POLYFILL: boolean =
+  (globalThis as { ReadableStream?: unknown }).ReadableStream === undefined;
+
+describe('memoryToolsGateScenario', () => {
+  beforeAll(() => {
+    if (NEEDS_READABLE_STREAM_POLYFILL) {
+      (globalThis as { ReadableStream?: unknown }).ReadableStream = NodeReadableStream;
+    }
+  });
+
+  afterAll(() => {
+    if (NEEDS_READABLE_STREAM_POLYFILL) {
+      delete (globalThis as { ReadableStream?: unknown }).ReadableStream;
+    }
+  });
+
+  test('is a CLI-only ai scenario', () => {
+    expect(memoryToolsGateScenario.id).toBe('memory-tools-gate');
+    expect(memoryToolsGateScenario.category).toBe('ai');
+    expect(memoryToolsGateScenario.cli).toBeDefined();
+    expect(memoryToolsGateScenario.web).toBeUndefined();
+  });
+
+  test('cli.run drives the mediated-write gate end-to-end (deny then confirm) against a real store', async () => {
+    const context = {
+      logger: new Logging.LogReporter<unknown>({ logger: new Logging.InMemoryLogger() })
+    } as unknown as IScenarioContext;
+    if (!memoryToolsGateScenario.cli) {
+      throw new Error('expected a CLI implementation');
+    }
+    expect(await memoryToolsGateScenario.cli.run(context)).toSucceedAndSatisfy((summary: string) => {
+      expect(summary).toContain('Run 1 (memory_write): DENIED by host gate');
+      expect(summary).toContain('store.get(note-1) === undefined');
+      expect(summary).toContain('Run 2 (memory_write): PROCEEDED under host confirmation');
+      expect(summary).toContain('record durably persisted');
+      expect(summary).toContain('memory-tools-gate scenario: PASS');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `tools/` packlet to `@fgv/ts-agent-memory` exposing memory operations as `AiAssist.IAiClientTool`s, ready for `AiAssist.executeClientToolTurn` (and, via the shared `JsonSchema.object(...)` schemas, `@fgv/ts-extras-mcp`). L2 is a pure consumer of the shipped L1 substrate — no new store/envelope capability, no temporal/ingest touched.

### Factory + five tools

`createMemoryTools({ store, retriever, registry, tools?, kinds?, codecs?, defaultCodec?, handleFor? }): ReadonlyArray<IAiClientTool>`

| Tool | Delegates to | Annotations |
|---|---|---|
| `memory_write` | `store.put` | `destructiveHint:false, idempotentHint:false, openWorldHint:false` |
| `memory_read` | `store.get` | `readOnlyHint:true, openWorldHint:false` |
| `memory_search` | `HybridRetriever.retrieve` | `readOnlyHint:true, openWorldHint:false` |
| `memory_context` | `LinkTraversalRetriever` (seeded `linkedFrom`) | `readOnlyHint:true, openWorldHint:false` |
| `memory_delete` | `store.delete` | `destructiveHint:true, idempotentHint:true, openWorldHint:false` |

Each is authored with a `JsonSchema.object(...)` `parametersSchema` (the schema IS the wire schema AND the validator); each `execute` validates/narrows → delegates → returns the `Result` (never swallowed).

## LOCKED consumer decisions (PersonAIlity-validated)

- **Scope isolation (make-or-break):** the factory closes over the **pre-scoped store** as the sole scope authority; **no tool's `parametersSchema` declares a `scope`** (or any scope-widening) property. Asserted structurally across the whole suite (the adoption gate).
- **Per-tool subset:** `tools?` selects the enabled set; default = read-only `['memory_search','memory_context']`. `memory_write`/`memory_delete` are **off by default** and opt-in only. (No coarse `readOnly?` flag.)
- **Mnemonic handle:** `memory_search`/`memory_context` accept a host `handleFor?(record)=>string` hook; the agent-visible key is the mnemonic when supplied, else the raw `MemoryId`.
- **Behavior annotations (Component 4):** populated per tool as above (consumes the `IAiClientToolConfig.annotations` field shipped in #524).
- **Write-safety:** `memory_write` passes the body string to `store.put` (which runs `registry.convert`); an `IWritePolicy.admit` reject → tool `Result.fail`; a dedup no-op → success discriminating `written`/`deduped` on the result value.

## Testbed scenario — mediated-write gate

`samples/testbed` scenario `memory-tools-gate` (CLI-only, **mocked Anthropic SSE stream, no live API/key**) drives `createMemoryTools` through `executeClientToolTurn` against a real in-memory `FileTreeMemoryStore`, wiring `onBeforeToolExecute`:
- **Run 1 (deny):** gate denies `memory_write` pending confirmation → `execute` never runs, synthesized denial fed into the continuation, turn continues; `store.get` confirms nothing persisted.
- **Run 2 (confirm):** same gate proceeds → record durably persisted (verified via `store.get`).

The full loop runs green in the unit test (jsdom, with a `node:stream/web` `ReadableStream` polyfill). **No STOP-FLAG: no live model turn is required.**

## Code-reviewer pass (layer 1, run synchronously before coverage closure)

- **P1:** none.
- **P2 (resolved):**
  - `.orDefault()` on the pre-put `store.get` silently masked a real store fault as a fresh write → now **propagates** the `Failure` (distinct from the `undefined` "not found" success); added a stub-store test covering the branch.
  - Inaccurate "mirrors the mcp idiom" comment + undocumented re-validation → reworded to explain the deliberate re-validation (heterogeneous `IAiClientTool[]` erases `TParams` to `unknown`; the schema `convert` is the narrowing step, also exercised by direct-call tests).
  - `ae-unresolved-link` warning from `{@link AiAssist.IAiClientTool}` (cross-package) in the generated api.md → replaced with a plain code-font reference; api.md now warning-free.
- **P2 (dispositioned → TECH_DEBT):** the `codecs?`/`defaultCodec?` params duplicate the store's codec wiring — required because `IMemoryStore.put` validates `envelope.id === codec-derived idStem` and does not derive the id itself, so `memory_write` must compute the stem up front. Reviewer confirmed **scope isolation holds** (codec `scope` is derived from `kind`, not agent input; a mismatch loudly rejects the write). Filed as a P3 TECH_DEBT follow-up: add an additive `IMemoryStore.resolveWriteAddress(kind, entityId)` and drop the duplicated params.
- **P3 (resolved):** removed no-op `.onSuccess((x)=>succeed(x))` wrappers; straightened a curly apostrophe in a schema description.

## Gates

- `@fgv/ts-agent-memory`: `rushx build` / `lint` / `test` all pass; **100% coverage** (360 tests); `etc/ts-agent-memory.api.md` regenerated (additive, no unresolved-link warnings).
- `samples/testbed`: `build` / `lint` / `test` pass (235 tests); scenario registered + snapshot updated; `@fgv/ts-agent-memory` added as a dependency via Rush (shrinkwrap committed).
- `rushx fixlint` run before the final commit; `rush change --bulk --bump-type minor` change file committed.

Copilot review loop: not yet run — will drive on this PR after open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory tools for reading, searching, updating, and deleting stored memory through the agent-facing interface.
  * Introduced a new testbed scenario showing how write access can be gated before changes are persisted.

* **Bug Fixes**
  * Improved memory write behavior to better handle duplicate content and avoid mismatched record handling.

* **Tests**
  * Added broad unit and end-to-end coverage for memory tool behavior, permissions, and persistence outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->