### PR TITLE
feat(ts-agent-memory): temporal versioned write path + temporal retrievers

### DIFF
--- a/.ai/tasks/active/agent-memory-temporal/design-note.md
+++ b/.ai/tasks/active/agent-memory-temporal/design-note.md
@@ -1,0 +1,52 @@
+# Design note — temporal versioned write path + temporal retrievers
+
+Stream: `agent-memory-temporal`. Library: `@fgv/ts-agent-memory` (active surface — additive/breaking OK).
+
+## OQ-11 — versioned identity / layout model: **subtree-per-entity** (LOCKED, consumer-backed)
+
+Every version of a temporal entity is a distinct file in a per-entity subtree:
+
+```
+<baseScope>/entities/<entityId>/<entityId>-v<seq>.md
+```
+
+- `<seq>` is the store's monotonic write counter (`envelope.seq`) — monotonic per store, so every version filename is unique and version ordering is total.
+- **Current version** = the latest version whose `temporal.invalid_at` is `null`/absent (highest `seq` among such, defensively, in case a prior invalidation did not complete).
+- Rejected alternative: flat + sidecar version-index file. Consumer (PersonAIlity, 2026-07-07) counselled against it — "two sources of truth, exactly what bites during crash recovery." Not adopted.
+- **No `id == filename == single current value` global assumption is baked.** For a temporal record, `envelope.id` is the *version* file stem (`<entityId>-v<seq>`) — the `MemoryId` — while `envelope.entityId` is the stable domain key. `id === filename stem` still holds (the store mints `id` = version stem), so `_verifyLoaded`'s `id === baseName` check and the codec round-trip both succeed **without relaxation** — the relaxation the brief anticipated is unnecessary because `id` is minted to the version stem rather than to `entityId`.
+
+## Identity codec
+
+`TemporalIdentityCodec` (new, `identityCodec.ts`) implements `IIdentityCodec` and the additive `ITemporalIdentityCodec` extension (`encodeVersion(entityId, seq)` / `decodeVersion(scope, stem)`; guarded by `isTemporalIdentityCodec`). `encode(entityId)` reports `isVersioned: true`, `scope = <baseScope>/entities/<entityId>`, `idStem = <entityId>`. The `entities/<entityId>` subtree scope is authoritative for disambiguating a version stem that itself contains `-v<digits>`.
+
+## Write policy — invalidate-don't-delete
+
+`TemporalVersionedPolicy` (new sibling, `writePolicy.ts`): `admit` always accepts (history is retained; never culls), `dedupScope: 'entity'` (an identical re-put of the current content is a no-op, not a redundant version). `applyUpdate` runs the same RFC-7386 merge (`nullAsDelete: true`, `arrayMergeBehavior: 'replace'`) restricted to `mutableFields` as the shipped policies.
+
+**Merge-patch-under-versioning (consumer-pinned).** A `put()` on an existing temporal entity projects the incoming record's mutable fields into a patch, merges it over the **current** version's content to form the **new** version's content, writes that as a **new** version file, and sets `invalid_at` on the prior current version. It is never an in-place mutation of the current version.
+
+## Store branches (`fileTreeMemoryStore.ts`)
+
+The three `if (addr.isVersioned) return fail(...)` fail-stops (get/put/delete) are replaced by dedicated `_readVersionedCurrent` / `_putVersioned` / `_deleteVersioned` methods, branched at the top of each op. The flat (non-versioned) path is **structurally unchanged** beyond the branch — no persisted record changes shape, no shipped store migrates.
+
+- **get** → current version (resolved from the derived index, filtered to the entity subtree scope).
+- **put** → new version file (durability order: persist the new version **first** — it carries the highest `seq`, so a crash before the prior-version invalidation completes still resolves the new version as current — then invalidate the prior current version).
+- **delete** → **soft delete (invalidate-don't-delete)**: set `invalid_at` on the current version, leaving history intact and the entity with no current version. Returns the invalidated version's `MemoryId`. Fails with "no record found" when there is no current version. Rationale: temporal kinds exist to retain history; a hard delete would defeat the audit purpose and the L3 `contradicts` interlock that will build on this path. (Documented decision for the brief's open "delete semantics" question.)
+- **`list({ asOf })`** → for temporal records, collapse each entity to the version valid at `asOf`; non-temporal records are timeless and pass through unchanged. When `asOf` is absent, `list` is byte-identical to before (flat-path guarantee). Transaction-time / full bi-temporal filtering is deferred (OQ-9).
+- `_mutableFieldAccessors` is **not** extended: `invalid_at` is set by the store directly, not carried on the consumer merge-patch path.
+
+## Retrievers (`retrieve/temporalRetrievers.ts`)
+
+All three declare `supportsTemporalQuery: true` and operate over temporal records (`envelope.temporal !== undefined`), grouped by entity:
+
+- `CurrentValidRetriever` — the current version per entity (invalid_at null/absent).
+- `AsOfRetriever` — the version valid at `query.asOf` per entity (empty when `asOf` is absent — that is its axis).
+- `HistoryRetriever` — every version per entity, ascending by `valid_at` then `seq`.
+
+The existing `guardRetrieverCapabilities` loud-degrade (a non-temporal retriever fails an `asOf` query) and the `HybridRetriever` `asOf` projection (strips `asOf` for non-temporal children, passes it to temporal children) light up unchanged when a temporal child is composed in.
+
+## Shared temporal selection (`types/temporal.ts`)
+
+`isTemporalRecord` / `isVersionCurrent` / `isVersionValidAt` / `selectCurrentVersion` / `selectVersionAsOf` — pure helpers shared by the store and the retrievers (types packlet has no upward deps).
+</content>
+</invoke>

--- a/common/changes/@fgv/ts-agent-memory/claude-agent-memory-temporal_2026-07-07-22-52.json
+++ b/common/changes/@fgv/ts-agent-memory/claude-agent-memory-temporal_2026-07-07-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Temporal versioned write path + temporal retrievers: temporal identity codec, temporal-versioned invalidate-don't-delete write policy, versioned store read/write/delete, AsOf/CurrentValid/History retrievers",
+      "type": "minor",
+      "packageName": "@fgv/ts-agent-memory"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
+++ b/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
@@ -24,6 +24,13 @@ export type AdmissionDecision = {
 };
 
 // @public
+export class AsOfRetriever implements IMemoryRetriever {
+    get capabilities(): IMemoryRetrieverCapabilities;
+    static create(index: IMemoryIndex): Result<AsOfRetriever>;
+    retrieve(query: IMemoryQuery): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>>;
+}
+
+// @public
 export function assertPortableFilenameStem(stem: string): Result<string>;
 
 // @public
@@ -48,6 +55,13 @@ export const Convert: {
 
 // @public
 export function createMemoryTools(params: ICreateMemoryToolsParams): ReadonlyArray<AiAssist.IAiClientTool>;
+
+// @public
+export class CurrentValidRetriever implements IMemoryRetriever {
+    get capabilities(): IMemoryRetrieverCapabilities;
+    static create(index: IMemoryIndex): Result<CurrentValidRetriever>;
+    retrieve(query: IMemoryQuery): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>>;
+}
 
 // @public
 export type DedupScope = 'content' | 'entity';
@@ -85,6 +99,13 @@ export class FileTreeMemoryStore implements IMemoryStore {
 
 // @public
 export function guardRetrieverCapabilities(query: IMemoryQuery, capabilities: IMemoryRetrieverCapabilities): Result<true>;
+
+// @public
+export class HistoryRetriever implements IMemoryRetriever {
+    get capabilities(): IMemoryRetrieverCapabilities;
+    static create(index: IMemoryIndex): Result<HistoryRetriever>;
+    retrieve(query: IMemoryQuery): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>>;
+}
 
 // @public
 export class HybridRetriever implements IMemoryRetriever {
@@ -349,9 +370,33 @@ export interface ISemanticRetrieverCreateParams {
 }
 
 // @public
+export function isTemporalIdentityCodec(codec: IIdentityCodec): codec is ITemporalIdentityCodec;
+
+// @public
+export function isTemporalRecord(record: IMemoryRecord<unknown>): boolean;
+
+// @public
+export function isVersionCurrent(record: IMemoryRecord<unknown>): boolean;
+
+// @public
+export function isVersionValidAt(record: IMemoryRecord<unknown>, asOf: number): boolean;
+
+// @public
 export interface ITemporalBlock {
     readonly invalid_at?: number | null;
     readonly valid_at?: number;
+}
+
+// @public
+export interface ITemporalIdentityCodec extends IIdentityCodec {
+    decodeVersion(scope: MemoryScopeKey, stem: string): Result<ITemporalVersionAddress>;
+    encodeVersion(entityId: EntityId, seq: number): Result<string>;
+}
+
+// @public
+export interface ITemporalVersionAddress {
+    readonly entityId: EntityId;
+    readonly seq: number;
 }
 
 // @public
@@ -524,6 +569,12 @@ export class ScoreUnionMergeStrategy implements IMergeStrategy {
 export function selectByQuery(entries: ReadonlyArray<IIndexedMemoryRecord>, query: IMemoryQuery): IMemoryRecord<unknown>[];
 
 // @public
+export function selectCurrentVersion(versions: ReadonlyArray<IMemoryRecord<unknown>>): IMemoryRecord<unknown> | undefined;
+
+// @public
+export function selectVersionAsOf(versions: ReadonlyArray<IMemoryRecord<unknown>>, asOf: number): IMemoryRecord<unknown> | undefined;
+
+// @public
 export const SEMANTIC_UNWIRED_MESSAGE: string;
 
 // @public
@@ -557,10 +608,35 @@ export class TagRetriever implements IMemoryRetriever {
 }
 
 // @public
+export const TEMPORAL_CAPABILITIES: IMemoryRetrieverCapabilities;
+
+// @public
 export const temporalConverter: Converter<ITemporalBlock>;
 
 // @public
+export class TemporalIdentityCodec implements ITemporalIdentityCodec {
+    readonly baseScope: string;
+    static create(baseScope: string): Result<TemporalIdentityCodec>;
+    decode(scope: MemoryScopeKey, encodedStem: string): Result<EntityId>;
+    decodeVersion(scope: MemoryScopeKey, stem: string): Result<ITemporalVersionAddress>;
+    encode(entityId: EntityId): Result<IIdentityCodecResult>;
+    encodeVersion(entityId: EntityId, seq: number): Result<string>;
+    static readonly entitiesSegment: string;
+    verifyRoundTrip(scope: MemoryScopeKey, stem: string): Result<true>;
+    static readonly versionInfix: string;
+}
+
+// @public
 export function temporalUnwiredMessage(kind?: Kind): string;
+
+// @public
+export class TemporalVersionedPolicy implements IWritePolicy {
+    admit(__incoming: IMemoryRecord<unknown>, __existing: ReadonlyArray<IMemoryRecord<unknown>>): Result<AdmissionDecision>;
+    applyUpdate(existing: IMemoryRecord<unknown>, patch: Record<string, unknown>): Result<IMemoryRecord<unknown>>;
+    static create(): Result<TemporalVersionedPolicy>;
+    readonly dedupScope: DedupScope;
+    readonly mutableFields: ReadonlyArray<string>;
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/libraries/ts-agent-memory/src/packlets/retrieve/index.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/index.ts
@@ -9,4 +9,5 @@ export * from './linkTraversalRetriever';
 export * from './tagRetriever';
 export * from './structuredFilterRetriever';
 export * from './semanticRetriever';
+export * from './temporalRetrievers';
 export * from './hybridRetriever';

--- a/libraries/ts-agent-memory/src/packlets/retrieve/temporalRetrievers.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/temporalRetrievers.ts
@@ -147,6 +147,13 @@ export class AsOfRetriever implements IMemoryRetriever {
  * Temporal retriever returning **every** version of each temporal entity matching
  * the query, ordered ascending by `valid_at` (then `seq` as a stable tiebreak) —
  * the entity's full history. Limited after ordering.
+ *
+ * @remarks
+ * When the query matches more than one entity, the result is a single
+ * CROSS-entity list globally sorted by `valid_at` — versions of different
+ * entities interleave, NOT grouped per entity — so `limit` truncates that
+ * globally-sorted list. Constrain to one entity (e.g. via `query.scope`) for a
+ * single entity's contiguous history.
  * @public
  */
 export class HistoryRetriever implements IMemoryRetriever {
@@ -180,14 +187,24 @@ export class HistoryRetriever implements IMemoryRetriever {
     );
   }
 
+  /** A version's world-truth start: its `valid_at`, defaulting to `created` when absent. */
+  private static _startOf(record: IMemoryRecord<unknown>): number {
+    const temporal: IMemoryRecord<unknown>['envelope']['temporal'] = record.envelope.temporal;
+    /* c8 ignore next 3 -- unreachable: HistoryRetriever orders only temporal records (pre-filtered by isTemporalRecord), so `temporal` is always present; the guard keeps the type honest */
+    if (temporal === undefined) {
+      return record.envelope.created;
+    }
+    return temporal.valid_at ?? record.envelope.created;
+  }
+
   /**
    * Ascending-by-`valid_at` comparator (a version's `valid_at` defaults to its
    * `created` when absent), with `seq` as a stable ascending tiebreak so
    * same-instant versions order by write sequence.
    */
   private static _byValidAtAscending(a: IMemoryRecord<unknown>, b: IMemoryRecord<unknown>): number {
-    const aStart: number = a.envelope.temporal?.valid_at ?? a.envelope.created;
-    const bStart: number = b.envelope.temporal?.valid_at ?? b.envelope.created;
+    const aStart: number = HistoryRetriever._startOf(a);
+    const bStart: number = HistoryRetriever._startOf(b);
     return aStart !== bStart ? aStart - bStart : a.envelope.seq - b.envelope.seq;
   }
 }

--- a/libraries/ts-agent-memory/src/packlets/retrieve/temporalRetrievers.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/temporalRetrievers.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Result, succeed } from '@fgv/ts-utils';
+import { IMemoryRecord, isTemporalRecord, selectCurrentVersion, selectVersionAsOf } from '../types';
+import { IMemoryIndex } from '../index';
+import {
+  IMemoryQuery,
+  IMemoryRetriever,
+  IMemoryRetrieverCapabilities,
+  guardRetrieverCapabilities,
+  indexedRecordMatchesQuery,
+  limitRecords,
+  recencyCompare
+} from './retriever';
+
+/**
+ * The capabilities every temporal retriever exposes: temporal "as-of" queries
+ * are operational (semantic recall and link traversal are not this retriever's
+ * concern).
+ * @public
+ */
+export const TEMPORAL_CAPABILITIES: IMemoryRetrieverCapabilities = {
+  supportsSemanticRecall: false,
+  supportsTemporalQuery: true,
+  supportsLinkTraversal: false
+};
+
+/**
+ * Group the temporal records surviving a query's scope / kind / tag / predicate
+ * pre-filter by entity (`kind` + `entityId`). Non-temporal records are excluded —
+ * the temporal retrievers operate only over versioned entities. The map values
+ * are each entity's versions (unordered).
+ */
+function groupTemporalVersionsByEntity(
+  index: IMemoryIndex,
+  query: IMemoryQuery
+): Map<string, IMemoryRecord<unknown>[]> {
+  const groups: Map<string, IMemoryRecord<unknown>[]> = new Map<string, IMemoryRecord<unknown>[]>();
+  for (const entry of index.entries()) {
+    if (!isTemporalRecord(entry.record) || !indexedRecordMatchesQuery(entry, query)) {
+      continue;
+    }
+    const key: string = `${entry.record.envelope.kind}\0${entry.record.envelope.entityId}`;
+    const existing: IMemoryRecord<unknown>[] | undefined = groups.get(key);
+    if (existing === undefined) {
+      groups.set(key, [entry.record]);
+    } else {
+      existing.push(entry.record);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Temporal retriever returning the **current** version of each temporal entity
+ * matching the query (the newest version whose `invalid_at` is null/absent),
+ * recency-ordered and limited. A fully-invalidated (soft-deleted) entity
+ * contributes nothing. Non-temporal records are not this retriever's concern.
+ * @public
+ */
+export class CurrentValidRetriever implements IMemoryRetriever {
+  private readonly _index: IMemoryIndex;
+
+  private constructor(index: IMemoryIndex) {
+    this._index = index;
+  }
+
+  /** {@inheritDoc IMemoryRetriever.capabilities} */
+  public get capabilities(): IMemoryRetrieverCapabilities {
+    return TEMPORAL_CAPABILITIES;
+  }
+
+  /** Family-convention factory. */
+  public static create(index: IMemoryIndex): Result<CurrentValidRetriever> {
+    return succeed(new CurrentValidRetriever(index));
+  }
+
+  /** {@inheritDoc IMemoryRetriever.retrieve} */
+  public retrieve(query: IMemoryQuery): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>> {
+    return Promise.resolve(
+      guardRetrieverCapabilities(query, this.capabilities).onSuccess(() => {
+        const selected: IMemoryRecord<unknown>[] = [];
+        for (const versions of groupTemporalVersionsByEntity(this._index, query).values()) {
+          const current: IMemoryRecord<unknown> | undefined = selectCurrentVersion(versions);
+          if (current !== undefined) {
+            selected.push(current);
+          }
+        }
+        selected.sort(recencyCompare);
+        return succeed(limitRecords(selected, query.limit));
+      })
+    );
+  }
+}
+
+/**
+ * Temporal retriever returning, for each temporal entity matching the query, the
+ * version valid at `query.asOf` (epoch ms). `asOf` is this retriever's axis: a
+ * query without it yields an empty success (a no-op contribution to a
+ * {@link HybridRetriever}, not a failure). Results are recency-ordered and
+ * limited.
+ * @public
+ */
+export class AsOfRetriever implements IMemoryRetriever {
+  private readonly _index: IMemoryIndex;
+
+  private constructor(index: IMemoryIndex) {
+    this._index = index;
+  }
+
+  /** {@inheritDoc IMemoryRetriever.capabilities} */
+  public get capabilities(): IMemoryRetrieverCapabilities {
+    return TEMPORAL_CAPABILITIES;
+  }
+
+  /** Family-convention factory. */
+  public static create(index: IMemoryIndex): Result<AsOfRetriever> {
+    return succeed(new AsOfRetriever(index));
+  }
+
+  /** {@inheritDoc IMemoryRetriever.retrieve} */
+  public retrieve(query: IMemoryQuery): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>> {
+    return Promise.resolve(
+      guardRetrieverCapabilities(query, this.capabilities).onSuccess(() => {
+        if (query.asOf === undefined) {
+          return succeed([]);
+        }
+        const asOf: number = query.asOf;
+        const selected: IMemoryRecord<unknown>[] = [];
+        for (const versions of groupTemporalVersionsByEntity(this._index, query).values()) {
+          const valid: IMemoryRecord<unknown> | undefined = selectVersionAsOf(versions, asOf);
+          if (valid !== undefined) {
+            selected.push(valid);
+          }
+        }
+        selected.sort(recencyCompare);
+        return succeed(limitRecords(selected, query.limit));
+      })
+    );
+  }
+}
+
+/**
+ * Temporal retriever returning **every** version of each temporal entity matching
+ * the query, ordered ascending by `valid_at` (then `seq` as a stable tiebreak) —
+ * the entity's full history. Limited after ordering.
+ * @public
+ */
+export class HistoryRetriever implements IMemoryRetriever {
+  private readonly _index: IMemoryIndex;
+
+  private constructor(index: IMemoryIndex) {
+    this._index = index;
+  }
+
+  /** {@inheritDoc IMemoryRetriever.capabilities} */
+  public get capabilities(): IMemoryRetrieverCapabilities {
+    return TEMPORAL_CAPABILITIES;
+  }
+
+  /** Family-convention factory. */
+  public static create(index: IMemoryIndex): Result<HistoryRetriever> {
+    return succeed(new HistoryRetriever(index));
+  }
+
+  /** {@inheritDoc IMemoryRetriever.retrieve} */
+  public retrieve(query: IMemoryQuery): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>> {
+    return Promise.resolve(
+      guardRetrieverCapabilities(query, this.capabilities).onSuccess(() => {
+        const history: IMemoryRecord<unknown>[] = [];
+        for (const versions of groupTemporalVersionsByEntity(this._index, query).values()) {
+          history.push(...versions);
+        }
+        history.sort(HistoryRetriever._byValidAtAscending);
+        return succeed(limitRecords(history, query.limit));
+      })
+    );
+  }
+
+  /**
+   * Ascending-by-`valid_at` comparator (a version's `valid_at` defaults to its
+   * `created` when absent), with `seq` as a stable ascending tiebreak so
+   * same-instant versions order by write sequence.
+   */
+  private static _byValidAtAscending(a: IMemoryRecord<unknown>, b: IMemoryRecord<unknown>): number {
+    const aStart: number = a.envelope.temporal?.valid_at ?? a.envelope.created;
+    const bStart: number = b.envelope.temporal?.valid_at ?? b.envelope.created;
+    return aStart !== bStart ? aStart - bStart : a.envelope.seq - b.envelope.seq;
+  }
+}

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -14,12 +14,17 @@ import {
   IMemoryEnvelope,
   IMemoryRecord,
   IProvenance,
+  ITemporalIdentityCodec,
   IWritePolicy,
   Kind,
   KnowledgeLwwPolicy,
   MemoryId,
   MemoryScopeKey,
-  Tag
+  Tag,
+  isTemporalIdentityCodec,
+  isTemporalRecord,
+  selectCurrentVersion,
+  selectVersionAsOf
 } from '../types';
 import { IBodyConverterRegistry as IRegistry, parseMemoryFile, serializeMemoryFile } from '../converters';
 import { IIndexedMemoryRecord, IMemoryIndex, MemoryIndex } from '../index';
@@ -47,8 +52,9 @@ export interface IMemoryStoreListFilter {
   /** Restrict to records carrying this tag (exact match). */
   readonly tag?: Tag;
   /**
-   * For temporal kinds: return only records valid at this epoch ms. No-op in
-   * B1 (no temporal kinds wired).
+   * For temporal (versioned) kinds: collapse each entity to the single version
+   * valid at this epoch ms. Non-temporal records are timeless and pass through
+   * unchanged. Absent = no temporal projection (every version is returned).
    */
   readonly asOf?: number;
 }
@@ -86,7 +92,10 @@ export interface IMemoryStore {
 
   /**
    * Delete a record by `(kind, entityId)`. Non-temporal kinds physically delete
-   * the file. Returns the {@link MemoryId} of the deleted record.
+   * the file and return the deleted record's {@link MemoryId}. Temporal
+   * (versioned) kinds SOFT-delete: the current version is invalidated
+   * (`invalid_at` set), history is retained, and the invalidated version's
+   * {@link MemoryId} is returned.
    */
   delete(kind: Kind, entityId: EntityId): Promise<Result<MemoryId>>;
 }
@@ -165,16 +174,6 @@ interface IPutOutcome {
   readonly evicted: ReadonlyArray<MemoryId>;
 }
 
-/**
- * The resolved storage address + content hash for a put, produced by the
- * synchronous prefix of `_putLocked` and handed to the async write tail.
- */
-interface IResolvedWriteAddress {
-  readonly scope: MemoryScopeKey;
-  readonly idStem: string;
-  readonly hash: string;
-}
-
 interface IInternalParams {
   readonly root: FileTree.IMutableFileTreeDirectoryItem;
   readonly registry: IRegistry;
@@ -198,9 +197,11 @@ interface IInternalParams {
  * write-lock so the index and the on-disk files never interleave.
  *
  * @remarks
- * B1 supports flat (non-versioned) layout only and string (markdown) bodies.
- * A codec reporting `isVersioned: true`, or a non-string body, fails loudly —
- * the versioned/temporal write path is a fast-follow.
+ * Bodies are string (markdown). Both layouts are supported: flat
+ * (one-file-per-entity, non-versioned) and versioned (subtree-per-entity,
+ * invalidate-don't-delete), dispatched per kind by the codec's `isVersioned`
+ * flag. A kind is flat with zero behavioral impact unless it opts into a
+ * {@link ITemporalIdentityCodec}.
  * @public
  */
 export class FileTreeMemoryStore implements IMemoryStore {
@@ -302,7 +303,11 @@ export class FileTreeMemoryStore implements IMemoryStore {
     const result: Result<IMemoryRecord<unknown> | undefined> = this._codecFor(kind).onSuccess((codec) =>
       codec.encode(entityId).onSuccess((addr) => {
         if (addr.isVersioned) {
-          return fail(`memory get '${entityId}': versioned/temporal layout not yet supported`);
+          // Versioned keyed read resolves the CURRENT version (highest-seq
+          // version whose `invalid_at` is null/absent) from the entity subtree,
+          // read off the derived index. `asOf` resolution is via `list({ asOf })`
+          // and the temporal retrievers.
+          return succeed(this._readVersionedCurrent(addr.scope));
         }
         return this._readRecord(addr.scope, addr.idStem);
       })
@@ -340,7 +345,48 @@ export class FileTreeMemoryStore implements IMemoryStore {
         return true;
       })
       .map((entry) => entry.record);
-    return succeed(matches);
+    if (filter?.asOf === undefined) {
+      // No temporal projection requested: byte-identical to the pre-temporal
+      // behavior (the flat-path guarantee — every version is returned).
+      return succeed(matches);
+    }
+    return succeed(FileTreeMemoryStore._projectAsOf(matches, filter.asOf));
+  }
+
+  /**
+   * Collapse temporal records to the single version valid at `asOf` per entity;
+   * non-temporal records are timeless and pass through unchanged (valid-time
+   * `asOf` applies only to versioned kinds; transaction-time / full bi-temporal
+   * filtering is deferred — OQ-9). An entity with no version valid at `asOf`
+   * contributes nothing.
+   */
+  private static _projectAsOf(
+    records: ReadonlyArray<IMemoryRecord<unknown>>,
+    asOf: number
+  ): ReadonlyArray<IMemoryRecord<unknown>> {
+    const passthrough: IMemoryRecord<unknown>[] = [];
+    const groups: Map<string, IMemoryRecord<unknown>[]> = new Map<string, IMemoryRecord<unknown>[]>();
+    for (const record of records) {
+      if (!isTemporalRecord(record)) {
+        passthrough.push(record);
+        continue;
+      }
+      const key: string = `${record.envelope.kind}\0${record.envelope.entityId}`;
+      const existing: IMemoryRecord<unknown>[] | undefined = groups.get(key);
+      if (existing === undefined) {
+        groups.set(key, [record]);
+      } else {
+        existing.push(record);
+      }
+    }
+    const result: IMemoryRecord<unknown>[] = [...passthrough];
+    for (const versions of groups.values()) {
+      const valid: IMemoryRecord<unknown> | undefined = selectVersionAsOf(versions, asOf);
+      if (valid !== undefined) {
+        result.push(valid);
+      }
+    }
+    return result;
   }
 
   /** {@inheritDoc IMemoryStore.put} */
@@ -479,32 +525,37 @@ export class FileTreeMemoryStore implements IMemoryStore {
       );
     }
     const body: string = record.body;
-    // Resolve the synchronous prefix (body validation → codec address → content
-    // hash) into a small descriptor, then bridge to the async write tail (which
-    // embeds on write). Keeping the sync prefix intact preserves the exact
-    // dedup/policy ordering of the original; only the embed step is new.
+    // Resolve the body converter + codec, then dispatch on layout. The flat
+    // (non-versioned) path keeps its exact dedup/policy ordering; the versioned
+    // path is a wholly separate branch so the flat path is behaviorally
+    // unchanged (the consumer adoption guarantee).
     return this._registry
       .convert(envelope.kind, body)
       .withErrorFormat((msg) => `memory put '${envelope.id}': invalid body: ${msg}`)
       .onSuccess(() => this._codecFor(envelope.kind))
-      .onSuccess(
-        (codec): Result<IResolvedWriteAddress> =>
-          codec.encode(envelope.entityId).onSuccess((addr): Result<IResolvedWriteAddress> => {
-            if (addr.isVersioned) {
-              return fail(`memory put '${envelope.entityId}': versioned/temporal layout not yet supported`);
-            }
-            if (envelope.id !== addr.idStem) {
-              return fail(
-                `memory put: envelope id '${envelope.id}' does not match codec-derived stem '${addr.idStem}'`
+      .thenOnSuccess((codec) =>
+        codec.encode(envelope.entityId).thenOnSuccess((addr) => {
+          if (addr.isVersioned) {
+            if (!isTemporalIdentityCodec(codec)) {
+              return Promise.resolve(
+                fail<IPutOutcome>(
+                  `memory put '${envelope.entityId}': codec for versioned kind '${envelope.kind}' does not implement the temporal codec interface`
+                )
               );
             }
-            return this._contentHash(envelope.kind, body, envelope.links).onSuccess((hash) =>
-              succeed({ scope: addr.scope, idStem: addr.idStem, hash })
+            return this._putVersioned(record, body, codec, addr.scope);
+          }
+          if (envelope.id !== addr.idStem) {
+            return Promise.resolve(
+              fail<IPutOutcome>(
+                `memory put: envelope id '${envelope.id}' does not match codec-derived stem '${addr.idStem}'`
+              )
             );
-          })
-      )
-      .thenOnSuccess((resolved) =>
-        this._writeResolved(record, body, resolved.scope, resolved.idStem, resolved.hash)
+          }
+          return this._contentHash(envelope.kind, body, envelope.links).thenOnSuccess((hash) =>
+            this._writeResolved(record, body, addr.scope, addr.idStem, hash)
+          );
+        })
       );
   }
 
@@ -774,29 +825,233 @@ export class FileTreeMemoryStore implements IMemoryStore {
   }
 
   private async _deleteLocked(kind: Kind, entityId: EntityId): Promise<Result<MemoryId>> {
-    return this._codecFor(kind)
-      .onSuccess((codec) => codec.encode(entityId))
-      .thenOnSuccess((addr) => {
+    return this._codecFor(kind).thenOnSuccess((codec) =>
+      codec.encode(entityId).thenOnSuccess((addr) => {
         if (addr.isVersioned) {
-          return Promise.resolve(
-            fail<MemoryId>(`memory delete '${entityId}': versioned/temporal layout not yet supported`)
+          return this._deleteVersioned(entityId, addr.scope);
+        }
+        return this._deleteFlat(entityId, addr.scope, addr.idStem);
+      })
+    );
+  }
+
+  /**
+   * Flat (non-versioned) delete: physically remove the record file + index
+   * entry, then prune the vector best-effort. Structurally unchanged from the
+   * pre-temporal delete path.
+   */
+  private async _deleteFlat(
+    entityId: EntityId,
+    scope: MemoryScopeKey,
+    idStem: string
+  ): Promise<Result<MemoryId>> {
+    return this._readRecord(scope, idStem).thenOnSuccess((existing) => {
+      if (existing === undefined) {
+        return Promise.resolve(fail<MemoryId>(`memory delete '${entityId}': no record found`));
+      }
+      // Delete the record file + index entry (authoritative), then prune the
+      // vector best-effort: a committed delete must not fail because the
+      // derived index could not be pruned.
+      return this._deleteFile(scope, idStem)
+        .onSuccess(() => this._index.patch('delete', { scope, record: existing }))
+        .thenOnSuccess(async () => {
+          await this._removeVectorBestEffort(existing.envelope.id);
+          return succeed(existing.envelope.id);
+        });
+    });
+  }
+
+  /**
+   * Resolve the current version of a temporal entity from the derived index: the
+   * highest-`seq` version under the entity subtree `scope` whose `invalid_at` is
+   * null/absent. `undefined` when the entity has no current version (never
+   * written, or fully invalidated / soft-deleted).
+   */
+  private _readVersionedCurrent(scope: MemoryScopeKey): IMemoryRecord<unknown> | undefined {
+    return selectCurrentVersion(this._versionsForEntity(scope));
+  }
+
+  /**
+   * Every persisted version of the entity whose subtree is `scope`. All version
+   * files for one entity live under exactly that scope (which encodes the
+   * entityId), so a scope filter over the index isolates one entity's versions.
+   */
+  private _versionsForEntity(scope: MemoryScopeKey): ReadonlyArray<IMemoryRecord<unknown>> {
+    return this._index
+      .entries()
+      .filter((entry) => entry.scope === scope)
+      .map((entry) => entry.record);
+  }
+
+  /**
+   * Versioned write (invalidate-don't-delete). Builds the new version's content
+   * (a first version from the incoming record, or a merge of the incoming patch
+   * over the current version), persists it as a NEW version file, then sets
+   * `invalid_at` on the prior current version.
+   *
+   * Durability order: the new version is persisted FIRST. It carries the highest
+   * `seq`, so a crash before the prior-version invalidation completes still
+   * resolves the new version as current (`selectCurrentVersion` breaks a
+   * two-current tie by highest `seq`), and `asOf` reads stay correct because each
+   * version's `valid_at` lower-bounds its interval.
+   */
+  private async _putVersioned(
+    record: IMemoryRecord<unknown>,
+    body: string,
+    codec: ITemporalIdentityCodec,
+    scope: MemoryScopeKey
+  ): Promise<Result<IPutOutcome>> {
+    const envelope: IMemoryEnvelope = record.envelope;
+    const entityId: EntityId = envelope.entityId;
+    const kind: Kind = envelope.kind;
+    const hashResult: Result<string> = this._contentHash(kind, body, envelope.links);
+    if (hashResult.isFailure()) {
+      return fail(hashResult.message);
+    }
+    const hash: string = hashResult.value;
+    const versions: ReadonlyArray<IMemoryRecord<unknown>> = this._versionsForEntity(scope);
+    const current: IMemoryRecord<unknown> | undefined = selectCurrentVersion(versions);
+    const policy: IWritePolicy = this._policyFor(kind);
+    const dedupScope: DedupScope = policy.dedupScope ?? DEFAULT_DEDUP_SCOPE;
+    // Entity-scoped dedup: an identical re-put of the CURRENT content is a no-op
+    // (does not spawn a redundant version). Content-scoped dedup is not a
+    // versioning concern, so only the entity granularity is honored here.
+    if (dedupScope === 'entity' && current !== undefined && current.envelope.contentHash === hash) {
+      return succeed({ record: current, evicted: [] });
+    }
+    const admission: Result<AdmissionDecision> = policy.admit(record, versions);
+    if (admission.isFailure()) {
+      return fail(admission.message);
+    }
+    if (admission.value.decision === 'reject') {
+      return fail(`memory put: rejected by policy: ${admission.value.reason}`);
+    }
+    // No culling on the versioned path — history is retained (invalidate-don't-delete).
+    const now: number = this._clock();
+    const seq: number = ++this._seq;
+    return codec
+      .encodeVersion(entityId, seq)
+      .withErrorFormat((msg) => `memory put '${entityId}': ${msg}`)
+      .thenOnSuccess((versionStem) =>
+        this._buildVersionedRecord(record, body, current, policy, hash, versionStem, now, seq)
+          .thenOnSuccess((built) => this._embedOnWrite(built))
+          .onSuccess((embeddedBuilt) => this._persist(embeddedBuilt, scope, versionStem))
+          .onSuccess((persisted) =>
+            current === undefined
+              ? succeed(persisted)
+              : this._invalidateVersion(scope, current, now).onSuccess(() => succeed(persisted))
+          )
+          .onSuccess((persisted) => succeed({ record: persisted, evicted: [] }))
+      );
+  }
+
+  /**
+   * Build the new version to persist. A first version takes the incoming
+   * content verbatim (its dedup `hash` is reused); a subsequent version projects
+   * the incoming record's mutable fields into a merge-patch and lets the policy
+   * merge them over the CURRENT version (the merge-patch-under-versioning
+   * contract), recomputing the content hash from the policy's output. Each
+   * version is its own record with its own transaction time (`created` = `now`)
+   * and a store-minted `id` = the version stem, so `id === filename stem` holds.
+   */
+  private _buildVersionedRecord(
+    incoming: IMemoryRecord<unknown>,
+    body: string,
+    current: IMemoryRecord<unknown> | undefined,
+    policy: IWritePolicy,
+    hash: string,
+    versionStem: string,
+    now: number,
+    seq: number
+  ): Result<IMemoryRecord<string>> {
+    const mintedId: MemoryId = versionStem as MemoryId;
+    const validAt: number = incoming.envelope.temporal?.valid_at ?? now;
+    if (current === undefined) {
+      const envelope: IMemoryEnvelope = {
+        ...incoming.envelope,
+        id: mintedId,
+        entityId: incoming.envelope.entityId,
+        created: now,
+        updated: now,
+        seq,
+        contentHash: hash,
+        temporal: { valid_at: validAt }
+      };
+      return succeed({ envelope, body });
+    }
+    const patch: Record<string, unknown> = this._projectMutablePatch(incoming, policy.mutableFields);
+    return policy
+      .applyUpdate(current, patch)
+      .withErrorFormat((msg) => `memory put '${incoming.envelope.entityId}': update failed: ${msg}`)
+      .onSuccess((updated) => {
+        if (typeof updated.body !== 'string') {
+          return fail(
+            `memory put '${
+              incoming.envelope.entityId
+            }': policy returned a non-string body (${typeof updated.body})`
           );
         }
-        return this._readRecord(addr.scope, addr.idStem).thenOnSuccess((existing) => {
-          if (existing === undefined) {
-            return Promise.resolve(fail<MemoryId>(`memory delete '${entityId}': no record found`));
+        const finalBody: string = updated.body;
+        return this._contentHash(updated.envelope.kind, finalBody, updated.envelope.links).onSuccess(
+          (finalHash) => {
+            const envelope: IMemoryEnvelope = {
+              ...updated.envelope,
+              id: mintedId,
+              entityId: incoming.envelope.entityId,
+              created: now,
+              updated: now,
+              seq,
+              contentHash: finalHash,
+              temporal: { valid_at: validAt }
+            };
+            return succeed({ envelope, body: finalBody });
           }
-          // Delete the record file + index entry (authoritative), then prune the
-          // vector best-effort: a committed delete must not fail because the
-          // derived index could not be pruned.
-          return this._deleteFile(addr.scope, addr.idStem)
-            .onSuccess(() => this._index.patch('delete', { scope: addr.scope, record: existing }))
-            .thenOnSuccess(async () => {
-              await this._removeVectorBestEffort(existing.envelope.id);
-              return succeed(existing.envelope.id);
-            });
-        });
+        );
       });
+  }
+
+  /**
+   * Set `invalid_at` on a prior current version (invalidate-don't-delete) and
+   * rewrite its file + index entry. The content hash is unchanged — `invalid_at`
+   * is temporal metadata, not part of `{ kind, body, links }` — so the version's
+   * identity is stable.
+   */
+  private _invalidateVersion(
+    scope: MemoryScopeKey,
+    version: IMemoryRecord<unknown>,
+    now: number
+  ): Result<IMemoryRecord<unknown>> {
+    if (typeof version.body !== 'string') {
+      /* c8 ignore next 2 -- defensive: every persisted version carries a string body (only string bodies are written) */
+      return fail(`memory put: cannot invalidate version '${version.envelope.id}': non-string body`);
+    }
+    const invalidated: IMemoryRecord<string> = {
+      envelope: {
+        ...version.envelope,
+        updated: now,
+        temporal: { ...version.envelope.temporal, invalid_at: now }
+      },
+      body: version.body
+    };
+    return this._persist(invalidated, scope, version.envelope.id);
+  }
+
+  /**
+   * Versioned delete: SOFT delete (invalidate-don't-delete). Sets `invalid_at` on
+   * the current version, leaving the entity's history intact and the entity with
+   * no current version. Returns the invalidated version's {@link MemoryId}. Fails
+   * with "no record found" when there is no current version — matching the flat
+   * delete's not-found semantics. History is retained deliberately: temporal
+   * kinds exist to preserve the audit trail (and the L3 `contradicts` interlock
+   * builds on it), so a hard delete would defeat the purpose.
+   */
+  private async _deleteVersioned(entityId: EntityId, scope: MemoryScopeKey): Promise<Result<MemoryId>> {
+    const current: IMemoryRecord<unknown> | undefined = this._readVersionedCurrent(scope);
+    if (current === undefined) {
+      return fail(`memory delete '${entityId}': no record found`);
+    }
+    const now: number = this._clock();
+    return this._invalidateVersion(scope, current, now).onSuccess(() => succeed(current.envelope.id));
   }
 
   /** Evict (physically delete) a single record file by id, patching the index. */

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -23,6 +23,7 @@ import {
   Tag,
   isTemporalIdentityCodec,
   isTemporalRecord,
+  isVersionCurrent,
   selectCurrentVersion,
   selectVersionAsOf
 } from '../types';
@@ -67,7 +68,9 @@ export interface IMemoryStore {
   /**
    * Keyed read by entity id. Resolves `entityId` to a storage address via the
    * registered {@link IIdentityCodec} for `kind`. Returns `undefined` when no
-   * record exists.
+   * record exists. For a versioned (temporal) kind this returns the current
+   * version, resolved from the derived in-memory index (not re-read/re-verified
+   * from disk per call — the index is kept in sync with every write).
    */
   get(kind: Kind, entityId: EntityId): Promise<Result<IMemoryRecord<unknown> | undefined>>;
 
@@ -916,52 +919,75 @@ export class FileTreeMemoryStore implements IMemoryStore {
     const envelope: IMemoryEnvelope = record.envelope;
     const entityId: EntityId = envelope.entityId;
     const kind: Kind = envelope.kind;
-    const hashResult: Result<string> = this._contentHash(kind, body, envelope.links);
-    if (hashResult.isFailure()) {
-      return fail(hashResult.message);
-    }
-    const hash: string = hashResult.value;
+    // Snapshot the entity's versions BEFORE the write. `priorCurrents` is every
+    // still-current version at snapshot time — normally one, but two-or-more if a
+    // prior invalidation partially failed; invalidating all of them lets the write
+    // self-heal a stuck state (P2-7).
     const versions: ReadonlyArray<IMemoryRecord<unknown>> = this._versionsForEntity(scope);
+    const priorCurrents: ReadonlyArray<IMemoryRecord<unknown>> = versions.filter(isVersionCurrent);
     const current: IMemoryRecord<unknown> | undefined = selectCurrentVersion(versions);
     const policy: IWritePolicy = this._policyFor(kind);
     const dedupScope: DedupScope = policy.dedupScope ?? DEFAULT_DEDUP_SCOPE;
-    // Entity-scoped dedup: an identical re-put of the CURRENT content is a no-op
-    // (does not spawn a redundant version). Content-scoped dedup is not a
-    // versioning concern, so only the entity granularity is honored here.
-    if (dedupScope === 'entity' && current !== undefined && current.envelope.contentHash === hash) {
-      return succeed({ record: current, evicted: [] });
-    }
-    // On the versioned path the admission cohort is the entity's ENTIRE version
-    // history (no target id to exclude — the new version does not exist yet), which
-    // differs from the flat path's "cohort excluding target id" shape.
-    const admission: Result<AdmissionDecision> = policy.admit(record, versions);
-    if (admission.isFailure()) {
-      return fail(admission.message);
-    }
-    if (admission.value.decision === 'reject') {
-      return fail(`memory put: rejected by policy: ${admission.value.reason}`);
-    }
-    // No culling on the versioned path — history is retained (invalidate-don't-delete).
-    const now: number = this._clock();
-    const seq: number = ++this._seq;
-    // World-truth start of the new version. The prior current version's world-truth
-    // interval must CLOSE at this same instant (not at `now`) so a backdated/future-dated
-    // `valid_at` leaves no gap or overlap on the valid-time axis.
-    const validAt: number = envelope.temporal?.valid_at ?? now;
-    return codec
-      .encodeVersion(entityId, seq)
-      .withErrorFormat((msg) => `memory put '${entityId}': ${msg}`)
-      .thenOnSuccess((versionStem) =>
-        this._buildVersionedRecord(record, body, current, policy, hash, versionStem, validAt, now, seq)
-          .thenOnSuccess((built) => this._embedOnWrite(built))
-          .onSuccess((embeddedBuilt) => this._persist(embeddedBuilt, scope, versionStem))
-          .onSuccess((persisted) =>
-            current === undefined
-              ? succeed(persisted)
-              : this._invalidateVersion(scope, current, validAt, now).onSuccess(() => succeed(persisted))
-          )
-          .onSuccess((persisted) => succeed({ record: persisted, evicted: [] }))
-      );
+    return this._contentHash(kind, body, envelope.links).thenOnSuccess((hash) => {
+      // Entity-scoped dedup: an identical re-put of the CURRENT content is a no-op
+      // (does not spawn a redundant version). Content-scoped dedup is not a
+      // versioning concern, so only the entity granularity is honored here.
+      if (dedupScope === 'entity' && current !== undefined && current.envelope.contentHash === hash) {
+        return Promise.resolve(succeed<IPutOutcome>({ record: current, evicted: [] }));
+      }
+      // On the versioned path the admission cohort is the entity's ENTIRE version
+      // history (no target id to exclude — the new version does not exist yet),
+      // which differs from the flat path's "cohort excluding target id" shape.
+      return policy.admit(record, versions).thenOnSuccess((decision) => {
+        if (decision.decision === 'reject') {
+          return Promise.resolve(fail<IPutOutcome>(`memory put: rejected by policy: ${decision.reason}`));
+        }
+        // No culling on the versioned path — history is retained (invalidate-don't-delete).
+        const now: number = this._clock();
+        const seq: number = ++this._seq;
+        // World-truth start of the new version. Each prior current version's
+        // world-truth interval CLOSES at this same instant (not at `now`) so a
+        // backdated/future-dated `valid_at` leaves no gap or overlap on the
+        // valid-time axis.
+        const validAt: number = envelope.temporal?.valid_at ?? now;
+        return codec
+          .encodeVersion(entityId, seq)
+          .withErrorFormat((msg) => `memory put '${entityId}': ${msg}`)
+          .thenOnSuccess((versionStem) =>
+            this._buildVersionedRecord(record, body, current, policy, hash, versionStem, validAt, now, seq)
+              .thenOnSuccess((built) => this._embedOnWrite(built))
+              .onSuccess((embeddedBuilt) => this._persist(embeddedBuilt, scope, versionStem))
+              .onSuccess((persisted) =>
+                this._invalidateCurrents(scope, priorCurrents, validAt, now).onSuccess(() =>
+                  succeed(persisted)
+                )
+              )
+              .onSuccess((persisted) => succeed({ record: persisted, evicted: [] }))
+          );
+      });
+    });
+  }
+
+  /**
+   * Invalidate a set of still-current versions (close each world-truth interval at
+   * `invalidAt`; stamp transaction-time `updated` = `now`). Chained so a mid-list
+   * failure propagates. Invalidating every prior current — not just the
+   * highest-`seq` pick — self-heals a state where a previous write's invalidation
+   * only partially completed (P2-7).
+   */
+  private _invalidateCurrents(
+    scope: MemoryScopeKey,
+    currents: ReadonlyArray<IMemoryRecord<unknown>>,
+    invalidAt: number,
+    now: number
+  ): Result<true> {
+    return currents.reduce<Result<true>>(
+      (acc, version) =>
+        acc.onSuccess(() =>
+          this._invalidateVersion(scope, version, invalidAt, now).onSuccess(() => succeed(true))
+        ),
+      succeed(true)
+    );
   }
 
   /**
@@ -1043,10 +1069,11 @@ export class FileTreeMemoryStore implements IMemoryStore {
     invalidAt: number,
     now: number
   ): Result<IMemoryRecord<unknown>> {
+    /* c8 ignore start -- defensive: every persisted version carries a string body (only string bodies are written) */
     if (typeof version.body !== 'string') {
-      /* c8 ignore next 2 -- defensive: every persisted version carries a string body (only string bodies are written) */
       return fail(`memory put: cannot invalidate version '${version.envelope.id}': non-string body`);
     }
+    /* c8 ignore stop */
     // `invalid_at` is the WORLD-TRUTH close of the interval (the superseding version's
     // `valid_at`, or the delete instant); `updated` is the transaction-time stamp.
     const invalidated: IMemoryRecord<string> = {
@@ -1070,14 +1097,18 @@ export class FileTreeMemoryStore implements IMemoryStore {
    * builds on it), so a hard delete would defeat the purpose.
    */
   private async _deleteVersioned(entityId: EntityId, scope: MemoryScopeKey): Promise<Result<MemoryId>> {
-    const current: IMemoryRecord<unknown> | undefined = this._readVersionedCurrent(scope);
+    const versions: ReadonlyArray<IMemoryRecord<unknown>> = this._versionsForEntity(scope);
+    const currents: ReadonlyArray<IMemoryRecord<unknown>> = versions.filter(isVersionCurrent);
+    const current: IMemoryRecord<unknown> | undefined = selectCurrentVersion(versions);
     if (current === undefined) {
       return fail(`memory delete '${entityId}': no record found`);
     }
     // A delete closes the world-truth interval at the delete instant (`now` for both
-    // the transaction stamp and the `invalid_at` boundary).
+    // the transaction stamp and the `invalid_at` boundary). Every still-current
+    // version is invalidated (self-heals a stuck two-current state — P2-7); the
+    // highest-`seq` current's id is returned.
     const now: number = this._clock();
-    return this._invalidateVersion(scope, current, now, now).onSuccess(() => succeed(current.envelope.id));
+    return this._invalidateCurrents(scope, currents, now, now).onSuccess(() => succeed(current.envelope.id));
   }
 
   /** Evict (physically delete) a single record file by id, patching the index. */

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -303,6 +303,11 @@ export class FileTreeMemoryStore implements IMemoryStore {
     const result: Result<IMemoryRecord<unknown> | undefined> = this._codecFor(kind).onSuccess((codec) =>
       codec.encode(entityId).onSuccess((addr) => {
         if (addr.isVersioned) {
+          if (!isTemporalIdentityCodec(codec)) {
+            return fail(
+              `memory get '${entityId}': codec for versioned kind '${kind}' does not implement the temporal codec interface`
+            );
+          }
           // Versioned keyed read resolves the CURRENT version (highest-seq
           // version whose `invalid_at` is null/absent) from the entity subtree,
           // read off the derived index. `asOf` resolution is via `list({ asOf })`
@@ -828,6 +833,13 @@ export class FileTreeMemoryStore implements IMemoryStore {
     return this._codecFor(kind).thenOnSuccess((codec) =>
       codec.encode(entityId).thenOnSuccess((addr) => {
         if (addr.isVersioned) {
+          if (!isTemporalIdentityCodec(codec)) {
+            return Promise.resolve(
+              fail<MemoryId>(
+                `memory delete '${entityId}': codec for versioned kind '${kind}' does not implement the temporal codec interface`
+              )
+            );
+          }
           return this._deleteVersioned(entityId, addr.scope);
         }
         return this._deleteFlat(entityId, addr.scope, addr.idStem);
@@ -919,6 +931,9 @@ export class FileTreeMemoryStore implements IMemoryStore {
     if (dedupScope === 'entity' && current !== undefined && current.envelope.contentHash === hash) {
       return succeed({ record: current, evicted: [] });
     }
+    // On the versioned path the admission cohort is the entity's ENTIRE version
+    // history (no target id to exclude — the new version does not exist yet), which
+    // differs from the flat path's "cohort excluding target id" shape.
     const admission: Result<AdmissionDecision> = policy.admit(record, versions);
     if (admission.isFailure()) {
       return fail(admission.message);
@@ -929,17 +944,21 @@ export class FileTreeMemoryStore implements IMemoryStore {
     // No culling on the versioned path — history is retained (invalidate-don't-delete).
     const now: number = this._clock();
     const seq: number = ++this._seq;
+    // World-truth start of the new version. The prior current version's world-truth
+    // interval must CLOSE at this same instant (not at `now`) so a backdated/future-dated
+    // `valid_at` leaves no gap or overlap on the valid-time axis.
+    const validAt: number = envelope.temporal?.valid_at ?? now;
     return codec
       .encodeVersion(entityId, seq)
       .withErrorFormat((msg) => `memory put '${entityId}': ${msg}`)
       .thenOnSuccess((versionStem) =>
-        this._buildVersionedRecord(record, body, current, policy, hash, versionStem, now, seq)
+        this._buildVersionedRecord(record, body, current, policy, hash, versionStem, validAt, now, seq)
           .thenOnSuccess((built) => this._embedOnWrite(built))
           .onSuccess((embeddedBuilt) => this._persist(embeddedBuilt, scope, versionStem))
           .onSuccess((persisted) =>
             current === undefined
               ? succeed(persisted)
-              : this._invalidateVersion(scope, current, now).onSuccess(() => succeed(persisted))
+              : this._invalidateVersion(scope, current, validAt, now).onSuccess(() => succeed(persisted))
           )
           .onSuccess((persisted) => succeed({ record: persisted, evicted: [] }))
       );
@@ -959,13 +978,15 @@ export class FileTreeMemoryStore implements IMemoryStore {
     body: string,
     current: IMemoryRecord<unknown> | undefined,
     policy: IWritePolicy,
-    hash: string,
+    // Reused only for the first-version branch (its content is taken verbatim); a
+    // subsequent version recomputes its hash from the merge-patched content.
+    firstVersionHash: string,
     versionStem: string,
+    validAt: number,
     now: number,
     seq: number
   ): Result<IMemoryRecord<string>> {
     const mintedId: MemoryId = versionStem as MemoryId;
-    const validAt: number = incoming.envelope.temporal?.valid_at ?? now;
     if (current === undefined) {
       const envelope: IMemoryEnvelope = {
         ...incoming.envelope,
@@ -974,7 +995,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
         created: now,
         updated: now,
         seq,
-        contentHash: hash,
+        contentHash: firstVersionHash,
         temporal: { valid_at: validAt }
       };
       return succeed({ envelope, body });
@@ -1019,17 +1040,20 @@ export class FileTreeMemoryStore implements IMemoryStore {
   private _invalidateVersion(
     scope: MemoryScopeKey,
     version: IMemoryRecord<unknown>,
+    invalidAt: number,
     now: number
   ): Result<IMemoryRecord<unknown>> {
     if (typeof version.body !== 'string') {
       /* c8 ignore next 2 -- defensive: every persisted version carries a string body (only string bodies are written) */
       return fail(`memory put: cannot invalidate version '${version.envelope.id}': non-string body`);
     }
+    // `invalid_at` is the WORLD-TRUTH close of the interval (the superseding version's
+    // `valid_at`, or the delete instant); `updated` is the transaction-time stamp.
     const invalidated: IMemoryRecord<string> = {
       envelope: {
         ...version.envelope,
         updated: now,
-        temporal: { ...version.envelope.temporal, invalid_at: now }
+        temporal: { ...version.envelope.temporal, invalid_at: invalidAt }
       },
       body: version.body
     };
@@ -1050,8 +1074,10 @@ export class FileTreeMemoryStore implements IMemoryStore {
     if (current === undefined) {
       return fail(`memory delete '${entityId}': no record found`);
     }
+    // A delete closes the world-truth interval at the delete instant (`now` for both
+    // the transaction stamp and the `invalid_at` boundary).
     const now: number = this._clock();
-    return this._invalidateVersion(scope, current, now).onSuccess(() => succeed(current.envelope.id));
+    return this._invalidateVersion(scope, current, now, now).onSuccess(() => succeed(current.envelope.id));
   }
 
   /** Evict (physically delete) a single record file by id, patching the index. */

--- a/libraries/ts-agent-memory/src/packlets/types/identityCodec.ts
+++ b/libraries/ts-agent-memory/src/packlets/types/identityCodec.ts
@@ -187,9 +187,16 @@ export class TemporalIdentityCodec implements ITemporalIdentityCodec {
       if (!TemporalIdentityCodec._versionSeqRe.test(seqText)) {
         return fail(`temporal codec: version stem '${stem}' has a non-integer version suffix '${seqText}'`);
       }
-      return Convert.entityId
-        .convert(entityId)
-        .onSuccess((branded) => succeed({ entityId: branded, seq: Number.parseInt(seqText, 10) }));
+      // The regex admits digit strings of unbounded length; `parseInt` would silently
+      // lose precision past MAX_SAFE_INTEGER, decoding a corrupt/tampered filename to a
+      // plausible-but-wrong `seq` that drives version ordering. Reject rather than corrupt.
+      const seq: number = Number.parseInt(seqText, 10);
+      if (!Number.isSafeInteger(seq)) {
+        return fail(
+          `temporal codec: version stem '${stem}' has a version suffix '${seqText}' outside the safe integer range`
+        );
+      }
+      return Convert.entityId.convert(entityId).onSuccess((branded) => succeed({ entityId: branded, seq }));
     });
   }
 

--- a/libraries/ts-agent-memory/src/packlets/types/identityCodec.ts
+++ b/libraries/ts-agent-memory/src/packlets/types/identityCodec.ts
@@ -51,6 +51,183 @@ export interface IIdentityCodec {
 }
 
 /**
+ * The `(entityId, version seq)` an {@link ITemporalIdentityCodec.decodeVersion}
+ * recovers from a version file address.
+ * @public
+ */
+export interface ITemporalVersionAddress {
+  /** The stable consumer-supplied domain key. */
+  readonly entityId: EntityId;
+  /** The version's monotonic `seq` (the `v<seq>` component of the file stem). */
+  readonly seq: number;
+}
+
+/**
+ * Additive extension of {@link IIdentityCodec} for versioned (temporal) kinds. A
+ * codec whose {@link IIdentityCodec.encode | encode} reports `isVersioned: true`
+ * implements this so the store can form and parse per-version filenames without
+ * knowing the layout. Non-versioned codecs do NOT implement it (probe with
+ * {@link isTemporalIdentityCodec}).
+ * @public
+ */
+export interface ITemporalIdentityCodec extends IIdentityCodec {
+  /**
+   * Form the version filename stem for a specific `(entityId, seq)`. The store
+   * appends the extension and writes it under the entity subtree returned by
+   * {@link IIdentityCodec.encode | encode}.
+   */
+  encodeVersion(entityId: EntityId, seq: number): Result<string>;
+
+  /**
+   * Parse a `(subtree scope, version stem)` back to its
+   * {@link ITemporalVersionAddress}. The subtree scope is authoritative for the
+   * `entityId`, disambiguating a stem whose `entityId` itself ends in
+   * `-v<digits>`.
+   */
+  decodeVersion(scope: MemoryScopeKey, stem: string): Result<ITemporalVersionAddress>;
+}
+
+/**
+ * Narrow an {@link IIdentityCodec} to {@link ITemporalIdentityCodec} by probing
+ * for the versioned methods. Used by the store when an `encode` result reports
+ * `isVersioned: true`.
+ * @public
+ */
+export function isTemporalIdentityCodec(codec: IIdentityCodec): codec is ITemporalIdentityCodec {
+  const candidate: Partial<ITemporalIdentityCodec> = codec as Partial<ITemporalIdentityCodec>;
+  return typeof candidate.encodeVersion === 'function' && typeof candidate.decodeVersion === 'function';
+}
+
+/**
+ * Identity codec for a versioned (temporal) kind family, resolving OQ-11 to the
+ * subtree-per-entity layout: every version of an entity is a distinct file under
+ * a per-entity subtree.
+ *
+ * @remarks
+ * - `encode`: scope = `<baseScope>/entities/<entityId>`, idStem = `<entityId>`,
+ *   `isVersioned = true`. The idStem is the stable entity prefix; the store forms
+ *   each version's filename via {@link TemporalIdentityCodec.encodeVersion}.
+ * - `encodeVersion`: version stem = `<entityId>-v<seq>`.
+ * - `decode` / `decodeVersion`: recover `entityId` (and `seq`) from a
+ *   `(subtree scope, version stem)` pair; the scope is authoritative for the
+ *   `entityId`.
+ * - Escaping: `baseScope` and `entityId` must each match the POSIX portable
+ *   filename set (they become path segments); `seq` is a non-negative integer.
+ * - Layout: `vault/<baseScope>/entities/<entityId>/<entityId>-v<seq>.md`.
+ * @public
+ */
+export class TemporalIdentityCodec implements ITemporalIdentityCodec {
+  /** The fixed subtree segment separating an entity's versions from its scope. */
+  public static readonly entitiesSegment: string = 'entities';
+  /** The version-stem infix: `<entityId>` + this + `<seq>`. */
+  public static readonly versionInfix: string = '-v';
+
+  /** A non-negative integer string (the version seq). */
+  private static readonly _versionSeqRe: RegExp = /^\d+$/;
+
+  /** The base scope segment this codec's entities live under. */
+  public readonly baseScope: string;
+
+  private constructor(baseScope: string) {
+    this.baseScope = baseScope;
+  }
+
+  /**
+   * Family-convention factory. Validates that `baseScope` is a single portable
+   * filename segment (it becomes the top-level path component).
+   */
+  public static create(baseScope: string): Result<TemporalIdentityCodec> {
+    return assertPortableFilenameStem(baseScope)
+      .withErrorFormat((msg) => `temporal codec: baseScope '${baseScope}': ${msg}`)
+      .onSuccess(() => succeed(new TemporalIdentityCodec(baseScope)));
+  }
+
+  /** {@inheritDoc IIdentityCodec.encode} */
+  public encode(entityId: EntityId): Result<IIdentityCodecResult> {
+    return assertPortableFilenameStem(entityId)
+      .withErrorFormat((msg) => `temporal codec: entityId '${entityId}': ${msg}`)
+      .onSuccess((stem) =>
+        succeed({
+          scope: `${this.baseScope}/${TemporalIdentityCodec.entitiesSegment}/${stem}` as MemoryScopeKey,
+          idStem: stem,
+          isVersioned: true
+        })
+      );
+  }
+
+  /** {@inheritDoc ITemporalIdentityCodec.encodeVersion} */
+  public encodeVersion(entityId: EntityId, seq: number): Result<string> {
+    return assertPortableFilenameStem(entityId)
+      .withErrorFormat((msg) => `temporal codec: entityId '${entityId}': ${msg}`)
+      .onSuccess((stem) => {
+        if (!Number.isInteger(seq) || seq < 0) {
+          return fail(`temporal codec: version seq '${seq}' must be a non-negative integer`);
+        }
+        return succeed(`${stem}${TemporalIdentityCodec.versionInfix}${seq}`);
+      });
+  }
+
+  /** {@inheritDoc IIdentityCodec.decode} */
+  public decode(scope: MemoryScopeKey, encodedStem: string): Result<EntityId> {
+    return this.decodeVersion(scope, encodedStem).onSuccess((addr) =>
+      Convert.entityId.convert(addr.entityId)
+    );
+  }
+
+  /** {@inheritDoc ITemporalIdentityCodec.decodeVersion} */
+  public decodeVersion(scope: MemoryScopeKey, stem: string): Result<ITemporalVersionAddress> {
+    return this._entityIdFromScope(scope).onSuccess((entityId) => {
+      const prefix: string = `${entityId}${TemporalIdentityCodec.versionInfix}`;
+      if (!stem.startsWith(prefix)) {
+        return fail(
+          `temporal codec: version stem '${stem}' must begin with '${prefix}' (from scope '${scope}')`
+        );
+      }
+      const seqText: string = stem.slice(prefix.length);
+      if (!TemporalIdentityCodec._versionSeqRe.test(seqText)) {
+        return fail(`temporal codec: version stem '${stem}' has a non-integer version suffix '${seqText}'`);
+      }
+      return Convert.entityId
+        .convert(entityId)
+        .onSuccess((branded) => succeed({ entityId: branded, seq: Number.parseInt(seqText, 10) }));
+    });
+  }
+
+  /** {@inheritDoc IIdentityCodec.verifyRoundTrip} */
+  public verifyRoundTrip(scope: MemoryScopeKey, stem: string): Result<true> {
+    return this.decodeVersion(scope, stem).onSuccess((addr) =>
+      this.encode(addr.entityId).onSuccess((encoded) =>
+        this.encodeVersion(addr.entityId, addr.seq).onSuccess((reStem) => {
+          if (encoded.scope !== scope || reStem !== stem) {
+            return fail(
+              `temporal codec: round-trip mismatch for scope '${scope}' stem '${stem}' (re-encoded to scope '${encoded.scope}' stem '${reStem}')`
+            );
+          }
+          return succeed(true);
+        })
+      )
+    );
+  }
+
+  /** Validate and extract the `entityId` from a `<baseScope>/entities/<entityId>` scope. */
+  private _entityIdFromScope(scope: MemoryScopeKey): Result<string> {
+    const segments: string[] = scope.split('/');
+    if (
+      segments.length !== 3 ||
+      segments[0] !== this.baseScope ||
+      segments[1] !== TemporalIdentityCodec.entitiesSegment
+    ) {
+      return fail(
+        `temporal codec: scope '${scope}' must be '${this.baseScope}/${TemporalIdentityCodec.entitiesSegment}/<entityId>'`
+      );
+    }
+    const entityId: string = segments[2];
+    return assertPortableFilenameStem(entityId)
+      .withErrorFormat((msg) => `temporal codec: entityId '${entityId}': ${msg}`)
+      .onSuccess(() => succeed(entityId));
+  }
+}
+
 /**
  * Identity codec for the knowledge kind family. A knowledge entity is keyed
  * by its consumer-supplied `docId`, which is used verbatim as the filename

--- a/libraries/ts-agent-memory/src/packlets/types/index.ts
+++ b/libraries/ts-agent-memory/src/packlets/types/index.ts
@@ -7,4 +7,5 @@ export * from './ids';
 export * from './envelope';
 export * from './filenameSafety';
 export * from './identityCodec';
+export * from './temporal';
 export * from './writePolicy';

--- a/libraries/ts-agent-memory/src/packlets/types/temporal.ts
+++ b/libraries/ts-agent-memory/src/packlets/types/temporal.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { IMemoryRecord } from './envelope';
+
+/**
+ * Whether a record participates in the versioned (temporal) layout. A temporal
+ * record always carries a {@link ITemporalBlock | temporal} block (the store
+ * stamps `valid_at` on every versioned write); an atemporal record never does,
+ * so presence of `temporal` is the discriminator. Independent of `id`/`entityId`
+ * divergence (MTM is flat yet has `entityId !== id`).
+ * @public
+ */
+export function isTemporalRecord(record: IMemoryRecord<unknown>): boolean {
+  return record.envelope.temporal !== undefined;
+}
+
+/**
+ * Whether a temporal record is a *current* version — its `temporal.invalid_at`
+ * is `null` or absent (the still-valid sentinel). A non-temporal record is never
+ * current in this sense (returns `false`).
+ * @public
+ */
+export function isVersionCurrent(record: IMemoryRecord<unknown>): boolean {
+  const temporal: IMemoryRecord<unknown>['envelope']['temporal'] = record.envelope.temporal;
+  if (temporal === undefined) {
+    return false;
+  }
+  return temporal.invalid_at === null || temporal.invalid_at === undefined;
+}
+
+/**
+ * Whether a temporal record's validity interval contains `asOf` (epoch ms):
+ * `valid_at <= asOf` and (`invalid_at` is null/absent OR `asOf < invalid_at`).
+ * The version's `valid_at` defaults to its `created` when absent; a non-temporal
+ * record is never "valid at" a point (returns `false`).
+ * @public
+ */
+export function isVersionValidAt(record: IMemoryRecord<unknown>, asOf: number): boolean {
+  const temporal: IMemoryRecord<unknown>['envelope']['temporal'] = record.envelope.temporal;
+  if (temporal === undefined) {
+    return false;
+  }
+  const start: number = temporal.valid_at ?? record.envelope.created;
+  if (start > asOf) {
+    return false;
+  }
+  const end: number | null | undefined = temporal.invalid_at;
+  if (end === null || end === undefined) {
+    return true;
+  }
+  return asOf < end;
+}
+
+/**
+ * The version with the highest `seq` among `candidates` (undefined when empty).
+ * `seq` is the store's monotonic write counter, so highest `seq` is the newest
+ * version. Shared tiebreak for {@link selectCurrentVersion} /
+ * {@link selectVersionAsOf}.
+ */
+function highestSeq(candidates: ReadonlyArray<IMemoryRecord<unknown>>): IMemoryRecord<unknown> | undefined {
+  let best: IMemoryRecord<unknown> | undefined;
+  for (const candidate of candidates) {
+    if (best === undefined || candidate.envelope.seq > best.envelope.seq) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
+/**
+ * Select the current version from a set of an entity's versions: the newest
+ * (highest `seq`) version whose `invalid_at` is null/absent. `undefined` when the
+ * entity has no current version (fully invalidated / soft-deleted, or empty).
+ * @public
+ */
+export function selectCurrentVersion(
+  versions: ReadonlyArray<IMemoryRecord<unknown>>
+): IMemoryRecord<unknown> | undefined {
+  return highestSeq(versions.filter(isVersionCurrent));
+}
+
+/**
+ * Select the version of an entity valid at `asOf` (epoch ms): the newest
+ * (highest `seq`) version whose validity interval contains `asOf`. `undefined`
+ * when no version was valid at that instant.
+ * @public
+ */
+export function selectVersionAsOf(
+  versions: ReadonlyArray<IMemoryRecord<unknown>>,
+  asOf: number
+): IMemoryRecord<unknown> | undefined {
+  return highestSeq(versions.filter((version) => isVersionValidAt(version, asOf)));
+}

--- a/libraries/ts-agent-memory/src/packlets/types/writePolicy.ts
+++ b/libraries/ts-agent-memory/src/packlets/types/writePolicy.ts
@@ -445,3 +445,130 @@ export class MemoryCapCullPolicy implements IWritePolicy {
     return succeed({ envelope, body: 'body' in merged ? merged.body : existing.body });
   }
 }
+
+/**
+ * Write policy for a versioned (temporal) kind family, implementing
+ * invalidate-don't-delete. Admission always accepts — history is retained, never
+ * culled — and updates apply the same RFC-7386 merge patch as
+ * {@link KnowledgeLwwPolicy}, restricted to the temporal mutable surface.
+ *
+ * @remarks
+ * The policy does NOT perform the version file writes or set `invalid_at` — that
+ * is the store's versioned write branch, driven by the kind's
+ * {@link ITemporalIdentityCodec}. The policy's role is limited to admission and
+ * the merge that forms the **new version's** content from the **current**
+ * version plus the incoming patch (the merge-patch-under-versioning contract).
+ *
+ * - **Dedup scope.** `'entity'` — an identical re-put of the current content is a
+ *   no-op (the store compares the incoming content hash against the current
+ *   version), so identical writes do not spawn redundant versions.
+ * - **Mutable surface.** `body` + the envelope metadata a consumer may revise
+ *   (`tags` / `links` / `provenance` / `embeddingRef`). `temporal` is NOT mutable
+ *   here — `valid_at` / `invalid_at` are set by the store's versioned branch.
+ * @public
+ */
+export class TemporalVersionedPolicy implements IWritePolicy {
+  /** The temporal mutable surface (mirrors {@link KnowledgeLwwPolicy}). */
+  public readonly mutableFields: ReadonlyArray<string> = [
+    'body',
+    'tags',
+    'links',
+    'provenance',
+    'embeddingRef'
+  ];
+
+  /** Versioned kinds dedup per-entity against the current version (see the class remarks). */
+  public readonly dedupScope: DedupScope = 'entity';
+
+  /** Deep-clones the mutable view without RFC-7386 null-deletion semantics. */
+  private readonly _cloneEditor: JsonEditor;
+  /** Applies the RFC-7386 merge patch. */
+  private readonly _mergeEditor: JsonEditor;
+
+  private constructor(cloneEditor: JsonEditor, mergeEditor: JsonEditor) {
+    this._cloneEditor = cloneEditor;
+    this._mergeEditor = mergeEditor;
+  }
+
+  /**
+   * Family-convention factory. Constructs the shared `JsonEditor` instances (one
+   * for cloning, one for the RFC-7386 merge), rules disabled — the same merge
+   * config as the shipped policies.
+   */
+  public static create(): Result<TemporalVersionedPolicy> {
+    return JsonEditor.create({}, []).onSuccess((cloneEditor) =>
+      JsonEditor.create(MERGE_PATCH_OPTIONS, []).onSuccess((mergeEditor) =>
+        succeed(new TemporalVersionedPolicy(cloneEditor, mergeEditor))
+      )
+    );
+  }
+
+  /** {@inheritDoc IWritePolicy.admit} */
+  public admit(
+    __incoming: IMemoryRecord<unknown>,
+    __existing: ReadonlyArray<IMemoryRecord<unknown>>
+  ): Result<AdmissionDecision> {
+    // Invalidate-don't-delete: always accept. Superseded versions are retained
+    // (invalidated), never culled.
+    return succeed({ decision: 'accept' });
+  }
+
+  /** {@inheritDoc IWritePolicy.applyUpdate} */
+  public applyUpdate(
+    existing: IMemoryRecord<unknown>,
+    patch: Record<string, unknown>
+  ): Result<IMemoryRecord<unknown>> {
+    // Project the mutable fields into a single record-level view, each sourced
+    // from its canonical location. `embeddingRef` is omitted when `undefined`.
+    const view: Record<string, unknown> = {
+      body: existing.body,
+      tags: existing.envelope.tags,
+      links: existing.envelope.links,
+      provenance: existing.envelope.provenance
+    };
+    if (existing.envelope.embeddingRef !== undefined) {
+      view.embeddingRef = existing.envelope.embeddingRef;
+    }
+
+    // Restrict the incoming patch to the declared mutable fields.
+    const scopedPatch: Record<string, unknown> = {};
+    for (const field of this.mutableFields) {
+      if (field in patch) {
+        scopedPatch[field] = patch[field];
+      }
+    }
+
+    // Clone the view (no null-deletion), then apply the RFC-7386 merge patch onto
+    // the clone so the current version is never mutated in place.
+    return this._cloneEditor
+      .mergeObjectInPlace({}, view as JsonObject)
+      .onSuccess((clone) => this._mergeEditor.mergeObjectInPlace(clone, scopedPatch as JsonObject))
+      .onSuccess((merged) => this._rebuild(existing, merged));
+  }
+
+  /**
+   * Reassemble a record from the merged mutable view. `body` / `tags` / `links` /
+   * `provenance` are required and may not be deleted by a patch; `embeddingRef`,
+   * when dropped by the merge, is restored as `undefined` (absent) — the same
+   * hash-stable semantics as {@link KnowledgeLwwPolicy}.
+   */
+  private _rebuild(existing: IMemoryRecord<unknown>, merged: JsonObject): Result<IMemoryRecord<unknown>> {
+    const required: ReadonlyArray<string> = ['body', 'tags', 'links', 'provenance'];
+    const missing: ReadonlyArray<string> = required.filter((field) => !(field in merged));
+    if (missing.length > 0) {
+      return fail(`temporal versioned: merge patch may not delete required field(s): ${missing.join(', ')}`);
+    }
+
+    // The merged values are JSON projections of the already-validated typed
+    // record; restore the domain types (structural restorations, not fresh
+    // untrusted input — mirrors KnowledgeLwwPolicy._rebuild).
+    const envelope: IMemoryEnvelope = {
+      ...existing.envelope,
+      tags: merged.tags as unknown as ReadonlyArray<Tag>,
+      links: merged.links as unknown as ReadonlyArray<IEdge>,
+      provenance: merged.provenance as unknown as IProvenance,
+      embeddingRef: 'embeddingRef' in merged ? (merged.embeddingRef as string | null) : undefined
+    };
+    return succeed({ envelope, body: merged.body });
+  }
+}

--- a/libraries/ts-agent-memory/src/test/unit/retrieve/temporalRetrievers.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/retrieve/temporalRetrievers.test.ts
@@ -152,6 +152,52 @@ describe('temporal retrievers', () => {
         expect(ids(records)).toEqual(['fact-1-v1', 'fact-2-v3']);
       });
     });
+
+    test('orders by created when a version has no valid_at', async () => {
+      const idx = MemoryIndex.create().orThrow();
+      const noValidAt: IIndexedMemoryRecord = {
+        scope: 'facts/entities/nv' as MemoryScopeKey,
+        record: {
+          envelope: envelopeConverter
+            .convert({
+              id: 'nv-v1',
+              entityId: 'nv',
+              kind: 'fact',
+              tags: [],
+              links: [],
+              created: 700,
+              updated: 700,
+              seq: 1,
+              contentHash: 'h',
+              provenance: { source: 'agent' },
+              temporal: {}
+            })
+            .orThrow(),
+          body: 'nv'
+        }
+      };
+      idx.rebuild([noValidAt, versionEntry({ entityId: 'early', seq: 2, validAt: 100 })]).orThrow();
+      const r = HistoryRetriever.create(idx).orThrow();
+      // `nv` has no valid_at → its start defaults to created (700), after early (100).
+      expect(await r.retrieve({})).toSucceedAndSatisfy((records) => {
+        expect(ids(records)).toEqual(['early-v2', 'nv-v1']);
+      });
+    });
+
+    test('breaks an equal-valid_at tie by ascending seq', async () => {
+      // Two versions of one entity sharing a valid_at — the seq tiebreak orders them.
+      const tieIndex = MemoryIndex.create().orThrow();
+      tieIndex
+        .rebuild([
+          versionEntry({ entityId: 'tie', seq: 5, validAt: 500, invalidAt: 500 }),
+          versionEntry({ entityId: 'tie', seq: 4, validAt: 500 })
+        ])
+        .orThrow();
+      const tieRetriever = HistoryRetriever.create(tieIndex).orThrow();
+      expect(await tieRetriever.retrieve({})).toSucceedAndSatisfy((records) => {
+        expect(ids(records)).toEqual(['tie-v4', 'tie-v5']);
+      });
+    });
   });
 
   describe('loud-degrade + Hybrid composite', () => {

--- a/libraries/ts-agent-memory/src/test/unit/retrieve/temporalRetrievers.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/retrieve/temporalRetrievers.test.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import {
+  AsOfRetriever,
+  CurrentValidRetriever,
+  HistoryRetriever,
+  HybridRetriever,
+  IIndexedMemoryRecord,
+  IMemoryRecord,
+  Kind,
+  MemoryIndex,
+  MemoryScopeKey,
+  RecencyRetriever,
+  ScoreUnionMergeStrategy,
+  envelopeConverter
+} from '../../../index';
+
+const factKind: Kind = 'fact' as Kind;
+
+interface IVersionSpec {
+  readonly entityId: string;
+  readonly seq: number;
+  readonly validAt: number;
+  // eslint-disable-next-line @rushstack/no-new-null -- invalid_at null is the meaningful still-valid sentinel
+  readonly invalidAt?: number | null;
+  readonly kind?: string;
+}
+
+function versionEntry(spec: IVersionSpec): IIndexedMemoryRecord {
+  const temporal: Record<string, unknown> = { valid_at: spec.validAt };
+  if (spec.invalidAt !== undefined) {
+    temporal.invalid_at = spec.invalidAt;
+  }
+  const record: IMemoryRecord<unknown> = {
+    envelope: envelopeConverter
+      .convert({
+        id: `${spec.entityId}-v${spec.seq}`,
+        entityId: spec.entityId,
+        kind: spec.kind ?? 'fact',
+        tags: [],
+        links: [],
+        created: spec.validAt,
+        updated: spec.validAt,
+        seq: spec.seq,
+        contentHash: `h-${spec.entityId}-${spec.seq}`,
+        provenance: { source: 'agent' },
+        temporal
+      })
+      .orThrow(),
+    body: `${spec.entityId} v${spec.seq}`
+  };
+  return { scope: `facts/entities/${spec.entityId}` as MemoryScopeKey, record };
+}
+
+/** A flat (non-temporal) entry, to prove the temporal retrievers ignore it. */
+function flatEntry(id: string): IIndexedMemoryRecord {
+  const record: IMemoryRecord<unknown> = {
+    envelope: envelopeConverter
+      .convert({
+        id,
+        entityId: id,
+        kind: 'knowledge',
+        tags: [],
+        links: [],
+        created: 0,
+        updated: 0,
+        seq: 0,
+        contentHash: `h-${id}`,
+        provenance: { source: 'agent' }
+      })
+      .orThrow(),
+    body: id
+  };
+  return { scope: 'knowledge' as MemoryScopeKey, record };
+}
+
+function ids(records: ReadonlyArray<IMemoryRecord<unknown>>): string[] {
+  return records.map((r) => r.envelope.id as string);
+}
+
+// fact-1: v1 [100,200), v2 [200,∞) current. fact-2: v1 [150,∞) current. Plus a flat doc.
+function buildIndex(): MemoryIndex {
+  const index = MemoryIndex.create().orThrow();
+  index
+    .rebuild([
+      versionEntry({ entityId: 'fact-1', seq: 1, validAt: 100, invalidAt: 200 }),
+      versionEntry({ entityId: 'fact-1', seq: 2, validAt: 200 }),
+      versionEntry({ entityId: 'fact-2', seq: 3, validAt: 150 }),
+      flatEntry('doc-a')
+    ])
+    .orThrow();
+  return index;
+}
+
+describe('temporal retrievers', () => {
+  const index: MemoryIndex = buildIndex();
+
+  describe('CurrentValidRetriever', () => {
+    const retriever = CurrentValidRetriever.create(index).orThrow();
+
+    test('declares supportsTemporalQuery', () => {
+      expect(retriever.capabilities.supportsTemporalQuery).toBe(true);
+    });
+
+    test('returns the current version per temporal entity, ignoring flat records', async () => {
+      expect(await retriever.retrieve({})).toSucceedAndSatisfy((records) => {
+        expect(ids(records).sort()).toEqual(['fact-1-v2', 'fact-2-v3']);
+      });
+    });
+
+    test('honors scope / kind pre-filter and limit', async () => {
+      expect(await retriever.retrieve({ kind: factKind, limit: 1 })).toSucceedAndSatisfy((records) => {
+        expect(records).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('AsOfRetriever', () => {
+    const retriever = AsOfRetriever.create(index).orThrow();
+
+    test('empty when no asOf axis is supplied', async () => {
+      expect(await retriever.retrieve({})).toSucceedWith([]);
+    });
+
+    test('returns the version valid at asOf per entity', async () => {
+      expect(await retriever.retrieve({ asOf: 150 })).toSucceedAndSatisfy((records) => {
+        // fact-1 v1 valid at 150; fact-2 v1 valid at 150.
+        expect(ids(records).sort()).toEqual(['fact-1-v1', 'fact-2-v3']);
+      });
+      expect(await retriever.retrieve({ asOf: 250 })).toSucceedAndSatisfy((records) => {
+        expect(ids(records).sort()).toEqual(['fact-1-v2', 'fact-2-v3']);
+      });
+      expect(await retriever.retrieve({ asOf: 50 })).toSucceedWith([]);
+    });
+  });
+
+  describe('HistoryRetriever', () => {
+    const retriever = HistoryRetriever.create(index).orThrow();
+
+    test('returns all versions ascending by valid_at', async () => {
+      expect(await retriever.retrieve({ kind: factKind })).toSucceedAndSatisfy((records) => {
+        expect(ids(records)).toEqual(['fact-1-v1', 'fact-2-v3', 'fact-1-v2']);
+      });
+    });
+
+    test('applies the limit after ordering', async () => {
+      expect(await retriever.retrieve({ kind: factKind, limit: 2 })).toSucceedAndSatisfy((records) => {
+        expect(ids(records)).toEqual(['fact-1-v1', 'fact-2-v3']);
+      });
+    });
+  });
+
+  describe('loud-degrade + Hybrid composite', () => {
+    test('a non-temporal retriever loud-degrades on an asOf query', async () => {
+      const recency = RecencyRetriever.create(index).orThrow();
+      expect(await recency.retrieve({ asOf: 150 })).toFailWith(/temporal query requires temporal index/i);
+    });
+
+    test('a Hybrid of [Recency, AsOf] lights up temporal recall via the temporal child', async () => {
+      const recency = RecencyRetriever.create(index).orThrow();
+      const asOf = AsOfRetriever.create(index).orThrow();
+      const hybrid = HybridRetriever.create(
+        [recency, asOf],
+        ScoreUnionMergeStrategy.create().orThrow()
+      ).orThrow();
+      // The union supports temporal query, so the guard passes; Recency gets asOf
+      // stripped (returns everything), AsOf returns the valid-at versions.
+      expect(hybrid.capabilities.supportsTemporalQuery).toBe(true);
+      expect(await hybrid.retrieve({ asOf: 250, kind: factKind })).toSucceedAndSatisfy((records) => {
+        // fact-1-v2 is surfaced by BOTH (recency all + asOf), so it ranks first.
+        expect(ids(records)[0]).toBe('fact-1-v2');
+        expect(ids(records)).toContain('fact-2-v3');
+      });
+    });
+  });
+});

--- a/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
@@ -546,8 +546,11 @@ describe('FileTreeMemoryStore', () => {
     });
   });
 
-  describe('versioned codec (loud degradation)', () => {
+  describe('versioned codec misconfiguration', () => {
     const versionedKind: Kind = 'versioned' as Kind;
+    // A codec that reports isVersioned:true but does NOT implement the temporal
+    // codec interface (no encodeVersion/decodeVersion) — a misconfiguration the
+    // store must reject loudly rather than mis-handle.
     const versionedCodec: IIdentityCodec = {
       encode: (entityId: EntityId): Result<IIdentityCodecResult> =>
         succeed({ scope: 'versioned' as MemoryScopeKey, idStem: entityId as string, isVersioned: true }),
@@ -566,21 +569,9 @@ describe('FileTreeMemoryStore', () => {
       }).orThrow();
     }
 
-    test('put fails loudly on a versioned layout', async () => {
+    test('put fails loudly when a versioned codec omits the temporal interface', async () => {
       expect(await versionedStore().put(makeRecord({ id: 'v', kind: 'versioned', body: 'x' }))).toFailWith(
-        /versioned\/temporal layout not yet supported/i
-      );
-    });
-
-    test('get fails loudly on a versioned layout', async () => {
-      expect(await versionedStore().get(versionedKind, 'v' as EntityId)).toFailWith(
-        /versioned\/temporal layout not yet supported/i
-      );
-    });
-
-    test('delete fails loudly on a versioned layout', async () => {
-      expect(await versionedStore().delete(versionedKind, 'v' as EntityId)).toFailWith(
-        /versioned\/temporal layout not yet supported/i
+        /does not implement the temporal codec interface/i
       );
     });
   });

--- a/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
@@ -574,6 +574,18 @@ describe('FileTreeMemoryStore', () => {
         /does not implement the temporal codec interface/i
       );
     });
+
+    test('get fails loudly when a versioned codec omits the temporal interface', async () => {
+      expect(await versionedStore().get(versionedKind, 'v' as EntityId)).toFailWith(
+        /does not implement the temporal codec interface/i
+      );
+    });
+
+    test('delete fails loudly when a versioned codec omits the temporal interface', async () => {
+      expect(await versionedStore().delete(versionedKind, 'v' as EntityId)).toFailWith(
+        /does not implement the temporal codec interface/i
+      );
+    });
   });
 
   describe('default codec', () => {

--- a/libraries/ts-agent-memory/src/test/unit/store/temporalStore.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/temporalStore.test.ts
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converters, Result, succeed } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
+import {
+  AdmissionDecision,
+  BodyConverterRegistry,
+  EntityId,
+  FileTreeMemoryStore,
+  IBodyConverterRegistry,
+  IIdentityCodec,
+  IMemoryRecord,
+  IWritePolicy,
+  Kind,
+  KnowledgeIdentityCodec,
+  MemoryScopeKey,
+  TemporalIdentityCodec,
+  TemporalVersionedPolicy
+} from '../../../index';
+
+const factKind: Kind = 'fact' as Kind;
+const knowledgeKind: Kind = 'knowledge' as Kind;
+const factScope: MemoryScopeKey = 'facts/entities/fact-1' as MemoryScopeKey;
+
+function mutableRoot(): FileTree.IMutableFileTreeDirectoryItem {
+  const tree = FileTree.inMemory([], { mutable: true }).orThrow();
+  const root = tree.getDirectory('/').orThrow();
+  if (!FileTree.isMutableDirectoryItem(root)) {
+    throw new Error('expected a mutable root directory');
+  }
+  return root;
+}
+
+function registry(): IBodyConverterRegistry {
+  const reg = BodyConverterRegistry.create().orThrow();
+  reg.register(factKind, Converters.string);
+  reg.register(knowledgeKind, Converters.string);
+  return reg;
+}
+
+const codecs: ReadonlyMap<Kind, IIdentityCodec> = new Map<Kind, IIdentityCodec>([
+  [factKind, TemporalIdentityCodec.create('facts').orThrow()],
+  [knowledgeKind, new KnowledgeIdentityCodec()]
+]);
+
+const temporalPolicies: ReadonlyMap<Kind, IWritePolicy> = new Map<Kind, IWritePolicy>([
+  [factKind, TemporalVersionedPolicy.create().orThrow()]
+]);
+
+/** A record the consumer hands to `put`. The store mints the version `id`. */
+function factRecord(entityId: string, body: string): IMemoryRecord<unknown> {
+  return {
+    envelope: {
+      id: entityId as unknown as IMemoryRecord<unknown>['envelope']['id'],
+      entityId: entityId as EntityId,
+      kind: factKind,
+      tags: [],
+      links: [],
+      created: 0,
+      updated: 0,
+      seq: 0,
+      contentHash: '',
+      provenance: { source: 'agent' }
+    },
+    body
+  };
+}
+
+function knowledgeRecord(id: string, body: string): IMemoryRecord<unknown> {
+  return {
+    envelope: {
+      id: id as unknown as IMemoryRecord<unknown>['envelope']['id'],
+      entityId: id as EntityId,
+      kind: knowledgeKind,
+      tags: [],
+      links: [],
+      created: 0,
+      updated: 0,
+      seq: 0,
+      contentHash: '',
+      provenance: { source: 'agent' }
+    },
+    body
+  };
+}
+
+describe('FileTreeMemoryStore — temporal (versioned) path', () => {
+  let clockValue: number;
+  const clock = (): number => clockValue;
+
+  function createStore(
+    root: FileTree.IMutableFileTreeDirectoryItem = mutableRoot(),
+    policies: ReadonlyMap<Kind, IWritePolicy> = temporalPolicies
+  ): FileTreeMemoryStore {
+    return FileTreeMemoryStore.create({
+      root,
+      registry: registry(),
+      codecs,
+      writePolicies: policies,
+      clock
+    }).orThrow();
+  }
+
+  beforeEach(() => {
+    clockValue = 1000;
+  });
+
+  describe('put / get', () => {
+    test('first put writes v1 under the entity subtree with a minted version id', async () => {
+      const store = createStore();
+      expect(await store.put(factRecord('fact-1', 'the sky is blue'))).toSucceedAndSatisfy((put) => {
+        expect(put.envelope.id).toBe('fact-1-v1');
+        expect(put.envelope.entityId).toBe('fact-1');
+        expect(put.envelope.temporal).toEqual({ valid_at: 1000 });
+      });
+      // Keyed get resolves the current version.
+      expect(await store.get(factKind, 'fact-1' as EntityId)).toSucceedAndSatisfy((got) => {
+        expect(got?.envelope.id).toBe('fact-1-v1');
+        expect(got?.body).toBe('the sky is blue');
+      });
+      // The version file lives at facts/entities/fact-1/fact-1-v1.md.
+      expect(await store.getById(factScope, 'fact-1-v1' as never)).toSucceedAndSatisfy((got) => {
+        expect(got?.body).toBe('the sky is blue');
+      });
+    });
+
+    test('get returns undefined for an entity with no versions', async () => {
+      const store = createStore();
+      expect(await store.get(factKind, 'nope' as EntityId)).toSucceedWith(undefined);
+    });
+  });
+
+  describe("merge-patch-under-versioning (invalidate-don't-delete)", () => {
+    test('a re-put yields a NEW version and invalidates the prior (both persist)', async () => {
+      const store = createStore();
+      expect(await store.put(factRecord('fact-1', 'the sky is blue'))).toSucceed();
+      clockValue = 2000;
+      expect(await store.put(factRecord('fact-1', 'the sky is grey'))).toSucceedAndSatisfy((put) => {
+        expect(put.envelope.id).toBe('fact-1-v2');
+        expect(put.envelope.temporal).toEqual({ valid_at: 2000 });
+        expect(put.body).toBe('the sky is grey');
+      });
+
+      // Both versions persist.
+      expect(await store.list({ kind: factKind })).toSucceedAndSatisfy((all) => {
+        expect(all.map((r) => r.envelope.id).sort()).toEqual(['fact-1-v1', 'fact-1-v2']);
+      });
+      // The prior version now carries invalid_at.
+      expect(await store.getById(factScope, 'fact-1-v1' as never)).toSucceedAndSatisfy((v1) => {
+        expect(v1?.envelope.temporal).toEqual({ valid_at: 1000, invalid_at: 2000 });
+      });
+      // The new version is current.
+      expect(await store.get(factKind, 'fact-1' as EntityId)).toSucceedAndSatisfy((cur) => {
+        expect(cur?.envelope.id).toBe('fact-1-v2');
+      });
+    });
+
+    test('survives a round-trip through disk (fresh store re-indexes the subtree)', async () => {
+      const root = mutableRoot();
+      const store = createStore(root);
+      expect(await store.put(factRecord('fact-1', 'v1 body'))).toSucceed();
+      clockValue = 2000;
+      expect(await store.put(factRecord('fact-1', 'v2 body'))).toSucceed();
+
+      const reopened = createStore(root);
+      expect(await reopened.list({ kind: factKind })).toSucceedAndSatisfy((all) => {
+        expect(all.map((r) => r.envelope.id).sort()).toEqual(['fact-1-v1', 'fact-1-v2']);
+      });
+      expect(await reopened.get(factKind, 'fact-1' as EntityId)).toSucceedAndSatisfy((cur) => {
+        expect(cur?.envelope.id).toBe('fact-1-v2');
+      });
+    });
+
+    test('an identical re-put is a no-op (entity dedup, no redundant version)', async () => {
+      const store = createStore();
+      expect(await store.put(factRecord('fact-1', 'same'))).toSucceed();
+      clockValue = 2000;
+      expect(await store.put(factRecord('fact-1', 'same'))).toSucceedAndSatisfy((put) => {
+        expect(put.envelope.id).toBe('fact-1-v1'); // still v1
+      });
+      expect(await store.list({ kind: factKind })).toSucceedAndSatisfy((all) => {
+        expect(all).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('list({ asOf }) and get resolution', () => {
+    test('asOf selects the version valid at the instant; get returns current', async () => {
+      const store = createStore();
+      expect(await store.put(factRecord('fact-1', 'blue'))).toSucceed(); // valid_at 1000
+      clockValue = 2000;
+      expect(await store.put(factRecord('fact-1', 'grey'))).toSucceed(); // v1 invalid_at 2000, v2 valid_at 2000
+
+      // At t=1500 only v1 was valid.
+      expect(await store.list({ kind: factKind, asOf: 1500 })).toSucceedAndSatisfy((at1500) => {
+        expect(at1500.map((r) => r.envelope.id)).toEqual(['fact-1-v1']);
+      });
+      // At t=2500 v2 is valid.
+      expect(await store.list({ kind: factKind, asOf: 2500 })).toSucceedAndSatisfy((at2500) => {
+        expect(at2500.map((r) => r.envelope.id)).toEqual(['fact-1-v2']);
+      });
+      // Before either version existed.
+      expect(await store.list({ kind: factKind, asOf: 500 })).toSucceedWith([]);
+      // get (no asOf) returns the current version.
+      expect(await store.get(factKind, 'fact-1' as EntityId)).toSucceedAndSatisfy((cur) => {
+        expect(cur?.envelope.id).toBe('fact-1-v2');
+      });
+    });
+
+    test('asOf passes non-temporal records through unchanged (timeless)', async () => {
+      const store = createStore();
+      expect(await store.put(knowledgeRecord('doc-a', 'flat body'))).toSucceed();
+      expect(await store.put(factRecord('fact-1', 'blue'))).toSucceed();
+      // asOf at an instant before the flat doc's created still includes it (timeless).
+      expect(await store.list({ asOf: 500 })).toSucceedAndSatisfy((snap) => {
+        expect(snap.map((r) => r.envelope.id).sort()).toEqual(['doc-a']);
+      });
+    });
+  });
+
+  describe("delete (soft / invalidate-don't-delete)", () => {
+    test('invalidates the current version, retains history, returns the invalidated id', async () => {
+      const store = createStore();
+      expect(await store.put(factRecord('fact-1', 'blue'))).toSucceed();
+      clockValue = 3000;
+      expect(await store.delete(factKind, 'fact-1' as EntityId)).toSucceedWith('fact-1-v1' as never);
+
+      // No current version after the soft delete.
+      expect(await store.get(factKind, 'fact-1' as EntityId)).toSucceedWith(undefined);
+      // But history is retained (the file still exists, now invalidated).
+      expect(await store.list({ kind: factKind })).toSucceedAndSatisfy((all) => {
+        expect(all).toHaveLength(1);
+        expect(all[0].envelope.temporal).toEqual({ valid_at: 1000, invalid_at: 3000 });
+      });
+      // A second delete finds no current version.
+      expect(await store.delete(factKind, 'fact-1' as EntityId)).toFailWith(/no record found/i);
+    });
+  });
+
+  describe('policy admission on the versioned path', () => {
+    test('a rejecting policy fails the put', async () => {
+      const rejectingCodec: IIdentityCodec = TemporalIdentityCodec.create('facts').orThrow();
+      const rejectPolicy: IWritePolicy = {
+        mutableFields: ['body'],
+        dedupScope: 'entity',
+        admit: (): Result<AdmissionDecision> => succeed({ decision: 'reject', reason: 'blocked' }),
+        applyUpdate: (existing): Result<IMemoryRecord<unknown>> => succeed(existing)
+      };
+      const store = FileTreeMemoryStore.create({
+        root: mutableRoot(),
+        registry: registry(),
+        codecs: new Map<Kind, IIdentityCodec>([[factKind, rejectingCodec]]),
+        writePolicies: new Map<Kind, IWritePolicy>([[factKind, rejectPolicy]]),
+        clock
+      }).orThrow();
+      expect(await store.put(factRecord('fact-1', 'blue'))).toFailWith(/rejected by policy: blocked/i);
+    });
+  });
+
+  describe('flat-path regression (adoption guarantee)', () => {
+    test('a non-temporal kind is unaffected: flat put/get/delete, no entities/ subtree', async () => {
+      const store = createStore();
+      expect(await store.put(knowledgeRecord('doc-a', 'flat body'))).toSucceedAndSatisfy((put) => {
+        // Flat: id === entityId, no temporal block, no minted version id.
+        expect(put.envelope.id).toBe('doc-a');
+        expect(put.envelope.entityId).toBe('doc-a');
+        expect(put.envelope.temporal).toBeUndefined();
+      });
+      expect(await store.get(knowledgeKind, 'doc-a' as EntityId)).toSucceedAndSatisfy((got) => {
+        expect(got?.body).toBe('flat body');
+      });
+      // The flat record lives at the flat knowledge scope, not under any entities/ subtree.
+      expect(await store.getById('knowledge' as MemoryScopeKey, 'doc-a' as never)).toSucceedAndSatisfy(
+        (got) => {
+          expect(got?.envelope.id).toBe('doc-a');
+        }
+      );
+      // Flat delete physically removes the record.
+      expect(await store.delete(knowledgeKind, 'doc-a' as EntityId)).toSucceedWith('doc-a' as never);
+      expect(await store.get(knowledgeKind, 'doc-a' as EntityId)).toSucceedWith(undefined);
+      expect(await store.list({ kind: knowledgeKind })).toSucceedWith([]);
+    });
+  });
+});

--- a/libraries/ts-agent-memory/src/test/unit/store/temporalStore.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/temporalStore.test.ts
@@ -4,7 +4,7 @@
  */
 
 import '@fgv/ts-utils-jest';
-import { Converters, Result, succeed } from '@fgv/ts-utils';
+import { Converters, Result, fail, succeed } from '@fgv/ts-utils';
 import { FileTree } from '@fgv/ts-json-base';
 import {
   AdmissionDecision,
@@ -13,26 +13,61 @@ import {
   FileTreeMemoryStore,
   IBodyConverterRegistry,
   IIdentityCodec,
+  IMemoryEnvelope,
   IMemoryRecord,
   IWritePolicy,
   Kind,
   KnowledgeIdentityCodec,
+  MemoryId,
   MemoryScopeKey,
   TemporalIdentityCodec,
-  TemporalVersionedPolicy
+  TemporalVersionedPolicy,
+  serializeMemoryFile
 } from '../../../index';
 
 const factKind: Kind = 'fact' as Kind;
 const knowledgeKind: Kind = 'knowledge' as Kind;
 const factScope: MemoryScopeKey = 'facts/entities/fact-1' as MemoryScopeKey;
 
-function mutableRoot(): FileTree.IMutableFileTreeDirectoryItem {
-  const tree = FileTree.inMemory([], { mutable: true }).orThrow();
+function mutableRoot(
+  files: ReadonlyArray<{ path: string; contents: string }> = []
+): FileTree.IMutableFileTreeDirectoryItem {
+  const tree = FileTree.inMemory([...files], { mutable: true }).orThrow();
   const root = tree.getDirectory('/').orThrow();
   if (!FileTree.isMutableDirectoryItem(root)) {
     throw new Error('expected a mutable root directory');
   }
   return root;
+}
+
+/**
+ * A raw seeded `fact-1` version file. `invalidAt` absent → a CURRENT version;
+ * seeding two current versions reproduces a stuck partial-invalidation state.
+ */
+function seedFactVersion(
+  seq: number,
+  validAt: number,
+  invalidAt?: number
+): { path: string; contents: string } {
+  const temporal: Record<string, unknown> =
+    invalidAt === undefined ? { valid_at: validAt } : { valid_at: validAt, invalid_at: invalidAt };
+  const envelope: IMemoryEnvelope = {
+    id: `fact-1-v${seq}` as MemoryId,
+    entityId: 'fact-1' as EntityId,
+    kind: factKind,
+    tags: [],
+    links: [],
+    created: validAt,
+    updated: validAt,
+    seq,
+    contentHash: `seed-${seq}`,
+    provenance: { source: 'agent' },
+    temporal
+  };
+  return {
+    path: `facts/entities/fact-1/fact-1-v${seq}.md`,
+    contents: serializeMemoryFile(envelope, `seed body v${seq}`).orThrow()
+  };
 }
 
 function registry(): IBodyConverterRegistry {
@@ -68,6 +103,12 @@ function factRecord(entityId: string, body: string): IMemoryRecord<unknown> {
     },
     body
   };
+}
+
+/** Like {@link factRecord} but supplying an explicit world-truth `valid_at`. */
+function factRecordAt(entityId: string, body: string, validAt: number): IMemoryRecord<unknown> {
+  const base = factRecord(entityId, body);
+  return { envelope: { ...base.envelope, temporal: { valid_at: validAt } }, body: base.body };
 }
 
 function knowledgeRecord(id: string, body: string): IMemoryRecord<unknown> {
@@ -241,23 +282,123 @@ describe('FileTreeMemoryStore — temporal (versioned) path', () => {
     });
   });
 
+  describe('world-truth valid-time boundary (P2-1)', () => {
+    test('a future-dated supersede closes the prior interval at the NEW valid_at (no gap)', async () => {
+      const store = createStore();
+      expect(await store.put(factRecord('fact-1', 'blue'))).toSucceed(); // v1 valid_at 1000
+      clockValue = 2000;
+      // The new version's world-truth validity starts in the future (5000), while
+      // the transaction happens now (2000).
+      expect(await store.put(factRecordAt('fact-1', 'grey', 5000))).toSucceedAndSatisfy((put) => {
+        expect(put.envelope.temporal).toEqual({ valid_at: 5000 });
+      });
+      // The prior version's interval closes at the NEW valid_at (5000), NOT `now` (2000).
+      expect(await store.getById(factScope, 'fact-1-v1' as never)).toSucceedAndSatisfy((v1) => {
+        expect(v1?.envelope.temporal).toEqual({ valid_at: 1000, invalid_at: 5000 });
+      });
+      // As-of between the two valid_ats still resolves to v1 — no gap on the axis.
+      expect(await store.list({ kind: factKind, asOf: 3000 })).toSucceedAndSatisfy((at3000) => {
+        expect(at3000.map((r) => r.envelope.id)).toEqual(['fact-1-v1']);
+      });
+    });
+  });
+
+  describe('self-healing invalidation (P2-7)', () => {
+    test('a put invalidates EVERY stuck-current prior version', async () => {
+      // Seed a corrupt state: two current versions (a prior invalidation only
+      // partially completed).
+      const root = mutableRoot([seedFactVersion(1, 100), seedFactVersion(2, 200)]);
+      const store = createStore(root);
+      clockValue = 3000;
+      expect(await store.put(factRecord('fact-1', 'v3 body'))).toSucceedAndSatisfy((put) => {
+        expect(put.envelope.id).toBe('fact-1-v3');
+      });
+      // BOTH stuck versions are now invalidated at the new valid_at (3000).
+      expect(await store.getById(factScope, 'fact-1-v1' as never)).toSucceedAndSatisfy((v1) => {
+        expect(v1?.envelope.temporal).toEqual({ valid_at: 100, invalid_at: 3000 });
+      });
+      expect(await store.getById(factScope, 'fact-1-v2' as never)).toSucceedAndSatisfy((v2) => {
+        expect(v2?.envelope.temporal).toEqual({ valid_at: 200, invalid_at: 3000 });
+      });
+      // Exactly one current version remains: the new one.
+      expect(await store.get(factKind, 'fact-1' as EntityId)).toSucceedAndSatisfy((cur) => {
+        expect(cur?.envelope.id).toBe('fact-1-v3');
+      });
+    });
+
+    test('a delete invalidates EVERY stuck-current prior version', async () => {
+      const root = mutableRoot([seedFactVersion(1, 100), seedFactVersion(2, 200)]);
+      const store = createStore(root);
+      clockValue = 4000;
+      expect(await store.delete(factKind, 'fact-1' as EntityId)).toSucceedWith('fact-1-v2' as never);
+      expect(await store.getById(factScope, 'fact-1-v1' as never)).toSucceedAndSatisfy((v1) => {
+        expect(v1?.envelope.temporal).toEqual({ valid_at: 100, invalid_at: 4000 });
+      });
+      expect(await store.getById(factScope, 'fact-1-v2' as never)).toSucceedAndSatisfy((v2) => {
+        expect(v2?.envelope.temporal).toEqual({ valid_at: 200, invalid_at: 4000 });
+      });
+      expect(await store.get(factKind, 'fact-1' as EntityId)).toSucceedWith(undefined);
+    });
+  });
+
   describe('policy admission on the versioned path', () => {
+    function storeWithPolicy(policy: IWritePolicy): FileTreeMemoryStore {
+      return FileTreeMemoryStore.create({
+        root: mutableRoot(),
+        registry: registry(),
+        codecs: new Map<Kind, IIdentityCodec>([[factKind, TemporalIdentityCodec.create('facts').orThrow()]]),
+        writePolicies: new Map<Kind, IWritePolicy>([[factKind, policy]]),
+        clock
+      }).orThrow();
+    }
+
     test('a rejecting policy fails the put', async () => {
-      const rejectingCodec: IIdentityCodec = TemporalIdentityCodec.create('facts').orThrow();
-      const rejectPolicy: IWritePolicy = {
+      const store = storeWithPolicy({
         mutableFields: ['body'],
         dedupScope: 'entity',
         admit: (): Result<AdmissionDecision> => succeed({ decision: 'reject', reason: 'blocked' }),
         applyUpdate: (existing): Result<IMemoryRecord<unknown>> => succeed(existing)
-      };
-      const store = FileTreeMemoryStore.create({
-        root: mutableRoot(),
-        registry: registry(),
-        codecs: new Map<Kind, IIdentityCodec>([[factKind, rejectingCodec]]),
-        writePolicies: new Map<Kind, IWritePolicy>([[factKind, rejectPolicy]]),
-        clock
-      }).orThrow();
+      });
       expect(await store.put(factRecord('fact-1', 'blue'))).toFailWith(/rejected by policy: blocked/i);
+    });
+
+    test('a policy whose admit fails propagates the failure', async () => {
+      const store = storeWithPolicy({
+        mutableFields: ['body'],
+        dedupScope: 'entity',
+        admit: (): Result<AdmissionDecision> => fail('admit exploded'),
+        applyUpdate: (existing): Result<IMemoryRecord<unknown>> => succeed(existing)
+      });
+      expect(await store.put(factRecord('fact-1', 'blue'))).toFailWith(/admit exploded/i);
+    });
+
+    test('a policy omitting dedupScope falls back to the default (entity) dedup', async () => {
+      const store = storeWithPolicy({
+        mutableFields: ['body'],
+        // dedupScope intentionally omitted → the store applies DEFAULT_DEDUP_SCOPE.
+        admit: (): Result<AdmissionDecision> => succeed({ decision: 'accept' }),
+        applyUpdate: (existing): Result<IMemoryRecord<unknown>> => succeed(existing)
+      });
+      expect(await store.put(factRecord('fact-1', 'same'))).toSucceed();
+      clockValue = 2000;
+      // Identical re-put is a no-op under the default entity dedup — no v2.
+      expect(await store.put(factRecord('fact-1', 'same'))).toSucceedAndSatisfy((put) => {
+        expect(put.envelope.id).toBe('fact-1-v1');
+      });
+    });
+
+    test('a policy that returns a non-string merged body fails the update', async () => {
+      const store = storeWithPolicy({
+        mutableFields: ['body'],
+        dedupScope: 'entity',
+        admit: (): Result<AdmissionDecision> => succeed({ decision: 'accept' }),
+        // Corrupt the merge output on the update branch.
+        applyUpdate: (existing): Result<IMemoryRecord<unknown>> =>
+          succeed({ envelope: existing.envelope, body: 42 })
+      });
+      expect(await store.put(factRecord('fact-1', 'v1'))).toSucceed();
+      clockValue = 2000;
+      expect(await store.put(factRecord('fact-1', 'v2'))).toFailWith(/non-string body/i);
     });
   });
 

--- a/libraries/ts-agent-memory/src/test/unit/types/temporalCodec.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/types/temporalCodec.test.ts
@@ -102,6 +102,14 @@ describe('TemporalIdentityCodec', () => {
         /non-integer version suffix/i
       );
     });
+
+    test('rejects a version suffix outside the safe integer range (corruption/tamper guard)', () => {
+      // A very long digit run passes the regex but overflows Number.MAX_SAFE_INTEGER;
+      // parseInt would silently lose precision, so decode must fail rather than corrupt seq.
+      expect(
+        codec.decodeVersion('facts/entities/fact-1' as MemoryScopeKey, 'fact-1-v99999999999999999999')
+      ).toFailWith(/outside the safe integer range/i);
+    });
   });
 
   describe('verifyRoundTrip', () => {

--- a/libraries/ts-agent-memory/src/test/unit/types/temporalCodec.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/types/temporalCodec.test.ts
@@ -116,6 +116,13 @@ describe('TemporalIdentityCodec', () => {
         /non-integer version suffix/i
       );
     });
+
+    test('fails on a non-canonical (zero-padded) seq stem', () => {
+      // `-v007` decodes to seq 7 but re-encodes to `-v7`, so it is not canonical.
+      expect(codec.verifyRoundTrip('facts/entities/fact-1' as MemoryScopeKey, 'fact-1-v007')).toFailWith(
+        /round-trip mismatch/i
+      );
+    });
   });
 });
 
@@ -226,6 +233,14 @@ describe('temporal selection helpers', () => {
     // A fully-invalidated entity has no current version.
     expect(selectCurrentVersion([v1])).toBeUndefined();
     expect(selectCurrentVersion([])).toBeUndefined();
+  });
+
+  test('selectCurrentVersion is order-independent (highest seq wins on an unsorted input)', () => {
+    const v3 = versionRecord(3, 300);
+    // Descending input: the first candidate is already the max, so a later
+    // candidate must NOT displace it.
+    expect(selectCurrentVersion([v3, v2])?.envelope.id).toBe('fact-1-v3');
+    expect(selectCurrentVersion([v2, v3])?.envelope.id).toBe('fact-1-v3');
   });
 
   test('selectVersionAsOf returns the highest-seq version valid at the instant', () => {

--- a/libraries/ts-agent-memory/src/test/unit/types/temporalCodec.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/types/temporalCodec.test.ts
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import {
+  EntityId,
+  IIdentityCodec,
+  IMemoryRecord,
+  KnowledgeIdentityCodec,
+  MemoryScopeKey,
+  TemporalIdentityCodec,
+  isTemporalIdentityCodec,
+  isTemporalRecord,
+  isVersionCurrent,
+  isVersionValidAt,
+  selectCurrentVersion,
+  selectVersionAsOf
+} from '../../../packlets/types';
+import { envelopeConverter } from '../../../packlets/converters';
+
+const codec: TemporalIdentityCodec = TemporalIdentityCodec.create('facts').orThrow();
+
+describe('TemporalIdentityCodec', () => {
+  describe('create', () => {
+    test('rejects a non-portable base scope', () => {
+      expect(TemporalIdentityCodec.create('has/slash')).toFailWith(/baseScope/i);
+    });
+  });
+
+  describe('encode', () => {
+    test('maps an entityId to the entity subtree, versioned', () => {
+      expect(codec.encode('fact-1' as EntityId)).toSucceedWith({
+        scope: 'facts/entities/fact-1' as MemoryScopeKey,
+        idStem: 'fact-1',
+        isVersioned: true
+      });
+    });
+
+    test('rejects a non-portable entityId', () => {
+      expect(codec.encode('bad/id' as EntityId)).toFailWith(/entityId/i);
+    });
+  });
+
+  describe('encodeVersion', () => {
+    test('forms the <entityId>-v<seq> stem', () => {
+      expect(codec.encodeVersion('fact-1' as EntityId, 7)).toSucceedWith('fact-1-v7');
+    });
+
+    test('rejects a negative or non-integer seq', () => {
+      expect(codec.encodeVersion('fact-1' as EntityId, -1)).toFailWith(/non-negative integer/i);
+      expect(codec.encodeVersion('fact-1' as EntityId, 1.5)).toFailWith(/non-negative integer/i);
+    });
+
+    test('rejects a non-portable entityId', () => {
+      expect(codec.encodeVersion('bad/id' as EntityId, 1)).toFailWith(/entityId/i);
+    });
+  });
+
+  describe('decode / decodeVersion', () => {
+    test('recovers the entityId and seq from a (scope, version stem)', () => {
+      expect(codec.decodeVersion('facts/entities/fact-1' as MemoryScopeKey, 'fact-1-v3')).toSucceedWith({
+        entityId: 'fact-1' as EntityId,
+        seq: 3
+      });
+      expect(codec.decode('facts/entities/fact-1' as MemoryScopeKey, 'fact-1-v3')).toSucceedWith(
+        'fact-1' as EntityId
+      );
+    });
+
+    test('disambiguates an entityId that itself ends in -v<digits> via the scope', () => {
+      // The subtree scope is authoritative for the entityId, so a stem whose
+      // entityId is `rev-v2` parses correctly.
+      expect(codec.decodeVersion('facts/entities/rev-v2' as MemoryScopeKey, 'rev-v2-v5')).toSucceedWith({
+        entityId: 'rev-v2' as EntityId,
+        seq: 5
+      });
+    });
+
+    test('rejects a scope that is not <base>/entities/<entityId>', () => {
+      expect(codec.decodeVersion('facts/fact-1' as MemoryScopeKey, 'fact-1-v0')).toFailWith(
+        /must be 'facts\/entities\/<entityId>'/i
+      );
+      expect(codec.decodeVersion('other/entities/fact-1' as MemoryScopeKey, 'fact-1-v0')).toFailWith(
+        /must be 'facts\/entities\/<entityId>'/i
+      );
+    });
+
+    test('rejects a non-portable entityId embedded in the scope', () => {
+      expect(codec.decodeVersion('facts/entities/ ' as MemoryScopeKey, ' -v0')).toFailWith(/entityId/i);
+    });
+
+    test('rejects a stem that does not carry the entity prefix', () => {
+      expect(codec.decodeVersion('facts/entities/fact-1' as MemoryScopeKey, 'other-v0')).toFailWith(
+        /must begin with 'fact-1-v'/i
+      );
+    });
+
+    test('rejects a stem with a non-integer version suffix', () => {
+      expect(codec.decodeVersion('facts/entities/fact-1' as MemoryScopeKey, 'fact-1-vX')).toFailWith(
+        /non-integer version suffix/i
+      );
+    });
+  });
+
+  describe('verifyRoundTrip', () => {
+    test('succeeds for a well-formed (scope, version stem)', () => {
+      expect(codec.verifyRoundTrip('facts/entities/fact-1' as MemoryScopeKey, 'fact-1-v9')).toSucceedWith(
+        true
+      );
+    });
+
+    test('fails when the stem cannot be decoded', () => {
+      expect(codec.verifyRoundTrip('facts/entities/fact-1' as MemoryScopeKey, 'fact-1-vZ')).toFailWith(
+        /non-integer version suffix/i
+      );
+    });
+  });
+});
+
+describe('isTemporalIdentityCodec', () => {
+  test('is true for a temporal codec', () => {
+    expect(isTemporalIdentityCodec(codec)).toBe(true);
+  });
+
+  test('is false for a flat codec', () => {
+    const flat: IIdentityCodec = new KnowledgeIdentityCodec();
+    expect(isTemporalIdentityCodec(flat)).toBe(false);
+  });
+});
+
+/** Build a temporal version record for the selection-helper tests. */
+// eslint-disable-next-line @rushstack/no-new-null -- invalid_at null is the meaningful still-valid sentinel
+function versionRecord(seq: number, validAt: number, invalidAt?: number | null): IMemoryRecord<unknown> {
+  const temporal: Record<string, unknown> = { valid_at: validAt };
+  if (invalidAt !== undefined) {
+    temporal.invalid_at = invalidAt;
+  }
+  return {
+    envelope: envelopeConverter
+      .convert({
+        id: `fact-1-v${seq}`,
+        entityId: 'fact-1',
+        kind: 'fact',
+        tags: [],
+        links: [],
+        created: validAt,
+        updated: validAt,
+        seq,
+        contentHash: `h${seq}`,
+        provenance: { source: 'agent' },
+        temporal
+      })
+      .orThrow(),
+    body: `body v${seq}`
+  };
+}
+
+describe('temporal selection helpers', () => {
+  const v1 = versionRecord(1, 100, 200);
+  const v2 = versionRecord(2, 200);
+  const atemporal: IMemoryRecord<unknown> = {
+    envelope: envelopeConverter
+      .convert({
+        id: 'doc',
+        entityId: 'doc',
+        kind: 'knowledge',
+        tags: [],
+        links: [],
+        created: 0,
+        updated: 0,
+        seq: 0,
+        contentHash: 'h',
+        provenance: { source: 'agent' }
+      })
+      .orThrow(),
+    body: 'flat'
+  };
+
+  test('isTemporalRecord keys off the temporal block', () => {
+    expect(isTemporalRecord(v1)).toBe(true);
+    expect(isTemporalRecord(atemporal)).toBe(false);
+  });
+
+  test('isVersionCurrent is true only for a null/absent invalid_at', () => {
+    expect(isVersionCurrent(v1)).toBe(false);
+    expect(isVersionCurrent(v2)).toBe(true);
+    expect(isVersionCurrent(versionRecord(3, 300, null))).toBe(true);
+    expect(isVersionCurrent(atemporal)).toBe(false);
+  });
+
+  test('isVersionValidAt bounds by valid_at and invalid_at', () => {
+    expect(isVersionValidAt(v1, 50)).toBe(false); // before valid_at
+    expect(isVersionValidAt(v1, 150)).toBe(true); // within [100, 200)
+    expect(isVersionValidAt(v1, 200)).toBe(false); // at invalid_at (exclusive)
+    expect(isVersionValidAt(v2, 500)).toBe(true); // still valid
+    expect(isVersionValidAt(atemporal, 500)).toBe(false);
+  });
+
+  test('isVersionValidAt defaults valid_at to created when absent', () => {
+    const noValidAt: IMemoryRecord<unknown> = {
+      envelope: envelopeConverter
+        .convert({
+          id: 'fact-1-v4',
+          entityId: 'fact-1',
+          kind: 'fact',
+          tags: [],
+          links: [],
+          created: 400,
+          updated: 400,
+          seq: 4,
+          contentHash: 'h4',
+          provenance: { source: 'agent' },
+          temporal: {}
+        })
+        .orThrow(),
+      body: 'v4'
+    };
+    expect(isVersionValidAt(noValidAt, 399)).toBe(false);
+    expect(isVersionValidAt(noValidAt, 400)).toBe(true);
+  });
+
+  test('selectCurrentVersion returns the highest-seq current version', () => {
+    expect(selectCurrentVersion([v1, v2])?.envelope.id).toBe('fact-1-v2');
+    // A fully-invalidated entity has no current version.
+    expect(selectCurrentVersion([v1])).toBeUndefined();
+    expect(selectCurrentVersion([])).toBeUndefined();
+  });
+
+  test('selectVersionAsOf returns the highest-seq version valid at the instant', () => {
+    expect(selectVersionAsOf([v1, v2], 150)?.envelope.id).toBe('fact-1-v1');
+    expect(selectVersionAsOf([v1, v2], 250)?.envelope.id).toBe('fact-1-v2');
+    expect(selectVersionAsOf([v1, v2], 50)).toBeUndefined();
+  });
+});

--- a/libraries/ts-agent-memory/src/test/unit/types/temporalPolicy.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/types/temporalPolicy.test.ts
@@ -84,5 +84,13 @@ describe('TemporalVersionedPolicy', () => {
         expect(updated.envelope.embeddingRef).toBeUndefined();
       });
     });
+
+    test('carries an untouched embeddingRef through a body-only patch', () => {
+      const existing = makeRecord({ embeddingRef: 'vec-1' }, 'the sky is blue');
+      expect(policy.applyUpdate(existing, { body: 'the sky is grey' })).toSucceedAndSatisfy((updated) => {
+        expect(updated.body).toBe('the sky is grey');
+        expect(updated.envelope.embeddingRef).toBe('vec-1');
+      });
+    });
   });
 });

--- a/libraries/ts-agent-memory/src/test/unit/types/temporalPolicy.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/types/temporalPolicy.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import {
+  EntityId,
+  IMemoryEnvelope,
+  IMemoryRecord,
+  IProvenance,
+  Kind,
+  MemoryId,
+  Tag,
+  TemporalVersionedPolicy
+} from '../../../packlets/types';
+
+function makeRecord(overrides?: Partial<IMemoryEnvelope>, body?: unknown): IMemoryRecord<unknown> {
+  const envelope: IMemoryEnvelope = {
+    id: 'fact-1-v1' as MemoryId,
+    entityId: 'fact-1' as EntityId,
+    kind: 'fact' as Kind,
+    tags: ['sky'] as Tag[],
+    links: [],
+    created: 1000,
+    updated: 1000,
+    seq: 1,
+    contentHash: 'hash-1',
+    provenance: { source: 'agent' } as IProvenance,
+    temporal: { valid_at: 1000 },
+    ...overrides
+  };
+  return { envelope, body: body ?? 'the sky is blue' };
+}
+
+describe('TemporalVersionedPolicy', () => {
+  let policy: TemporalVersionedPolicy;
+
+  beforeEach(() => {
+    policy = TemporalVersionedPolicy.create().orThrow();
+  });
+
+  test('exposes the temporal mutable surface and entity dedup', () => {
+    expect(policy.mutableFields).toEqual(['body', 'tags', 'links', 'provenance', 'embeddingRef']);
+    expect(policy.dedupScope).toBe('entity');
+  });
+
+  describe('admit', () => {
+    test("always accepts (invalidate-don't-delete: never culls)", () => {
+      expect(policy.admit(makeRecord(), [])).toSucceedWith({ decision: 'accept' });
+      expect(policy.admit(makeRecord(), [makeRecord(), makeRecord()])).toSucceedWith({
+        decision: 'accept'
+      });
+    });
+  });
+
+  describe('applyUpdate (forms the new version content)', () => {
+    test('replaces a string body wholesale', () => {
+      const existing = makeRecord(undefined, 'the sky is blue');
+      expect(policy.applyUpdate(existing, { body: 'the sky is grey' })).toSucceedAndSatisfy((updated) => {
+        expect(updated.body).toBe('the sky is grey');
+      });
+    });
+
+    test('merges tags / provenance and preserves untouched envelope metadata', () => {
+      const existing = makeRecord({ provenance: { source: 'agent', by: 'curator' } as IProvenance });
+      expect(
+        policy.applyUpdate(existing, { tags: ['sky', 'weather'], provenance: { model: 'gpt' } })
+      ).toSucceedAndSatisfy((updated) => {
+        expect(updated.envelope.tags).toEqual(['sky', 'weather']);
+        expect(updated.envelope.provenance).toEqual({ source: 'agent', by: 'curator', model: 'gpt' });
+        // Identity/transaction-time fields are carried verbatim (the store restamps them).
+        expect(updated.envelope.entityId).toBe('fact-1');
+      });
+    });
+
+    test('rejects a patch that deletes a required field', () => {
+      expect(policy.applyUpdate(makeRecord(), { body: null })).toFailWith(/may not delete required field/i);
+    });
+
+    test('restores embeddingRef as absent when a null patch drops it (hash-stable)', () => {
+      const existing = makeRecord({ embeddingRef: 'vec-1' });
+      expect(policy.applyUpdate(existing, { embeddingRef: null })).toSucceedAndSatisfy((updated) => {
+        expect(updated.envelope.embeddingRef).toBeUndefined();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Lights up the temporal (versioned) write path and temporal retrievers in `@fgv/ts-agent-memory`. Every temporal seam was already typed in v1 but stubbed to fail loudly; this stream implements the write/read logic behind them. No serialization change — the envelope converters already round-trip `temporal` / `valid_at` / `invalid_at`.

## Versioned layout — OQ-11: subtree-per-entity (consumer-backed)

```
<baseScope>/entities/<entityId>/<entityId>-v<seq>.md
```

`<seq>` is the store's monotonic write counter. **Current version** = the newest (highest-`seq`) version whose `temporal.invalid_at` is null/absent. Rejected the flat+sidecar-index alternative (PersonAIlity: "two sources of truth, exactly what bites during crash recovery"). No `id == filename == single current value` global assumption is baked: for a temporal record `envelope.id` is the *version* stem (the `MemoryId`) and `envelope.entityId` is the stable domain key — `id === filename stem` still holds (the store mints `id` = version stem), so `_verifyLoaded` and the codec round-trip need no relaxation.

## What ships

- **`TemporalIdentityCodec`** + `ITemporalIdentityCodec` (additive `encodeVersion` / `decodeVersion`) + `isTemporalIdentityCodec` guard. The subtree scope is authoritative for the entityId, disambiguating a stem whose entityId itself contains `-v<digits>`.
- **`TemporalVersionedPolicy`** — invalidate-don't-delete: `admit` always accepts (history retained, never culled), `dedupScope: 'entity'`, RFC-7386 merge restricted to the mutable surface.
- **Store branches** (`get` / `put` / `delete` / `list({asOf})`) — fully separate from the flat path.
  - **Merge-patch-under-versioning** (consumer-pinned): a re-`put` merges the incoming patch over the **current** version to form the **new** version's content, writes it as a new version, and sets `invalid_at` on the prior — never in-place mutation.
  - **Durability order**: new version persisted first (highest `seq` → resolves as current even if a later invalidation step fails), then prior currents invalidated.
  - **P2-1 valid-time boundary**: the prior version's interval closes at the **new version's `valid_at`** (backdated/future-dated safe), not at the transaction instant — so an `asOf` between the two `valid_at`s leaves no gap.
  - **P2-7 self-healing**: put and delete invalidate **every** still-current prior version, so a partial-invalidation failure self-heals on the next write/delete.
  - **delete** = soft delete (invalidate current version; history retained). Documented decision for the brief's open delete-semantics question — temporal kinds exist to preserve the audit trail (and the L3 `contradicts` interlock builds on it).
- **Retrievers** — `CurrentValidRetriever` / `AsOfRetriever` / `HistoryRetriever`, all `supportsTemporalQuery: true`. The existing loud-degrade guard and `HybridRetriever` `asOf` projection light up unchanged when a temporal child is composed in.

## Flat-path no-migration guarantee

Knowledge/LTM/MTM stay `isVersioned: false`, flat, with **zero behavioral impact** until a kind opts into a temporal codec. `list()` without `asOf` is byte-identical to before. Asserted by a flat put/get/delete regression test (no `entities/` subtree, no minted version id, no `temporal` block). No shipped store migrates; no persisted record changes shape.

## Code-review dispositions (two reviewers; final)

- **P2-1** (invalidation valid-time boundary) — fixed (`_invalidateVersion(scope, version, invalidAt, now)`), test added.
- **P2-2** (get/delete codec guards for a mis-typed versioned codec) — fixed, tests added.
- **P2-7** (self-healing: invalidate every current, not just the highest-seq pick) — fixed, put + delete self-heal tests added.
- **Chaining refactor** — `_putVersioned` now Result-chains `_contentHash` + `policy.admit` (matches file convention; removes the untestable hash-fail branch).
- **Coverage gaps** — all closed with real tests (admit-fail policy, non-string merged body, non-canonical `-v007` round-trip mismatch, order-independent `selectCurrentVersion`, `embeddingRef` carry-through, HistoryRetriever seq tiebreak + created fallback, dedupScope default fallback). One genuinely-unreachable defensive guard (`HistoryRetriever._startOf` on a pre-filtered temporal record) carries a `c8 ignore`.
- **P2-8 / P3-9** — dispositioned as docs: `IMemoryStore.get` notes versioned reads resolve from the derived index; `HistoryRetriever` notes its result is a cross-entity merge under `limit`.

## Gates

- `rushx build` / `rushx lint` clean; `rushx test` **419 passing, 100% coverage** (statements/branches/functions/lines) in `libraries/ts-agent-memory`.
- `etc/ts-agent-memory.api.md` regenerated — additive only (new `Temporal*` / `AsOf`/`CurrentValid`/`History` exports + `isTemporal*` / `isVersion*` / `selectVersion*` helpers; no removed/changed surface).
- Bulk changefile committed (`minor`).

**No live canary needed** — pure store/retriever logic, no external API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added temporal/versioned memory support, including current, as-of, and full-history retrieval.
  * Introduced version-aware identity handling and selection helpers for temporal records.
  * Added versioned write behavior that keeps history while updating the current version.

* **Bug Fixes**
  * Soft deletes now preserve prior versions instead of removing history.
  * Temporal listing now returns the correct version for a given point in time.

* **Tests**
  * Added coverage for temporal retrieval, storage, identity encoding, and update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->