### PR TITLE
feat(ts-agent-memory): L3 ingest orchestrator

### DIFF
--- a/.ai/tasks/active/agent-memory-l3-ingest/design-note.md
+++ b/.ai/tasks/active/agent-memory-l3-ingest/design-note.md
@@ -1,0 +1,139 @@
+# L3 ingest orchestrator — implementation design note
+
+Companion to `brief.md`. Records the decisions the brief left open (or delegated
+to the implementer) and the reconciliations the implementation makes. All
+LOCKED consumer decisions from the brief are honored verbatim; this note only
+covers the open/underspecified points.
+
+## 1. Stage-4 exact-dedup hash key — `{ kind, body }` (design §9.2)
+
+The brief flags a discrepancy: the store's content hash is over
+`{ kind, body, links }` (`fileTreeMemoryStore._contentHash`), while the design's
+stage-4 exact dedup specifies `canonicalize({ kind, body })`.
+
+**Decision: stage-4 exact dedup computes its own `{ kind, body }` key** (via the
+same `Hash.Crc32Normalizer` the store uses), NOT the store's `links`-inclusive
+hash.
+
+Rationale: stage 4 (resolve/dedup) runs BEFORE stage 5 (relate), so a
+candidate's `links` are not yet final when exact dedup runs — the relation
+extractor attaches more edges in stage 5. Including `links` in the stage-4 key
+would make the key unstable across the pipeline (the same fact would hash
+differently depending on how many edges stage 5 later adds), defeating dedup.
+`{ kind, body }` is the stable "is this the same fact" identity at intake time.
+The store's own `{ kind, body, links }` hash still runs at write time (stage 6)
+as the durable dedup key — the two keys serve different phases and do not
+conflict.
+
+## 2. Similarity-dedup threshold default — `0.85`
+
+The brief leaves the stage-4 layer-2 cosine threshold unspecified. Default:
+**`0.85`** (cosine similarity in `[-1, 1]`; a candidate is surfaced to the
+`IEntityResolver` only when its nearest neighbor scores `>= 0.85`).
+
+Rationale: 0.85 is a conservative near-duplicate threshold for normalized
+sentence embeddings — high enough that only genuinely-near-duplicate candidates
+reach the resolver (avoiding spurious `duplicate-of`/`merge-into` verdicts on
+merely topically-related records), while below the ~0.9+ range where only
+trivial paraphrases match. It is exposed as
+`IMemoryIngestOrchestratorCreateParams.similarityThreshold` (default `0.85`) so a
+deployment tunes it against its own embedder's score distribution without a code
+change.
+
+## 3. Verdict → write disposition mapping
+
+`IEntityResolver` returns `new | duplicate-of | supersede | merge-into`. fgv maps
+each to a write disposition:
+
+| verdict | disposition | store action |
+|---|---|---|
+| `new` | `written` | `put` the candidate as a fresh record |
+| `duplicate-of` | `deduped` | no write; result references the existing `target` |
+| `supersede` | `written` (or `superseded`) | `put` the candidate; result records `supersededId = target` (the contradicts→temporal interlock applies when the kind is temporal) |
+| `merge-into` | `merged` | re-address the candidate to `target`'s `entityId` and `put` (the store's policy `applyUpdate` merges the mutable fields) |
+
+Layer-1 exact `{ kind, body }` matches yield `duplicate-of` automatically
+(without invoking the resolver). Without a resolver (OQ-13), layer-2 is skipped
+entirely: a non-exact candidate is always `new` — the deterministic-identity
+host path.
+
+## 4. Stage-5 write-time cycle guard
+
+The design specifies a write-time cycle guard (`buildCycleKey` via
+`Crc32Normalizer`/RFC-8785), distinct from the read-time BFS in
+`linkTraversalRetriever`.
+
+**Decision:** the guard enforces **directed-acyclicity over the union link
+graph** — existing outbound edges (from the store index) plus the stage-5
+proposed edges. A proposed edge whose addition would close a directed cycle is
+rejected loudly (the whole ingest fails; edges are all-or-nothing per item). The
+guard uses `buildCycleKey(source, target, type)` — a `Crc32Normalizer` canonical
+hash — as the deterministic per-edge identity for de-duplicating proposed edges;
+cycle detection itself is DFS reachability (does `target` already reach `source`?).
+
+**Flagged interpretation (brief did not specify cycle scope):** this enforces
+**global** directed-acyclicity across all link types. That is conservative — it
+would also reject a legitimate mutual associative pair (`A -mentions-> B` +
+`B -mentions-> A`). Because the brief's only stated requirement is "reject a
+cycle-inducing edge," global acyclicity is the minimal reasonable
+interpretation. Deployments that need mutual associative links can set
+`cycleGuard: 'off'`. A per-link-type refinement (acyclic only for hierarchical
+types like `supersedes`/`contradicts`/`derived-from`) is a clean future additive
+change and is noted as such.
+
+Stage-5 edges must be **sourced from a candidate being written in this ingest**
+(edges land on the source record's `envelope.links`, which is only writable for
+records this pipeline persists). An edge whose `source` is not a candidate
+reference id is rejected. An edge whose `target` resolves to neither a sibling
+candidate nor an existing store record is rejected (loud, not silent-drop).
+
+Edge source/target ids are **entity-reference ids** (the codec `idStem`). For a
+temporal kind that is the stable entity stem (`<entityId>`), not a specific
+version stem (`<entityId>-v<seq>`) — the version stem is transient, the entity
+stem is the durable reference.
+
+## 5. `contradicts` → temporal-versioned interlock
+
+When a stage-5 `contradicts` edge is attached to a candidate whose kind is
+**temporal** (the codec's `encode` reports `isVersioned: true`), the write is
+routed through the store's versioned `put` path (which it already is, for a
+temporal kind). That path invalidates the prior current version (`invalid_at`
+set) and writes a new version — exactly the "temporal-versioned" behavior the
+design calls for. The orchestrator recognizes the interlock and records
+`interlock: 'temporal-versioned'` on the result item.
+
+A `contradicts` edge on a **non-temporal** kind is persisted as a plain link (no
+interlock) — matching the brief's note that partial-L3 `contradicts` edges
+persist as ordinary `links`.
+
+## 6. `ICandidateRecord.envelope` omitted fields
+
+The design (`:825`) writes
+`Omit<IMemoryEnvelope, 'id' | 'contentHash' | 'created' | 'updated'>` (four
+fields). `seq` is ALSO store-stamped (the monotonic write counter). This
+implementation omits **all five** store-owned fields:
+`Omit<IMemoryEnvelope, 'id' | 'seq' | 'contentHash' | 'created' | 'updated'>`.
+The host supplies `entityId`, `kind`, `tags`, `links`, `provenance`,
+`temporal?`, `embeddingRef?`; fgv derives `id` (codec) and the store stamps the
+rest.
+
+## 7. Additive-provenance non-regression
+
+The provenance lineage fields (`by` / `model` / `confidence` / `derivedFrom`)
+are already additive/optional on the shipped `IProvenance` (only `source` is
+required). The stream preserves this: a pre-existing `mtm`/`ltm` record whose
+provenance carries only `source` loads and validates unchanged, and stage-6
+stamping merges `{ source: 'host-ingest', derivedFrom? }` over the host-supplied
+provenance without requiring any lineage field. Asserted as an explicit
+non-regression test.
+
+## 8. Testbed proof
+
+End-to-end proof is delivered as an orchestrator integration test with fully
+mocked host stages (classifier / extractor / resolver / relation-extractor) over
+a real `FileTreeMemoryStore` + `InMemoryCosineIndex`. A `samples/testbed`
+scenario is **not** added: the pipeline is pure library logic with no live model
+on the fgv-owned path (the host stages are the only model-driven parts, and they
+are mocked), so the unit-level end-to-end test exercises the identical code path
+a testbed scenario would. No live API call is involved (STOP-FLAG condition from
+the brief's scope item 6 is not triggered).

--- a/.ai/tasks/active/agent-memory-l3-ingest/design-note.md
+++ b/.ai/tasks/active/agent-memory-l3-ingest/design-note.md
@@ -57,6 +57,18 @@ Layer-1 exact `{ kind, body }` matches yield `duplicate-of` automatically
 entirely: a non-exact candidate is always `new` — the deterministic-identity
 host path.
 
+**Target-bearing verdict safety (post-review hardening).** Every verdict that
+carries a target (`duplicate-of` / `supersede` / `merge-into`) is validated
+uniformly by fgv before it is acted on: the target must be a real store record
+(a non-compliant host resolver can never smuggle a bogus id into the result) AND
+its `kind` must equal the candidate's `kind` (a cross-kind target would write to
+the wrong scope; fgv rejects loudly). `merge-into` additionally **UNIONs** the
+target's pre-existing `tags` / `links` / `provenance` with the candidate's
+before the write — the store's `applyUpdate` replaces array fields wholesale
+(`arrayMergeBehavior: 'replace'`), so passing only the candidate's (usually
+sparse) fields would silently wipe the target's prior links/tags. The unioned
+link list is de-duplicated by canonical edge key so no edge appears twice.
+
 ## 4. Stage-5 write-time cycle guard
 
 The design specifies a write-time cycle guard (`buildCycleKey` via

--- a/common/changes/@fgv/ts-agent-memory/claude-agent-memory-l3-ingest_2026-07-08-14-09.json
+++ b/common/changes/@fgv/ts-agent-memory/claude-agent-memory-l3-ingest_2026-07-08-14-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "L3 ingest orchestrator: staged host interfaces, six-stage single-item-first-class pipeline, exact+similarity dedup, write-time edge/cycle safety, provenance stamping, contradicts->temporal interlock",
+      "type": "minor",
+      "packageName": "@fgv/ts-agent-memory"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
+++ b/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
@@ -46,8 +46,6 @@ export class BodyConverterRegistry implements IBodyConverterRegistry {
     registerSchema<T>(kind: Kind, schema: JsonSchema.ISchemaValidator<T>): void;
 }
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-agent-memory" does not have an export "Hash"
-//
 // @public
 export function buildCycleKey(edge: ICycleGuardEdge): Result<string>;
 

--- a/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
+++ b/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
@@ -31,6 +31,9 @@ export class AsOfRetriever implements IMemoryRetriever {
 }
 
 // @public
+export function assertNoCycles(existing: ReadonlyArray<ICycleGuardEdge>, proposed: ReadonlyArray<ICycleGuardEdge>): Result<true>;
+
+// @public
 export function assertPortableFilenameStem(stem: string): Result<string>;
 
 // @public
@@ -42,6 +45,14 @@ export class BodyConverterRegistry implements IBodyConverterRegistry {
     register<T>(kind: Kind, converter: Converter<T>): void;
     registerSchema<T>(kind: Kind, schema: JsonSchema.ISchemaValidator<T>): void;
 }
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-agent-memory" does not have an export "Hash"
+//
+// @public
+export function buildCycleKey(edge: ICycleGuardEdge): Result<string>;
+
+// @public
+export const CONTRADICTS_LINK_TYPE: LinkType;
 
 // @public
 export const Convert: {
@@ -64,6 +75,9 @@ export class CurrentValidRetriever implements IMemoryRetriever {
 }
 
 // @public
+export type CycleGuardMode = 'reject' | 'off';
+
+// @public
 export type DedupScope = 'content' | 'entity';
 
 // @public
@@ -71,6 +85,12 @@ export const DEFAULT_DEDUP_SCOPE: DedupScope;
 
 // @public
 export const DEFAULT_MEMORY_TOOLS: ReadonlyArray<MemoryToolName>;
+
+// @public
+export const DEFAULT_SIMILARITY_THRESHOLD: number;
+
+// @public
+export const DEFAULT_SIMILARITY_TOP_K: number;
 
 // @public
 export function defaultMemoryScopeEncoding(scope: MemoryScopeKey): Result<string>;
@@ -108,6 +128,9 @@ export class HistoryRetriever implements IMemoryRetriever {
 }
 
 // @public
+export const HOST_INGEST_PROVENANCE_SOURCE: string;
+
+// @public
 export class HybridRetriever implements IMemoryRetriever {
     get capabilities(): IMemoryRetrieverCapabilities;
     static create(retrievers: ReadonlyArray<IMemoryRetriever>, mergeStrategy: IMergeStrategy): Result<HybridRetriever>;
@@ -124,6 +147,18 @@ export interface IBodyConverterRegistry {
 }
 
 // @public
+export interface ICandidateEdge {
+    readonly edge: IEdge;
+    readonly source: MemoryId;
+}
+
+// @public
+export interface ICandidateRecord {
+    readonly body: unknown;
+    readonly envelope: Omit<IMemoryEnvelope, StoreStampedEnvelopeField>;
+}
+
+// @public
 export interface ICreateMemoryToolsParams {
     readonly codecs?: ReadonlyMap<Kind, IIdentityCodec>;
     readonly defaultCodec?: IIdentityCodec;
@@ -136,6 +171,16 @@ export interface ICreateMemoryToolsParams {
 }
 
 // @public
+export interface ICycleGuardEdge {
+    // (undocumented)
+    readonly source: MemoryId;
+    // (undocumented)
+    readonly target: MemoryId;
+    // (undocumented)
+    readonly type: LinkType;
+}
+
+// @public
 export interface IEdge {
     readonly confidence?: number;
     readonly invalid_at?: number | null;
@@ -143,6 +188,23 @@ export interface IEdge {
     readonly target: MemoryId;
     readonly type: LinkType;
     readonly valid_at?: number;
+}
+
+// @public
+export interface IEntityResolutionCandidate {
+    readonly id: MemoryId;
+    readonly record: IMemoryRecord<unknown>;
+    readonly score: number;
+}
+
+// @public
+export interface IEntityResolver {
+    resolve(candidate: ICandidateRecord, similar: ReadonlyArray<IEntityResolutionCandidate>): Promise<Result<ResolutionVerdict>>;
+}
+
+// @public
+export interface IFactExtractor {
+    extract(item: IIngestItem, classification: IMemoryClassification): Promise<Result<ReadonlyArray<ICandidateRecord>>>;
 }
 
 // @public
@@ -181,9 +243,47 @@ export interface IIndexedMemoryRecord {
 }
 
 // @public
+export interface IIngestedRecordResult {
+    readonly candidate: ICandidateRecord;
+    readonly disposition: IngestDisposition;
+    readonly edges: ReadonlyArray<ICandidateEdge>;
+    readonly id: MemoryId;
+    readonly interlock?: 'temporal-versioned';
+    readonly record?: IMemoryRecord<unknown>;
+    readonly resolution: ResolutionVerdict;
+}
+
+// @public
+export interface IIngestItem {
+    readonly content: unknown;
+    readonly id: string;
+    readonly metadata?: Record<string, unknown>;
+    readonly sourceId?: MemoryId;
+}
+
+// @public
+export interface IIngestItemResult {
+    readonly item: IIngestItem;
+    readonly records: ReadonlyArray<IIngestedRecordResult>;
+}
+
+// @public
 export interface IMemoryCapCullPolicyParams {
     readonly maxRecords?: number;
     readonly mutableFields: ReadonlyArray<string>;
+}
+
+// @public
+export interface IMemoryClassification {
+    readonly [key: string]: unknown;
+    readonly confidence?: number;
+    readonly kind: Kind;
+    readonly tags?: ReadonlyArray<Tag>;
+}
+
+// @public
+export interface IMemoryClassifier {
+    classify(item: IIngestItem): Promise<Result<IMemoryClassification>>;
 }
 
 // @public
@@ -217,6 +317,30 @@ export interface IMemoryIndex {
     entries(): ReadonlyArray<IIndexedMemoryRecord>;
     patch(op: MemoryIndexPatchOp, entry: IIndexedMemoryRecord): Result<IIndexedMemoryRecord>;
     rebuild(entries: ReadonlyArray<IIndexedMemoryRecord>): Result<number>;
+}
+
+// @public
+export interface IMemoryIngestOrchestrator {
+    ingestBatch(items: ReadonlyArray<IIngestItem>): Promise<Result<ReadonlyArray<IIngestItemResult>>>;
+    ingestItem(item: IIngestItem): Promise<Result<IIngestItemResult>>;
+}
+
+// @public
+export interface IMemoryIngestOrchestratorCreateParams {
+    readonly classifier: IMemoryClassifier;
+    readonly codecs?: ReadonlyMap<Kind, IIdentityCodec>;
+    readonly cycleGuard?: CycleGuardMode;
+    readonly defaultCodec?: IIdentityCodec;
+    readonly embed?: MemoryEmbedder;
+    readonly entityResolver?: IEntityResolver;
+    readonly extractor: IFactExtractor;
+    readonly logger?: Logging.ILogger;
+    readonly registry: IBodyConverterRegistry;
+    readonly relationExtractor: IRelationExtractor;
+    readonly similarityThreshold?: number;
+    readonly similarityTopK?: number;
+    readonly store: IMemoryStore;
+    readonly vectorIndex?: IVectorIndex;
 }
 
 // @public
@@ -338,6 +462,9 @@ export interface IMergeStrategy {
 export function indexedRecordMatchesQuery(entry: IIndexedMemoryRecord, query: IMemoryQuery): boolean;
 
 // @public
+export type IngestDisposition = 'written' | 'deduped' | 'merged';
+
+// @public
 export class InMemoryCosineIndex implements IVectorIndex {
     add(id: MemoryId, vector: Float32Array): Promise<Result<string>>;
     static create(): Result<InMemoryCosineIndex>;
@@ -355,6 +482,23 @@ export interface IProvenance {
     readonly derivedFrom?: MemoryId;
     readonly model?: string;
     readonly source: ProvenanceSource;
+}
+
+// @public
+export interface IRelationCandidate {
+    readonly candidate: ICandidateRecord;
+    readonly id: MemoryId;
+}
+
+// @public
+export interface IRelationContext {
+    readonly candidates: ReadonlyArray<IRelationCandidate>;
+    readonly item: IIngestItem;
+}
+
+// @public
+export interface IRelationExtractor {
+    relate(context: IRelationContext): Promise<Result<ReadonlyArray<ICandidateEdge>>>;
 }
 
 // @public
@@ -501,6 +645,13 @@ export class MemoryIndex implements IMemoryIndex {
 export type MemoryIndexPatchOp = 'put' | 'delete';
 
 // @public
+export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
+    static create(params: IMemoryIngestOrchestratorCreateParams): Result<MemoryIngestOrchestrator>;
+    ingestBatch(items: ReadonlyArray<IIngestItem>): Promise<Result<ReadonlyArray<IIngestItemResult>>>;
+    ingestItem(item: IIngestItem): Promise<Result<IIngestItemResult>>;
+}
+
+// @public
 export type MemoryObservationOutcome = 'success' | 'failure';
 
 // @public
@@ -560,6 +711,20 @@ export class RecencyRetriever implements IMemoryRetriever {
 }
 
 // @public
+export type ResolutionVerdict = {
+    readonly verdict: 'new';
+} | {
+    readonly verdict: 'duplicate-of';
+    readonly target: MemoryId;
+} | {
+    readonly verdict: 'supersede';
+    readonly target: MemoryId;
+} | {
+    readonly verdict: 'merge-into';
+    readonly target: MemoryId;
+};
+
+// @public
 export class ScoreUnionMergeStrategy implements IMergeStrategy {
     static create(): Result<ScoreUnionMergeStrategy>;
     merge(resultSets: ReadonlyArray<ReadonlyArray<IMemoryRecord<unknown>>>): Result<ReadonlyArray<IMemoryRecord<unknown>>>;
@@ -589,6 +754,9 @@ export function serializeMemoryFile(envelope: IMemoryEnvelope, body: string): Re
 
 // @public
 export function splitFrontmatter(raw: string): Result<IMemoryFileParts>;
+
+// @public
+export type StoreStampedEnvelopeField = 'id' | 'seq' | 'contentHash' | 'created' | 'updated';
 
 // @public
 export class StructuredFilterRetriever implements IMemoryRetriever {

--- a/libraries/ts-agent-memory/src/index.ts
+++ b/libraries/ts-agent-memory/src/index.ts
@@ -11,3 +11,4 @@ export * from './packlets/retrieve';
 export * from './packlets/observe';
 export * from './packlets/vector';
 export * from './packlets/tools';
+export * from './packlets/ingest';

--- a/libraries/ts-agent-memory/src/packlets/ingest/cycleGuard.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/cycleGuard.ts
@@ -18,17 +18,17 @@ export interface ICycleGuardEdge {
 }
 
 /**
- * Build the design's `buildCycleKey` — a deterministic, canonical
- * ({@link Hash.Crc32Normalizer}, RFC-8785) identity for a directed edge. Used to
- * de-duplicate proposed edges so a repeated `(source, target, type)` proposal
+ * Build the design's `buildCycleKey` — a deterministic, canonical (RFC-8785,
+ * via `Crc32Normalizer` from `@fgv/ts-utils`) identity for a directed edge. Used
+ * to de-duplicate proposed edges so a repeated `(source, target, type)` proposal
  * contributes a single graph edge (and never spuriously "re-closes" a cycle).
  * @public
  */
 export function buildCycleKey(edge: ICycleGuardEdge): Result<string> {
   return new Hash.Crc32Normalizer().computeHash({
-    source: edge.source as string,
-    target: edge.target as string,
-    type: edge.type as string
+    source: edge.source,
+    target: edge.target,
+    type: edge.type
   });
 }
 
@@ -77,7 +77,7 @@ export function assertNoCycles(
         }
         // Reachability: does `target` already reach `source`? If so, adding
         // `source -> target` closes a directed cycle.
-        if (reaches(adjacency, edge.target as string, edge.source as string)) {
+        if (reaches(adjacency, edge.target, edge.source)) {
           return fail(
             `ingest cycle guard: edge '${edge.source}' -${edge.type}-> '${edge.target}' would create a cycle`
           );
@@ -106,8 +106,8 @@ function addEdge(adjacency: Map<string, Set<string>>, seenKeys: Set<string>, key
     return;
   }
   seenKeys.add(keyed.key);
-  const source: string = keyed.edge.source as string;
-  const target: string = keyed.edge.target as string;
+  const source: string = keyed.edge.source;
+  const target: string = keyed.edge.target;
   const targets: Set<string> | undefined = adjacency.get(source);
   if (targets === undefined) {
     adjacency.set(source, new Set<string>([target]));

--- a/libraries/ts-agent-memory/src/packlets/ingest/cycleGuard.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/cycleGuard.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Hash, Result, fail, mapResults, succeed } from '@fgv/ts-utils';
+import { LinkType, MemoryId } from '../types';
+
+/**
+ * A directed edge in the link graph the cycle guard reasons over: `source` links
+ * to `target` under relation `type`.
+ * @public
+ */
+export interface ICycleGuardEdge {
+  readonly source: MemoryId;
+  readonly target: MemoryId;
+  readonly type: LinkType;
+}
+
+/**
+ * Build the design's `buildCycleKey` — a deterministic, canonical
+ * ({@link Hash.Crc32Normalizer}, RFC-8785) identity for a directed edge. Used to
+ * de-duplicate proposed edges so a repeated `(source, target, type)` proposal
+ * contributes a single graph edge (and never spuriously "re-closes" a cycle).
+ * @public
+ */
+export function buildCycleKey(edge: ICycleGuardEdge): Result<string> {
+  return new Hash.Crc32Normalizer().computeHash({
+    source: edge.source as string,
+    target: edge.target as string,
+    type: edge.type as string
+  });
+}
+
+/**
+ * Write-time cycle guard. Given the graph's EXISTING directed edges plus a set of
+ * PROPOSED edges, verify that adding the proposed edges keeps the union graph a
+ * DAG. Fails loudly, naming the first proposed edge that would close a directed
+ * cycle.
+ *
+ * @remarks
+ * Distinct from the read-time BFS in `LinkTraversalRetriever` (which tolerates
+ * cycles via a visited-set): this is a WRITE-time admission check. Cycle
+ * detection is DFS reachability — a proposed `source -> target` edge closes a
+ * cycle iff `target` already reaches `source` in the graph built so far. Proposed
+ * edges are folded in one at a time (in order), so an intra-batch cycle
+ * (`A->B`, `B->A` both proposed) is caught as well as a batch-vs-existing cycle.
+ *
+ * See the design note §4: this enforces GLOBAL directed-acyclicity over all link
+ * types (conservative — a mutual associative pair is rejected). Callers that need
+ * mutual links disable the guard.
+ * @public
+ */
+export function assertNoCycles(
+  existing: ReadonlyArray<ICycleGuardEdge>,
+  proposed: ReadonlyArray<ICycleGuardEdge>
+): Result<true> {
+  // Canonically key every edge up front (the only fallible step); the graph
+  // building + cycle detection below is then pure.
+  return keyEdges(existing).onSuccess((existingKeyed) =>
+    keyEdges(proposed).onSuccess((proposedKeyed) => {
+      // Adjacency map, de-duplicated by canonical edge key so a repeated edge is
+      // one arc. Seed with the existing edges, then fold in each proposed edge,
+      // checking reachability BEFORE inserting it.
+      const adjacency: Map<string, Set<string>> = new Map<string, Set<string>>();
+      const seenKeys: Set<string> = new Set<string>();
+      for (const keyed of existingKeyed) {
+        addEdge(adjacency, seenKeys, keyed);
+      }
+      for (const keyed of proposedKeyed) {
+        const edge: ICycleGuardEdge = keyed.edge;
+        // A self-loop is the degenerate one-node cycle.
+        if (edge.source === edge.target) {
+          return fail(
+            `ingest cycle guard: edge '${edge.source}' -${edge.type}-> '${edge.target}' is a self-loop`
+          );
+        }
+        // Reachability: does `target` already reach `source`? If so, adding
+        // `source -> target` closes a directed cycle.
+        if (reaches(adjacency, edge.target as string, edge.source as string)) {
+          return fail(
+            `ingest cycle guard: edge '${edge.source}' -${edge.type}-> '${edge.target}' would create a cycle`
+          );
+        }
+        addEdge(adjacency, seenKeys, keyed);
+      }
+      return succeed(true);
+    })
+  );
+}
+
+/** An edge paired with its canonical cycle key. */
+interface IKeyedEdge {
+  readonly edge: ICycleGuardEdge;
+  readonly key: string;
+}
+
+/** Canonically key a set of edges (the guard's only fallible step). */
+function keyEdges(edges: ReadonlyArray<ICycleGuardEdge>): Result<ReadonlyArray<IKeyedEdge>> {
+  return mapResults(edges.map((edge) => buildCycleKey(edge).onSuccess((key) => succeed({ edge, key }))));
+}
+
+/** Add an edge to the adjacency map, de-duplicated by its canonical key. */
+function addEdge(adjacency: Map<string, Set<string>>, seenKeys: Set<string>, keyed: IKeyedEdge): void {
+  if (seenKeys.has(keyed.key)) {
+    return;
+  }
+  seenKeys.add(keyed.key);
+  const source: string = keyed.edge.source as string;
+  const target: string = keyed.edge.target as string;
+  const targets: Set<string> | undefined = adjacency.get(source);
+  if (targets === undefined) {
+    adjacency.set(source, new Set<string>([target]));
+  } else {
+    targets.add(target);
+  }
+}
+
+/** DFS reachability: is `to` reachable from `from` over `adjacency`? */
+function reaches(adjacency: ReadonlyMap<string, Set<string>>, from: string, to: string): boolean {
+  const visited: Set<string> = new Set<string>();
+  const stack: string[] = [from];
+  while (stack.length > 0) {
+    const node: string = stack.pop() as string;
+    if (node === to) {
+      return true;
+    }
+    if (visited.has(node)) {
+      continue;
+    }
+    visited.add(node);
+    const neighbors: Set<string> | undefined = adjacency.get(node);
+    if (neighbors !== undefined) {
+      for (const neighbor of neighbors) {
+        if (!visited.has(neighbor)) {
+          stack.push(neighbor);
+        }
+      }
+    }
+  }
+  return false;
+}

--- a/libraries/ts-agent-memory/src/packlets/ingest/hostStages.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/hostStages.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Result } from '@fgv/ts-utils';
+import { MemoryId } from '../types';
+import {
+  ICandidateEdge,
+  ICandidateRecord,
+  IEntityResolutionCandidate,
+  IIngestItem,
+  IMemoryClassification,
+  ResolutionVerdict
+} from './model';
+
+/**
+ * Stage 2 — the host's classifier. Decides what {@link IIngestItem} maps to
+ * which memory {@link Kind} (and optional tags / confidence). LOCKED as a
+ * separate staged interface (OQ-10): the host plugs its existing classifier
+ * machinery in here rather than surrendering to an opaque ingestor.
+ * @public
+ */
+export interface IMemoryClassifier {
+  /**
+   * Classify one item. A `fail` aborts the item's ingest loudly (fgv never
+   * guesses a kind).
+   */
+  classify(item: IIngestItem): Promise<Result<IMemoryClassification>>;
+}
+
+/**
+ * Stage 3 — the host's fact extractor. Turns a classified item into zero or more
+ * {@link ICandidateRecord}s. Each candidate's body is validated against the
+ * kind's registered Converter by fgv before it can reach the store (the typed
+ * validation boundary — no unchecked host data is persisted).
+ * @public
+ */
+export interface IFactExtractor {
+  /**
+   * Extract candidate records from a classified item. An empty array is a valid
+   * result (the item yielded nothing memorable).
+   */
+  extract(
+    item: IIngestItem,
+    classification: IMemoryClassification
+  ): Promise<Result<ReadonlyArray<ICandidateRecord>>>;
+}
+
+/**
+ * Stage 4 (optional) — the host's entity resolver (OQ-13, LOCKED OPTIONAL). When
+ * supplied, fgv surfaces near-duplicate {@link IEntityResolutionCandidate}s (from
+ * layer-2 similarity search) and the resolver returns a
+ * {@link ResolutionVerdict}. When ABSENT, stage-4 dedup falls back to
+ * exact-`{ kind, body }`-hash only — the deterministic-identity host path.
+ * @public
+ */
+export interface IEntityResolver {
+  /**
+   * Decide whether `candidate` is new, a duplicate of / supersedes / merges into
+   * one of the surfaced `similar` records. `similar` is non-empty and ordered by
+   * descending score when the resolver is invoked (fgv only calls it when
+   * layer-2 surfaces at least one over-threshold neighbor).
+   */
+  resolve(
+    candidate: ICandidateRecord,
+    similar: ReadonlyArray<IEntityResolutionCandidate>
+  ): Promise<Result<ResolutionVerdict>>;
+}
+
+/**
+ * The context fgv hands the host's relation extractor (stage 5): the source item
+ * plus the candidates fgv is about to write, each paired with its resolved
+ * reference id (the codec `idStem`). The extractor proposes attributed edges over
+ * these ids and existing store records.
+ * @public
+ */
+export interface IRelationContext {
+  /** The item being ingested. */
+  readonly item: IIngestItem;
+  /** The candidates fgv is about to write, each with its resolved reference id. */
+  readonly candidates: ReadonlyArray<IRelationCandidate>;
+}
+
+/**
+ * A candidate paired with its resolved reference id, handed to the relation
+ * extractor so it can source edges from it.
+ * @public
+ */
+export interface IRelationCandidate {
+  /** The candidate about to be written. */
+  readonly candidate: ICandidateRecord;
+  /** Its resolved reference id (codec `idStem` — the stable entity reference). */
+  readonly id: MemoryId;
+}
+
+/**
+ * Stage 5 — the host's relation extractor. Proposes attributed edges among the
+ * candidates and existing records. fgv owns the validation, the write-time cycle
+ * guard, and the actual persistence of the edges (the host brings only the
+ * relationship judgment).
+ * @public
+ */
+export interface IRelationExtractor {
+  /**
+   * Propose the edges to attach for this ingest. An empty array is valid (no
+   * relations). Every proposed {@link ICandidateEdge.source | source} must be one
+   * of the context's candidate reference ids.
+   */
+  relate(context: IRelationContext): Promise<Result<ReadonlyArray<ICandidateEdge>>>;
+}

--- a/libraries/ts-agent-memory/src/packlets/ingest/index.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+export * from './model';
+export * from './hostStages';
+export * from './cycleGuard';
+export * from './orchestrator';

--- a/libraries/ts-agent-memory/src/packlets/ingest/model.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/model.ts
@@ -156,9 +156,17 @@ export interface IIngestedRecordResult {
   /** The stage-5 edges attached to this candidate before the write. */
   readonly edges: ReadonlyArray<ICandidateEdge>;
   /**
-   * Set to `'temporal-versioned'` when the contradicts→temporal interlock fired:
-   * a `contradicts` edge on a temporal-kind candidate routed the write through
-   * the versioned put path (prior version invalidated, new version written).
+   * Informational diagnostic, set to `'temporal-versioned'` when the
+   * contradicts→temporal interlock is recognized: a `contradicts` edge was
+   * attached to a candidate of a temporal kind.
+   *
+   * @remarks
+   * A temporal kind ALWAYS writes through the store's versioned put path (that is
+   * the codec's `isVersioned` behavior — the prior version is invalidated and a
+   * new version written on every write, contradicts edge or not). This flag does
+   * NOT cause that routing; it is a diagnostic marker that the contradicts-driven
+   * scenario occurred, so callers can distinguish a contradiction-superseding
+   * version from an ordinary revision.
    */
   readonly interlock?: 'temporal-versioned';
 }

--- a/libraries/ts-agent-memory/src/packlets/ingest/model.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/model.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { IEdge, IMemoryEnvelope, IMemoryRecord, Kind, MemoryId, Tag } from '../types';
+
+/**
+ * A single unit of raw source material handed to the ingest pipeline. The host
+ * owns the shape of {@link IIngestItem.content | content} — fgv never interprets
+ * it; it flows opaquely into the host's classifier and extractor (stages 2-3).
+ *
+ * Single-item ingest is FIRST-CLASS: the orchestrator's primary entry point
+ * takes one `IIngestItem` (per-turn streaming), and the batch entry point is a
+ * convenience loop over it.
+ * @public
+ */
+export interface IIngestItem {
+  /**
+   * Host-owned identity for this source item. Opaque to fgv; used only in
+   * diagnostics and echoed back on the {@link IIngestItemResult}.
+   */
+  readonly id: string;
+  /**
+   * The opaque source payload the host's classifier / extractor understand
+   * (e.g. a raw turn, a document, a tool-call transcript). Never interpreted by
+   * fgv.
+   */
+  readonly content: unknown;
+  /**
+   * Optional back-link to the memory record this item was derived from (e.g. the
+   * MTM turn an extracted fact came from). When present, fgv stamps it as
+   * {@link IProvenance.derivedFrom | provenance.derivedFrom} on every record
+   * ingested from this item (stage 6) — the cross-kind provenance spine.
+   */
+  readonly sourceId?: MemoryId;
+  /** Optional opaque metadata carried alongside the item; never interpreted by fgv. */
+  readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * The host classifier's verdict for an {@link IIngestItem} (stage 2). Guides the
+ * host's own extractor (stage 3) and supplies the default `kind` / `tags` /
+ * `confidence` fgv stamps when the extractor does not override them.
+ *
+ * Extensible: the `[key: string]: unknown` arm lets the host attach an opaque
+ * classification payload without changing this interface.
+ * @public
+ */
+export interface IMemoryClassification {
+  /** The record kind the item classifies as. */
+  readonly kind: Kind;
+  /** Optional tags the classifier assigns. */
+  readonly tags?: ReadonlyArray<Tag>;
+  /** Optional classifier confidence in `[0, 1]`; flows to `provenance.confidence`. */
+  readonly confidence?: number;
+  /** Opaque, host-owned extension payload — never interpreted by fgv. */
+  readonly [key: string]: unknown;
+}
+
+/**
+ * The store-owned envelope fields fgv derives or stamps: `id` (from the codec),
+ * and the transaction-time metadata (`seq` / `contentHash` / `created` /
+ * `updated`). A {@link ICandidateRecord} supplies everything EXCEPT these.
+ * @public
+ */
+export type StoreStampedEnvelopeField = 'id' | 'seq' | 'contentHash' | 'created' | 'updated';
+
+/**
+ * A host-extracted candidate record (stage 3 output). The host supplies the
+ * full envelope MINUS the {@link StoreStampedEnvelopeField | store-stamped
+ * fields} (fgv derives `id` from the codec; the store stamps the rest) plus the
+ * typed body. Every candidate body is validated against the kind's registered
+ * Converter before it can reach the store (the typed validation boundary).
+ * @public
+ */
+export interface ICandidateRecord {
+  /** The host-supplied envelope, minus the store-stamped fields. */
+  readonly envelope: Omit<IMemoryEnvelope, StoreStampedEnvelopeField>;
+  /** The per-kind body (a markdown string in v1), validated on ingest. */
+  readonly body: unknown;
+}
+
+/**
+ * A near-duplicate candidate surfaced to the {@link IEntityResolver} by stage-4
+ * layer-2 similarity search: an existing record whose embedding is within the
+ * similarity threshold of the incoming candidate.
+ * @public
+ */
+export interface IEntityResolutionCandidate {
+  /** The existing record's id. */
+  readonly id: MemoryId;
+  /** The existing record. */
+  readonly record: IMemoryRecord<unknown>;
+  /** The backend similarity score (higher = more similar). */
+  readonly score: number;
+}
+
+/**
+ * The four dedup verdicts a {@link IEntityResolver} (or fgv's exact-match layer)
+ * returns for a candidate. See the design note §3 for the verdict → write
+ * disposition mapping.
+ * @public
+ */
+export type ResolutionVerdict =
+  | { readonly verdict: 'new' }
+  | { readonly verdict: 'duplicate-of'; readonly target: MemoryId }
+  | { readonly verdict: 'supersede'; readonly target: MemoryId }
+  | { readonly verdict: 'merge-into'; readonly target: MemoryId };
+
+/**
+ * How a candidate was ultimately written (or not) after resolution.
+ *
+ * - `written` — persisted as a fresh record (verdict `new`), or as a superseding
+ *   record (verdict `supersede`).
+ * - `deduped` — not written; an existing record satisfied it (verdict
+ *   `duplicate-of`, incl. every layer-1 exact `{ kind, body }` match).
+ * - `merged` — merged into an existing target entity (verdict `merge-into`).
+ * @public
+ */
+export type IngestDisposition = 'written' | 'deduped' | 'merged';
+
+/**
+ * A stage-5 attributed edge proposal: the {@link ICandidateEdge.edge | edge} to
+ * add, sourced from {@link ICandidateEdge.source | source}. The source MUST be a
+ * candidate being written in this ingest (edges land on the source record's
+ * `envelope.links`); the edge's `target` must resolve to a sibling candidate or
+ * an existing store record.
+ * @public
+ */
+export interface ICandidateEdge {
+  /** The reference id (codec `idStem`) of the candidate the edge originates from. */
+  readonly source: MemoryId;
+  /** The attributed edge (type / target / optional confidence / provenance). */
+  readonly edge: IEdge;
+}
+
+/**
+ * Per-candidate outcome of an ingest run.
+ * @public
+ */
+export interface IIngestedRecordResult {
+  /** The candidate the outcome is for. */
+  readonly candidate: ICandidateRecord;
+  /** The resolution verdict fgv reached (or the resolver returned). */
+  readonly resolution: ResolutionVerdict;
+  /** What the write ultimately did. */
+  readonly disposition: IngestDisposition;
+  /**
+   * The stored record's id: the newly-written id (`written` / `merged`), or the
+   * existing target's id (`deduped`).
+   */
+  readonly id: MemoryId;
+  /** The persisted record, when a write happened (`written` / `merged`). */
+  readonly record?: IMemoryRecord<unknown>;
+  /** The stage-5 edges attached to this candidate before the write. */
+  readonly edges: ReadonlyArray<ICandidateEdge>;
+  /**
+   * Set to `'temporal-versioned'` when the contradicts→temporal interlock fired:
+   * a `contradicts` edge on a temporal-kind candidate routed the write through
+   * the versioned put path (prior version invalidated, new version written).
+   */
+  readonly interlock?: 'temporal-versioned';
+}
+
+/**
+ * The result of ingesting a single {@link IIngestItem}: the item plus the
+ * per-candidate outcomes (one item can yield zero or many candidate records).
+ * @public
+ */
+export interface IIngestItemResult {
+  /** The item that was ingested. */
+  readonly item: IIngestItem;
+  /** The per-candidate outcomes, in extraction order. */
+  readonly records: ReadonlyArray<IIngestedRecordResult>;
+}

--- a/libraries/ts-agent-memory/src/packlets/ingest/orchestrator.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/orchestrator.ts
@@ -17,6 +17,7 @@ import {
   LinkType,
   MemoryId,
   MemoryScopeKey,
+  Tag,
   isTemporalRecord,
   isVersionCurrent
 } from '../types';
@@ -164,9 +165,14 @@ interface ICandidatePlan {
   readonly writeEntityId: EntityId;
   /** The reference id used in stage-5 edges (the write target's `idStem`). */
   readonly refId: MemoryId;
+  /** The resolution verdict; carries the target id on its target-bearing arms. */
   readonly verdict: ResolutionVerdict;
-  /** The dedup target id when the verdict is `duplicate-of` (no write). */
-  readonly dedupTargetId?: MemoryId;
+  /**
+   * The pre-ingest target record for a `merge-into` write — its existing
+   * `tags` / `links` / `provenance` are UNIONed with the candidate's at stage 6
+   * so a wholesale-replace merge never wipes them.
+   */
+  readonly mergeTarget?: IMemoryRecord<unknown>;
 }
 
 /**
@@ -328,7 +334,15 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     );
   }
 
-  /** Turn a resolved verdict into a candidate plan (re-addressing merge-into to the target). */
+  /**
+   * Turn a resolved verdict into a candidate plan. A `new` verdict writes under the
+   * candidate's own address. Every TARGET-bearing verdict
+   * (`duplicate-of` / `supersede` / `merge-into`) is validated uniformly: the
+   * target must be a real store record (fgv owns validation — a non-compliant host
+   * resolver never smuggles a bogus id through) AND its kind must equal the
+   * candidate's kind (a cross-kind target would write to the wrong scope). Only
+   * `merge-into` re-addresses the write to the target's entity.
+   */
   private _planFromVerdict(
     item: IIngestItem,
     candidate: ICandidateRecord,
@@ -336,23 +350,33 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     verdict: ResolutionVerdict,
     byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>>
   ): Result<ICandidatePlan> {
-    if (verdict.verdict === 'duplicate-of') {
+    if (verdict.verdict === 'new') {
       return Convert.memoryId.convert(addr.idStem).onSuccess((refId) =>
         succeed({
           candidate,
           writeAddress: addr,
           writeEntityId: candidate.envelope.entityId,
           refId,
-          verdict,
-          dedupTargetId: verdict.target
+          verdict
         })
       );
     }
+    // duplicate-of | supersede | merge-into: the target must exist and share the
+    // candidate's kind.
+    const target: IMemoryRecord<unknown> | undefined = byId.get(verdict.target);
+    if (target === undefined) {
+      return fail(
+        `ingest '${item.id}': ${verdict.verdict} target '${verdict.target}' does not exist in the store`
+      );
+    }
+    if (target.envelope.kind !== candidate.envelope.kind) {
+      return fail(
+        `ingest '${item.id}': ${verdict.verdict} target '${verdict.target}' is kind '${target.envelope.kind}' but the candidate is kind '${candidate.envelope.kind}'`
+      );
+    }
     if (verdict.verdict === 'merge-into') {
-      const target: IMemoryRecord<unknown> | undefined = byId.get(verdict.target);
-      if (target === undefined) {
-        return fail(`ingest '${item.id}': merge-into target '${verdict.target}' does not exist in the store`);
-      }
+      // Re-address the write to the target's entity, carrying the target record so
+      // stage 6 can UNION its existing tags/links (never overwrite them).
       const targetEntityId: EntityId = target.envelope.entityId;
       return this._resolveAddress(targetEntityId, target.envelope.kind)
         .withErrorFormat((msg) => `ingest '${item.id}': ${msg}`)
@@ -363,12 +387,13 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
               writeAddress: targetAddr,
               writeEntityId: targetEntityId,
               refId,
-              verdict
+              verdict,
+              mergeTarget: target
             })
           )
         );
     }
-    // 'new' | 'supersede': write under the candidate's own address.
+    // duplicate-of | supersede: write under the candidate's own address.
     return Convert.memoryId.convert(addr.idStem).onSuccess((refId) =>
       succeed({
         candidate,
@@ -416,11 +441,19 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     wiring: ISimilarityWiring,
     byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>>
   ): Promise<Result<ResolutionVerdict>> {
-    const provisional: IMemoryRecord<unknown> = MemoryIngestOrchestrator._provisionalRecord(
-      candidate,
-      addr.idStem,
-      body
+    return MemoryIngestOrchestrator._provisionalRecord(candidate, addr.idStem, body).thenOnSuccess(
+      (provisional) => this._resolveViaSimilarityEmbedded(candidate, addr, wiring, byId, provisional)
     );
+  }
+
+  /** Layer-2 continuation once the candidate has a provisional record to embed. */
+  private async _resolveViaSimilarityEmbedded(
+    candidate: ICandidateRecord,
+    addr: IIdentityCodecResult,
+    wiring: ISimilarityWiring,
+    byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>>,
+    provisional: IMemoryRecord<unknown>
+  ): Promise<Result<ResolutionVerdict>> {
     const embedded: Result<Float32Array> = await this._capture(
       () => wiring.embed(provisional),
       `ingest '${candidate.envelope.entityId}': embed candidate`
@@ -479,17 +512,34 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     return this._exactKey(kind, body).onSuccess((key) =>
       mapResults(
         cohort.map((record) =>
-          this._exactKey(record.envelope.kind, record.body as string).onSuccess((recordKey) =>
-            succeed({ id: record.envelope.id, key: recordKey })
+          MemoryIngestOrchestrator._recordBodyString(record).onSuccess((recordBody) =>
+            this._exactKey(record.envelope.kind, recordBody).onSuccess((recordKey) =>
+              succeed({ id: record.envelope.id, key: recordKey })
+            )
           )
         )
       ).onSuccess((keyed) => succeed(keyed.find((entry) => entry.key === key)?.id))
     );
   }
 
+  /**
+   * The body of a persisted record, required to be a string (the store persists
+   * only string bodies). Fails loudly rather than blind-casting an `unknown` body
+   * into the exact-dedup hash — a non-string existing body is a store-integrity
+   * fault, surfaced with context, not a silent miscompute.
+   */
+  private static _recordBodyString(record: IMemoryRecord<unknown>): Result<string> {
+    if (typeof record.body !== 'string') {
+      return fail(
+        `ingest: stored record '${record.envelope.id}' has a non-string body (got ${typeof record.body})`
+      );
+    }
+    return succeed(record.body);
+  }
+
   /** The stage-4 exact-dedup key over `{ kind, body }` (design note §1). */
   private _exactKey(kind: Kind, body: string): Result<string> {
-    return this._hasher.computeHash({ kind: kind as string, body });
+    return this._hasher.computeHash({ kind, body });
   }
 
   /** Stage 5 — relate (host), validate edges, and run the write-time cycle guard. */
@@ -510,7 +560,7 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     if (proposed.isFailure()) {
       return proposed;
     }
-    const refIds: ReadonlySet<string> = new Set<string>(writablePlans.map((plan) => plan.refId as string));
+    const refIds: ReadonlySet<string> = new Set<string>(writablePlans.map((plan) => plan.refId));
     const validation: Result<true> = this._validateEdges(item, proposed.value, refIds, byId);
     if (validation.isFailure()) {
       return fail(validation.message);
@@ -539,10 +589,10 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
   ): Result<true> {
     return mapResults(
       edges.map((edge) => {
-        if (!refIds.has(edge.source as string)) {
+        if (!refIds.has(edge.source)) {
           return fail(`ingest '${item.id}': edge source '${edge.source}' is not a candidate being written`);
         }
-        if (!refIds.has(edge.edge.target as string) && byId.get(edge.edge.target) === undefined) {
+        if (!refIds.has(edge.edge.target) && byId.get(edge.edge.target) === undefined) {
           return fail(
             `ingest '${item.id}': edge target '${edge.edge.target}' resolves to neither a sibling candidate nor an existing record`
           );
@@ -560,13 +610,13 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
   ): Promise<Result<IIngestedRecordResult>> {
     const myEdges: ReadonlyArray<ICandidateEdge> = allEdges.filter((e) => e.source === plan.refId);
     if (plan.verdict.verdict === 'duplicate-of') {
-      // No write: the existing target satisfied the candidate.
-      const targetId: MemoryId = plan.dedupTargetId as MemoryId;
+      // No write: the existing target satisfied the candidate. The target id is a
+      // typed field of the narrowed `duplicate-of` verdict — no cast, no guard.
       return succeed({
         candidate: plan.candidate,
         resolution: plan.verdict,
         disposition: 'deduped',
-        id: targetId,
+        id: plan.verdict.target,
         edges: myEdges
       });
     }
@@ -598,28 +648,76 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     plan: ICandidatePlan,
     myEdges: ReadonlyArray<ICandidateEdge>
   ): Result<IMemoryRecord<unknown>> {
-    return Convert.memoryId.convert(plan.writeAddress.idStem).onSuccess((id) => {
-      const base: Omit<IMemoryEnvelope, 'id' | 'seq' | 'contentHash' | 'created' | 'updated'> =
-        plan.candidate.envelope;
-      const provenance: IProvenance = {
-        ...base.provenance,
-        source: HOST_INGEST_PROVENANCE_SOURCE,
-        ...(item.sourceId !== undefined ? { derivedFrom: item.sourceId } : {})
-      };
-      const links: ReadonlyArray<IEdge> = [...base.links, ...myEdges.map((e) => e.edge)];
-      const envelope: IMemoryEnvelope = {
-        ...base,
-        id,
-        entityId: plan.writeEntityId,
-        seq: 0,
-        contentHash: '',
-        created: 0,
-        updated: 0,
-        provenance,
-        links
-      };
-      return succeed({ envelope, body: plan.candidate.body });
-    });
+    const base: Omit<IMemoryEnvelope, 'id' | 'seq' | 'contentHash' | 'created' | 'updated'> =
+      plan.candidate.envelope;
+    // For merge-into the store's `applyUpdate` REPLACES array fields wholesale, so
+    // the persisted envelope must already carry the UNION of the target's existing
+    // tags/links/provenance and the candidate's — otherwise the merge silently
+    // wipes the target's prior links/tags.
+    const target: IMemoryRecord<unknown> | undefined = plan.mergeTarget;
+    const priorLinks: ReadonlyArray<IEdge> = target !== undefined ? target.envelope.links : [];
+    const priorTags: ReadonlyArray<Tag> = target !== undefined ? target.envelope.tags : [];
+    const priorProvenance: IProvenance = target !== undefined ? target.envelope.provenance : { source: '' };
+    return Convert.memoryId.convert(plan.writeAddress.idStem).onSuccess((id) =>
+      // Dedup the combined links by canonical edge key: the target's prior links, the
+      // candidate's own links, and the stage-5 edges (two candidates that resolve
+      // merge-into the SAME target share a `refId` — hence the same `myEdges` — and a
+      // relation extractor may repeat an edge) each appear exactly once.
+      this._dedupEdges([...priorLinks, ...base.links, ...myEdges.map((e) => e.edge)]).onSuccess((links) => {
+        const provenance: IProvenance = {
+          // Preserve the target's provenance extension keys, overlay the candidate's,
+          // then stamp the host-ingest source + derivedFrom (target present only for
+          // merge-into; otherwise the seed is inert).
+          ...(target !== undefined ? priorProvenance : {}),
+          ...base.provenance,
+          source: HOST_INGEST_PROVENANCE_SOURCE,
+          ...(item.sourceId !== undefined ? { derivedFrom: item.sourceId } : {})
+        };
+        const envelope: IMemoryEnvelope = {
+          ...base,
+          id,
+          entityId: plan.writeEntityId,
+          seq: 0,
+          contentHash: '',
+          created: 0,
+          updated: 0,
+          provenance,
+          tags: MemoryIngestOrchestrator._unionTags(priorTags, base.tags),
+          links
+        };
+        return succeed({ envelope, body: plan.candidate.body });
+      })
+    );
+  }
+
+  /** Union two tag lists, de-duplicated, preserving first-occurrence order. */
+  private static _unionTags(prior: ReadonlyArray<Tag>, incoming: ReadonlyArray<Tag>): ReadonlyArray<Tag> {
+    const seen: Set<string> = new Set<string>();
+    const out: Tag[] = [];
+    for (const tag of [...prior, ...incoming]) {
+      if (!seen.has(tag)) {
+        seen.add(tag);
+        out.push(tag);
+      }
+    }
+    return out;
+  }
+
+  /** De-duplicate a link list by canonical edge hash, preserving first-occurrence order. */
+  private _dedupEdges(edges: ReadonlyArray<IEdge>): Result<ReadonlyArray<IEdge>> {
+    const seen: Set<string> = new Set<string>();
+    const deduped: IEdge[] = [];
+    return mapResults(
+      edges.map((edge) =>
+        this._hasher.computeHash(edge).onSuccess((key) => {
+          if (!seen.has(key)) {
+            seen.add(key);
+            deduped.push(edge);
+          }
+          return succeed(key);
+        })
+      )
+    ).onSuccess(() => succeed(deduped));
   }
 
   /** Resolve a `(kind, entityId)` to its storage address via the registered codec. */
@@ -671,16 +769,18 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     candidate: ICandidateRecord,
     idStem: string,
     body: string
-  ): IMemoryRecord<unknown> {
-    const envelope: IMemoryEnvelope = {
-      ...candidate.envelope,
-      id: idStem as MemoryId,
-      seq: 0,
-      contentHash: '',
-      created: 0,
-      updated: 0
-    };
-    return { envelope, body };
+  ): Result<IMemoryRecord<unknown>> {
+    return Convert.memoryId.convert(idStem).onSuccess((id) => {
+      const envelope: IMemoryEnvelope = {
+        ...candidate.envelope,
+        id,
+        seq: 0,
+        contentHash: '',
+        created: 0,
+        updated: 0
+      };
+      return succeed({ envelope, body });
+    });
   }
 
   /** Require a candidate body to be a string (the store persists only string bodies). */

--- a/libraries/ts-agent-memory/src/packlets/ingest/orchestrator.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/orchestrator.ts
@@ -1,0 +1,697 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Hash, Logging, Result, fail, mapResults, succeed } from '@fgv/ts-utils';
+import {
+  Convert,
+  EntityId,
+  IEdge,
+  IIdentityCodec,
+  IIdentityCodecResult,
+  IMemoryEnvelope,
+  IMemoryRecord,
+  IProvenance,
+  Kind,
+  LinkType,
+  MemoryId,
+  MemoryScopeKey,
+  isTemporalRecord,
+  isVersionCurrent
+} from '../types';
+import { IBodyConverterRegistry } from '../converters';
+import { IMemoryStore } from '../store';
+import { IVectorIndex, MemoryEmbedder } from '../vector';
+import { ICycleGuardEdge, assertNoCycles } from './cycleGuard';
+import {
+  IEntityResolver,
+  IFactExtractor,
+  IMemoryClassifier,
+  IRelationCandidate,
+  IRelationExtractor
+} from './hostStages';
+import {
+  ICandidateEdge,
+  ICandidateRecord,
+  IEntityResolutionCandidate,
+  IIngestItem,
+  IIngestItemResult,
+  IIngestedRecordResult,
+  IMemoryClassification,
+  IngestDisposition,
+  ResolutionVerdict
+} from './model';
+
+/**
+ * The provenance source stamped on every record the ingest pipeline writes.
+ * @public
+ */
+export const HOST_INGEST_PROVENANCE_SOURCE: string = 'host-ingest';
+
+/**
+ * The link type whose presence on a temporal-kind candidate fires the
+ * contradicts→temporal-versioned interlock.
+ * @public
+ */
+export const CONTRADICTS_LINK_TYPE: LinkType = 'contradicts' as LinkType;
+
+/**
+ * The default stage-4 layer-2 cosine similarity threshold (design note §2). A
+ * near-duplicate candidate is surfaced to the {@link IEntityResolver} only when
+ * its nearest neighbor scores `>= 0.85`.
+ * @public
+ */
+export const DEFAULT_SIMILARITY_THRESHOLD: number = 0.85;
+
+/**
+ * The default top-K for stage-4 layer-2 similarity candidate generation.
+ * @public
+ */
+export const DEFAULT_SIMILARITY_TOP_K: number = 5;
+
+/**
+ * How the write-time cycle guard behaves: `'reject'` (default — a cycle-inducing
+ * edge fails the ingest) or `'off'` (no acyclicity constraint, for deployments
+ * whose link graphs are legitimately cyclic — e.g. mutual associative links).
+ * @public
+ */
+export type CycleGuardMode = 'reject' | 'off';
+
+/**
+ * The fgv-owned six-stage ingest orchestrator. Composes the host's staged
+ * classify / extract / (optional) resolve / relate machinery around fgv's owned
+ * validation boundary, dedup, edge + cycle safety, provenance stamping, and the
+ * contradicts→temporal interlock.
+ * @public
+ */
+export interface IMemoryIngestOrchestrator {
+  /**
+   * Ingest a SINGLE item end-to-end (the first-class per-turn streaming path).
+   */
+  ingestItem(item: IIngestItem): Promise<Result<IIngestItemResult>>;
+
+  /**
+   * Ingest a batch of items. A convenience loop over {@link
+   * IMemoryIngestOrchestrator.ingestItem | ingestItem} — items are processed in
+   * order and the first failure aborts the batch.
+   */
+  ingestBatch(items: ReadonlyArray<IIngestItem>): Promise<Result<ReadonlyArray<IIngestItemResult>>>;
+}
+
+/**
+ * Parameters for {@link MemoryIngestOrchestrator.create}.
+ * @public
+ */
+export interface IMemoryIngestOrchestratorCreateParams {
+  /** The store every write bottoms out in (stage 6). */
+  readonly store: IMemoryStore;
+  /** Per-kind body converter registry — the stage-3 typed validation boundary. */
+  readonly registry: IBodyConverterRegistry;
+  /** Per-kind identity codecs (maps a candidate `entityId` to its storage address). */
+  readonly codecs?: ReadonlyMap<Kind, IIdentityCodec>;
+  /** Default identity codec for kinds without an explicit entry. */
+  readonly defaultCodec?: IIdentityCodec;
+  /** Stage 2 — the host's classifier. */
+  readonly classifier: IMemoryClassifier;
+  /** Stage 3 — the host's fact extractor. */
+  readonly extractor: IFactExtractor;
+  /** Stage 5 — the host's relation extractor. */
+  readonly relationExtractor: IRelationExtractor;
+  /**
+   * Stage 4 (optional, OQ-13) — the host's entity resolver. Absent → stage-4
+   * dedup is exact-`{ kind, body }`-hash only (the deterministic-identity path).
+   */
+  readonly entityResolver?: IEntityResolver;
+  /**
+   * Optional vector index for stage-4 layer-2 similarity candidate-gen. Wired
+   * together with {@link IMemoryIngestOrchestratorCreateParams.embed | embed} AND
+   * {@link IMemoryIngestOrchestratorCreateParams.entityResolver | entityResolver};
+   * absent (or either co-requisite absent) → layer-2 is skipped and dedup is
+   * exact-only.
+   */
+  readonly vectorIndex?: IVectorIndex;
+  /** Optional embedder used to embed a candidate for layer-2 similarity search. */
+  readonly embed?: MemoryEmbedder;
+  /**
+   * Stage-4 layer-2 cosine threshold. Defaults to {@link
+   * DEFAULT_SIMILARITY_THRESHOLD} (`0.85`).
+   */
+  readonly similarityThreshold?: number;
+  /**
+   * Stage-4 layer-2 top-K. Defaults to {@link DEFAULT_SIMILARITY_TOP_K} (`5`).
+   */
+  readonly similarityTopK?: number;
+  /** Write-time cycle guard mode. Defaults to `'reject'`. */
+  readonly cycleGuard?: CycleGuardMode;
+  /** Diagnostic logger (defaults to a no-op). */
+  readonly logger?: Logging.ILogger;
+}
+
+/** The fully-wired stage-4 layer-2 dependencies (present only when all three are supplied). */
+interface ISimilarityWiring {
+  readonly resolver: IEntityResolver;
+  readonly vectorIndex: IVectorIndex;
+  readonly embed: MemoryEmbedder;
+}
+
+/** Internal per-candidate plan threaded through the pipeline. */
+interface ICandidatePlan {
+  readonly candidate: ICandidateRecord;
+  /** The write target's storage address (re-addressed to the target for merge-into). */
+  readonly writeAddress: IIdentityCodecResult;
+  /** The write target's entity id (re-addressed for merge-into). */
+  readonly writeEntityId: EntityId;
+  /** The reference id used in stage-5 edges (the write target's `idStem`). */
+  readonly refId: MemoryId;
+  readonly verdict: ResolutionVerdict;
+  /** The dedup target id when the verdict is `duplicate-of` (no write). */
+  readonly dedupTargetId?: MemoryId;
+}
+
+/**
+ * Default {@link IMemoryIngestOrchestrator}.
+ * @public
+ */
+export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
+  private readonly _store: IMemoryStore;
+  private readonly _registry: IBodyConverterRegistry;
+  private readonly _codecs: ReadonlyMap<Kind, IIdentityCodec>;
+  private readonly _defaultCodec: IIdentityCodec | undefined;
+  private readonly _classifier: IMemoryClassifier;
+  private readonly _extractor: IFactExtractor;
+  private readonly _relationExtractor: IRelationExtractor;
+  private readonly _similarity: ISimilarityWiring | undefined;
+  private readonly _similarityThreshold: number;
+  private readonly _similarityTopK: number;
+  private readonly _cycleGuard: CycleGuardMode;
+  private readonly _logger: Logging.ILogger;
+  private readonly _hasher: Hash.Crc32Normalizer;
+
+  private constructor(params: IMemoryIngestOrchestratorCreateParams) {
+    this._store = params.store;
+    this._registry = params.registry;
+    this._codecs = params.codecs ?? new Map<Kind, IIdentityCodec>();
+    this._defaultCodec = params.defaultCodec;
+    this._classifier = params.classifier;
+    this._extractor = params.extractor;
+    this._relationExtractor = params.relationExtractor;
+    this._similarity =
+      params.entityResolver !== undefined && params.vectorIndex !== undefined && params.embed !== undefined
+        ? { resolver: params.entityResolver, vectorIndex: params.vectorIndex, embed: params.embed }
+        : undefined;
+    this._similarityThreshold = params.similarityThreshold ?? DEFAULT_SIMILARITY_THRESHOLD;
+    this._similarityTopK = params.similarityTopK ?? DEFAULT_SIMILARITY_TOP_K;
+    this._cycleGuard = params.cycleGuard ?? 'reject';
+    this._logger = params.logger ?? new Logging.NoOpLogger();
+    this._hasher = new Hash.Crc32Normalizer();
+  }
+
+  /** Family-convention factory. */
+  public static create(params: IMemoryIngestOrchestratorCreateParams): Result<MemoryIngestOrchestrator> {
+    return succeed(new MemoryIngestOrchestrator(params));
+  }
+
+  /** {@inheritDoc IMemoryIngestOrchestrator.ingestItem} */
+  public async ingestItem(item: IIngestItem): Promise<Result<IIngestItemResult>> {
+    return (await this._classify(item))
+      .thenOnSuccess((classification) => this._extract(item, classification))
+      .thenOnSuccess((candidates) => this._processCandidates(item, candidates));
+  }
+
+  /** {@inheritDoc IMemoryIngestOrchestrator.ingestBatch} */
+  public async ingestBatch(
+    items: ReadonlyArray<IIngestItem>
+  ): Promise<Result<ReadonlyArray<IIngestItemResult>>> {
+    const results: IIngestItemResult[] = [];
+    for (const item of items) {
+      const result: Result<IIngestItemResult> = await this.ingestItem(item);
+      if (result.isFailure()) {
+        return fail(result.message);
+      }
+      results.push(result.value);
+    }
+    return succeed(results);
+  }
+
+  /** Stage 2 — classify (host), normalizing a rejected promise into a Failure. */
+  private async _classify(item: IIngestItem): Promise<Result<IMemoryClassification>> {
+    return this._capture(() => this._classifier.classify(item), `ingest '${item.id}': classify`);
+  }
+
+  /** Stage 3 — extract (host), normalizing a rejected promise into a Failure. */
+  private async _extract(
+    item: IIngestItem,
+    classification: IMemoryClassification
+  ): Promise<Result<ReadonlyArray<ICandidateRecord>>> {
+    return this._capture(() => this._extractor.extract(item, classification), `ingest '${item.id}': extract`);
+  }
+
+  /**
+   * Stages 3b-6 over the extracted candidates: validate bodies, resolve/dedup
+   * (stage 4), relate + cycle guard (stage 5), and load-with-provenance (stage 6).
+   */
+  private async _processCandidates(
+    item: IIngestItem,
+    candidates: ReadonlyArray<ICandidateRecord>
+  ): Promise<Result<IIngestItemResult>> {
+    // Snapshot the store once; stage-4 resolution and the cycle guard reason over
+    // the pre-ingest state.
+    const snapshotResult: Result<ReadonlyArray<IMemoryRecord<unknown>>> = await this._store.list();
+    if (snapshotResult.isFailure()) {
+      return fail(`ingest '${item.id}': failed to snapshot store: ${snapshotResult.message}`);
+    }
+    const snapshot: ReadonlyArray<IMemoryRecord<unknown>> = snapshotResult.value;
+    const byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>> = MemoryIngestOrchestrator._indexById(snapshot);
+
+    // Stage 3b + 4: validate each body and resolve a verdict/plan.
+    const plans: ICandidatePlan[] = [];
+    for (const candidate of candidates) {
+      const planResult: Result<ICandidatePlan> = await this._planCandidate(item, candidate, snapshot, byId);
+      if (planResult.isFailure()) {
+        return fail(planResult.message);
+      }
+      plans.push(planResult.value);
+    }
+
+    // Stage 5: relate over the writable candidates, validate + cycle-guard.
+    const writablePlans: ICandidatePlan[] = plans.filter((plan) => plan.verdict.verdict !== 'duplicate-of');
+    const edgesResult: Result<ReadonlyArray<ICandidateEdge>> = await this._relate(
+      item,
+      writablePlans,
+      snapshot,
+      byId
+    );
+    if (edgesResult.isFailure()) {
+      return fail(edgesResult.message);
+    }
+    const edges: ReadonlyArray<ICandidateEdge> = edgesResult.value;
+
+    // Stage 6: load-with-provenance, in extraction order.
+    const records: IIngestedRecordResult[] = [];
+    for (const plan of plans) {
+      const outcome: Result<IIngestedRecordResult> = await this._loadCandidate(item, plan, edges);
+      if (outcome.isFailure()) {
+        return fail(outcome.message);
+      }
+      records.push(outcome.value);
+    }
+    return succeed({ item, records });
+  }
+
+  /** Stage 3b + 4 for one candidate: validate body, resolve address, resolve verdict. */
+  private async _planCandidate(
+    item: IIngestItem,
+    candidate: ICandidateRecord,
+    snapshot: ReadonlyArray<IMemoryRecord<unknown>>,
+    byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>>
+  ): Promise<Result<ICandidatePlan>> {
+    const kind: Kind = candidate.envelope.kind;
+    // Stage 3b: the typed validation boundary — no unchecked host body reaches the store.
+    const bodyResult: Result<string> = this._registry
+      .convert(kind, candidate.body)
+      .withErrorFormat((msg) => `ingest '${item.id}': candidate body for kind '${kind}' is invalid: ${msg}`)
+      .onSuccess(() => MemoryIngestOrchestrator._asStringBody(item, candidate));
+    if (bodyResult.isFailure()) {
+      return fail(bodyResult.message);
+    }
+    const body: string = bodyResult.value;
+
+    const addrResult: Result<IIdentityCodecResult> = this._resolveAddress(candidate.envelope.entityId, kind);
+    if (addrResult.isFailure()) {
+      return fail(`ingest '${item.id}': ${addrResult.message}`);
+    }
+    const addr: IIdentityCodecResult = addrResult.value;
+
+    return (await this._resolveVerdict(candidate, kind, body, addr, snapshot, byId)).onSuccess((verdict) =>
+      this._planFromVerdict(item, candidate, addr, verdict, byId)
+    );
+  }
+
+  /** Turn a resolved verdict into a candidate plan (re-addressing merge-into to the target). */
+  private _planFromVerdict(
+    item: IIngestItem,
+    candidate: ICandidateRecord,
+    addr: IIdentityCodecResult,
+    verdict: ResolutionVerdict,
+    byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>>
+  ): Result<ICandidatePlan> {
+    if (verdict.verdict === 'duplicate-of') {
+      return Convert.memoryId.convert(addr.idStem).onSuccess((refId) =>
+        succeed({
+          candidate,
+          writeAddress: addr,
+          writeEntityId: candidate.envelope.entityId,
+          refId,
+          verdict,
+          dedupTargetId: verdict.target
+        })
+      );
+    }
+    if (verdict.verdict === 'merge-into') {
+      const target: IMemoryRecord<unknown> | undefined = byId.get(verdict.target);
+      if (target === undefined) {
+        return fail(`ingest '${item.id}': merge-into target '${verdict.target}' does not exist in the store`);
+      }
+      const targetEntityId: EntityId = target.envelope.entityId;
+      return this._resolveAddress(targetEntityId, target.envelope.kind)
+        .withErrorFormat((msg) => `ingest '${item.id}': ${msg}`)
+        .onSuccess((targetAddr) =>
+          Convert.memoryId.convert(targetAddr.idStem).onSuccess((refId) =>
+            succeed({
+              candidate,
+              writeAddress: targetAddr,
+              writeEntityId: targetEntityId,
+              refId,
+              verdict
+            })
+          )
+        );
+    }
+    // 'new' | 'supersede': write under the candidate's own address.
+    return Convert.memoryId.convert(addr.idStem).onSuccess((refId) =>
+      succeed({
+        candidate,
+        writeAddress: addr,
+        writeEntityId: candidate.envelope.entityId,
+        refId,
+        verdict
+      })
+    );
+  }
+
+  /**
+   * Stage 4 — resolve a dedup verdict. Layer 1: an exact `{ kind, body }` match in
+   * the candidate's scope is a `duplicate-of` (design note §1). Layer 2 (only when
+   * a resolver + vector index + embedder are all wired): embed the candidate,
+   * surface over-threshold neighbors, and dispatch to the {@link IEntityResolver}.
+   * Otherwise the verdict is `new` (the exact-only fall-back path).
+   */
+  private async _resolveVerdict(
+    candidate: ICandidateRecord,
+    kind: Kind,
+    body: string,
+    addr: IIdentityCodecResult,
+    snapshot: ReadonlyArray<IMemoryRecord<unknown>>,
+    byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>>
+  ): Promise<Result<ResolutionVerdict>> {
+    return this._findExactMatch(kind, body, addr.scope, snapshot).thenOnSuccess(async (matchId) => {
+      if (matchId !== undefined) {
+        return succeed({ verdict: 'duplicate-of', target: matchId });
+      }
+      const layer2: ISimilarityWiring | undefined = this._similarity;
+      if (layer2 === undefined) {
+        // No layer-2: exact-only fall-back (the deterministic-identity host path).
+        return succeed({ verdict: 'new' });
+      }
+      return this._resolveViaSimilarity(candidate, addr, body, layer2, byId);
+    });
+  }
+
+  /** Layer-2 similarity candidate-gen + resolver dispatch. */
+  private async _resolveViaSimilarity(
+    candidate: ICandidateRecord,
+    addr: IIdentityCodecResult,
+    body: string,
+    wiring: ISimilarityWiring,
+    byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>>
+  ): Promise<Result<ResolutionVerdict>> {
+    const provisional: IMemoryRecord<unknown> = MemoryIngestOrchestrator._provisionalRecord(
+      candidate,
+      addr.idStem,
+      body
+    );
+    const embedded: Result<Float32Array> = await this._capture(
+      () => wiring.embed(provisional),
+      `ingest '${candidate.envelope.entityId}': embed candidate`
+    );
+    if (embedded.isFailure()) {
+      return fail(embedded.message);
+    }
+    const queried = await this._capture(
+      () => wiring.vectorIndex.query(embedded.value, this._similarityTopK),
+      `ingest '${candidate.envelope.entityId}': similarity query`
+    );
+    if (queried.isFailure()) {
+      return fail(queried.message);
+    }
+    const similar: IEntityResolutionCandidate[] = [];
+    for (const hit of queried.value) {
+      if (hit.score < this._similarityThreshold || hit.id === addr.idStem) {
+        continue;
+      }
+      const record: IMemoryRecord<unknown> | undefined = byId.get(hit.id);
+      if (record !== undefined) {
+        similar.push({ id: hit.id, record, score: hit.score });
+      }
+    }
+    if (similar.length === 0) {
+      return succeed({ verdict: 'new' });
+    }
+    return this._capture(
+      () => wiring.resolver.resolve(candidate, similar),
+      `ingest '${candidate.envelope.entityId}': resolve`
+    );
+  }
+
+  /**
+   * Find an existing record in `scope` whose `{ kind, body }` hash matches the
+   * candidate's (layer-1 exact dedup). Invalidated temporal versions are excluded
+   * — only a live (non-temporal or current) record deduplicates a candidate.
+   */
+  private _findExactMatch(
+    kind: Kind,
+    body: string,
+    scope: MemoryScopeKey,
+    snapshot: ReadonlyArray<IMemoryRecord<unknown>>
+  ): Result<MemoryId | undefined> {
+    // Same-kind, same-scope, LIVE (non-temporal or current) records are the exact
+    // cohort. `_resolveAddress(...).map(...).orDefault()` collapses an unresolved
+    // codec to a non-matching scope with no explicit failure branch.
+    const cohort: ReadonlyArray<IMemoryRecord<unknown>> = snapshot.filter(
+      (record) =>
+        record.envelope.kind === kind &&
+        !(isTemporalRecord(record) && !isVersionCurrent(record)) &&
+        this._resolveAddress(record.envelope.entityId, record.envelope.kind)
+          .onSuccess((addr) => succeed(addr.scope))
+          .orDefault() === scope
+    );
+    return this._exactKey(kind, body).onSuccess((key) =>
+      mapResults(
+        cohort.map((record) =>
+          this._exactKey(record.envelope.kind, record.body as string).onSuccess((recordKey) =>
+            succeed({ id: record.envelope.id, key: recordKey })
+          )
+        )
+      ).onSuccess((keyed) => succeed(keyed.find((entry) => entry.key === key)?.id))
+    );
+  }
+
+  /** The stage-4 exact-dedup key over `{ kind, body }` (design note §1). */
+  private _exactKey(kind: Kind, body: string): Result<string> {
+    return this._hasher.computeHash({ kind: kind as string, body });
+  }
+
+  /** Stage 5 — relate (host), validate edges, and run the write-time cycle guard. */
+  private async _relate(
+    item: IIngestItem,
+    writablePlans: ReadonlyArray<ICandidatePlan>,
+    snapshot: ReadonlyArray<IMemoryRecord<unknown>>,
+    byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>>
+  ): Promise<Result<ReadonlyArray<ICandidateEdge>>> {
+    const relationCandidates: IRelationCandidate[] = writablePlans.map((plan) => ({
+      candidate: plan.candidate,
+      id: plan.refId
+    }));
+    const proposed: Result<ReadonlyArray<ICandidateEdge>> = await this._capture(
+      () => this._relationExtractor.relate({ item, candidates: relationCandidates }),
+      `ingest '${item.id}': relate`
+    );
+    if (proposed.isFailure()) {
+      return proposed;
+    }
+    const refIds: ReadonlySet<string> = new Set<string>(writablePlans.map((plan) => plan.refId as string));
+    const validation: Result<true> = this._validateEdges(item, proposed.value, refIds, byId);
+    if (validation.isFailure()) {
+      return fail(validation.message);
+    }
+    if (this._cycleGuard === 'reject') {
+      const guard: Result<true> = assertNoCycles(
+        MemoryIngestOrchestrator._existingEdges(snapshot),
+        proposed.value.map((e) => ({ source: e.source, target: e.edge.target, type: e.edge.type }))
+      );
+      if (guard.isFailure()) {
+        return fail(`ingest '${item.id}': ${guard.message}`);
+      }
+    }
+    return succeed(proposed.value);
+  }
+
+  /**
+   * Validate stage-5 edges: each `source` must be a candidate being written; each
+   * `target` must resolve to a sibling candidate or an existing store record.
+   */
+  private _validateEdges(
+    item: IIngestItem,
+    edges: ReadonlyArray<ICandidateEdge>,
+    refIds: ReadonlySet<string>,
+    byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>>
+  ): Result<true> {
+    return mapResults(
+      edges.map((edge) => {
+        if (!refIds.has(edge.source as string)) {
+          return fail(`ingest '${item.id}': edge source '${edge.source}' is not a candidate being written`);
+        }
+        if (!refIds.has(edge.edge.target as string) && byId.get(edge.edge.target) === undefined) {
+          return fail(
+            `ingest '${item.id}': edge target '${edge.edge.target}' resolves to neither a sibling candidate nor an existing record`
+          );
+        }
+        return succeed(true);
+      })
+    ).onSuccess(() => succeed(true));
+  }
+
+  /** Stage 6 — stamp provenance + edges, admit through the store, record the outcome. */
+  private async _loadCandidate(
+    item: IIngestItem,
+    plan: ICandidatePlan,
+    allEdges: ReadonlyArray<ICandidateEdge>
+  ): Promise<Result<IIngestedRecordResult>> {
+    const myEdges: ReadonlyArray<ICandidateEdge> = allEdges.filter((e) => e.source === plan.refId);
+    if (plan.verdict.verdict === 'duplicate-of') {
+      // No write: the existing target satisfied the candidate.
+      const targetId: MemoryId = plan.dedupTargetId as MemoryId;
+      return succeed({
+        candidate: plan.candidate,
+        resolution: plan.verdict,
+        disposition: 'deduped',
+        id: targetId,
+        edges: myEdges
+      });
+    }
+    return this._buildRecord(item, plan, myEdges).thenOnSuccess(async (record) =>
+      (await this._store.put(record))
+        .withErrorFormat((msg) => `ingest '${item.id}': write failed: ${msg}`)
+        .onSuccess((persisted) => {
+          const disposition: IngestDisposition = plan.verdict.verdict === 'merge-into' ? 'merged' : 'written';
+          const interlock: 'temporal-versioned' | undefined =
+            plan.writeAddress.isVersioned && myEdges.some((e) => e.edge.type === CONTRADICTS_LINK_TYPE)
+              ? 'temporal-versioned'
+              : undefined;
+          return succeed({
+            candidate: plan.candidate,
+            resolution: plan.verdict,
+            disposition,
+            id: persisted.envelope.id,
+            record: persisted,
+            edges: myEdges,
+            ...(interlock !== undefined ? { interlock } : {})
+          });
+        })
+    );
+  }
+
+  /** Build the fully-stamped record to persist (provenance + edges + placeholder txn fields). */
+  private _buildRecord(
+    item: IIngestItem,
+    plan: ICandidatePlan,
+    myEdges: ReadonlyArray<ICandidateEdge>
+  ): Result<IMemoryRecord<unknown>> {
+    return Convert.memoryId.convert(plan.writeAddress.idStem).onSuccess((id) => {
+      const base: Omit<IMemoryEnvelope, 'id' | 'seq' | 'contentHash' | 'created' | 'updated'> =
+        plan.candidate.envelope;
+      const provenance: IProvenance = {
+        ...base.provenance,
+        source: HOST_INGEST_PROVENANCE_SOURCE,
+        ...(item.sourceId !== undefined ? { derivedFrom: item.sourceId } : {})
+      };
+      const links: ReadonlyArray<IEdge> = [...base.links, ...myEdges.map((e) => e.edge)];
+      const envelope: IMemoryEnvelope = {
+        ...base,
+        id,
+        entityId: plan.writeEntityId,
+        seq: 0,
+        contentHash: '',
+        created: 0,
+        updated: 0,
+        provenance,
+        links
+      };
+      return succeed({ envelope, body: plan.candidate.body });
+    });
+  }
+
+  /** Resolve a `(kind, entityId)` to its storage address via the registered codec. */
+  private _resolveAddress(entityId: EntityId, kind: Kind): Result<IIdentityCodecResult> {
+    const codec: IIdentityCodec | undefined = this._codecs.get(kind) ?? this._defaultCodec;
+    if (codec === undefined) {
+      return fail(`no identity codec registered for kind '${kind}'`);
+    }
+    return codec.encode(entityId);
+  }
+
+  /** Run a host hook, normalizing a thrown/rejected hook into a Failure (never throws across the seam). */
+  private async _capture<T>(op: () => Promise<Result<T>>, label: string): Promise<Result<T>> {
+    try {
+      return await op();
+    } catch (err) {
+      const message: string = `${label} threw: ${String(err)}`;
+      this._logger.warn(message);
+      return fail(message);
+    }
+  }
+
+  /** Index a record snapshot by id (last write wins on an id collision across scopes). */
+  private static _indexById(
+    records: ReadonlyArray<IMemoryRecord<unknown>>
+  ): ReadonlyMap<MemoryId, IMemoryRecord<unknown>> {
+    const byId: Map<MemoryId, IMemoryRecord<unknown>> = new Map<MemoryId, IMemoryRecord<unknown>>();
+    for (const record of records) {
+      byId.set(record.envelope.id, record);
+    }
+    return byId;
+  }
+
+  /** Every existing outbound edge in the snapshot, as cycle-guard edges. */
+  private static _existingEdges(
+    records: ReadonlyArray<IMemoryRecord<unknown>>
+  ): ReadonlyArray<ICycleGuardEdge> {
+    const edges: ICycleGuardEdge[] = [];
+    for (const record of records) {
+      for (const edge of record.envelope.links) {
+        edges.push({ source: record.envelope.id, target: edge.target, type: edge.type });
+      }
+    }
+    return edges;
+  }
+
+  /** A provisional record for embedding a candidate (placeholder txn-time fields). */
+  private static _provisionalRecord(
+    candidate: ICandidateRecord,
+    idStem: string,
+    body: string
+  ): IMemoryRecord<unknown> {
+    const envelope: IMemoryEnvelope = {
+      ...candidate.envelope,
+      id: idStem as MemoryId,
+      seq: 0,
+      contentHash: '',
+      created: 0,
+      updated: 0
+    };
+    return { envelope, body };
+  }
+
+  /** Require a candidate body to be a string (the store persists only string bodies). */
+  private static _asStringBody(item: IIngestItem, candidate: ICandidateRecord): Result<string> {
+    if (typeof candidate.body !== 'string') {
+      return fail(
+        `ingest '${item.id}': candidate body for kind '${
+          candidate.envelope.kind
+        }' must be a string (got ${typeof candidate.body})`
+      );
+    }
+    return succeed(candidate.body);
+  }
+}

--- a/libraries/ts-agent-memory/src/test/unit/ingest/cycleGuard.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/ingest/cycleGuard.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import { ICycleGuardEdge, LinkType, MemoryId, assertNoCycles, buildCycleKey } from '../../../index';
+
+const rel: LinkType = 'rel' as LinkType;
+
+function edge(source: string, target: string, type: LinkType = rel): ICycleGuardEdge {
+  return { source: source as MemoryId, target: target as MemoryId, type };
+}
+
+describe('buildCycleKey', () => {
+  test('is deterministic for the same edge', () => {
+    expect(buildCycleKey(edge('a', 'b'))).toSucceedAndSatisfy((key: string) => {
+      expect(buildCycleKey(edge('a', 'b'))).toSucceedWith(key);
+    });
+  });
+
+  test('differs by direction and type', () => {
+    const forward = buildCycleKey(edge('a', 'b')).orThrow();
+    const reverse = buildCycleKey(edge('b', 'a')).orThrow();
+    const typed = buildCycleKey(edge('a', 'b', 'other' as LinkType)).orThrow();
+    expect(forward).not.toBe(reverse);
+    expect(forward).not.toBe(typed);
+  });
+});
+
+describe('assertNoCycles', () => {
+  test('accepts an acyclic graph', () => {
+    expect(assertNoCycles([edge('a', 'b')], [edge('b', 'c'), edge('c', 'd')])).toSucceed();
+  });
+
+  test('rejects a proposed edge that closes a cycle against existing edges', () => {
+    expect(assertNoCycles([edge('a', 'b'), edge('b', 'c')], [edge('c', 'a')])).toFailWith(
+      /would create a cycle/
+    );
+  });
+
+  test('rejects a cycle formed entirely within the proposed batch', () => {
+    expect(assertNoCycles([], [edge('a', 'b'), edge('b', 'a')])).toFailWith(/would create a cycle/);
+  });
+
+  test('rejects a self-loop', () => {
+    expect(assertNoCycles([], [edge('a', 'a')])).toFailWith(/self-loop/);
+  });
+
+  test('tolerates a duplicate proposed edge (deduped by canonical key)', () => {
+    expect(assertNoCycles([], [edge('a', 'b'), edge('a', 'b')])).toSucceed();
+  });
+
+  test('tolerates a duplicate existing edge', () => {
+    expect(assertNoCycles([edge('a', 'b'), edge('a', 'b')], [edge('b', 'c')])).toSucceed();
+  });
+
+  test('accepts a diamond (shared descendant is not a cycle)', () => {
+    expect(assertNoCycles([], [edge('a', 'b'), edge('a', 'c'), edge('b', 'd'), edge('c', 'd')])).toSucceed();
+  });
+
+  test('reachability tolerates a frontier node reached by two paths (revisit guard)', () => {
+    // Existing graph: a->c, a->b, b->c. A proposed edge z->a runs reachability
+    // from `a`, whose DFS pushes `c` twice before it is visited — exercising the
+    // visited-node skip in the traversal.
+    expect(assertNoCycles([edge('a', 'c'), edge('a', 'b'), edge('b', 'c')], [edge('z', 'a')])).toSucceed();
+  });
+});

--- a/libraries/ts-agent-memory/src/test/unit/ingest/orchestrator.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/ingest/orchestrator.test.ts
@@ -38,6 +38,7 @@ import {
   Kind,
   KnowledgeIdentityCodec,
   LinkType,
+  LtmIdentityCodec,
   MemoryEmbedder,
   MemoryId,
   MemoryIngestOrchestrator,
@@ -54,6 +55,7 @@ const noteKind: Kind = 'note' as Kind;
 const factKind: Kind = 'fact' as Kind;
 const numKind: Kind = 'num' as Kind;
 const orphanKind: Kind = 'orphan' as Kind;
+const ltmKind: Kind = 'ltm' as Kind;
 
 // --- shared fixtures ----------------------------------------------------------
 let clockValue: number;
@@ -76,12 +78,14 @@ function registry(): IBodyConverterRegistry {
   reg.register(factKind, Converters.string);
   reg.register(numKind, Converters.number);
   reg.register(orphanKind, Converters.string);
+  reg.register(ltmKind, Converters.string);
   return reg;
 }
 
 const codecs: ReadonlyMap<Kind, IIdentityCodec> = new Map<Kind, IIdentityCodec>([
   [noteKind, new KnowledgeIdentityCodec()],
   [numKind, new KnowledgeIdentityCodec()],
+  [ltmKind, new LtmIdentityCodec()],
   [factKind, TemporalIdentityCodec.create('facts').orThrow()]
 ]);
 
@@ -970,5 +974,185 @@ describe('MemoryIngestOrchestrator — optional constructor params', () => {
     }).orThrow();
     expect(await orch.ingestItem({ id: 'doc-1', content: 'x' })).toFailWith(/classifier boom/);
     expect(logger.logged.some((m) => /classifier boom/.test(m))).toBe(true);
+  });
+});
+
+describe('MemoryIngestOrchestrator — review-punch-list fixes', () => {
+  test('a stored record with a non-string body fails the exact-dedup pass loudly', async () => {
+    const weird: IMemoryRecord<unknown> = {
+      envelope: {
+        id: 'weird' as MemoryId,
+        entityId: 'weird' as EntityId,
+        kind: noteKind,
+        tags: [],
+        links: [],
+        created: 0,
+        updated: 0,
+        seq: 0,
+        contentHash: '',
+        provenance: { source: 'agent' }
+      },
+      body: 42
+    };
+    const store = mockStore({ list: () => Promise.resolve(succeed([weird])) });
+    const orch = buildOrchestrator({ store });
+    expect(await orch.ingestItem({ id: 'doc-1', content: 'hello' })).toFailWith(
+      /stored record 'weird' has a non-string body/
+    );
+  });
+
+  test('duplicate stage-5 edges are deduped on the written record', async () => {
+    const store = buildStore();
+    await putNote(store, 'doc-a', 'anchor');
+    const orch = buildOrchestrator({
+      store,
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'goodbye')])),
+      relationExtractor: relater(() =>
+        succeed([candEdge('doc-b', 'rel', 'doc-a'), candEdge('doc-b', 'rel', 'doc-a')])
+      )
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: 'doc-a' }]);
+    });
+  });
+
+  test('two candidates merging into the same target do not duplicate a shared edge', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putNote(store, 'doc-a', 'apple pie');
+    await putNote(store, 'doc-x', 'target');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver((__c, similar) => succeed({ verdict: 'merge-into', target: similar[0].id })),
+      extractor: extractor(() =>
+        succeed([candidate(noteKind, 'doc-b', 'apple tart'), candidate(noteKind, 'doc-c', 'apple tart')])
+      ),
+      relationExtractor: relater(() => succeed([candEdge('doc-a', 'rel', 'doc-x')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceed();
+    expect(await store.get(noteKind, 'doc-a' as EntityId)).toSucceedAndSatisfy(
+      (rec: IMemoryRecord<unknown> | undefined) => {
+        expect(rec?.envelope.links).toEqual([{ type: 'rel', target: 'doc-x' }]);
+      }
+    );
+  });
+});
+
+describe('MemoryIngestOrchestrator — merge-into safety (second review)', () => {
+  // Seed a record with pre-existing tags + links under a flat codec (id === entityId).
+  async function putFull(
+    store: FileTreeMemoryStore,
+    kind: Kind,
+    entityId: string,
+    body: string,
+    opts: { tags?: ReadonlyArray<string>; links?: IMemoryEnvelope['links'] } = {}
+  ): Promise<void> {
+    const rec: IMemoryRecord<unknown> = {
+      envelope: {
+        id: entityId as MemoryId,
+        entityId: entityId as EntityId,
+        kind,
+        tags: (opts.tags ?? []) as ReadonlyArray<Tag>,
+        links: opts.links ?? [],
+        created: 0,
+        updated: 0,
+        seq: 0,
+        contentHash: '',
+        provenance: { source: 'agent' }
+      },
+      body
+    };
+    (await store.put(rec)).orThrow();
+  }
+
+  test('merge-into UNIONs the target’s existing tags + links (never overwrites them)', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putFull(store, noteKind, 'doc-a', 'apple pie', {
+      tags: ['old-tag'],
+      links: [{ type: 'existing' as LinkType, target: 'doc-z' as MemoryId }]
+    });
+    await putFull(store, noteKind, 'doc-x', 'target of stage-5');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver((__c, similar) => succeed({ verdict: 'merge-into', target: similar[0].id })),
+      extractor: extractor(() =>
+        succeed([
+          candidate(noteKind, 'doc-b', 'apple tart', {
+            tags: ['new-tag'],
+            links: [{ type: 'candlink' as LinkType, target: 'doc-z' as MemoryId }]
+          })
+        ])
+      ),
+      relationExtractor: relater(() => succeed([candEdge('doc-a', 'stage5', 'doc-x')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].disposition).toBe('merged');
+    });
+    expect(await store.get(noteKind, 'doc-a' as EntityId)).toSucceedAndSatisfy(
+      (rec: IMemoryRecord<unknown> | undefined) => {
+        // Original tag preserved AND the candidate's tag gained, each once.
+        expect([...(rec?.envelope.tags ?? [])].sort()).toEqual(['new-tag', 'old-tag']);
+        // Original link + candidate link + stage-5 edge, each exactly once.
+        expect(rec?.envelope.links).toEqual([
+          { type: 'existing', target: 'doc-z' },
+          { type: 'candlink', target: 'doc-z' },
+          { type: 'stage5', target: 'doc-x' }
+        ]);
+      }
+    );
+  });
+
+  test('merge-into a different-kind target fails loudly', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    // A DIFFERENT-kind (ltm) record embedded so it surfaces as a neighbor of a note candidate.
+    await putFull(store, ltmKind, 'conv-1', 'apple pie');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver((__c, similar) => succeed({ verdict: 'merge-into', target: similar[0].id })),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
+      /merge-into target 'conv-1' is kind 'ltm' but the candidate is kind 'note'/
+    );
+  });
+
+  test('supersede with a non-existent target fails loudly', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putFull(store, noteKind, 'doc-a', 'apple pie');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver(() => succeed({ verdict: 'supersede', target: 'ghost' as MemoryId })),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
+      /supersede target 'ghost' does not exist/
+    );
+  });
+
+  test('duplicate-of with a non-existent target fails loudly', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putFull(store, noteKind, 'doc-a', 'apple pie');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver(() => succeed({ verdict: 'duplicate-of', target: 'ghost' as MemoryId })),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
+      /duplicate-of target 'ghost' does not exist/
+    );
   });
 });

--- a/libraries/ts-agent-memory/src/test/unit/ingest/orchestrator.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/ingest/orchestrator.test.ts
@@ -1,0 +1,974 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converters, Logging, Result, fail, succeed } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
+import {
+  BodyConverterRegistry,
+  CONTRADICTS_LINK_TYPE,
+  DEFAULT_SIMILARITY_THRESHOLD,
+  DEFAULT_SIMILARITY_TOP_K,
+  EntityId,
+  FileTreeMemoryStore,
+  HOST_INGEST_PROVENANCE_SOURCE,
+  IBodyConverterRegistry,
+  ICandidateEdge,
+  ICandidateRecord,
+  IEntityResolutionCandidate,
+  IEntityResolver,
+  IFactExtractor,
+  IIdentityCodec,
+  IIngestItem,
+  IIngestItemResult,
+  InMemoryCosineIndex,
+  IMemoryClassification,
+  IMemoryClassifier,
+  IMemoryEnvelope,
+  IMemoryRecord,
+  IMemoryStore,
+  IProvenance,
+  IRelationContext,
+  IRelationExtractor,
+  IVectorIndex,
+  IVectorQueryHit,
+  IWritePolicy,
+  Kind,
+  KnowledgeIdentityCodec,
+  LinkType,
+  MemoryEmbedder,
+  MemoryId,
+  MemoryIngestOrchestrator,
+  MemoryScopeKey,
+  ResolutionVerdict,
+  Tag,
+  TemporalIdentityCodec,
+  TemporalVersionedPolicy,
+  serializeMemoryFile
+} from '../../../index';
+
+// --- kinds --------------------------------------------------------------------
+const noteKind: Kind = 'note' as Kind;
+const factKind: Kind = 'fact' as Kind;
+const numKind: Kind = 'num' as Kind;
+const orphanKind: Kind = 'orphan' as Kind;
+
+// --- shared fixtures ----------------------------------------------------------
+let clockValue: number;
+const clock = (): number => clockValue;
+
+function mutableRoot(
+  files: ReadonlyArray<{ path: string; contents: string }> = []
+): FileTree.IMutableFileTreeDirectoryItem {
+  const tree = FileTree.inMemory([...files], { mutable: true }).orThrow();
+  const root = tree.getDirectory('/').orThrow();
+  if (!FileTree.isMutableDirectoryItem(root)) {
+    throw new Error('expected a mutable root directory');
+  }
+  return root;
+}
+
+function registry(): IBodyConverterRegistry {
+  const reg = BodyConverterRegistry.create().orThrow();
+  reg.register(noteKind, Converters.string);
+  reg.register(factKind, Converters.string);
+  reg.register(numKind, Converters.number);
+  reg.register(orphanKind, Converters.string);
+  return reg;
+}
+
+const codecs: ReadonlyMap<Kind, IIdentityCodec> = new Map<Kind, IIdentityCodec>([
+  [noteKind, new KnowledgeIdentityCodec()],
+  [numKind, new KnowledgeIdentityCodec()],
+  [factKind, TemporalIdentityCodec.create('facts').orThrow()]
+]);
+
+const policies: ReadonlyMap<Kind, IWritePolicy> = new Map<Kind, IWritePolicy>([
+  [factKind, TemporalVersionedPolicy.create().orThrow()]
+]);
+
+// A deterministic embedder keyed by body text (three-dimensional vectors so
+// cosine relationships are controllable). Unknown bodies map to a distinct axis.
+const VECTORS: ReadonlyMap<string, ReadonlyArray<number>> = new Map<string, ReadonlyArray<number>>([
+  ['apple pie', [1, 0, 0]],
+  ['apple tart', [0.99, 0.14, 0]],
+  ['banana bread', [0, 1, 0]]
+]);
+const embed: MemoryEmbedder = (record) => {
+  if (record.body === 'boom') {
+    return Promise.resolve(fail('embed boom'));
+  }
+  const vec: ReadonlyArray<number> = VECTORS.get(record.body as string) ?? [0, 0, 1];
+  return Promise.resolve(succeed(Float32Array.from(vec)));
+};
+
+// --- mock host stages ---------------------------------------------------------
+function classifier(fn: (item: IIngestItem) => Result<IMemoryClassification>): IMemoryClassifier {
+  return { classify: (item) => Promise.resolve(fn(item)) };
+}
+function throwingClassifier(): IMemoryClassifier {
+  return {
+    classify: () => {
+      throw new Error('classifier boom');
+    }
+  };
+}
+function extractor(
+  fn: (item: IIngestItem, c: IMemoryClassification) => Result<ReadonlyArray<ICandidateRecord>>
+): IFactExtractor {
+  return { extract: (item, c) => Promise.resolve(fn(item, c)) };
+}
+function resolver(
+  fn: (
+    candidate: ICandidateRecord,
+    similar: ReadonlyArray<IEntityResolutionCandidate>
+  ) => Result<ResolutionVerdict>
+): IEntityResolver {
+  return { resolve: (candidate, similar) => Promise.resolve(fn(candidate, similar)) };
+}
+function relater(fn: (ctx: IRelationContext) => Result<ReadonlyArray<ICandidateEdge>>): IRelationExtractor {
+  return { relate: (ctx) => Promise.resolve(fn(ctx)) };
+}
+
+const noEdges: IRelationExtractor = relater(() => succeed([]));
+const classifyNote: IMemoryClassifier = classifier(() => succeed({ kind: noteKind, confidence: 0.9 }));
+
+/** Extractor that emits one note candidate per item, body = item.content, entityId = item.id. */
+function oneNoteExtractor(): IFactExtractor {
+  return extractor((item) => succeed([candidate(noteKind, item.id, item.content as string)]));
+}
+
+function candidate(
+  kind: Kind,
+  entityId: string,
+  body: unknown,
+  opts: {
+    readonly tags?: ReadonlyArray<string>;
+    readonly links?: ICandidateRecord['envelope']['links'];
+    readonly provenance?: IProvenance;
+    readonly temporal?: IMemoryEnvelope['temporal'];
+  } = {}
+): ICandidateRecord {
+  return {
+    envelope: {
+      entityId: entityId as EntityId,
+      kind,
+      tags: (opts.tags ?? []) as ReadonlyArray<Tag>,
+      links: opts.links ?? [],
+      provenance: opts.provenance ?? { source: 'agent' },
+      ...(opts.temporal !== undefined ? { temporal: opts.temporal } : {})
+    },
+    body
+  };
+}
+
+function candEdge(source: string, type: string, target: string, confidence?: number): ICandidateEdge {
+  return {
+    source: source as MemoryId,
+    edge: {
+      type: type as LinkType,
+      target: target as MemoryId,
+      ...(confidence !== undefined ? { confidence } : {})
+    }
+  };
+}
+
+interface IBuildParams {
+  readonly files?: ReadonlyArray<{ path: string; contents: string }>;
+  readonly registry?: IBodyConverterRegistry;
+  readonly vectorIndex?: IVectorIndex;
+  readonly embed?: MemoryEmbedder;
+}
+
+function buildStore(params: IBuildParams = {}): FileTreeMemoryStore {
+  return FileTreeMemoryStore.create({
+    root: mutableRoot(params.files),
+    registry: params.registry ?? registry(),
+    codecs,
+    writePolicies: policies,
+    clock,
+    vectorIndex: params.vectorIndex,
+    embed: params.embed
+  }).orThrow();
+}
+
+interface IOrchestratorParams {
+  readonly store: IMemoryStore;
+  readonly registry?: IBodyConverterRegistry;
+  readonly classifier?: IMemoryClassifier;
+  readonly extractor?: IFactExtractor;
+  readonly relationExtractor?: IRelationExtractor;
+  readonly entityResolver?: IEntityResolver;
+  readonly vectorIndex?: IVectorIndex;
+  readonly embed?: MemoryEmbedder;
+  readonly similarityThreshold?: number;
+  readonly cycleGuard?: 'reject' | 'off';
+}
+
+function buildOrchestrator(params: IOrchestratorParams): MemoryIngestOrchestrator {
+  return MemoryIngestOrchestrator.create({
+    store: params.store,
+    registry: params.registry ?? registry(),
+    codecs,
+    classifier: params.classifier ?? classifyNote,
+    extractor: params.extractor ?? oneNoteExtractor(),
+    relationExtractor: params.relationExtractor ?? noEdges,
+    entityResolver: params.entityResolver,
+    vectorIndex: params.vectorIndex,
+    embed: params.embed,
+    similarityThreshold: params.similarityThreshold,
+    cycleGuard: params.cycleGuard
+  }).orThrow();
+}
+
+/** A seeded note file with only `source` provenance (the additive-provenance baseline). */
+function seedNote(
+  id: string,
+  body: string,
+  provenance: Record<string, unknown> = { source: 'agent' }
+): {
+  path: string;
+  contents: string;
+} {
+  const envelope: IMemoryEnvelope = {
+    id: id as MemoryId,
+    entityId: id as EntityId,
+    kind: noteKind,
+    tags: [],
+    links: [],
+    created: 1,
+    updated: 1,
+    seq: 4,
+    contentHash: 'seed',
+    provenance: provenance as unknown as IProvenance
+  };
+  return { path: `knowledge/${id}.md`, contents: serializeMemoryFile(envelope, body).orThrow() };
+}
+
+beforeEach(() => {
+  clockValue = 1000;
+});
+
+describe('MemoryIngestOrchestrator', () => {
+  describe('create', () => {
+    test('constructs via the factory', () => {
+      expect(
+        MemoryIngestOrchestrator.create({
+          store: buildStore(),
+          registry: registry(),
+          codecs,
+          classifier: classifyNote,
+          extractor: oneNoteExtractor(),
+          relationExtractor: noEdges
+        })
+      ).toSucceed();
+    });
+
+    test('exposes the documented similarity defaults', () => {
+      expect(DEFAULT_SIMILARITY_THRESHOLD).toBe(0.85);
+      expect(DEFAULT_SIMILARITY_TOP_K).toBe(5);
+    });
+  });
+
+  describe('single-item ingest (first-class path)', () => {
+    test('classifies, extracts, and writes one record end-to-end with host-ingest provenance + derivedFrom', async () => {
+      const store = buildStore();
+      const orch = buildOrchestrator({ store });
+      const sourceId: MemoryId = 'turn-3' as MemoryId;
+      const result = await orch.ingestItem({ id: 'doc-1', content: 'the sky is blue', sourceId });
+      expect(result).toSucceedAndSatisfy((r: IIngestItemResult) => {
+        expect(r.item.id).toBe('doc-1');
+        expect(r.records).toHaveLength(1);
+        const rec = r.records[0];
+        expect(rec.disposition).toBe('written');
+        expect(rec.resolution.verdict).toBe('new');
+        expect(rec.id).toBe('doc-1');
+        expect(rec.record?.envelope.provenance.source).toBe(HOST_INGEST_PROVENANCE_SOURCE);
+        expect(rec.record?.envelope.provenance.derivedFrom).toBe('turn-3');
+        expect(rec.record?.body).toBe('the sky is blue');
+        expect(rec.interlock).toBeUndefined();
+      });
+      expect(await store.get(noteKind, 'doc-1' as EntityId)).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown> | undefined) => {
+          expect(rec?.body).toBe('the sky is blue');
+        }
+      );
+    });
+
+    test('omits derivedFrom when the item carries no sourceId', async () => {
+      const store = buildStore();
+      const orch = buildOrchestrator({ store });
+      const result = await orch.ingestItem({ id: 'doc-1', content: 'a fact' });
+      expect(result).toSucceedAndSatisfy((r: IIngestItemResult) => {
+        expect(r.records[0].record?.envelope.provenance.derivedFrom).toBeUndefined();
+        expect(r.records[0].record?.envelope.provenance.source).toBe(HOST_INGEST_PROVENANCE_SOURCE);
+      });
+    });
+
+    test('yields an empty record set when the extractor finds nothing memorable', async () => {
+      const store = buildStore();
+      const orch = buildOrchestrator({ store, extractor: extractor(() => succeed([])) });
+      expect(await orch.ingestItem({ id: 'doc-1', content: 'noise' })).toSucceedAndSatisfy(
+        (r: IIngestItemResult) => {
+          expect(r.records).toEqual([]);
+        }
+      );
+    });
+  });
+
+  describe('host-stage failures abort loudly', () => {
+    test('classifier failure', async () => {
+      const orch = buildOrchestrator({
+        store: buildStore(),
+        classifier: classifier(() => fail('cannot classify'))
+      });
+      expect(await orch.ingestItem({ id: 'doc-1', content: 'x' })).toFailWith(/cannot classify/);
+    });
+
+    test('classifier throw is captured as a failure', async () => {
+      const orch = buildOrchestrator({ store: buildStore(), classifier: throwingClassifier() });
+      expect(await orch.ingestItem({ id: 'doc-1', content: 'x' })).toFailWith(
+        /classify threw.*classifier boom/
+      );
+    });
+
+    test('extractor failure', async () => {
+      const orch = buildOrchestrator({
+        store: buildStore(),
+        extractor: extractor(() => fail('extract error'))
+      });
+      expect(await orch.ingestItem({ id: 'doc-1', content: 'x' })).toFailWith(/extract error/);
+    });
+
+    test('relation-extractor failure', async () => {
+      const orch = buildOrchestrator({
+        store: buildStore(),
+        relationExtractor: relater(() => fail('relate error'))
+      });
+      expect(await orch.ingestItem({ id: 'doc-1', content: 'x' })).toFailWith(/relate error/);
+    });
+  });
+
+  describe('stage 3b — typed validation boundary', () => {
+    test('rejects a candidate whose body fails the kind converter', async () => {
+      const orch = buildOrchestrator({
+        store: buildStore(),
+        extractor: extractor(() => succeed([candidate(noteKind, 'doc-1', 42)]))
+      });
+      expect(await orch.ingestItem({ id: 'doc-1', content: 'x' })).toFailWith(
+        /candidate body for kind 'note' is invalid/
+      );
+    });
+
+    test('rejects a non-string body even when the converter accepts it', async () => {
+      const orch = buildOrchestrator({
+        store: buildStore(),
+        extractor: extractor(() => succeed([candidate(numKind, 'n-1', 42)]))
+      });
+      expect(await orch.ingestItem({ id: 'n-1', content: 'x' })).toFailWith(/must be a string/);
+    });
+
+    test('fails when no identity codec is registered for the candidate kind', async () => {
+      const orch = buildOrchestrator({
+        store: buildStore(),
+        extractor: extractor(() => succeed([candidate(orphanKind, 'o-1', 'body')]))
+      });
+      expect(await orch.ingestItem({ id: 'o-1', content: 'x' })).toFailWith(/no identity codec/);
+    });
+  });
+
+  describe('stage 4 — exact dedup (layer 1)', () => {
+    test('an exact {kind,body} match in scope is duplicate-of (no resolver)', async () => {
+      const store = buildStore({ files: [seedNote('doc-a', 'hello')] });
+      const orch = buildOrchestrator({
+        store,
+        extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'hello')]))
+      });
+      expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+        expect(r.records[0].disposition).toBe('deduped');
+        expect(r.records[0].resolution).toEqual({ verdict: 'duplicate-of', target: 'doc-a' });
+        expect(r.records[0].id).toBe('doc-a');
+      });
+      // doc-b was never written.
+      expect(await store.get(noteKind, 'doc-b' as EntityId)).toSucceedWith(undefined);
+    });
+
+    test('exact dedup takes precedence over the resolver (resolver never called)', async () => {
+      const vectorIndex = InMemoryCosineIndex.create().orThrow();
+      const store = buildStore({ files: [seedNote('doc-a', 'hello')] });
+      const orch = buildOrchestrator({
+        store,
+        entityResolver: resolver(() => fail('resolver must not be called')),
+        vectorIndex,
+        embed,
+        extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'hello')]))
+      });
+      expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+        expect(r.records[0].disposition).toBe('deduped');
+      });
+    });
+
+    test('a distinct body is a fresh write (no resolver → exact-only fall-back)', async () => {
+      const store = buildStore({ files: [seedNote('doc-a', 'hello')] });
+      const orch = buildOrchestrator({
+        store,
+        extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'goodbye')]))
+      });
+      expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+        expect(r.records[0].disposition).toBe('written');
+        expect(r.records[0].resolution.verdict).toBe('new');
+      });
+    });
+  });
+});
+
+// --- similarity + resolver fixtures ------------------------------------------
+const classifyFact: IMemoryClassifier = classifier(() => succeed({ kind: factKind }));
+function oneFactExtractor(): IFactExtractor {
+  return extractor((item) => succeed([candidate(factKind, item.id, item.content as string)]));
+}
+
+async function putNote(store: FileTreeMemoryStore, id: string, body: string): Promise<void> {
+  const rec: IMemoryRecord<unknown> = {
+    envelope: {
+      id: id as MemoryId,
+      entityId: id as EntityId,
+      kind: noteKind,
+      tags: [],
+      links: [],
+      created: 0,
+      updated: 0,
+      seq: 0,
+      contentHash: '',
+      provenance: { source: 'agent' }
+    },
+    body
+  };
+  (await store.put(rec)).orThrow();
+}
+
+function mockStore(overrides: Partial<IMemoryStore>): IMemoryStore {
+  return {
+    get:
+      overrides.get ??
+      ((): Promise<Result<IMemoryRecord<unknown> | undefined>> => Promise.resolve(succeed(undefined))),
+    getById:
+      overrides.getById ??
+      ((): Promise<Result<IMemoryRecord<unknown> | undefined>> => Promise.resolve(succeed(undefined))),
+    list:
+      overrides.list ??
+      ((): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>> => Promise.resolve(succeed([]))),
+    put: overrides.put ?? ((r): Promise<Result<IMemoryRecord<unknown>>> => Promise.resolve(succeed(r))),
+    delete: overrides.delete ?? ((): Promise<Result<MemoryId>> => Promise.resolve(fail('n/a')))
+  };
+}
+
+describe('MemoryIngestOrchestrator — stage 4 similarity (layer 2)', () => {
+  test('resolver verdict new writes the candidate despite a near-duplicate', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putNote(store, 'doc-a', 'apple pie');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver(() => succeed({ verdict: 'new' })),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].disposition).toBe('written');
+      expect(r.records[0].resolution.verdict).toBe('new');
+    });
+  });
+
+  test('resolver verdict duplicate-of dedups against the surfaced neighbor', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putNote(store, 'doc-a', 'apple pie');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver((__c, similar) => succeed({ verdict: 'duplicate-of', target: similar[0].id })),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].disposition).toBe('deduped');
+      expect(r.records[0].id).toBe('doc-a');
+    });
+    expect(await store.get(noteKind, 'doc-b' as EntityId)).toSucceedWith(undefined);
+  });
+
+  test('resolver verdict supersede writes the candidate and records the superseded target', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putNote(store, 'doc-a', 'apple pie');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver((__c, similar) => succeed({ verdict: 'supersede', target: similar[0].id })),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].disposition).toBe('written');
+      expect(r.records[0].resolution).toEqual({ verdict: 'supersede', target: 'doc-a' });
+      expect(r.records[0].id).toBe('doc-b');
+    });
+    expect(await store.get(noteKind, 'doc-b' as EntityId)).toSucceedAndSatisfy(
+      (rec: IMemoryRecord<unknown> | undefined) => expect(rec?.body).toBe('apple tart')
+    );
+  });
+
+  test('resolver verdict merge-into re-addresses the write to the target entity', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putNote(store, 'doc-a', 'apple pie');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver((__c, similar) => succeed({ verdict: 'merge-into', target: similar[0].id })),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].disposition).toBe('merged');
+      expect(r.records[0].id).toBe('doc-a');
+    });
+    // The merge updated doc-a's body (LWW merge patch) and never minted doc-b.
+    expect(await store.get(noteKind, 'doc-a' as EntityId)).toSucceedAndSatisfy(
+      (rec: IMemoryRecord<unknown> | undefined) => expect(rec?.body).toBe('apple tart')
+    );
+    expect(await store.get(noteKind, 'doc-b' as EntityId)).toSucceedWith(undefined);
+  });
+
+  test('merge-into with a non-existent target fails loudly', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putNote(store, 'doc-a', 'apple pie');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver(() => succeed({ verdict: 'merge-into', target: 'ghost' as MemoryId })),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
+      /merge-into target 'ghost' does not exist/
+    );
+  });
+
+  test('a below-threshold neighbor is not surfaced (resolver not called)', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putNote(store, 'doc-a', 'apple pie');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver(() => fail('resolver must not be called')),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'banana bread')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].resolution.verdict).toBe('new');
+    });
+  });
+
+  test('the candidate self-hit is excluded from surfaced neighbors', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putNote(store, 'doc-a', 'apple pie');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      entityResolver: resolver(() => fail('resolver must not be called')),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-a', 'apple tart')]))
+    });
+    // Re-ingesting the SAME entity: its own prior vector is the only over-threshold
+    // hit, and it is skipped as the self-hit, so no resolver dispatch occurs.
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].resolution.verdict).toBe('new');
+      expect(r.records[0].disposition).toBe('written');
+    });
+  });
+
+  test('a surfaced hit with no backing record is skipped', async () => {
+    const ghostIndex: IVectorIndex = {
+      add: (id) => Promise.resolve(succeed(id as string)),
+      remove: (id) => Promise.resolve(succeed(id)),
+      query: (): Promise<Result<ReadonlyArray<IVectorQueryHit>>> =>
+        Promise.resolve(succeed([{ id: 'ghost' as MemoryId, score: 0.99 }]))
+    };
+    const orch = buildOrchestrator({
+      store: buildStore(),
+      vectorIndex: ghostIndex,
+      embed,
+      entityResolver: resolver(() => fail('resolver must not be called')),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].resolution.verdict).toBe('new');
+    });
+  });
+
+  test('an embedder failure surfaces loudly', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const orch = buildOrchestrator({
+      store: buildStore(),
+      vectorIndex,
+      embed,
+      entityResolver: resolver(() => succeed({ verdict: 'new' })),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'boom')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(/embed boom/);
+  });
+
+  test('a similarity-query failure surfaces loudly', async () => {
+    const failingIndex: IVectorIndex = {
+      add: (id) => Promise.resolve(succeed(id as string)),
+      remove: (id) => Promise.resolve(succeed(id)),
+      query: (): Promise<Result<ReadonlyArray<IVectorQueryHit>>> => Promise.resolve(fail('query kaput'))
+    };
+    const orch = buildOrchestrator({
+      store: buildStore(),
+      vectorIndex: failingIndex,
+      embed,
+      entityResolver: resolver(() => succeed({ verdict: 'new' })),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(/query kaput/);
+  });
+
+  test('a custom similarityThreshold gates the resolver dispatch', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putNote(store, 'doc-a', 'apple pie');
+    const orch = buildOrchestrator({
+      store,
+      vectorIndex,
+      embed,
+      similarityThreshold: 0.999, // 0.99 neighbor now falls below threshold
+      entityResolver: resolver(() => fail('resolver must not be called')),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].resolution.verdict).toBe('new');
+    });
+  });
+});
+
+describe('MemoryIngestOrchestrator — layer-2 wiring gates (exact-only fall-back)', () => {
+  const failResolver: IEntityResolver = resolver(() => fail('resolver must not be called'));
+  const almostSimilar = extractor(() => succeed([candidate(noteKind, 'doc-b', 'apple tart')]));
+
+  test('no resolver → exact-only', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const store = buildStore({ vectorIndex, embed });
+    await putNote(store, 'doc-a', 'apple pie');
+    const orch = buildOrchestrator({ store, vectorIndex, embed, extractor: almostSimilar });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) =>
+      expect(r.records[0].resolution.verdict).toBe('new')
+    );
+  });
+
+  test('resolver + embed but no vector index → exact-only', async () => {
+    const orch = buildOrchestrator({
+      store: buildStore(),
+      embed,
+      entityResolver: failResolver,
+      extractor: almostSimilar
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) =>
+      expect(r.records[0].resolution.verdict).toBe('new')
+    );
+  });
+
+  test('resolver + vector index but no embedder → exact-only', async () => {
+    const vectorIndex = InMemoryCosineIndex.create().orThrow();
+    const orch = buildOrchestrator({
+      store: buildStore(),
+      vectorIndex,
+      entityResolver: failResolver,
+      extractor: almostSimilar
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) =>
+      expect(r.records[0].resolution.verdict).toBe('new')
+    );
+  });
+});
+
+describe('MemoryIngestOrchestrator — stage 5 relate + cycle guard', () => {
+  test('attaches a valid edge to an existing record', async () => {
+    const store = buildStore();
+    await putNote(store, 'doc-a', 'anchor');
+    const orch = buildOrchestrator({
+      store,
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'goodbye')])),
+      relationExtractor: relater(() => succeed([candEdge('doc-b', 'mentions', 'doc-a', 0.7)]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].edges).toHaveLength(1);
+      expect(r.records[0].record?.envelope.links).toEqual([
+        { type: 'mentions', target: 'doc-a', confidence: 0.7 }
+      ]);
+    });
+  });
+
+  test('attaches an edge between two sibling candidates', async () => {
+    const orch = buildOrchestrator({
+      store: buildStore(),
+      extractor: extractor(() =>
+        succeed([candidate(noteKind, 'doc-b', 'first'), candidate(noteKind, 'doc-c', 'second')])
+      ),
+      relationExtractor: relater(() => succeed([candEdge('doc-b', 'rel', 'doc-c')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records).toHaveLength(2);
+      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: 'doc-c' }]);
+      expect(r.records[1].edges).toEqual([]);
+    });
+  });
+
+  test('rejects an edge whose source is not a candidate being written', async () => {
+    const orch = buildOrchestrator({
+      store: buildStore(),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'x')])),
+      relationExtractor: relater(() => succeed([candEdge('ghost', 'rel', 'doc-b')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
+      /edge source 'ghost' is not a candidate being written/
+    );
+  });
+
+  test('rejects an edge whose target resolves to nothing', async () => {
+    const orch = buildOrchestrator({
+      store: buildStore(),
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'x')])),
+      relationExtractor: relater(() => succeed([candEdge('doc-b', 'rel', 'ghost')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
+      /edge target 'ghost' resolves to neither/
+    );
+  });
+
+  test('rejects a cycle-inducing edge (default guard)', async () => {
+    const orch = buildOrchestrator({
+      store: buildStore(),
+      extractor: extractor(() =>
+        succeed([candidate(noteKind, 'doc-b', 'first'), candidate(noteKind, 'doc-c', 'second')])
+      ),
+      relationExtractor: relater(() =>
+        succeed([candEdge('doc-b', 'rel', 'doc-c'), candEdge('doc-c', 'rel', 'doc-b')])
+      )
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(/would create a cycle/);
+  });
+
+  test('cycleGuard "off" admits an otherwise-cyclic edge set', async () => {
+    const orch = buildOrchestrator({
+      store: buildStore(),
+      cycleGuard: 'off',
+      extractor: extractor(() =>
+        succeed([candidate(noteKind, 'doc-b', 'first'), candidate(noteKind, 'doc-c', 'second')])
+      ),
+      relationExtractor: relater(() =>
+        succeed([candEdge('doc-b', 'rel', 'doc-c'), candEdge('doc-c', 'rel', 'doc-b')])
+      )
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: 'doc-c' }]);
+      expect(r.records[1].record?.envelope.links).toEqual([{ type: 'rel', target: 'doc-b' }]);
+    });
+  });
+
+  test('a contradicts edge on a NON-temporal kind persists as a plain link (no interlock)', async () => {
+    const store = buildStore();
+    await putNote(store, 'doc-a', 'anchor');
+    const orch = buildOrchestrator({
+      store,
+      extractor: extractor(() => succeed([candidate(noteKind, 'doc-b', 'goodbye')])),
+      relationExtractor: relater(() => succeed([candEdge('doc-b', 'contradicts', 'doc-a')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].interlock).toBeUndefined();
+      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'contradicts', target: 'doc-a' }]);
+    });
+  });
+});
+
+describe('MemoryIngestOrchestrator — contradicts→temporal interlock', () => {
+  test('a contradicts edge on a temporal kind invalidates the prior version and writes a new one', async () => {
+    const store = buildStore();
+    const firstOrch = buildOrchestrator({
+      store,
+      classifier: classifyFact,
+      extractor: oneFactExtractor()
+    });
+    clockValue = 1000;
+    const first = await firstOrch.ingestItem({ id: 'fact-1', content: 'the sky is blue' });
+    const v1Id: MemoryId = first.orThrow().records[0].id;
+    expect(v1Id).toBe('fact-1-v1');
+
+    clockValue = 2000;
+    const secondOrch = buildOrchestrator({
+      store,
+      classifier: classifyFact,
+      extractor: extractor(() => succeed([candidate(factKind, 'fact-1', 'the sky is grey')])),
+      relationExtractor: relater(() => succeed([candEdge('fact-1', 'contradicts', v1Id)]))
+    });
+    expect(await secondOrch.ingestItem({ id: 'fact-1', content: 'the sky is grey' })).toSucceedAndSatisfy(
+      (r: IIngestItemResult) => {
+        expect(r.records[0].interlock).toBe('temporal-versioned');
+        expect(r.records[0].disposition).toBe('written');
+        expect(r.records[0].record?.envelope.links).toEqual([{ type: CONTRADICTS_LINK_TYPE, target: v1Id }]);
+      }
+    );
+
+    // The current version is the new (contradicting) one.
+    expect(await store.get(factKind, 'fact-1' as EntityId)).toSucceedAndSatisfy(
+      (rec: IMemoryRecord<unknown> | undefined) => expect(rec?.body).toBe('the sky is grey')
+    );
+    // The prior version is invalidated (invalidate-don't-delete).
+    expect(await store.list()).toSucceedAndSatisfy((all: ReadonlyArray<IMemoryRecord<unknown>>) => {
+      const v1 = all.find((rec) => rec.envelope.id === v1Id);
+      expect(v1?.envelope.temporal?.invalid_at).toBe(2000);
+    });
+  });
+
+  test('an invalidated version does not exact-dedup a later candidate that repeats its body', async () => {
+    const store = buildStore();
+    clockValue = 1000;
+    const o1 = buildOrchestrator({ store, classifier: classifyFact, extractor: oneFactExtractor() });
+    const first = await o1.ingestItem({ id: 'fact-1', content: 'blue' });
+    const v1Id: MemoryId = first.orThrow().records[0].id;
+
+    clockValue = 2000;
+    const o2 = buildOrchestrator({
+      store,
+      classifier: classifyFact,
+      extractor: extractor(() => succeed([candidate(factKind, 'fact-1', 'grey')])),
+      relationExtractor: relater(() => succeed([candEdge('fact-1', 'contradicts', v1Id)]))
+    });
+    (await o2.ingestItem({ id: 'fact-1', content: 'grey' })).orThrow();
+
+    // Re-introduce the ORIGINAL body: the invalidated v1 must be skipped by exact
+    // dedup, so this is a NEW version, not a duplicate-of.
+    clockValue = 3000;
+    const o3 = buildOrchestrator({
+      store,
+      classifier: classifyFact,
+      extractor: extractor(() => succeed([candidate(factKind, 'fact-1', 'blue')]))
+    });
+    expect(await o3.ingestItem({ id: 'fact-1', content: 'blue' })).toSucceedAndSatisfy(
+      (r: IIngestItemResult) => {
+        expect(r.records[0].resolution.verdict).toBe('new');
+        expect(r.records[0].disposition).toBe('written');
+      }
+    );
+  });
+});
+
+describe('MemoryIngestOrchestrator — additive-provenance non-regression', () => {
+  test('a pre-existing record with only source provenance still loads and validates unchanged', async () => {
+    const store = buildStore({ files: [seedNote('legacy', 'old note', { source: 'human' })] });
+    // Loads at construction time.
+    expect(await store.getById('knowledge' as MemoryScopeKey, 'legacy' as MemoryId)).toSucceedAndSatisfy(
+      (rec: IMemoryRecord<unknown> | undefined) => {
+        expect(rec?.envelope.provenance).toEqual({ source: 'human' });
+        expect(rec?.envelope.provenance.by).toBeUndefined();
+        expect(rec?.envelope.provenance.derivedFrom).toBeUndefined();
+      }
+    );
+    // An unrelated ingest does not disturb it.
+    const orch = buildOrchestrator({ store });
+    (await orch.ingestItem({ id: 'fresh', content: 'new content' })).orThrow();
+    expect(await store.getById('knowledge' as MemoryScopeKey, 'legacy' as MemoryId)).toSucceedAndSatisfy(
+      (rec: IMemoryRecord<unknown> | undefined) => {
+        expect(rec?.envelope.provenance).toEqual({ source: 'human' });
+      }
+    );
+  });
+});
+
+describe('MemoryIngestOrchestrator — ingestBatch', () => {
+  test('ingests a batch in order', async () => {
+    const store = buildStore();
+    const orch = buildOrchestrator({ store });
+    const result = await orch.ingestBatch([
+      { id: 'doc-1', content: 'one' },
+      { id: 'doc-2', content: 'two' }
+    ]);
+    expect(result).toSucceedAndSatisfy((results: ReadonlyArray<IIngestItemResult>) => {
+      expect(results).toHaveLength(2);
+      expect(results.map((r) => r.item.id)).toEqual(['doc-1', 'doc-2']);
+      expect(results.every((r) => r.records[0].disposition === 'written')).toBe(true);
+    });
+  });
+
+  test('aborts the batch on the first item failure', async () => {
+    const orch = buildOrchestrator({
+      store: buildStore(),
+      classifier: classifier((item) =>
+        item.id === 'bad' ? fail('classify bad') : succeed({ kind: noteKind })
+      )
+    });
+    expect(
+      await orch.ingestBatch([
+        { id: 'bad', content: 'one' },
+        { id: 'doc-2', content: 'two' }
+      ])
+    ).toFailWith(/classify bad/);
+  });
+});
+
+describe('MemoryIngestOrchestrator — store failure paths', () => {
+  test('a store snapshot (list) failure aborts the item', async () => {
+    const store = mockStore({ list: () => Promise.resolve(fail('list down')) });
+    const orch = buildOrchestrator({ store });
+    expect(await orch.ingestItem({ id: 'doc-1', content: 'x' })).toFailWith(
+      /failed to snapshot store.*list down/
+    );
+  });
+
+  test('a store put failure surfaces as a write failure', async () => {
+    const store = mockStore({ put: () => Promise.resolve(fail('put kaput')) });
+    const orch = buildOrchestrator({ store });
+    expect(await orch.ingestItem({ id: 'doc-1', content: 'x' })).toFailWith(/write failed.*put kaput/);
+  });
+});
+
+describe('MemoryIngestOrchestrator — optional constructor params', () => {
+  test('falls back to defaultCodec when no per-kind codec map is supplied', async () => {
+    const store = buildStore();
+    const orch = MemoryIngestOrchestrator.create({
+      store,
+      registry: registry(),
+      defaultCodec: new KnowledgeIdentityCodec(),
+      classifier: classifyNote,
+      extractor: oneNoteExtractor(),
+      relationExtractor: noEdges
+    }).orThrow();
+    expect(await orch.ingestItem({ id: 'doc-1', content: 'hello' })).toSucceedAndSatisfy(
+      (r: IIngestItemResult) => expect(r.records[0].disposition).toBe('written')
+    );
+  });
+
+  test('honors an explicit similarityTopK and logs a captured host throw to the supplied logger', async () => {
+    const logger = new Logging.InMemoryLogger('detail');
+    const orch = MemoryIngestOrchestrator.create({
+      store: buildStore(),
+      registry: registry(),
+      codecs,
+      classifier: throwingClassifier(),
+      extractor: oneNoteExtractor(),
+      relationExtractor: noEdges,
+      similarityTopK: 3,
+      logger
+    }).orThrow();
+    expect(await orch.ingestItem({ id: 'doc-1', content: 'x' })).toFailWith(/classifier boom/);
+    expect(logger.logged.some((m) => /classifier boom/.test(m))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The final stream of the agent-memory arc: a green-field `ingest/` packlet in `@fgv/ts-agent-memory` adding the fgv-owned **six-stage ingestion pipeline** with four host-plugged staged interfaces. The host brings classify/extract/relate judgment; **fgv owns** the typed validation boundary, dedup, edge/cycle safety, provenance stamping, and the `contradicts`→temporal interlock.

Additive on the active `ts-agent-memory` surface. No live API calls — pure library logic (host stages are mocked in tests).

## Six-stage pipeline (`MemoryIngestOrchestrator`)

1. **Intake** — a single `IIngestItem` (first-class per-turn path) or a batch loop.
2. **Classify** *(host `IMemoryClassifier`)* → `IMemoryClassification`.
3. **Extract** *(host `IFactExtractor`)* → `ICandidateRecord[]`; **each body validated against the kind's registered Converter** before it can reach the store.
4. **Resolve/dedup** *(fgv)* — layer-1 exact `{kind,body}` hash + layer-2 vector-similarity candidate-gen dispatched to the optional host `IEntityResolver` (`new | duplicate-of | supersede | merge-into`).
5. **Relate** *(host `IRelationExtractor`)* — fgv validates edges + runs the **write-time cycle guard** (`buildCycleKey`/`assertNoCycles`, distinct from the read-time BFS).
6. **Load-with-provenance** *(fgv)* — stamps `IProvenance { source: 'host-ingest', derivedFrom }`, admits through the per-kind `IWritePolicy`, `put`.

## LOCKED consumer decisions (honored)

- **OQ-10 — staged host interfaces**, not an opaque ingestor: `IMemoryClassifier` + `IFactExtractor` + `IEntityResolver?` + `IRelationExtractor`.
- **OQ-13 — `IEntityResolver` optional**: absent → stage-4 falls back to exact-`{kind,body}`-hash only (the deterministic-identity host path).
- **Single-item ingest first-class**: `ingestItem(item)` is the primary entry point; `ingestBatch` composes over it.
- **Additive/optional provenance, no migration**: a pre-existing `mtm`/`ltm` record with only `source` provenance still loads/validates (asserted as a non-regression test).

## Open decisions resolved (see `design-note.md`)

- **Stage-4 exact-dedup key = `{kind, body}`** (design §9.2), *not* the store's `{kind,body,links}` hash — links aren't final until stage 5, so a links-inclusive key would be unstable across the pipeline.
- **Similarity threshold default = `0.85`** (cosine), exposed as `similarityThreshold`.
- **Cycle guard = global directed-acyclicity** over existing + proposed edges; conservative (rejects mutual associative pairs) with a `cycleGuard: 'off'` escape hatch for legitimately-cyclic graphs.
- **`ICandidateRecord.envelope`** omits all five store-owned fields (`id | seq | contentHash | created | updated`).

## `contradicts` → temporal interlock

A `contradicts` edge on a **temporal-kind** candidate is recognized and routed through the store's versioned put path (prior version invalidated via `invalid_at`, new version written); the result carries `interlock: 'temporal-versioned'`. A `contradicts` edge on a non-temporal kind persists as a plain link. Built on the merged temporal write path (#526).

## Code-review findings (two internal passes, both resolved)

**Pass 1:**
- **P1** — unsafe `record.body as string` in exact-dedup: now a Result-returning string-body check that fails loudly on a non-string stored body (test added).
- **P2** — `dedupTargetId` cast: removed the field; `duplicate-of` reads its typed `target` off the narrowed verdict.
- **P2** — edge duplication: `_dedupEdges` de-dups links by canonical key.
- **P2** — TSDoc `{@link Hash.Crc32Normalizer}` unresolved-link → plain-text reference (no `ae-unresolved-link` in api.md).
- **P3** — `_provisionalRecord` id via `Convert.memoryId`.

**Pass 2 (merge-into path):**
- **DATA LOSS (fixed)** — `merge-into` now **UNIONs** the target's existing `tags`/`links`/`provenance` with the candidate's before the write (the store's `applyUpdate` replaces arrays wholesale, which would otherwise wipe the target's prior links/tags). Test asserts original + candidate + stage-5 edges each appear once.
- **Kind safety (fixed)** — every target-bearing verdict (`duplicate-of`/`supersede`/`merge-into`) now rejects loudly if the target's `kind` differs from the candidate's (test added).
- **Uniform existence check (fixed)** — target existence validated for `duplicate-of`/`supersede` too, not just `merge-into` (tests added).
- **P3** — dropped trivial `Brand<string>`→`string` casts; clarified the `interlock` TSDoc (diagnostic marker, not a routing gate).

## Gates

- `rushx build` ✅ · `rushx lint` ✅ (clean, `fixlint` run) · `rushx test` ✅ **482 tests, 100% coverage** (statements/branches/functions/lines) across the whole package. The filtered-run coverage-variance note on `orchestrator.ts:370` is covered in the full run.
- `etc/ts-agent-memory.api.md` regenerated (additive only — new `ingest/` exports; no changed/removed symbols).

No live canary needed (pure library logic; host stages mocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new ingest flow that classifies items, extracts records, deduplicates similar content, and writes results with safer relation handling.
  * Added support for cycle-safe link creation and special handling for contradictory links on temporal records.

* **Bug Fixes**
  * Improved duplicate handling so merged records retain existing tags, links, and provenance.
  * Added safeguards to prevent invalid writes, self-referential links, and accidental graph cycles during ingest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->