### PR TITLE
test(ts-agent-memory): antagonist torture tests + two store fixes they surfaced

### DIFF
--- a/.ai/tasks/active/agent-memory-antagonist/brief.md
+++ b/.ai/tasks/active/agent-memory-antagonist/brief.md
@@ -1,0 +1,68 @@
+# Brief — agent-memory antagonist: adversarial torture tests for the near-miss invariant classes
+
+> **STATUS: DRAFT — commission AFTER `agent-memory-l3-ingest` (#527) merges to `release`.**
+> The antagonist tortures the *corrected* substrate, not a known-broken merge-into path.
+> Scope v1: `@fgv/ts-agent-memory` (temporal + L3 ingest + L2 write path). A sibling
+> `ai-assist-antagonist` (provider response-shape + param-rejection class) is a natural follow-on.
+
+**Surface:** `@fgv/ts-agent-memory` (**active** — additive test-only work; no production behavior change unless a torture test surfaces a real bug, in which case STOP and report it, don't paper over it).
+**Ships under the enforced coverage gate.** New tests only; existing 100% coverage must not regress.
+
+## Charter — hole-driven, not coverage-driven
+
+You are an **antagonist**, not an SDET writing happy-path coverage. Your mandate: **assume every invariant below is subtly violable, and for each, construct the minimal input or sequence that breaks it, then write the test that would FAIL against a plausible-but-wrong implementation.** A torture test that passes on the first run is only interesting if you can articulate the wrong implementation it would have caught. Where a test surfaces a *real* current bug: **STOP, do not fix it silently, report it** (per TESTING_GUIDELINES "never paper over failures") — the point of this stream is to find the bugs the happy-path suite missed.
+
+**Output form is open — choose per target:**
+- **Adversarial unit tests** for pure functions (dedup keys, cycle guard, seq decode, temporal boundary math).
+- **Integration tests** for multi-step sequences (crash-mid-write, corrupt-then-read, merge-into-then-read, contradicts-then-asOf) over a REAL `FileTreeMemoryStore` + `InMemoryCosineIndex` (mirror the L3 e2e fixtures — no stubbed store/index).
+- **One-shot property / fuzz harnesses** where the input space is large (random `valid_at`/`invalid_at` interval sets; random edge graphs for the cycle guard; random version-write interleavings). Keep them deterministic (seeded) so they're CI-stable, OR mark them clearly as one-shot exploratory (run-once, not in the gated suite) and report findings.
+
+## Target inventory — the near-miss invariant classes (each caught LATE this arc)
+
+For each, the "wrong implementation" to hunt is in parentheses.
+
+### 1. Write-path union vs. replace
+- **merge-into must UNION the target's prior `tags`/`links`/`provenance`, never replace** (the store's `applyUpdate` uses `arrayMergeBehavior:'replace'`). *This shipped broken and was caught by a 2nd review.* Torture: target with rich prior links/tags + a sparse merge-into candidate; two candidates merge-into the same target in one batch (edge/tag dedup); merge-into where the candidate's links overlap the target's; merge-into onto a target that itself was previously merged-into. (Wrong impl: builds the write from the candidate's envelope alone.)
+- **Stage-4 exact-dedup key stability across phases** — `{kind,body}` must NOT include `links` (which stage 5 mutates). Torture: same fact ingested twice where stage-5 attaches different edge counts → must still dedup. (Wrong impl: keys on `{kind,body,links}`.)
+
+### 2. Bi-temporal / two-clock boundaries
+- **Invalidation closes the prior version's world-truth interval at the new `valid_at`, not transaction `now`.** *Shipped broken (P2-1), caught by review.* Torture: backdated write (`valid_at` < now); future-dated write (`valid_at` > now) → assert NO `asOf` gap in `[now, valid_at)` and no overlap; a sequence of out-of-order `valid_at`s; `asOf` exactly at a boundary (`asOf === invalid_at` exclusive, `asOf === valid_at` inclusive). (Wrong impl: closes at `now`.)
+- **`list({asOf})` / retriever boundary math** — half-open interval `[valid_at, invalid_at)`; multiple entities; `asOf` before any version; `asOf` after all invalidated.
+
+### 3. Partial-failure / crash-mid-write self-healing
+- **Persist-new-version-first-then-invalidate must be crash-recoverable, and a stuck 2nd-current must self-heal on the next write/delete.** *Shipped with an orphan-marker gap (P2-7), caught by review.* Torture: inject a failing `_invalidateVersion` (a store/index seam that fails after the new version persists) → assert `selectCurrentVersion` still resolves the newest, then a subsequent put/delete invalidates ALL stuck currents; seed two/three simultaneously-"current" versions and assert self-heal. (Wrong impl: invalidates only the highest-seq pick.)
+
+### 4. Corrupt / adversarial on-disk data
+- **`decodeVersion` rejects a `seq` outside the safe-integer range** and non-canonical stems. *Caught by CodeRabbit.* Torture: `-v` + 30-digit suffix; `-v007` (non-canonical) round-trip; `-v-1`; `-v` with no digits; an `entityId` that itself ends in `-v<digits>`.
+- **Non-string body from a store is a loud store-integrity failure, not a silent cast.** *Shipped as a blind `as string` (P1), caught by review.* Torture: a store/mock whose `list()` returns a record with a non-string body → ingest exact-dedup must fail with context, not miscompute the hash.
+- Tampered/duplicate version files under one entity subtree; a version file whose `envelope.entityId` disagrees with its subtree scope.
+
+### 5. Host-boundary hostility (the host is adversarial/buggy)
+- **A non-compliant `IEntityResolver` returning a bogus/foreign-kind/nonexistent target must be rejected loudly, uniformly across `duplicate-of`/`supersede`/`merge-into`.** *Shipped with inconsistent validation (only merge-into checked), caught by 2nd review.* Torture: resolver returns a target id not in the surfaced `similar` set; a target of a different `kind`; a target that doesn't exist; for each of the three target-bearing verdicts.
+- **A `handleFor` (L2) / embedder / host stage that THROWS must be caught at the Result boundary, not escape.** *L2 `handleFor` shipped unguarded, caught by CodeRabbit.* Torture: throwing `handleFor`, throwing/ rejecting classifier/extractor/resolver/relation-extractor, throwing embedder → each degrades or fails-with-context, never an unhandled rejection.
+- A classifier/extractor returning a candidate whose `body` fails the kind's Converter → rejected before any store write.
+
+### 6. Cycle guard adversarial graphs
+- **Write-time cycle guard rejects any edge that closes a directed cycle over the union (existing + proposed) graph.** Torture: a proposed edge that closes a cycle *through existing store edges* (not just proposed ones); a long chain A→B→C→…→A; a self-loop; a diamond with a back-edge; duplicate proposed edges (canonical-key dedup); an edge whose `target` is a sibling candidate vs. an existing record vs. neither (loud reject); the `cycleGuard:'off'` escape actually disables it.
+
+### 7. Enum-branch parity & convert/validate symmetry
+- **Every verdict/branch of an enum gets the same validation** (the target-existence gap was one branch missing it). Torture: exercise EVERY arm of `ResolutionVerdict`, `IngestDisposition`, the temporal retriever set, and assert none has a validation hole its siblings have.
+- (Cross-ref, likely already covered but worth an adversarial pass:) a converter that drops a field the type carries (the `aiClientToolConfig`/`annotations` class) — for any `@fgv/ts-agent-memory` Converter, round-trip a value with every optional field set and assert none is silently dropped.
+
+## Constraints
+
+- No `any`; `Result<T>`; declarative `@fgv/ts-utils-jest` matchers; real store/index in integration tests (no over-mocking that hides the real path — the exact failure mode TESTING_GUIDELINES warns about). Deterministic/seeded for anything CI-gated.
+- **If a torture test surfaces a real bug: STOP and report it with the failing input + the invariant it violates. Do NOT fix production code silently and do NOT weaken the test to pass.** A found bug is the deliverable, not a failure of this stream.
+- New tests must not drop existing 100% coverage.
+
+## Sequence
+
+Per target class: enumerate the "wrong implementations" → construct the breaking input → write the test → run it → (pass: note the wrong-impl it guards; fail: STOP + report). Then `rushx fixlint`/`lint`/`build`/`test` @ 100% → `code-reviewer` on the diff (test-quality: are these genuinely adversarial or dressed-up happy paths?) → `rush change` (`--bump-type patch`, test-only) → PR onto `release`.
+
+## Proof of work
+
+`git log`; gate tails (100%, no regression); per-target-class: the torture tests added + a one-line "wrong implementation this would catch" for each; **any real bug found, reported prominently at the top of the report** with failing input + violated invariant; `code-reviewer` disposition (did it judge the tests genuinely adversarial?).
+
+## Why this stream exists
+
+Across the agent-memory arc, every listed invariant was **implemented plausibly and passed its happy-path tests, but had a hole a second adversarial pass found** (merge-into data loss, temporal valid-time gap, orphaned invalidation, seq overflow, non-string body cast, inconsistent verdict validation, unguarded host callback). The happy-path suite + a single review is not sufficient for substrate this load-bearing (the L3 `contradicts` interlock, L2 agent writes, and PersonAIlity's durable memory all sit on it). An explicit antagonist, run once against the corrected code, converts "we got lucky on the second review" into "we hunted these classes deliberately."

--- a/.ai/tasks/active/agent-memory-antagonist/brief.md
+++ b/.ai/tasks/active/agent-memory-antagonist/brief.md
@@ -1,9 +1,10 @@
 # Brief — agent-memory antagonist: adversarial torture tests for the near-miss invariant classes
 
-> **STATUS: DRAFT — commission AFTER `agent-memory-l3-ingest` (#527) merges to `release`.**
-> The antagonist tortures the *corrected* substrate, not a known-broken merge-into path.
-> Scope v1: `@fgv/ts-agent-memory` (temporal + L3 ingest + L2 write path). A sibling
-> `ai-assist-antagonist` (provider response-shape + param-rejection class) is a natural follow-on.
+> **STATUS: COMMISSIONED (phase 1) — #527 merged to `release` (`124c19c73`); the antagonist tortures the *corrected* substrate.**
+>
+> **Two-phase plan (principal-directed):**
+> - **Phase 1 (this brief, running now):** `@fgv/ts-agent-memory` (temporal + L3 ingest + L2 write path) — the seven near-miss invariant classes below.
+> - **Phase 2 (GO/NO-GO after phase 1):** a sibling `ai-assist-antagonist` (provider response-shape + param-rejection class — Gemini image-refusal finishReason, frontier routing, thinking/temperature conflicts, converter field-drop). **Do NOT start phase 2** — it is gated on phase 1 proving valuable (real bugs found and/or genuinely-adversarial tests judged worth the pattern). Phase 1's report feeds the go/no-go.
 
 **Surface:** `@fgv/ts-agent-memory` (**active** — additive test-only work; no production behavior change unless a torture test surfaces a real bug, in which case STOP and report it, don't paper over it).
 **Ships under the enforced coverage gate.** New tests only; existing 100% coverage must not regress.

--- a/common/changes/@fgv/ts-agent-memory/claude-agent-memory-antagonist_2026-07-08-14-52.json
+++ b/common/changes/@fgv/ts-agent-memory/claude-agent-memory-antagonist_2026-07-08-14-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add antagonist torture tests for ts-agent-memory (cycle guard through existing edges, temporal boundary math, converter round-trip symmetry, resolver/verdict validation parity); test-only, no production changes.",
+      "type": "none",
+      "packageName": "@fgv/ts-agent-memory"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory",
+  "email": "erikfortune@outlook.com"
+}

--- a/common/changes/@fgv/ts-agent-memory/claude-agent-memory-antagonist_2026-07-08-14-52.json
+++ b/common/changes/@fgv/ts-agent-memory/claude-agent-memory-antagonist_2026-07-08-14-52.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Antagonist torture tests plus two store fixes they surfaced: (1) content-scoped dedup no longer swallows a same-id metadata-only update (a same-id re-put with unchanged body/links but revised tags/provenance now reaches applyUpdate instead of being collapsed as a content duplicate; cross-id collapse and identical-re-put idempotence are unchanged); (2) load-time verification now cross-checks the envelope's entityId against the scope-derived entityId, rejecting a tampered/corrupt file whose frontmatter declares a foreign entityId.",
+      "comment": "Antagonist torture tests plus two store fixes they surfaced: (1) a same-id metadata-only update is no longer swallowed by content-hash dedup on ANY write path (flat content-scoped, flat entity-scoped, and the temporal-versioned path) — a same-id re-put with unchanged body/links but revised tags/provenance now reaches applyUpdate (minting a new version on the temporal path) instead of being collapsed as a duplicate; cross-id content collapse and identical-re-put idempotence are unchanged; (2) load-time verification now cross-checks the envelope's entityId against the scope-derived entityId, rejecting a tampered/corrupt file whose frontmatter declares a foreign entityId.",
       "type": "patch",
       "packageName": "@fgv/ts-agent-memory"
     }

--- a/common/changes/@fgv/ts-agent-memory/claude-agent-memory-antagonist_2026-07-08-14-52.json
+++ b/common/changes/@fgv/ts-agent-memory/claude-agent-memory-antagonist_2026-07-08-14-52.json
@@ -1,8 +1,8 @@
 {
   "changes": [
     {
-      "comment": "Add antagonist torture tests for ts-agent-memory (cycle guard through existing edges, temporal boundary math, converter round-trip symmetry, resolver/verdict validation parity); test-only, no production changes.",
-      "type": "none",
+      "comment": "Antagonist torture tests plus two store fixes they surfaced: (1) content-scoped dedup no longer swallows a same-id metadata-only update (a same-id re-put with unchanged body/links but revised tags/provenance now reaches applyUpdate instead of being collapsed as a content duplicate; cross-id collapse and identical-re-put idempotence are unchanged); (2) load-time verification now cross-checks the envelope's entityId against the scope-derived entityId, rejecting a tampered/corrupt file whose frontmatter declares a foreign entityId.",
+      "type": "patch",
       "packageName": "@fgv/ts-agent-memory"
     }
   ],

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -947,10 +947,19 @@ export class FileTreeMemoryStore implements IMemoryStore {
     const policy: IWritePolicy = this._policyFor(kind);
     const dedupScope: DedupScope = policy.dedupScope ?? DEFAULT_DEDUP_SCOPE;
     return this._contentHash(kind, body, envelope.links).thenOnSuccess((hash) => {
-      // Entity-scoped dedup: an identical re-put of the CURRENT content is a no-op
-      // (does not spawn a redundant version). Content-scoped dedup is not a
-      // versioning concern, so only the entity granularity is honored here.
-      if (dedupScope === 'entity' && current !== undefined && current.envelope.contentHash === hash) {
+      // Entity-scoped dedup: a re-put is a no-op only when the CURRENT content AND
+      // its mutable metadata are unchanged (does not spawn a redundant version).
+      // A metadata-only revision (tags/provenance — declared mutable by
+      // TemporalVersionedPolicy) must NOT be swallowed here: it mints a new
+      // version via the applyUpdate merge in `_buildVersionedRecord`, mirroring
+      // the flat path. Content-scoped dedup is not a versioning concern, so only
+      // the entity granularity is honored here.
+      if (
+        dedupScope === 'entity' &&
+        current !== undefined &&
+        current.envelope.contentHash === hash &&
+        this._isMutableMetadataUnchanged(current, record)
+      ) {
         return Promise.resolve(succeed<IPutOutcome>({ record: current, evicted: [] }));
       }
       // On the versioned path the admission cohort is the entity's ENTIRE version

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -592,14 +592,32 @@ export class FileTreeMemoryStore implements IMemoryStore {
     // (Tags / provenance are metadata and are NOT part of the hash; see
     // design-lock §2.5.)
     if (dedupScope === 'content') {
-      const duplicate: IMemoryRecord<unknown> | undefined = this._findByContentHash(scope, hash);
+      // Cross-id content collapse: an identical { kind, body, links } triple under
+      // a DIFFERENT id is a no-op (knowledge family). A same-id match is excluded
+      // here and falls through to the LWW path below so a metadata-only revision
+      // (tags / provenance — outside the content hash but inside the policy's
+      // mutableFields) actually applies. Content-dedup must never shadow LWW for
+      // the same entity.
+      const duplicate: IMemoryRecord<unknown> | undefined = this._findByContentHash(
+        scope,
+        hash,
+        record.envelope.id
+      );
       if (duplicate !== undefined) {
         return succeed({ record: duplicate, evicted: [] });
       }
     }
     return this._readRecord(scope, idStem).thenOnSuccess((existing) => {
-      if (dedupScope === 'entity' && existing !== undefined && existing.envelope.contentHash === hash) {
-        // Entity-scoped dedup: an identical re-put of the same entity is a no-op.
+      // Same-id re-put is a no-op ONLY when the content hash matches AND the
+      // mutable metadata is also unchanged. The content hash covers
+      // { kind, body, links }; a matching hash with revised tags/provenance is a
+      // real update that must reach applyUpdate, not be swallowed as a duplicate
+      // (both dedup scopes).
+      if (
+        existing !== undefined &&
+        existing.envelope.contentHash === hash &&
+        this._isMutableMetadataUnchanged(existing, record)
+      ) {
         return Promise.resolve(succeed({ record: existing, evicted: [] }));
       }
       // The admission cohort is the set of records the policy's cap applies to:
@@ -1164,12 +1182,50 @@ export class FileTreeMemoryStore implements IMemoryStore {
       .map((entry) => entry.record);
   }
 
-  /** Find a record in `scope` whose `contentHash` equals `hash`, if any. */
-  private _findByContentHash(scope: MemoryScopeKey, hash: string): IMemoryRecord<unknown> | undefined {
+  /**
+   * Find a record in `scope` whose `contentHash` equals `hash`, if any,
+   * optionally excluding a specific id. `excludeId` lets the content-scoped
+   * dedup skip the same-id record so it does not shadow the LWW update path.
+   */
+  private _findByContentHash(
+    scope: MemoryScopeKey,
+    hash: string,
+    excludeId?: string
+  ): IMemoryRecord<unknown> | undefined {
     const match: IIndexedMemoryRecord | undefined = this._index
       .entries()
-      .find((entry) => entry.scope === scope && entry.record.envelope.contentHash === hash);
+      .find(
+        (entry) =>
+          entry.scope === scope &&
+          entry.record.envelope.contentHash === hash &&
+          entry.record.envelope.id !== excludeId
+      );
     return match?.record;
+  }
+
+  /**
+   * True when `incoming`'s caller-authored mutable metadata (`tags` / `provenance`)
+   * canonically equals `existing`'s. `body` and `links` are covered by the content
+   * hash; `embeddingRef` is store-derived (not caller metadata) and is deliberately
+   * excluded so a same-content re-put is not treated as changed merely because the
+   * store already stamped an embedding. Used to keep an identical re-put a no-op
+   * without swallowing a genuine metadata revision.
+   *
+   * Canonicalization never fails for a validated record (`tags`/`provenance` are
+   * always plain JSON); a failure is defaulted to a non-matching sentinel so the
+   * write flows to `applyUpdate` (which re-validates) rather than silently
+   * no-op-ing on an un-canonicalizable value.
+   */
+  private _isMutableMetadataUnchanged(
+    existing: IMemoryRecord<unknown>,
+    incoming: IMemoryRecord<unknown>
+  ): boolean {
+    const key = (record: IMemoryRecord<unknown>): string =>
+      this._hasher
+        .canonicalize({ tags: record.envelope.tags, provenance: record.envelope.provenance })
+        .orDefault('');
+    const existingKey: string = key(existing);
+    return existingKey !== '' && existingKey === key(incoming);
   }
 
   private _contentHash(kind: Kind, body: string, links: IMemoryEnvelope['links']): Result<string> {
@@ -1214,7 +1270,15 @@ export class FileTreeMemoryStore implements IMemoryStore {
     });
   }
 
-  /** Enforce `envelope.id === filename stem` and the codec round-trip on load. */
+  /**
+   * Enforce `envelope.id === filename stem`, the codec round-trip, AND that the
+   * envelope's own `entityId` agrees with the id decoded from the subtree scope.
+   * The round-trip only validates (scope, stem) consistency; the codec derives
+   * `entityId` from the scope path and never reads the envelope's `entityId`
+   * field, so a tampered/corrupt file whose frontmatter declares a foreign
+   * `entityId` would otherwise load undetected — and `entityId` is trusted
+   * verbatim downstream (e.g. merge-into re-addressing). Cross-check it here.
+   */
   private _verifyLoaded(
     scope: MemoryScopeKey,
     file: FileTree.IFileTreeFileItem,
@@ -1226,9 +1290,18 @@ export class FileTreeMemoryStore implements IMemoryStore {
       );
     }
     return this._codecFor(record.envelope.kind)
-      .onSuccess((codec) => codec.verifyRoundTrip(scope, file.baseName))
+      .onSuccess((codec) =>
+        codec.verifyRoundTrip(scope, file.baseName).onSuccess(() => codec.decode(scope, file.baseName))
+      )
       .withErrorFormat((msg) => `memory file '${file.absolutePath}': ${msg}`)
-      .onSuccess(() => succeed(record));
+      .onSuccess((decodedEntityId) => {
+        if (decodedEntityId !== record.envelope.entityId) {
+          return fail(
+            `memory file '${file.absolutePath}': envelope entityId '${record.envelope.entityId}' does not match scope-derived entityId '${decodedEntityId}'`
+          );
+        }
+        return succeed(record);
+      });
   }
 
   /**

--- a/libraries/ts-agent-memory/src/test/unit/converters/antagonistRoundTrip.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/converters/antagonistRoundTrip.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Antagonist torture test — convert/validate round-trip symmetry (target class
+ * 7): every OPTIONAL field the envelope/edge/provenance shapes carry must
+ * survive a full on-disk round-trip (serialize → YAML text → parse), not just a
+ * single `Converter.convert` pass in memory. This exercises the exact path a
+ * corrupted or field-dropping serializer/parser pair would break, mirroring the
+ * `aiClientToolConfig`/`annotations` field-drop class named in the brief.
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converters } from '@fgv/ts-utils';
+import {
+  BodyConverterRegistry,
+  IBodyConverterRegistry,
+  IMemoryEnvelope,
+  parseMemoryFile,
+  serializeMemoryFile
+} from '../../../index';
+
+const kind = 'note' as IMemoryEnvelope['kind'];
+
+function registry(): IBodyConverterRegistry {
+  const reg = BodyConverterRegistry.create().orThrow();
+  reg.register(kind, Converters.string);
+  return reg;
+}
+
+describe('antagonist — full on-disk round-trip preserves every optional field', () => {
+  // Wrong impl this catches: a serializer/parser pair where one side silently
+  // drops an optional field (the exact class of bug the brief calls out for
+  // `aiClientToolConfig`/`annotations`-shaped converters) — e.g. omitting
+  // `temporal.invalid_at: null`, an edge's `valid_at`/`invalid_at`/`provenance`,
+  // a `null` `embeddingRef`, or a provenance extension key, because the author
+  // forgot to thread it through both the YAML emit AND the envelope Converter.
+  test('every optional envelope/edge/provenance field set simultaneously survives a full YAML round-trip', () => {
+    const envelope: IMemoryEnvelope = {
+      id: 'doc-1' as IMemoryEnvelope['id'],
+      entityId: 'doc-1' as IMemoryEnvelope['entityId'],
+      kind,
+      tags: ['t1', 't2'] as unknown as IMemoryEnvelope['tags'],
+      links: [
+        {
+          type: 'rel' as never,
+          target: 'doc-2' as never,
+          confidence: 0.42,
+          provenance: { source: 'agent', by: 'curator', extra: { nested: true } },
+          valid_at: 111,
+
+          invalid_at: null
+        }
+      ],
+      created: 1000,
+      updated: 2000,
+      seq: 7,
+      contentHash: 'abc123',
+      provenance: {
+        source: 'host-ingest',
+        by: 'erik',
+        model: 'gpt-5',
+        confidence: 0.87,
+        derivedFrom: 'turn-3' as never,
+        // Opaque extension keys (per IProvenance's `[key: string]: unknown` arm).
+        sentiment: { score: 0.5 },
+        epistemic: 'belief'
+      },
+
+      temporal: { valid_at: 500, invalid_at: null },
+
+      embeddingRef: null
+    };
+
+    const raw = serializeMemoryFile(envelope, 'the body text').orThrow();
+    expect(parseMemoryFile(raw, registry())).toSucceedAndSatisfy((record) => {
+      // Deep-equal the ENTIRE envelope, not field-by-field — a partial assertion
+      // list is exactly how a single dropped field slips through review.
+      expect(record.envelope).toEqual(envelope);
+      expect(record.body).toBe('the body text');
+    });
+  });
+
+  test('an absent temporal/embeddingRef/edge-optionals round-trips to fully absent (no null-vs-undefined drift)', () => {
+    const envelope: IMemoryEnvelope = {
+      id: 'doc-2' as IMemoryEnvelope['id'],
+      entityId: 'doc-2' as IMemoryEnvelope['entityId'],
+      kind,
+      tags: [],
+      links: [{ type: 'rel' as never, target: 'doc-3' as never }],
+      created: 0,
+      updated: 0,
+      seq: 0,
+      contentHash: '',
+      provenance: { source: 'agent' }
+    };
+    const raw = serializeMemoryFile(envelope, 'body').orThrow();
+    expect(parseMemoryFile(raw, registry())).toSucceedAndSatisfy((record) => {
+      expect(record.envelope.temporal).toBeUndefined();
+      expect(record.envelope.embeddingRef).toBeUndefined();
+      expect(record.envelope.links[0].confidence).toBeUndefined();
+      expect(record.envelope.links[0].provenance).toBeUndefined();
+      expect(record.envelope.links[0].valid_at).toBeUndefined();
+      expect(record.envelope.links[0].invalid_at).toBeUndefined();
+      expect(record.envelope).toEqual(envelope);
+    });
+  });
+});

--- a/libraries/ts-agent-memory/src/test/unit/ingest/antagonistCycleAndParity.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/ingest/antagonistCycleAndParity.test.ts
@@ -33,6 +33,7 @@ import {
   IMemoryRecord,
   IRelationContext,
   IRelationExtractor,
+  InMemoryCosineIndex,
   Kind,
   KnowledgeIdentityCodec,
   MemoryId,
@@ -230,7 +231,6 @@ describe('antagonist — resolver target need not be a surfaced `similar` candid
       await putFull(store, 'doc-a', 'apple pie'); // will be surfaced as `similar`
       await putFull(store, 'doc-q', 'unrelated target'); // exists, but never surfaced
 
-      const { InMemoryCosineIndex } = await import('../../../index');
       const vectorIndex = InMemoryCosineIndex.create().orThrow();
       const embed = (): Promise<Result<Float32Array>> =>
         Promise.resolve(succeed(Float32Array.from([1, 0, 0])));
@@ -285,7 +285,6 @@ describe('antagonist — enum-branch parity: uniform structural rejection across
     async (verdict) => {
       const store = buildStore();
       await putFull(store, 'doc-a', 'apple pie');
-      const { InMemoryCosineIndex } = await import('../../../index');
       const vectorIndex = InMemoryCosineIndex.create().orThrow();
       const embed = (): Promise<Result<Float32Array>> =>
         Promise.resolve(succeed(Float32Array.from([1, 0, 0])));
@@ -338,7 +337,6 @@ describe('antagonist — enum-branch parity: uniform structural rejection across
         body: 'apple pie'
       };
       (await store.put(foreignRec)).orThrow();
-      const { InMemoryCosineIndex } = await import('../../../index');
       const vectorIndex = InMemoryCosineIndex.create().orThrow();
       const embed = (): Promise<Result<Float32Array>> =>
         Promise.resolve(succeed(Float32Array.from([1, 0, 0])));

--- a/libraries/ts-agent-memory/src/test/unit/ingest/antagonistCycleAndParity.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/ingest/antagonistCycleAndParity.test.ts
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Antagonist torture tests — cycle guard adversarial graphs (target class 6) and
+ * enum-branch parity (target class 7), exercised at the ORCHESTRATOR/integration
+ * level over a real {@link FileTreeMemoryStore}, complementing the pure-function
+ * unit tests in `cycleGuard.test.ts` and the per-verdict tests in
+ * `orchestrator.test.ts`.
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converters, Result, succeed } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
+import {
+  BodyConverterRegistry,
+  EntityId,
+  FileTreeMemoryStore,
+  IBodyConverterRegistry,
+  ICandidateEdge,
+  ICandidateRecord,
+  IEntityResolutionCandidate,
+  IEntityResolver,
+  IFactExtractor,
+  IIdentityCodec,
+  IIngestItem,
+  IIngestItemResult,
+  IMemoryClassification,
+  IMemoryClassifier,
+  IMemoryEnvelope,
+  IMemoryRecord,
+  IRelationContext,
+  IRelationExtractor,
+  Kind,
+  KnowledgeIdentityCodec,
+  MemoryId,
+  MemoryIngestOrchestrator,
+  ResolutionVerdict,
+  Tag
+} from '../../../index';
+
+const noteKind: Kind = 'note' as Kind;
+
+function mutableRoot(): FileTree.IMutableFileTreeDirectoryItem {
+  const tree = FileTree.inMemory([], { mutable: true }).orThrow();
+  const root = tree.getDirectory('/').orThrow();
+  if (!FileTree.isMutableDirectoryItem(root)) {
+    throw new Error('expected a mutable root directory');
+  }
+  return root;
+}
+
+function registry(): IBodyConverterRegistry {
+  const reg = BodyConverterRegistry.create().orThrow();
+  reg.register(noteKind, Converters.string);
+  return reg;
+}
+
+const codecs: ReadonlyMap<Kind, IIdentityCodec> = new Map<Kind, IIdentityCodec>([
+  [noteKind, new KnowledgeIdentityCodec()]
+]);
+
+function buildStore(): FileTreeMemoryStore {
+  return FileTreeMemoryStore.create({ root: mutableRoot(), registry: registry(), codecs }).orThrow();
+}
+
+async function putFull(
+  store: FileTreeMemoryStore,
+  entityId: string,
+  body: string,
+  links: IMemoryEnvelope['links'] = []
+): Promise<void> {
+  const rec: IMemoryRecord<unknown> = {
+    envelope: {
+      id: entityId as MemoryId,
+      entityId: entityId as EntityId,
+      kind: noteKind,
+      tags: [],
+      links,
+      created: 0,
+      updated: 0,
+      seq: 0,
+      contentHash: '',
+      provenance: { source: 'agent' }
+    },
+    body
+  };
+  (await store.put(rec)).orThrow();
+}
+
+function classifier(fn: (item: IIngestItem) => Result<IMemoryClassification>): IMemoryClassifier {
+  return { classify: (item) => Promise.resolve(fn(item)) };
+}
+function extractor(
+  fn: (item: IIngestItem, c: IMemoryClassification) => Result<ReadonlyArray<ICandidateRecord>>
+): IFactExtractor {
+  return { extract: (item, c) => Promise.resolve(fn(item, c)) };
+}
+function relater(fn: (ctx: IRelationContext) => Result<ReadonlyArray<ICandidateEdge>>): IRelationExtractor {
+  return { relate: (ctx) => Promise.resolve(fn(ctx)) };
+}
+function resolver(
+  fn: (
+    candidate: ICandidateRecord,
+    similar: ReadonlyArray<IEntityResolutionCandidate>
+  ) => Result<ResolutionVerdict>
+): IEntityResolver {
+  return { resolve: (candidate, similar) => Promise.resolve(fn(candidate, similar)) };
+}
+
+const classifyNote: IMemoryClassifier = classifier(() => succeed({ kind: noteKind }));
+
+function candidate(
+  entityId: string,
+  body: unknown,
+  links: ICandidateRecord['envelope']['links'] = []
+): ICandidateRecord {
+  return {
+    envelope: {
+      entityId: entityId as EntityId,
+      kind: noteKind,
+      tags: [],
+      links,
+      provenance: { source: 'agent' }
+    },
+    body
+  };
+}
+
+function candEdge(source: string, type: string, target: string): ICandidateEdge {
+  return { source: source as MemoryId, edge: { type: type as never, target: target as MemoryId } };
+}
+
+function buildOrchestrator(params: {
+  store: FileTreeMemoryStore;
+  extractor: IFactExtractor;
+  relationExtractor: IRelationExtractor;
+  entityResolver?: IEntityResolver;
+}): MemoryIngestOrchestrator {
+  return MemoryIngestOrchestrator.create({
+    store: params.store,
+    registry: registry(),
+    codecs,
+    classifier: classifyNote,
+    extractor: params.extractor,
+    relationExtractor: params.relationExtractor,
+    entityResolver: params.entityResolver
+  }).orThrow();
+}
+
+describe('antagonist — cycle guard through EXISTING store edges (integration)', () => {
+  // Wrong impl this catches: an orchestrator that only feeds the cycle guard the
+  // proposed-edge batch (as its own pure-function unit tests do) and forgets to
+  // fold in the store snapshot's existing edges, so a cycle that closes THROUGH
+  // an already-persisted edge is silently admitted.
+  test('a proposed edge that closes a cycle through a pre-existing on-disk edge is rejected', async () => {
+    const store = buildStore();
+    // Existing on-disk edge: doc-a -> doc-b (persisted before this ingest runs).
+    await putFull(store, 'doc-a', 'anchor-a', [{ type: 'rel' as never, target: 'doc-b' as MemoryId }]);
+    await putFull(store, 'doc-b', 'anchor-b');
+
+    // This ingest re-writes doc-b (a 'new'-verdict same-id update, since no
+    // resolver is wired) and proposes doc-b -> doc-a, which — unioned with the
+    // EXISTING doc-a -> doc-b edge — closes a 2-cycle that exists ONLY because of
+    // the on-disk edge, not anything proposed in this batch.
+    const orch = buildOrchestrator({
+      store,
+      extractor: extractor(() => succeed([candidate('doc-b', 'anchor-b-v2')])),
+      relationExtractor: relater(() => succeed([candEdge('doc-b', 'rel', 'doc-a')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(/would create a cycle/);
+
+    // Confirm the guard fired BEFORE any write — doc-b's content must be unchanged.
+    expect(await store.get(noteKind, 'doc-b' as EntityId)).toSucceedAndSatisfy(
+      (rec: IMemoryRecord<unknown> | undefined) => expect(rec?.body).toBe('anchor-b')
+    );
+  });
+
+  test('a long existing chain plus one proposed edge closing the loop is rejected', async () => {
+    const store = buildStore();
+    // Existing chain: a -> b -> c -> d (four pre-existing on-disk edges spanning
+    // three hops), persisted before this ingest.
+    await putFull(store, 'chain-a', 'a', [{ type: 'rel' as never, target: 'chain-b' as MemoryId }]);
+    await putFull(store, 'chain-b', 'b', [{ type: 'rel' as never, target: 'chain-c' as MemoryId }]);
+    await putFull(store, 'chain-c', 'c', [{ type: 'rel' as never, target: 'chain-d' as MemoryId }]);
+    await putFull(store, 'chain-d', 'd');
+
+    // Proposed: chain-d -> chain-a, closing the whole loop through the existing chain.
+    const orch = buildOrchestrator({
+      store,
+      extractor: extractor(() => succeed([candidate('chain-d', 'd-v2')])),
+      relationExtractor: relater(() => succeed([candEdge('chain-d', 'rel', 'chain-a')]))
+    });
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(/would create a cycle/);
+  });
+
+  test('cycleGuard "off" admits a cycle that closes through an existing edge', async () => {
+    const store = buildStore();
+    await putFull(store, 'doc-a', 'anchor-a', [{ type: 'rel' as never, target: 'doc-b' as MemoryId }]);
+    await putFull(store, 'doc-b', 'anchor-b');
+    const orch = MemoryIngestOrchestrator.create({
+      store,
+      registry: registry(),
+      codecs,
+      classifier: classifyNote,
+      extractor: extractor(() => succeed([candidate('doc-b', 'anchor-b-v2')])),
+      relationExtractor: relater(() => succeed([candEdge('doc-b', 'rel', 'doc-a')])),
+      cycleGuard: 'off'
+    }).orThrow();
+    expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: 'doc-a' }]);
+    });
+  });
+});
+
+describe('antagonist — resolver target need not be a surfaced `similar` candidate (structural-only gate)', () => {
+  // Documents (and locks in) the actual contract: fgv validates a target-bearing
+  // verdict STRUCTURALLY (exists in the store + matching kind), uniformly across
+  // all three target-bearing verdicts, regardless of whether the resolver's
+  // choice was among the `similar` candidates it was shown. Wrong impl this
+  // guards against: fgv silently restricting itself to `similar` membership
+  // (which would incorrectly reject a host resolver with external knowledge), OR
+  // fgv skipping the structural check for one of the three verdicts.
+  test.each(['duplicate-of', 'supersede', 'merge-into'] as const)(
+    "verdict '%s' targeting a valid existing record OUTSIDE the surfaced similar set is accepted",
+    async (verdict) => {
+      const store = buildStore();
+      await putFull(store, 'doc-a', 'apple pie'); // will be surfaced as `similar`
+      await putFull(store, 'doc-q', 'unrelated target'); // exists, but never surfaced
+
+      const { InMemoryCosineIndex } = await import('../../../index');
+      const vectorIndex = InMemoryCosineIndex.create().orThrow();
+      const embed = (): Promise<Result<Float32Array>> =>
+        Promise.resolve(succeed(Float32Array.from([1, 0, 0])));
+      // Only doc-a is embedded/indexed; doc-q is never surfaced by similarity —
+      // it can only be reached by the resolver's own out-of-band choice.
+      (await vectorIndex.add('doc-a' as MemoryId, Float32Array.from([1, 0, 0]))).orThrow();
+
+      const orch = MemoryIngestOrchestrator.create({
+        store,
+        registry: registry(),
+        codecs,
+        classifier: classifyNote,
+        extractor: extractor(() => succeed([candidate('doc-b', 'apple tart')])),
+        relationExtractor: relater(() => succeed([])),
+        vectorIndex,
+        embed,
+        entityResolver: resolver(() => succeed({ verdict, target: 'doc-q' as MemoryId } as ResolutionVerdict))
+      }).orThrow();
+
+      const result = await orch.ingestItem({ id: 'i', content: 'x' });
+      if (verdict === 'duplicate-of') {
+        expect(result).toSucceedAndSatisfy((r: IIngestItemResult) => {
+          expect(r.records[0].disposition).toBe('deduped');
+          expect(r.records[0].id).toBe('doc-q');
+        });
+      } else if (verdict === 'supersede') {
+        expect(result).toSucceedAndSatisfy((r: IIngestItemResult) => {
+          expect(r.records[0].disposition).toBe('written');
+          expect(r.records[0].resolution).toEqual({ verdict: 'supersede', target: 'doc-q' });
+        });
+      } else {
+        expect(result).toSucceedAndSatisfy((r: IIngestItemResult) => {
+          expect(r.records[0].disposition).toBe('merged');
+          expect(r.records[0].id).toBe('doc-q');
+        });
+      }
+    }
+  );
+});
+
+describe('antagonist — enum-branch parity: uniform structural rejection across target-bearing verdicts', () => {
+  // A single table-driven test locking in that EVERY target-bearing verdict arm
+  // shares the SAME two structural checks (existence, then kind match) in the
+  // SAME order — the exact class of hole ("only merge-into checked") that a
+  // prior review caught. Wrong impl this guards against: a future edit that adds
+  // a fourth verdict or refactors validation per-branch and re-introduces an
+  // asymmetric gap.
+  const verdicts = ['duplicate-of', 'supersede', 'merge-into'] as const;
+
+  test.each(verdicts)(
+    "verdict '%s' rejects a nonexistent target with the SAME message shape",
+    async (verdict) => {
+      const store = buildStore();
+      await putFull(store, 'doc-a', 'apple pie');
+      const { InMemoryCosineIndex } = await import('../../../index');
+      const vectorIndex = InMemoryCosineIndex.create().orThrow();
+      const embed = (): Promise<Result<Float32Array>> =>
+        Promise.resolve(succeed(Float32Array.from([1, 0, 0])));
+      const orch = MemoryIngestOrchestrator.create({
+        store,
+        registry: registry(),
+        codecs,
+        classifier: classifyNote,
+        extractor: extractor(() => succeed([candidate('doc-b', 'apple tart')])),
+        relationExtractor: relater(() => succeed([])),
+        vectorIndex,
+        embed,
+        entityResolver: resolver(() => succeed({ verdict, target: 'ghost' as MemoryId } as ResolutionVerdict))
+      }).orThrow();
+      (await vectorIndex.add('doc-a' as MemoryId, Float32Array.from([1, 0, 0]))).orThrow();
+      expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
+        `ingest 'i': ${verdict} target 'ghost' does not exist in the store`
+      );
+    }
+  );
+
+  test.each(verdicts)(
+    "verdict '%s' rejects a foreign-kind target with the SAME message shape",
+    async (verdict) => {
+      const otherKind: Kind = 'other' as Kind;
+      const reg = registry();
+      reg.register(otherKind, Converters.string);
+      const otherCodecs: ReadonlyMap<Kind, IIdentityCodec> = new Map<Kind, IIdentityCodec>([
+        ...codecs,
+        [otherKind, new KnowledgeIdentityCodec()]
+      ]);
+      const store = FileTreeMemoryStore.create({
+        root: mutableRoot(),
+        registry: reg,
+        codecs: otherCodecs
+      }).orThrow();
+      const foreignRec: IMemoryRecord<unknown> = {
+        envelope: {
+          id: 'foreign-1' as MemoryId,
+          entityId: 'foreign-1' as EntityId,
+          kind: otherKind,
+          tags: [] as ReadonlyArray<Tag>,
+          links: [],
+          created: 0,
+          updated: 0,
+          seq: 0,
+          contentHash: '',
+          provenance: { source: 'agent' }
+        },
+        body: 'apple pie'
+      };
+      (await store.put(foreignRec)).orThrow();
+      const { InMemoryCosineIndex } = await import('../../../index');
+      const vectorIndex = InMemoryCosineIndex.create().orThrow();
+      const embed = (): Promise<Result<Float32Array>> =>
+        Promise.resolve(succeed(Float32Array.from([1, 0, 0])));
+      const orch = MemoryIngestOrchestrator.create({
+        store,
+        registry: reg,
+        codecs: otherCodecs,
+        classifier: classifyNote,
+        extractor: extractor(() => succeed([candidate('doc-b', 'apple tart')])),
+        relationExtractor: relater(() => succeed([])),
+        vectorIndex,
+        embed,
+        entityResolver: resolver(() =>
+          succeed({ verdict, target: 'foreign-1' as MemoryId } as ResolutionVerdict)
+        )
+      }).orThrow();
+      (await vectorIndex.add('foreign-1' as MemoryId, Float32Array.from([1, 0, 0]))).orThrow();
+      expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
+        `ingest 'i': ${verdict} target 'foreign-1' is kind 'other' but the candidate is kind 'note'`
+      );
+    }
+  );
+});

--- a/libraries/ts-agent-memory/src/test/unit/store/antagonistTemporalBoundary.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/antagonistTemporalBoundary.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Antagonist torture tests — bi-temporal / two-clock boundary math (target class
+ * 2), complementing `temporalCodec.test.ts` (which already covers the
+ * `invalid_at`-exclusive boundary and the future-dated-supersede no-gap case).
+ * This file targets two remaining gaps: the `valid_at`-inclusive boundary, and
+ * an out-of-order sequence of `valid_at` writes.
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converters } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
+import {
+  BodyConverterRegistry,
+  EntityId,
+  FileTreeMemoryStore,
+  IBodyConverterRegistry,
+  IIdentityCodec,
+  IMemoryRecord,
+  IWritePolicy,
+  Kind,
+  MemoryScopeKey,
+  TemporalIdentityCodec,
+  TemporalVersionedPolicy,
+  envelopeConverter,
+  isVersionValidAt
+} from '../../../index';
+
+const factKind: Kind = 'fact' as Kind;
+const factScope: MemoryScopeKey = 'facts/entities/fact-1' as MemoryScopeKey;
+
+function mutableRoot(): FileTree.IMutableFileTreeDirectoryItem {
+  const tree = FileTree.inMemory([], { mutable: true }).orThrow();
+  const root = tree.getDirectory('/').orThrow();
+  if (!FileTree.isMutableDirectoryItem(root)) {
+    throw new Error('expected a mutable root directory');
+  }
+  return root;
+}
+
+function registry(): IBodyConverterRegistry {
+  const reg = BodyConverterRegistry.create().orThrow();
+  reg.register(factKind, Converters.string);
+  return reg;
+}
+
+const codecs: ReadonlyMap<Kind, IIdentityCodec> = new Map<Kind, IIdentityCodec>([
+  [factKind, TemporalIdentityCodec.create('facts').orThrow()]
+]);
+const policies: ReadonlyMap<Kind, IWritePolicy> = new Map<Kind, IWritePolicy>([
+  [factKind, TemporalVersionedPolicy.create().orThrow()]
+]);
+
+function factRecordAt(entityId: string, body: string, validAt?: number): IMemoryRecord<unknown> {
+  return {
+    envelope: {
+      id: entityId as unknown as IMemoryRecord<unknown>['envelope']['id'],
+      entityId: entityId as EntityId,
+      kind: factKind,
+      tags: [],
+      links: [],
+      created: 0,
+      updated: 0,
+      seq: 0,
+      contentHash: '',
+      provenance: { source: 'agent' },
+      ...(validAt !== undefined ? { temporal: { valid_at: validAt } } : {})
+    },
+    body
+  };
+}
+
+describe('antagonist — isVersionValidAt: valid_at is INCLUSIVE (start-boundary parity with the exclusive end)', () => {
+  // Wrong impl this catches: a `>` (strict) comparison for the start boundary
+  // instead of `<=`, which would incorrectly exclude the instant a version FIRST
+  // became valid — an asymmetry with the already-tested exclusive end boundary.
+  test('a version is valid AT its own valid_at instant, not just strictly after it', () => {
+    const v1 = {
+      envelope: envelopeConverter
+        .convert({
+          id: 'fact-1-v1',
+          entityId: 'fact-1',
+          kind: 'fact',
+          tags: [],
+          links: [],
+          created: 100,
+          updated: 100,
+          seq: 1,
+          contentHash: 'h1',
+          provenance: { source: 'agent' },
+          temporal: { valid_at: 100, invalid_at: 200 }
+        })
+        .orThrow(),
+      body: 'v1'
+    };
+    expect(isVersionValidAt(v1, 99)).toBe(false); // strictly before
+    expect(isVersionValidAt(v1, 100)).toBe(true); // AT valid_at — inclusive start
+    expect(isVersionValidAt(v1, 199)).toBe(true); // just before invalid_at
+    expect(isVersionValidAt(v1, 200)).toBe(false); // AT invalid_at — exclusive end
+  });
+});
+
+describe('antagonist — out-of-order valid_at sequence (no gap/overlap regardless of write order)', () => {
+  let clockValue: number;
+  const clock = (): number => clockValue;
+
+  function createStore(): FileTreeMemoryStore {
+    return FileTreeMemoryStore.create({
+      root: mutableRoot(),
+      registry: registry(),
+      codecs,
+      writePolicies: policies,
+      clock
+    }).orThrow();
+  }
+
+  // Wrong impl this catches: an implementation that assumes valid_at is
+  // monotonically increasing with seq (e.g. sorts by valid_at instead of seq for
+  // "current" resolution), which breaks the moment a caller backdates a SECOND
+  // time after an earlier future-dated write.
+  test('two consecutive backdated writes still close each prior interval at the NEW valid_at, not now', async () => {
+    const store = createStore();
+    clockValue = 1000;
+    // v1: valid_at defaults to transaction time (1000).
+    expect(await store.put(factRecordAt('fact-1', 'blue'))).toSucceed();
+
+    clockValue = 2000;
+    // v2: backdated BEHIND v1's own valid_at (500 < 1000) — a correction asserting
+    // "actually, this was already true starting at t=500".
+    expect(await store.put(factRecordAt('fact-1', 'grey', 500))).toSucceedAndSatisfy((put) => {
+      expect(put.envelope.temporal).toEqual({ valid_at: 500 });
+    });
+    // v1's interval must close at v2's valid_at (500), not the transaction time (2000).
+    expect(await store.getById(factScope, 'fact-1-v1' as never)).toSucceedAndSatisfy((v1) => {
+      expect(v1?.envelope.temporal).toEqual({ valid_at: 1000, invalid_at: 500 });
+    });
+
+    clockValue = 3000;
+    // v3: backdated again, even further behind (100 < 500) — a SECOND correction.
+    expect(await store.put(factRecordAt('fact-1', 'black', 100))).toSucceedAndSatisfy((put) => {
+      expect(put.envelope.temporal).toEqual({ valid_at: 100 });
+    });
+    // v2's interval must close at v3's valid_at (100), not the transaction time (3000).
+    expect(await store.getById(factScope, 'fact-1-v2' as never)).toSucceedAndSatisfy((v2) => {
+      expect(v2?.envelope.temporal).toEqual({ valid_at: 500, invalid_at: 100 });
+    });
+    // `selectCurrentVersion` still resolves the newest write by `seq` (v3),
+    // regardless of `valid_at` no longer being seq-monotonic.
+    expect(await store.get(factKind, 'fact-1' as EntityId)).toSucceedAndSatisfy((cur) => {
+      expect(cur?.envelope.id).toBe('fact-1-v3');
+      expect(cur?.body).toBe('black');
+    });
+  });
+});

--- a/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
@@ -165,6 +165,20 @@ describe('FileTreeMemoryStore', () => {
       const root = mutableRoot([{ path: 'elsewhere/doc.md', contents: knowledgeFile('doc', 'body') }]);
       expect(createStore({ root })).toFailWith(/does not match expected scope/i);
     });
+
+    test('fails loudly when a seeded file envelope entityId disagrees with its subtree scope', () => {
+      // The id matches the filename stem and the scope round-trips, but the
+      // envelope's own entityId is foreign — a tamper/corruption the codec
+      // round-trip alone (which derives entityId from the scope path, never
+      // reading the envelope field) would not catch. entityId is trusted
+      // verbatim downstream, so the load must reject it.
+      const root = mutableRoot([
+        { path: 'knowledge/doc-a.md', contents: knowledgeFile('doc-a', 'body', { entityId: 'doc-999' }) }
+      ]);
+      expect(createStore({ root })).toFailWith(
+        /entityId 'doc-999' does not match scope-derived entityId 'doc-a'/i
+      );
+    });
   });
 
   describe('factory defaults', () => {
@@ -296,6 +310,56 @@ describe('FileTreeMemoryStore', () => {
       );
       // doc-b was never written.
       expect(await store.get(knowledgeKind, 'doc-b' as EntityId)).toSucceedWith(undefined);
+    });
+
+    test('a same-id re-put with unchanged body but revised tags applies the update (content dedup must not swallow it)', async () => {
+      // Content-scoped dedup collapses identical content across DIFFERENT ids,
+      // but a same-id re-put whose body/links are unchanged while tags change is
+      // a real LWW update: tags are outside the content hash yet inside the
+      // policy's mutableFields, so the metadata revision must reach applyUpdate.
+      const store = createStore().orThrow();
+      let firstSeq: number = -1;
+      expect(await store.put(makeRecord({ id: 'doc', body: 'same', tags: ['orig'] }))).toSucceedAndSatisfy(
+        (first: IMemoryRecord<unknown>) => {
+          firstSeq = first.envelope.seq;
+          expect(first.envelope.tags).toEqual(['orig']);
+        }
+      );
+      clockValue = 2000;
+      expect(
+        await store.put(makeRecord({ id: 'doc', body: 'same', tags: ['orig', 'added'] }))
+      ).toSucceedAndSatisfy((second: IMemoryRecord<unknown>) => {
+        expect(second.envelope.tags).toEqual(['orig', 'added']);
+        expect(second.envelope.seq).toBe(firstSeq + 1);
+        expect(second.envelope.updated).toBe(2000);
+      });
+      // The persisted record reflects the metadata update.
+      expect(await store.get(knowledgeKind, 'doc' as EntityId)).toSucceedAndSatisfy(
+        (r: IMemoryRecord<unknown> | undefined) => {
+          expect(r?.envelope.tags).toEqual(['orig', 'added']);
+        }
+      );
+    });
+
+    test('a same-id re-put with unchanged body AND unchanged metadata stays a no-op', async () => {
+      // The idempotence guard: identical content AND identical mutable metadata
+      // must not bump seq/updated (regression guard alongside the fix above).
+      const store = createStore().orThrow();
+      let firstSeq: number = -1;
+      let firstUpdated: number = -1;
+      expect(await store.put(makeRecord({ id: 'doc', body: 'same', tags: ['a'] }))).toSucceedAndSatisfy(
+        (first: IMemoryRecord<unknown>) => {
+          firstSeq = first.envelope.seq;
+          firstUpdated = first.envelope.updated;
+        }
+      );
+      clockValue = 2000;
+      expect(await store.put(makeRecord({ id: 'doc', body: 'same', tags: ['a'] }))).toSucceedAndSatisfy(
+        (second: IMemoryRecord<unknown>) => {
+          expect(second.envelope.seq).toBe(firstSeq);
+          expect(second.envelope.updated).toBe(firstUpdated);
+        }
+      );
     });
   });
 

--- a/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
@@ -785,6 +785,30 @@ describe('FileTreeMemoryStore', () => {
       });
     });
 
+    test('entity-scoped dedup: a same-id re-put with unchanged body but revised tags applies the update', async () => {
+      // The metadata-unchanged gate on the same-id no-op is shared across BOTH
+      // dedup scopes; this asserts it on the entity (experience) family too, so a
+      // future split of the two branches cannot silently regress this side.
+      const store = memoryStore();
+      let firstSeq: number = -1;
+      expect(
+        await store.put(
+          makeRecord({ id: 'turn-5', entityId: 'conv-1:5', kind: 'mtm', body: 'same', tags: ['a'] })
+        )
+      ).toSucceedAndSatisfy((r) => {
+        firstSeq = r.envelope.seq;
+        expect(r.envelope.tags).toEqual(['a']);
+      });
+      expect(
+        await store.put(
+          makeRecord({ id: 'turn-5', entityId: 'conv-1:5', kind: 'mtm', body: 'same', tags: ['a', 'b'] })
+        )
+      ).toSucceedAndSatisfy((r) => {
+        expect(r.envelope.tags).toEqual(['a', 'b']);
+        expect(r.envelope.seq).toBe(firstSeq + 1);
+      });
+    });
+
     test('merge-patch updates the body of an existing memory entity (distinct content)', async () => {
       const store = memoryStore();
       let firstCreated: number = -1;

--- a/libraries/ts-agent-memory/src/test/unit/store/temporalStore.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/temporalStore.test.ts
@@ -111,6 +111,19 @@ function factRecordAt(entityId: string, body: string, validAt: number): IMemoryR
   return { envelope: { ...base.envelope, temporal: { valid_at: validAt } }, body: base.body };
 }
 
+/** Like {@link factRecord} but supplying revised `tags` (metadata surface). */
+function factRecordWithTags(
+  entityId: string,
+  body: string,
+  tags: ReadonlyArray<string>
+): IMemoryRecord<unknown> {
+  const base = factRecord(entityId, body);
+  return {
+    envelope: { ...base.envelope, tags: tags as unknown as IMemoryEnvelope['tags'] },
+    body: base.body
+  };
+}
+
 function knowledgeRecord(id: string, body: string): IMemoryRecord<unknown> {
   return {
     envelope: {
@@ -225,6 +238,33 @@ describe('FileTreeMemoryStore — temporal (versioned) path', () => {
       });
       expect(await store.list({ kind: factKind })).toSucceedAndSatisfy((all) => {
         expect(all).toHaveLength(1);
+      });
+    });
+
+    test('a metadata-only revision (same body, revised tags) mints a new version, not swallowed', async () => {
+      // TemporalVersionedPolicy declares tags/provenance mutable and
+      // _buildVersionedRecord merges them via applyUpdate; the content-hash dedup
+      // must NOT short-circuit a metadata-only revision, or that merge branch is
+      // unreachable and the revision is dropped entirely.
+      const store = createStore();
+      expect(await store.put(factRecord('fact-1', 'same'))).toSucceedAndSatisfy((v1) => {
+        expect(v1.envelope.id).toBe('fact-1-v1');
+        expect(v1.envelope.tags).toEqual([]);
+      });
+      clockValue = 2000;
+      expect(await store.put(factRecordWithTags('fact-1', 'same', ['reviewed']))).toSucceedAndSatisfy(
+        (v2) => {
+          expect(v2.envelope.id).toBe('fact-1-v2'); // a NEW version was minted
+          expect(v2.envelope.tags).toEqual(['reviewed']); // metadata merged in
+        }
+      );
+      // History retained (prior version invalidated), current resolves to v2.
+      expect(await store.list({ kind: factKind })).toSucceedAndSatisfy((all) => {
+        expect(all.map((r) => r.envelope.id).sort()).toEqual(['fact-1-v1', 'fact-1-v2']);
+      });
+      expect(await store.get(factKind, 'fact-1' as EntityId)).toSucceedAndSatisfy((cur) => {
+        expect(cur?.envelope.id).toBe('fact-1-v2');
+        expect(cur?.envelope.tags).toEqual(['reviewed']);
       });
     });
   });


### PR DESCRIPTION
## Summary

The **agent-memory antagonist** stream (phase 1): hole-driven adversarial torture tests for the seven near-miss invariant classes that were each caught *late* across the agent-memory arc (L2 tools, annotations, temporal, L3 ingest). The charter was: for each invariant, construct the input that would fail against a plausible-but-wrong implementation, and **if a torture test surfaces a real bug, STOP and report it** rather than paper over it.

It found **two real, confirmed store bugs** on the (corrected, post-L3) substrate. Both are fixed here with regression tests, per the principal's disposition.

## Bugs found and fixed

### Bug 1 — content-hash dedup swallowed a same-id metadata-only update (all three write paths)

`KnowledgeLwwPolicy` / `MemoryCapCullPolicy` / `TemporalVersionedPolicy` all declare `tags`/`provenance` in their `mutableFields` — "the metadata a consumer may revise without minting a new entity." But the store's content-hash no-op fired **before** the LWW / merge path on a content-hash match alone, so a same-id re-put whose body+links were unchanged while tags/provenance were revised was collapsed as a duplicate — making the declared mutable surface unreachable.

- **Flat path (`_writeResolved`)**: content collapse now fires only across a **different** id (`_findByContentHash` gained an `excludeId`); a same-id re-put is a no-op only when the mutable metadata (`{tags, provenance}`, canonicalized via the CRC normalizer) is **also** unchanged, else it reaches `applyUpdate`. Applies uniformly to both content- and entity-dedup scopes.
- **Temporal path (`_putVersioned`)** *(caught by the internal code-reviewer as an incomplete first fix)*: the same gate was missing here, and worse — `_buildVersionedRecord` calls `applyUpdate` specifically to mint a new version carrying merged metadata, but the early dedup return made that branch unreachable, so a metadata-only revision on a temporal record was **dropped entirely**. The gate now lets a metadata-only revision mint a new version via the existing merge path.

Cross-id content collapse and identical-re-put idempotence are preserved (regression-tested in all directions). `embeddingRef` is deliberately excluded from the metadata-equality check (it is store-derived, not caller metadata — including it would break the no-op once an embedder is wired).

### Bug 2 — tampered `envelope.entityId` loaded undetected

`_verifyLoaded` checked `envelope.id === filename stem` and the codec round-trip, but the round-trip derives `entityId` from the **scope path** and never read the envelope's own `entityId` field — so a corrupt/tampered file whose frontmatter declared a foreign `entityId` loaded with the wrong id, which is then trusted verbatim downstream (e.g. merge-into re-addressing). `_verifyLoaded` now cross-checks `envelope.entityId` against `codec.decode(scope, stem)` and rejects a mismatch. Verified safe for all four codecs (flat Knowledge/Ltm brand the stem, Temporal decodes the base id, MTM reconstructs the `conv:turn` composite) — no false-rejection of valid records.

## Torture tests (test-only, all genuinely adversarial)

Each documents the wrong-implementation it guards:
- `antagonistTemporalBoundary.test.ts` — inclusive `valid_at` start boundary (`>` vs `>=`); out-of-order backdated writes closing prior intervals at the next version's `valid_at`, not `now`.
- `antagonistCycleAndParity.test.ts` — a proposed edge closing a cycle **through a pre-existing on-disk edge** (guards an orchestrator that forgets the store snapshot); `cycleGuard: 'off'` actually disables; enum-branch parity across all three target-bearing verdicts.
- `antagonistRoundTrip.test.ts` — whole-envelope `toEqual` with every optional field populated (guards silent field-drop) + absent-stays-absent (null/undefined drift).

## Review

- **Internal `code-reviewer` pass** run pre-PR on the full diff. Findings: **P1** — Bug 1's fix was incomplete on the temporal path (fixed, above); **P2** — no entity-scope regression test for the shared gate (added); **P3** — inline dynamic `import()` in a torture test (converted to static). Both stated fixes independently verified sound (same-id/cross-id split, `''` sentinel safe in both failure directions, Bug 2 cross-check safe for all four codecs). All torture tests judged genuinely adversarial, not dressed-up happy paths.

## Gates

`rushx build` ✅ · `rushx lint` ✅ (clean, `fixlint` run) · `rushx test` ✅ **100% coverage** (statements/branches/functions/lines). Additive only — no public API surface change (both fixes touch private methods); `api.md` unchanged. Changeset entry: `patch` (production bug fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Metadata-only updates now correctly create a new version or update the existing record instead of being ignored.
  - File loading now rejects records when the stored identifier doesn’t match the file’s scoped identifier.
  - Bi-temporal date handling now respects inclusive start and exclusive end boundaries.
  - Ingest checks now correctly block cycles using existing stored links and handle resolver targets more consistently.

- **Tests**
  - Added broader coverage for serialization, temporal behavior, data integrity, and ingest edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->