### PR TITLE
feat(crypto-utils): export MultibaseSpkiPublicKeyRegExp; widen import to accept string

### DIFF
--- a/common/changes/@fgv/ts-extras/multibase-spki-brand-followup_2026-07-08-17-30.json
+++ b/common/changes/@fgv/ts-extras/multibase-spki-brand-followup_2026-07-08-17-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "crypto-utils: export the MultibaseSpkiPublicKeyRegExp shape pattern next to the existing MultibaseSpkiPublicKey brand/guard/converter (single source of truth for consumers that need the pattern directly), and widen importPublicKeyFromMultibaseSpki to accept a plain string so callers holding an unbranded value can import it without first branding. The isValidMultibaseSpkiPublicKey guard now requires a non-empty base64url body (rejects the degenerate 'm'), aligning it with the exported pattern; no real exported key is affected.",
+      "type": "minor",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -459,6 +459,7 @@ declare namespace CryptoUtils {
         exportPublicKeyAsMultibaseSpki,
         importPublicKeyFromMultibaseSpki,
         isValidMultibaseSpkiPublicKey,
+        MultibaseSpkiPublicKeyRegExp,
         multibaseBase64UrlDecode,
         multibaseBase64UrlEncode,
         HpkeProvider,
@@ -1593,9 +1594,10 @@ interface IModelSpecMap {
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-function importPublicKeyFromMultibaseSpki(encoded: MultibaseSpkiPublicKey, algorithm: KeyPairAlgorithm, provider: ICryptoProvider): Promise<Result<CryptoKey>>;
+function importPublicKeyFromMultibaseSpki(encoded: string, algorithm: KeyPairAlgorithm, provider: ICryptoProvider): Promise<Result<CryptoKey>>;
 
 // @public
 interface IMustacheTemplateOptions {
@@ -1790,6 +1792,8 @@ const isoDateTime: Converter<DateTime, unknown>;
 // @public
 function isResponsesOnlyModel(descriptor: IAiProviderDescriptor, modelId: string): boolean;
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
@@ -2152,6 +2156,13 @@ type MultibaseSpkiPublicKey = Brand<string, 'MultibaseSpkiPublicKey'>;
 //
 // @public
 const multibaseSpkiPublicKey: Converter<MultibaseSpkiPublicKey>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+const MultibaseSpkiPublicKeyRegExp: RegExp;
 
 declare namespace Mustache {
     export {

--- a/libraries/ts-extras/src/packlets/crypto-utils/index.browser.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/index.browser.ts
@@ -71,6 +71,7 @@ export {
   exportPublicKeyAsMultibaseSpki,
   importPublicKeyFromMultibaseSpki,
   isValidMultibaseSpkiPublicKey,
+  MultibaseSpkiPublicKeyRegExp,
   multibaseBase64UrlDecode,
   multibaseBase64UrlEncode
 } from './spkiHelpers';

--- a/libraries/ts-extras/src/packlets/crypto-utils/index.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/index.ts
@@ -64,6 +64,7 @@ export {
   exportPublicKeyAsMultibaseSpki,
   importPublicKeyFromMultibaseSpki,
   isValidMultibaseSpkiPublicKey,
+  MultibaseSpkiPublicKeyRegExp,
   multibaseBase64UrlDecode,
   multibaseBase64UrlEncode
 } from './spkiHelpers';

--- a/libraries/ts-extras/src/packlets/crypto-utils/spkiHelpers.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/spkiHelpers.ts
@@ -97,16 +97,41 @@ export function base64UrlNoPadDecode(encoded: string): Result<Uint8Array> {
 }
 
 /**
- * Type guard for {@link CryptoUtils.MultibaseSpkiPublicKey}: a string that starts
- * with the multibase `'m'` prefix and whose body matches the base64url-no-pad shape.
- * Shares the exact body-shape rule used by {@link CryptoUtils.base64UrlNoPadDecode}.
+ * The structural *shape* of a {@link CryptoUtils.MultibaseSpkiPublicKey}: the
+ * multibase `'m'` prefix followed by a non-empty base64url-no-pad body
+ * (`A-Z`, `a-z`, `0-9`, `-`, `_`).
+ *
+ * This is a shape prefilter, not full validation: it does not decode the DER
+ * SPKI or verify the key material or algorithm (that happens in
+ * {@link CryptoUtils.importPublicKeyFromMultibaseSpki}). The authoritative guard
+ * is {@link CryptoUtils.isValidMultibaseSpkiPublicKey}, which enforces this
+ * pattern **and** additionally rejects a body whose length is an impossible
+ * base64 remainder. Exposed for callers that need the pattern directly (e.g. a
+ * JSON-schema `pattern` field); prefer the guard/converter for validation.
+ *
+ * @public
+ */
+export const MultibaseSpkiPublicKeyRegExp: RegExp = /^m[A-Za-z0-9_-]+$/;
+
+/**
+ * Type guard for {@link CryptoUtils.MultibaseSpkiPublicKey}: a string matching
+ * {@link CryptoUtils.MultibaseSpkiPublicKeyRegExp} (multibase `'m'` prefix + a
+ * non-empty base64url-no-pad body) whose body also satisfies the base64url-no-pad
+ * length rule shared with {@link CryptoUtils.base64UrlNoPadDecode}. This is a
+ * structural *shape* check, not full validation — it does not decode the DER SPKI
+ * or verify the key material/algorithm (a malformed-but-well-shaped string fails
+ * later, with clear context, in {@link CryptoUtils.importPublicKeyFromMultibaseSpki}).
  *
  * @param value - The value to test.
  * @returns `true` if `value` is a well-formed multibase SPKI public key string.
  * @public
  */
 export function isValidMultibaseSpkiPublicKey(value: unknown): value is MultibaseSpkiPublicKey {
-  return typeof value === 'string' && value.startsWith('m') && isBase64UrlNoPadBody(value.slice(1));
+  return (
+    typeof value === 'string' &&
+    MultibaseSpkiPublicKeyRegExp.test(value) &&
+    isBase64UrlNoPadBody(value.slice(1))
+  );
 }
 
 /**
@@ -183,6 +208,10 @@ export async function exportPublicKeyAsMultibaseSpki(
  * the provider to import the key with the algorithm parameters from
  * {@link CryptoUtils.keyPairAlgorithmParams}.
  *
+ * Accepts a plain `string` (not only a branded {@link CryptoUtils.MultibaseSpkiPublicKey}),
+ * so callers holding an unbranded value read from storage or the wire can import
+ * it directly; a malformed value fails with error context rather than throwing.
+ *
  * @param encoded - A multibase SPKI string produced by {@link CryptoUtils.exportPublicKeyAsMultibaseSpki}.
  * @param algorithm - The {@link CryptoUtils.KeyPairAlgorithm} the key was generated for.
  * @param provider - The {@link CryptoUtils.ICryptoProvider} to use for the import operation.
@@ -190,7 +219,7 @@ export async function exportPublicKeyAsMultibaseSpki(
  * @public
  */
 export async function importPublicKeyFromMultibaseSpki(
-  encoded: MultibaseSpkiPublicKey,
+  encoded: string,
   algorithm: KeyPairAlgorithm,
   provider: ICryptoProvider
 ): Promise<Result<CryptoKey>> {

--- a/libraries/ts-extras/src/test/unit/crypto/spkiHelpers.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/spkiHelpers.test.ts
@@ -146,6 +146,18 @@ describe('exportPublicKeyAsMultibaseSpki / importPublicKeyFromMultibaseSpki', ()
       expect(CryptoUtils.isValidMultibaseSpkiPublicKey(encoded)).toBe(true);
       expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert(encoded)).toSucceedWith(encoded);
     });
+
+    test('accepts a plain (unbranded) string, not only the branded type', async () => {
+      const pair = (await provider.generateKeyPair('ed25519', true)).orThrow();
+      const branded = (await CryptoUtils.exportPublicKeyAsMultibaseSpki(pair.publicKey, provider)).orThrow();
+      // A plain string variable — e.g. a value read from storage or the wire —
+      // imports directly, without first branding it through the guard/converter.
+      const raw: string = branded;
+      const result = await CryptoUtils.importPublicKeyFromMultibaseSpki(raw, 'ed25519', provider);
+      expect(result).toSucceedAndSatisfy((key) => {
+        expect(key.type).toBe('public');
+      });
+    });
   });
 });
 
@@ -226,7 +238,6 @@ describe('multibase delegation equivalence (behavior-preserving refactor)', () =
 
 describe('isValidMultibaseSpkiPublicKey', () => {
   test('accepts well-formed multibase base64url-no-pad values', () => {
-    expect(CryptoUtils.isValidMultibaseSpkiPublicKey('m')).toBe(true); // 'm' + empty body
     expect(CryptoUtils.isValidMultibaseSpkiPublicKey('mSGVsbG8')).toBe(true);
     expect(CryptoUtils.isValidMultibaseSpkiPublicKey('mAAAA')).toBe(true);
     expect(CryptoUtils.isValidMultibaseSpkiPublicKey('mabc-_ABC')).toBe(true);
@@ -249,6 +260,25 @@ describe('isValidMultibaseSpkiPublicKey', () => {
     expect(CryptoUtils.isValidMultibaseSpkiPublicKey('m!@#$%')).toBe(false);
     expect(CryptoUtils.isValidMultibaseSpkiPublicKey('mA')).toBe(false); // body length % 4 === 1
   });
+
+  test('rejects the degenerate empty body ("m" alone)', () => {
+    // A real key never encodes to an empty body; the shape guard requires a
+    // non-empty base64url body, matching MultibaseSpkiPublicKeyRegExp.
+    expect(CryptoUtils.isValidMultibaseSpkiPublicKey('m')).toBe(false);
+  });
+});
+
+describe('MultibaseSpkiPublicKeyRegExp', () => {
+  test('is the shape underlying the guard (matches iff the guard accepts, minus the base64 length rule)', () => {
+    // The exported pattern is the multibase-m + non-empty base64url-no-pad shape.
+    expect(CryptoUtils.MultibaseSpkiPublicKeyRegExp.test('mSGVsbG8')).toBe(true);
+    expect(CryptoUtils.MultibaseSpkiPublicKeyRegExp.test('mabc-_ABC')).toBe(true);
+    // Rejects: empty body, wrong/missing prefix, and non-base64url characters.
+    expect(CryptoUtils.MultibaseSpkiPublicKeyRegExp.test('m')).toBe(false);
+    expect(CryptoUtils.MultibaseSpkiPublicKeyRegExp.test('zSGVsbG8')).toBe(false);
+    expect(CryptoUtils.MultibaseSpkiPublicKeyRegExp.test('SGVsbG8')).toBe(false);
+    expect(CryptoUtils.MultibaseSpkiPublicKeyRegExp.test('m!@#$%')).toBe(false);
+  });
 });
 
 describe('Converters.multibaseSpkiPublicKey', () => {
@@ -256,9 +286,13 @@ describe('Converters.multibaseSpkiPublicKey', () => {
     expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert('mSGVsbG8')).toSucceedWith(
       'mSGVsbG8' as MultibaseSpkiPublicKey
     );
-    expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert('m')).toSucceedWith(
-      'm' as MultibaseSpkiPublicKey
+    expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert('mabc-_ABC')).toSucceedWith(
+      'mabc-_ABC' as MultibaseSpkiPublicKey
     );
+  });
+
+  test('fails on the degenerate empty body ("m" alone)', () => {
+    expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert('m')).toFail();
   });
 
   test('fails on a non-string input', () => {


### PR DESCRIPTION
## Summary

Two small, additive follow-ups to the `MultibaseSpkiPublicKey` surface in `@fgv/ts-extras` crypto-utils (the brand/guard/converter and the widened `exportPublicKeyAsMultibaseSpki` already shipped in #519). These close the last gaps so consumers can retire their local re-declarations and share one source of truth.

## Changes

1. **Export `MultibaseSpkiPublicKeyRegExp`** — the multibase-`m` + non-empty base64url-no-pad shape (`/^m[A-Za-z0-9_-]+$/`), co-located with the guard/converter. **It is load-bearing in `isValidMultibaseSpkiPublicKey`**: the guard now tests against this exact pattern and *additionally* enforces the base64url length rule shared with `base64UrlNoPadDecode`. So the exported pattern and the guard cannot silently diverge — the whole point of consolidating.

2. **Widen `importPublicKeyFromMultibaseSpki` to accept `string`** (was branded-only `MultibaseSpkiPublicKey`). A caller holding an unbranded value read from storage or the wire can now import it directly, without first routing it through the guard/converter. This is a **source-compatible widening** — a branded value is already a `string`, so every existing caller still compiles.

## Behavior note (intentional, safe)

Aligning the guard with the exported pattern tightens one degenerate case: `isValidMultibaseSpkiPublicKey('m')` (the `'m'` prefix with an **empty** body) now returns `false` (previously `true`). No real key ever encodes to an empty body — `exportPublicKeyAsMultibaseSpki` always produces a many-character base64url body — so **no valid key is affected**. Two existing tests that pinned the old empty-body acceptance were updated to assert the stricter behavior; the per-algorithm round-trip tests (all five `KeyPairAlgorithm`s) confirm real exported keys still validate and import.

## Validation posture (unchanged, documented)

The guard/regexp remain a structural **shape** check (prefix + base64url charset + valid base64 length), not full DER/SPKI/algorithm validation — a malformed-but-well-shaped string still fails later, with clear context, in `importPublicKeyFromMultibaseSpki`. The TSDoc states this explicitly on both the regexp and the guard. Result posture preserved: the converter returns `fail(...)`, never throws.

## Tests added

- `MultibaseSpkiPublicKeyRegExp` matches/rejects (incl. the empty-body, wrong-prefix, and non-base64url cases).
- Guard + converter reject the degenerate `'m'`.
- `importPublicKeyFromMultibaseSpki` accepts a plain (`string`-typed, unbranded) value and round-trips.

## Gates

`rushx build` ✅ · `rushx lint` ✅ (clean, `fixlint` run) · `rushx test` ✅ **100% coverage** (all four metrics). `api.md` updated for the new export + widened signature (committed). Changeset: `minor` (additive exports + source-compatible widening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable pattern for validating multibase SPKI public keys.
  * Public-key import now accepts regular strings and reports malformed input through standard validation errors.

* **Bug Fixes**
  * Invalid keys with only the multibase prefix (`"m"`) are now correctly rejected.
  * Strengthened validation to require a non-empty, properly formatted key body.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->