### PR TITLE
ci: bump all workflows to Node 24.15.0 (LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           email: ErikFortune@outlook.com
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.22.0
+          node-version: 24.15.0
       - name: Verify Change Logs
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then

--- a/.github/workflows/publish-alpha-impl.yml
+++ b/.github/workflows/publish-alpha-impl.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.22.0
+          node-version: 24.15.0
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC support

--- a/.github/workflows/publish-alpha-legacy.yml
+++ b/.github/workflows/publish-alpha-legacy.yml
@@ -18,7 +18,7 @@ jobs:
           email: ${{secrets.GH_USER_EMAIL}}
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.22.0
+          node-version: 24.15.0
       - name: Verify Change Logs
         run: node common/scripts/install-run-rush.js change --verify --target-branch ${GITHUB_REF_NAME}
       - name: Rush Install

--- a/.github/workflows/publish-legacy.yml
+++ b/.github/workflows/publish-legacy.yml
@@ -18,7 +18,7 @@ jobs:
           email: ${{secrets.GH_USER_EMAIL}}
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.22.0
+          node-version: 24.15.0
       - name: Verify Change Logs
         run: node common/scripts/install-run-rush.js change --verify --target-branch ${GITHUB_REF_NAME}
       - name: Rush Install

--- a/.github/workflows/publish-major-impl.yml
+++ b/.github/workflows/publish-major-impl.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.22.0
+          node-version: 24.15.0
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC support

--- a/.github/workflows/publish-major-legacy.yml
+++ b/.github/workflows/publish-major-legacy.yml
@@ -18,7 +18,7 @@ jobs:
           email: ${{secrets.GH_USER_EMAIL}}
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.22.0
+          node-version: 24.15.0
       - name: Verify Change Logs
         run: node common/scripts/install-run-rush.js change --verify --target-branch ${GITHUB_REF_NAME}
       - name: Rush Install

--- a/.github/workflows/publish-release-impl.yml
+++ b/.github/workflows/publish-release-impl.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.22.0
+          node-version: 24.15.0
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC support


### PR DESCRIPTION
## Problem

Every workflow pinned the exact patch `node-version: 22.22.0`, which is no longer available in the `actions/setup-node` version manifest — failing the publish jobs (and CI is on the same pin, so it would fail on its next run too).

## Change

Bump the Node pin to **`24.15.0`** in all seven workflows:
- `ci.yml`
- `publish-alpha-impl.yml`, `publish-release-impl.yml`, `publish-major-impl.yml`
- `publish-alpha-legacy.yml`, `publish-legacy.yml`, `publish-major-legacy.yml`

## Why 24.15.0

It's the Node 24 LTS floor **already blessed in `rush.json`**:

```
"nodeSupportedVersionRange": ">=22.22.0 <23.0.0 || >=24.15.0 <25.0.0"
```

So `rush install` / `rush publish` stay in-range with **no `rush.json` change** — the range already brackets Node 24. Exact-pin style is preserved (matching the repo convention) at the version the maintainer already validated. `actions/setup-node@v4` supports Node 24; the only other `node …` references are `node common/scripts/install-run-rush.js`, which use the runner's Node (now 24).

## Verification

This PR's own CI runs `ci.yml` at the new `24.15.0` — a green build here is end-to-end proof the toolchain (Rush + pnpm + Heft + the full build/test) works on Node 24 before any publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_