### PR TITLE
fix(ts-res): anchor .npmignore config/ so the config packlet is published

### DIFF
--- a/common/changes/@fgv/ts-res/ts-res-config-npmignore_2026-07-12.json
+++ b/common/changes/@fgv/ts-res/ts-res-config-npmignore_2026-07-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix packaging: the config packlet's built output (lib/packlets/config and dist/packlets/config, including index.browser) was omitted from the published tarball. An unanchored `config/` in .npmignore matched the packlet dir at any depth; pnpm 11's native packer applies that strictly (npm's older delegated packer did not), silently dropping the packlet and breaking browser-target consumers ('Could not resolve ./packlets/config/index.browser'). Anchor the pattern to the package root (/config/) so it excludes only the top-level build-config dir.",
+      "type": "patch",
+      "packageName": "@fgv/ts-res"
+    }
+  ],
+  "packageName": "@fgv/ts-res",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-res/.npmignore
+++ b/libraries/ts-res/.npmignore
@@ -26,7 +26,12 @@ dist/**/*.test.*
 .eslintrc*
 jest.config.*
 tsconfig.json
-config/
+# Root-anchored: excludes the top-level build-config dir (api-extractor.json, rig.json, etc.)
+# WITHOUT matching the `config` PACKLET's built output (lib/packlets/config, dist/.../config).
+# An un-anchored `config/` matches a `config` dir at ANY depth; pnpm 11's native packer applies
+# that strictly (npm's older packer did not), which silently dropped the config packlet from the
+# tarball. Keep this anchored.
+/config/
 
 # Source files (if publishing only built output)
 # Uncomment if you only want to publish dist/lib


### PR DESCRIPTION
## Problem

A consumer's browser build against the new alpha fails:

```
Could not resolve "./packlets/config/index.browser" from "./packlets/config/index.browser?commonjs-external"
```

`@fgv/ts-res`'s **`config` packlet built output was missing from the published tarball** — `lib/packlets/config/**` and `dist/packlets/config/**`, including `index.browser.js`, which `lib/index.browser.js` imports.

## Root cause — a toolchain-change regression, not a ts-res change

ts-res's source hasn't changed. `libraries/ts-res/.npmignore` has always had a bare `config/` line, intended to exclude the top-level **build-config** dir (`config/api-extractor.json`, `rig.json`, …). But `.npmignore` uses **gitignore semantics — an unanchored `config/` matches a `config` directory at *any* depth**, so it also matches the **`config` packlet** (`lib/packlets/config/`, `dist/packlets/config/`).

This didn't bite before because **pnpm ≤10 delegated packing to `npm pack`**, whose ignore-walker didn't drop the nested dir. **pnpm 11 packs natively** and applies the pattern strictly, so the config packlet silently vanished from the tarball. Same `.npmignore`, different packer → regression. (This is a direct consequence of the pnpm 9→11 upgrade in #534.)

## Fix

Anchor the pattern to the package root — `config/` → **`/config/`** — plus a comment explaining why. It still excludes the top-level build-config dir but never the packlet.

Scanned every library/tool: **ts-res is the only package** whose packlet name collides with a bare `.npmignore` directory pattern, so this is isolated.

## Verified under the real pnpm-11 packer

`pnpm pack` (pnpm 11.12.0) on the fixed package:
- ✅ **60 config-packlet files restored** — `lib/packlets/config/index.browser.js` (+ `.d.ts`, `.map`) and the `dist/` equivalents are now in the tarball.
- ✅ Top-level build-config `config/` still excluded (`/config/` anchor confirmed).

Changeset: `patch` (`@fgv/ts-res`).

## Note

This should ship in the **same alpha** as the pnpm-11 upgrade (#534) — that upgrade is what exposed the latent `.npmignore` bug, and the config packlet stays dropped until this merges. After merge to `release` → `prerelease`, re-publish and the browser build resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_