### PR TITLE
feat(crypto-utils): let HpkeProvider.openBase accept a caller-supplied recipient public key

### DIFF
--- a/common/changes/@fgv/ts-extras/hpke-openbase-caller-pubkey_2026-07-12-00-00.json
+++ b/common/changes/@fgv/ts-extras/hpke-openbase-caller-pubkey_2026-07-12-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add an optional recipientPublicKey parameter to HpkeProvider.openBase, and a new spkiToRawX25519 helper, so callers can supply the recipient's raw X25519 public key and avoid requiring the recipient private key to be extractable.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -462,6 +462,7 @@ declare namespace CryptoUtils {
         MultibaseSpkiPublicKeyRegExp,
         multibaseBase64UrlDecode,
         multibaseBase64UrlEncode,
+        spkiToRawX25519,
         HpkeProvider,
         IHpkeSealResult,
         isEncryptedFile,
@@ -753,7 +754,7 @@ class HpkeProvider {
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "HpkeProvider"
     static encodeEnvelope(result: IHpkeSealResult): Uint8Array;
     hkdf(secret: Uint8Array, salt: Uint8Array, info: Uint8Array, length: number): Promise<Result<Uint8Array>>;
-    openBase(recipientPrivateKey: CryptoKey, info: Uint8Array, aad: Uint8Array, enc: Uint8Array, ciphertext: Uint8Array): Promise<Result<Uint8Array>>;
+    openBase(recipientPrivateKey: CryptoKey, info: Uint8Array, aad: Uint8Array, enc: Uint8Array, ciphertext: Uint8Array, recipientPublicKey?: Uint8Array): Promise<Result<Uint8Array>>;
     sealBase(recipientPublicKey: CryptoKey, info: Uint8Array, aad: Uint8Array, plaintext: Uint8Array): Promise<Result<IHpkeSealResult>>;
 }
 
@@ -2381,6 +2382,11 @@ type SecretProvider = (secretName: string) => Promise<Result<Uint8Array>>;
 //
 // @public
 const SMART_JSON_PROMPT_HINT: string;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "HpkeProvider"
+//
+// @public
+function spkiToRawX25519(spki: Uint8Array): Result<Uint8Array>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IAiProviderDescriptor"
 //

--- a/libraries/ts-extras/src/packlets/crypto-utils/hpkeProvider.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/hpkeProvider.ts
@@ -206,23 +206,34 @@ async function _kemEncap(
 
 // RFC 9180 §4.1 DHKEM Decap — deserializes enc, DH with recipient privkey,
 // derives same shared_secret via ExtractAndExpand.
-// Requires recipientPrivateKey to be extractable (JWK export needed for pkRm).
+// The DH step (deriveBits) works on a non-extractable recipientPrivateKey. Recovering the
+// recipient's own public key bytes (pkRm) for kem_context normally requires a JWK export, which
+// in turn requires recipientPrivateKey to be extractable — UNLESS the caller supplies pkRm
+// directly (raw 32-byte X25519 public key), in which case no JWK export happens and
+// recipientPrivateKey may be non-extractable.
 async function _kemDecap(
   subtle: SubtleCrypto,
   enc: Uint8Array,
-  recipientPrivateKey: CryptoKey
+  recipientPrivateKey: CryptoKey,
+  recipientPublicKey?: Uint8Array
 ): Promise<Uint8Array<ArrayBuffer>> {
   const pkE = await subtle.importKey('raw', _toBufferView(enc), { name: 'X25519' }, true, []);
   const dh = new Uint8Array(
     await subtle.deriveBits({ name: 'X25519', public: pkE }, recipientPrivateKey, 256)
   );
-  // Recover recipient's own public key from JWK x field (base64url-encoded raw X25519 public key).
-  const jwk = (await subtle.exportKey('jwk', recipientPrivateKey)) as JsonWebKey;
-  /* c8 ignore next 3 - defensive: X25519 JWK always has an x field; unreachable via public API */
-  if (!jwk.x) {
-    throw new Error('HPKE Decap: failed to extract public key bytes from recipient private key JWK');
+  let pkRm: Uint8Array;
+  if (recipientPublicKey !== undefined) {
+    // Caller-supplied; length already validated in openBase.
+    pkRm = recipientPublicKey;
+  } else {
+    // Recover recipient's own public key from JWK x field (base64url-encoded raw X25519 public key).
+    const jwk = (await subtle.exportKey('jwk', recipientPrivateKey)) as JsonWebKey;
+    /* c8 ignore next 3 - defensive: X25519 JWK always has an x field; unreachable via public API */
+    if (!jwk.x) {
+      throw new Error('HPKE Decap: failed to extract public key bytes from recipient private key JWK');
+    }
+    pkRm = _base64UrlDecode(jwk.x);
   }
-  const pkRm = _base64UrlDecode(jwk.x);
   const kemContext = _concat(enc, pkRm);
   const eaePrk = await _labeledExtract(subtle, _KEM_SUITE_ID, new Uint8Array(0), 'eae_prk', dh);
   return _labeledExpand(subtle, _KEM_SUITE_ID, eaePrk, 'shared_secret', kemContext, _N_SECRET);
@@ -370,12 +381,20 @@ export class HpkeProvider {
    *
    * @param recipientPrivateKey - Recipient's X25519 private `CryptoKey`
    *   (`algorithm.name === 'X25519'`, `type === 'private'`, `usages` includes `'deriveBits'`).
-   *   **Must be extractable** (`extractable: true`) — the recipient's public key bytes
-   *   are recovered from the JWK `x` field during Decap.
+   *   **Must be extractable** (`extractable: true`) only when `recipientPublicKey` is not
+   *   supplied — the recipient's public key bytes are then recovered from the JWK `x` field
+   *   during Decap. When `recipientPublicKey` is supplied, `recipientPrivateKey` may be
+   *   non-extractable.
    * @param info - Context-binding bytes. Must exactly match `info` from `sealBase`.
    * @param aad - Must exactly match `aad` from `sealBase`.
    * @param enc - The encapsulated key from `sealBase` — exactly 32 bytes.
    * @param ciphertext - The ciphertext from `sealBase` — `plaintext.length + 16` bytes.
+   * @param recipientPublicKey - Optional raw 32-byte X25519 public key matching
+   *   `recipientPrivateKey` (`pkRm` in RFC 9180 §4.1). Public material — supplying it lets
+   *   Decap build `kem_context` without exporting `recipientPrivateKey` to JWK, so
+   *   `recipientPrivateKey` no longer needs to be extractable. A mismatched value only breaks
+   *   the caller's own decryption (AEAD authentication fails) — it cannot be used to attack
+   *   another party's ciphertext.
    * @returns `Success` with decrypted plaintext bytes, or `Failure` with error context.
    */
   public async openBase(
@@ -383,7 +402,8 @@ export class HpkeProvider {
     info: Uint8Array,
     aad: Uint8Array,
     enc: Uint8Array,
-    ciphertext: Uint8Array
+    ciphertext: Uint8Array,
+    recipientPublicKey?: Uint8Array
   ): Promise<Result<Uint8Array>> {
     if (enc.length !== _N_PK) {
       return fail(`HPKE openBase: enc must be ${_N_PK} bytes, got ${enc.length}`);
@@ -393,8 +413,13 @@ export class HpkeProvider {
         `HPKE openBase: ciphertext too short (minimum ${_N_T} bytes for auth tag, got ${ciphertext.length})`
       );
     }
+    if (recipientPublicKey !== undefined && recipientPublicKey.length !== _N_PK) {
+      return fail(
+        `HPKE openBase: recipientPublicKey must be ${_N_PK} bytes, got ${recipientPublicKey.length}`
+      );
+    }
     const result = await captureAsyncResult(async () => {
-      const sharedSecret = await _kemDecap(this._subtle, enc, recipientPrivateKey);
+      const sharedSecret = await _kemDecap(this._subtle, enc, recipientPrivateKey, recipientPublicKey);
       const { key, baseNonce } = await _keyScheduleBase(this._subtle, sharedSecret, info);
       const aesKey = await this._subtle.importKey('raw', key, { name: 'AES-GCM' }, false, ['decrypt']);
       const pt = await this._subtle.decrypt(

--- a/libraries/ts-extras/src/packlets/crypto-utils/index.browser.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/index.browser.ts
@@ -73,7 +73,8 @@ export {
   isValidMultibaseSpkiPublicKey,
   MultibaseSpkiPublicKeyRegExp,
   multibaseBase64UrlDecode,
-  multibaseBase64UrlEncode
+  multibaseBase64UrlEncode,
+  spkiToRawX25519
 } from './spkiHelpers';
 
 // HPKE base mode (RFC 9180) — DHKEM(X25519, HKDF-SHA256) + HKDF-SHA256 + AES-256-GCM

--- a/libraries/ts-extras/src/packlets/crypto-utils/index.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/index.ts
@@ -66,7 +66,8 @@ export {
   isValidMultibaseSpkiPublicKey,
   MultibaseSpkiPublicKeyRegExp,
   multibaseBase64UrlDecode,
-  multibaseBase64UrlEncode
+  multibaseBase64UrlEncode,
+  spkiToRawX25519
 } from './spkiHelpers';
 
 // HPKE base mode (RFC 9180) — DHKEM(X25519, HKDF-SHA256) + HKDF-SHA256 + AES-256-GCM

--- a/libraries/ts-extras/src/packlets/crypto-utils/spkiHelpers.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/spkiHelpers.ts
@@ -231,3 +231,36 @@ export async function importPublicKeyFromMultibaseSpki(
     (e) => `importPublicKeyFromMultibaseSpki: ${e}`
   );
 }
+
+// DER prefix for an X25519 SubjectPublicKeyInfo: SEQUENCE { SEQUENCE { OID id-X25519 }, BIT STRING }.
+// SEQUENCE(42) / SEQUENCE(5) / OID 1.3.101.110 (id-X25519) / BIT STRING(33, 0 unused bits).
+const _X25519_SPKI_PREFIX: ReadonlyArray<number> = [
+  0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x6e, 0x03, 0x21, 0x00
+];
+const _X25519_SPKI_LENGTH: number = _X25519_SPKI_PREFIX.length + 32;
+
+/**
+ * Strips the fixed DER prefix from an X25519 SubjectPublicKeyInfo blob, returning the raw
+ * 32-byte public key.
+ *
+ * An X25519 SPKI is always exactly 44 bytes: a fixed 12-byte prefix (SEQUENCE / AlgorithmIdentifier
+ * with OID 1.3.101.110 / BIT STRING) followed by the 32-byte raw key. Use this to convert a
+ * SPKI-held recipient public key into the raw form accepted by {@link HpkeProvider.openBase}'s
+ * `recipientPublicKey` parameter.
+ *
+ * @param spki - The DER-encoded X25519 SubjectPublicKeyInfo bytes.
+ * @returns `Success` with the raw 32-byte public key, or `Failure` if `spki` is not a
+ *   well-formed 44-byte X25519 SPKI blob.
+ * @public
+ */
+export function spkiToRawX25519(spki: Uint8Array): Result<Uint8Array> {
+  if (spki.length !== _X25519_SPKI_LENGTH) {
+    return fail(`spkiToRawX25519: expected ${_X25519_SPKI_LENGTH} bytes, got ${spki.length}`);
+  }
+  for (let i = 0; i < _X25519_SPKI_PREFIX.length; i++) {
+    if (spki[i] !== _X25519_SPKI_PREFIX[i]) {
+      return fail(`spkiToRawX25519: byte ${i} does not match the expected X25519 SPKI prefix`);
+    }
+  }
+  return succeed(spki.slice(_X25519_SPKI_PREFIX.length));
+}

--- a/libraries/ts-extras/src/test/unit/crypto/hpkeProvider.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/hpkeProvider.test.ts
@@ -21,7 +21,7 @@
 import '@fgv/ts-utils-jest';
 
 import * as crypto from 'crypto';
-import { HpkeProvider, IHpkeSealResult } from '../../../packlets/crypto-utils';
+import { HpkeProvider, IHpkeSealResult, spkiToRawX25519 } from '../../../packlets/crypto-utils';
 import {
   HKDF_RFC5869_CASE1,
   RECIPIENT_PRIV_JWK,
@@ -249,6 +249,95 @@ describe('HpkeProvider', () => {
       expect(await hpke.hkdf(secret, new Uint8Array(0), new TextEncoder().encode('ctx'), 8161)).toFailWith(
         /exceeds maximum 8160 bytes/i
       );
+    });
+  });
+
+  describe('openBase with caller-supplied recipientPublicKey', () => {
+    let hpke: HpkeProvider;
+
+    beforeEach(() => {
+      hpke = HpkeProvider.create(subtle).orThrow();
+    });
+
+    test('round-trips with a non-extractable recipient private key', async () => {
+      const pair = (await subtle.generateKey({ name: 'X25519' }, false, ['deriveBits'])) as CryptoKeyPair;
+      expect(pair.privateKey.extractable).toBe(false);
+      const rawPublicKey = new Uint8Array(await subtle.exportKey('raw', pair.publicKey));
+
+      const info = new TextEncoder().encode('test-app/v1\x00non-extractable');
+      const aad = new TextEncoder().encode('aad-data');
+      const plaintext = new TextEncoder().encode('Hello, non-extractable World!');
+
+      const sealed = (await hpke.sealBase(pair.publicKey, info, aad, plaintext)).orThrow();
+      expect(
+        await hpke.openBase(pair.privateKey, info, aad, sealed.enc, sealed.ciphertext, rawPublicKey)
+      ).toSucceedAndSatisfy((pt) => {
+        expect(pt).toEqual(plaintext);
+      });
+    });
+
+    test('round-trips without recipientPublicKey (back-compat, extractable key)', async () => {
+      const recipientPub = await importRecipientPub();
+      const recipientPriv = await importRecipientPriv();
+      const info = new TextEncoder().encode('test-app/v1\x00back-compat');
+      const aad = new Uint8Array(0);
+      const plaintext = new TextEncoder().encode('back-compat message');
+
+      const sealed = (await hpke.sealBase(recipientPub, info, aad, plaintext)).orThrow();
+      expect(
+        await hpke.openBase(recipientPriv, info, aad, sealed.enc, sealed.ciphertext)
+      ).toSucceedAndSatisfy((pt) => {
+        expect(pt).toEqual(plaintext);
+      });
+    });
+
+    test('fails closed when recipientPublicKey is wrong (valid length, wrong key)', async () => {
+      const pair = (await subtle.generateKey({ name: 'X25519' }, false, ['deriveBits'])) as CryptoKeyPair;
+      const otherPair = (await subtle.generateKey({ name: 'X25519' }, true, ['deriveBits'])) as CryptoKeyPair;
+      const wrongPublicKey = new Uint8Array(await subtle.exportKey('raw', otherPair.publicKey));
+
+      const info = new TextEncoder().encode('ctx');
+      const aad = new Uint8Array(0);
+      const plaintext = new TextEncoder().encode('secret');
+
+      const sealed = (await hpke.sealBase(pair.publicKey, info, aad, plaintext)).orThrow();
+      expect(
+        await hpke.openBase(pair.privateKey, info, aad, sealed.enc, sealed.ciphertext, wrongPublicKey)
+      ).toFail();
+    });
+
+    test('returns Failure when recipientPublicKey has the wrong length', async () => {
+      const recipientPriv = await importRecipientPriv();
+      const enc = new Uint8Array(32);
+      const ciphertext = new Uint8Array(32);
+      const badLengthKey = new Uint8Array(31);
+      expect(
+        await hpke.openBase(
+          recipientPriv,
+          new Uint8Array(0),
+          new Uint8Array(0),
+          enc,
+          ciphertext,
+          badLengthKey
+        )
+      ).toFailWith(/recipientPublicKey must be 32 bytes/i);
+    });
+
+    test('integrates with spkiToRawX25519: SPKI-exported key feeds openBase directly', async () => {
+      const pair = (await subtle.generateKey({ name: 'X25519' }, false, ['deriveBits'])) as CryptoKeyPair;
+      const publicSpki = new Uint8Array(await subtle.exportKey('spki', pair.publicKey));
+      const rawPublicKey = spkiToRawX25519(publicSpki).orThrow();
+
+      const info = new TextEncoder().encode('ctx');
+      const aad = new Uint8Array(0);
+      const plaintext = new TextEncoder().encode('spki-fed secret');
+
+      const sealed = (await hpke.sealBase(pair.publicKey, info, aad, plaintext)).orThrow();
+      expect(
+        await hpke.openBase(pair.privateKey, info, aad, sealed.enc, sealed.ciphertext, rawPublicKey)
+      ).toSucceedAndSatisfy((pt) => {
+        expect(pt).toEqual(plaintext);
+      });
     });
   });
 

--- a/libraries/ts-extras/src/test/unit/crypto/spkiHelpers.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/spkiHelpers.test.ts
@@ -20,6 +20,7 @@
 
 import '@fgv/ts-utils-jest';
 
+import * as crypto from 'crypto';
 import * as CryptoUtils from '../../../packlets/crypto-utils';
 import type { KeyPairAlgorithm, MultibaseSpkiPublicKey } from '../../../packlets/crypto-utils';
 
@@ -316,5 +317,50 @@ describe('Converters.multibaseSpkiPublicKey', () => {
     expect(CryptoUtils.Converters.multibaseSpkiPublicKey.convert('mA')).toFailWith(
       /malformed base64url body/i
     );
+  });
+});
+
+describe('spkiToRawX25519', () => {
+  test('strips the DER prefix, matching the raw-exported public key', async () => {
+    const pair = (await provider.generateKeyPair('x25519', true)).orThrow();
+    const spki = (await provider.exportPublicKeySpki(pair.publicKey)).orThrow();
+    const raw = CryptoUtils.spkiToRawX25519(spki);
+    expect(raw).toSucceed();
+
+    const subtle = (crypto as { webcrypto: { subtle: SubtleCrypto } }).webcrypto.subtle;
+    const expectedRaw = new Uint8Array(await subtle.exportKey('raw', pair.publicKey));
+    expect(raw.orThrow()).toEqual(expectedRaw);
+  });
+
+  test('fails on a wrong-length blob', () => {
+    expect(CryptoUtils.spkiToRawX25519(new Uint8Array(43))).toFailWith(/expected 44 bytes, got 43/i);
+    expect(CryptoUtils.spkiToRawX25519(new Uint8Array(45))).toFailWith(/expected 44 bytes, got 45/i);
+  });
+
+  test('fails on a valid-length blob with the wrong prefix', () => {
+    const wrongPrefix = new Uint8Array(44);
+    wrongPrefix.fill(0xff);
+    expect(CryptoUtils.spkiToRawX25519(wrongPrefix)).toFailWith(
+      /does not match the expected X25519 SPKI prefix/i
+    );
+  });
+
+  test('integrates with HpkeProvider.openBase: SPKI-exported key feeds openBase directly', async () => {
+    const subtle = (crypto as { webcrypto: { subtle: SubtleCrypto } }).webcrypto.subtle;
+    const pair = (await subtle.generateKey({ name: 'X25519' }, false, ['deriveBits'])) as CryptoKeyPair;
+    const spkiPublicKey = new Uint8Array(await subtle.exportKey('spki', pair.publicKey));
+    const rawPublicKey = CryptoUtils.spkiToRawX25519(spkiPublicKey).orThrow();
+
+    const hpke = CryptoUtils.HpkeProvider.create(subtle).orThrow();
+    const info = new TextEncoder().encode('ctx');
+    const aad = new Uint8Array(0);
+    const plaintext = new TextEncoder().encode('spki round-trip');
+
+    const sealed = (await hpke.sealBase(pair.publicKey, info, aad, plaintext)).orThrow();
+    expect(
+      await hpke.openBase(pair.privateKey, info, aad, sealed.enc, sealed.ciphertext, rawPublicKey)
+    ).toSucceedAndSatisfy((pt) => {
+      expect(pt).toEqual(plaintext);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`HpkeProvider.openBase` required the recipient's X25519 private key to be `extractable: true` — **not** to use the key, but solely so DHKEM Decap could recover the recipient's own public key bytes (`pkRm`) via `exportKey('jwk', …)` to build `kem_context` (RFC 9180 §4.1). `pkRm` is *public* material; forcing extractability meant any holder of the `CryptoKey` could export the raw *private* key. This lets the caller supply `pkRm` directly, so the recipient private key can stay **non-extractable** (the WebCrypto default, safer posture).

## Change (additive, source-compatible)

- **`openBase`** gains an optional 6th positional param `recipientPublicKey?: Uint8Array` (raw 32-byte X25519 `pkRm`), length-validated (`=== 32`) alongside the existing `enc`/`ciphertext` checks. Omitted → today's exact behavior; **no compat break**.
- **`_kemDecap`** uses the caller-supplied `pkRm` when provided and **skips the JWK export** entirely; otherwise falls back to today's JWK recovery. The DH `deriveBits` step is byte-for-byte unchanged (it never required extractability — only the JWK export did).
- **New helper `spkiToRawX25519(spki): Result<Uint8Array>`** (exported from both crypto-utils entry points) — strips the fixed 12-byte X25519 SPKI DER prefix (`30 2a 30 05 06 03 2b 65 6e 03 21 00`, validated) to the raw 32 bytes, so callers holding a SPKI-encoded recipient key have a clean path into `openBase`. This keeps `openBase` at the RFC-primitive (raw) level while giving SPKI consumers a reusable converter.
- Docstrings: the `recipientPrivateKey` "must be extractable" requirement is now **conditional** (only when `recipientPublicKey` is omitted); the new param documents the security posture.
- `sealBase` is unchanged — it exports the recipient's *public* key, which is public material.

## Security — caller-supplied `pkRm` is safe (fail-closed)

A wrong `pkRm` feeds `kem_context` → a different derived shared secret → a different AES-GCM key → authentication fails → `Failure`. The caller can only break **its own** decryption, never gain one — same trust class as the already-caller-supplied `info`/`aad`. Locked in by a test: a valid-length-but-wrong public key returns `Failure` (AEAD auth), never a throw or wrong plaintext.

## Tests (100% coverage)

- **Non-extractable round-trip** (the payoff): generate the recipient keypair with `extractable: false` on the private key, assert it, `sealBase` → `openBase` with the supplied `pkRm` → decrypts. Proves non-extractable recipient keys now work.
- **Back-compat**: `openBase` without `recipientPublicKey` (extractable key) still round-trips.
- **Fail-closed**: wrong `pkRm` → `Failure`.
- **Wrong-length**: 31 bytes → clear validation failure, no decrypt attempted.
- **`spkiToRawX25519`**: SPKI export → helper → equals `exportKey('raw', …)`; wrong length and valid-length-wrong-prefix both `fail`.
- **Integration**: `spkiToRawX25519` output fed to `openBase` with a non-extractable key → round-trips.

## Gates

`rushx build` ✅ · `rushx lint` ✅ · `rushx test` ✅ **100%** (all four metrics; hpkeProvider + spkiHelpers verified independently). `api.md` updated for the new param + export. Changeset: `minor` (additive). Reviewed the crypto directly (the `_kemDecap` branch, the SPKI prefix bytes, and the two security-critical tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for supplying a recipient’s raw X25519 public key when opening HPKE-encrypted data.
  * Added `spkiToRawX25519` to convert SPKI-formatted X25519 public keys into raw key bytes.
  * HPKE decryption can now work with non-extractable recipient private keys when the public key is provided.

* **Bug Fixes**
  * Added validation for public key length and format.
  * Prevented decryption when an incorrect recipient public key is supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->