### PR TITLE
feat(ts-prompt-assist): composer-emitted compose observation record

### DIFF
--- a/common/changes/@fgv/ts-prompt-assist/prompt-assist-compose-observation_2026-07-12-00-00.json
+++ b/common/changes/@fgv/ts-prompt-assist/prompt-assist-compose-observation_2026-07-12-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "observe: add a composer-emitted 'compose' observation record. HorizontalComposer.compose gains an optional observation seam (IHorizontalComposeParams.observation, obtained from the new PromptLibrary.observationSeam getter) — when supplied it times the merge, builds an IPromptComposeObservation nesting each contributor's resolve trace, and dispatches it through the library's observer fan-out sharing the library's seq authority. Adds the 'compose' PromptObservationPhase, IPromptComposeObservation / IPromptComposeContributorObservation / IPromptObservationSeam / IPromptObservationCommon; PromptObservationStore.query handles the new phase (qualifiers never match a compose record; safeguard filters see compose findings). Additive and source-compatible; when the seam is omitted compose behaves exactly as before with zero overhead.",
+      "type": "minor",
+      "packageName": "@fgv/ts-prompt-assist"
+    }
+  ],
+  "packageName": "@fgv/ts-prompt-assist",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
+++ b/libraries/ts-prompt-assist/etc/ts-prompt-assist.api.md
@@ -220,6 +220,7 @@ export interface IHorizontalComposeParams {
     readonly composedDescriptor: IPromptDescriptor;
     readonly contributors: ReadonlyArray<IContributorSpec>;
     readonly logicalSlots: ReadonlyArray<ILogicalSlotConfig>;
+    readonly observation?: IPromptObservationSeam;
     readonly safetyPolicy?: IPromptSafetyPolicy;
 }
 
@@ -288,6 +289,23 @@ export interface IPromptCandidateRecord<TQualifierNames extends string = string>
     readonly body: string;
     readonly conditions: ResourceJson.Json.ConditionSetDecl<TQualifierNames>;
     readonly isPartial?: boolean;
+}
+
+// @public
+export interface IPromptComposeContributorObservation {
+    readonly promptId: PromptId;
+    readonly provenance: number;
+    readonly trace: IPromptResolveTrace;
+}
+
+// @public
+export interface IPromptComposeObservation extends IPromptObservationCommon {
+    readonly contributors: ReadonlyArray<IPromptComposeContributorObservation>;
+    readonly error?: string;
+    readonly outcome: 'success' | 'failure';
+    readonly phase: 'compose';
+    readonly provenanceTrace?: ReadonlyMap<SlotName, ReadonlyArray<ISlotProvenanceEntry>>;
+    readonly safeguardFindings?: ReadonlyArray<ISafeguardFinding>;
 }
 
 // @public
@@ -369,14 +387,18 @@ export type IPromptLibraryQualifiersInput<TQualifierNames extends string = strin
 })>;
 
 // @public
-export interface IPromptObservationBase {
+export interface IPromptObservationBase extends IPromptObservationCommon {
+    readonly qualifierContext: IQualifierContext;
+    readonly substitutions?: PromptSubstitutions;
+}
+
+// @public
+export interface IPromptObservationCommon {
     readonly chain: ReadonlyArray<ScopeKey>;
     readonly contentHash: string;
     readonly durationMs: number;
     readonly promptId: PromptId;
-    readonly qualifierContext: IQualifierContext;
     readonly seq: number;
-    readonly substitutions?: PromptSubstitutions;
     readonly timestamp: number;
 }
 
@@ -398,7 +420,14 @@ export interface IPromptObservationQuery {
 }
 
 // @public
-export type IPromptObservationRecord = IPromptResolveObservation | IPromptOutputObservation;
+export type IPromptObservationRecord = IPromptResolveObservation | IPromptOutputObservation | IPromptComposeObservation;
+
+// @public
+export interface IPromptObservationSeam {
+    nextSeq(): number;
+    now(): number;
+    observe(record: IPromptObservationRecord): Promise<void>;
+}
 
 // @public
 export interface IPromptObservationStoreCreateParams {
@@ -757,6 +786,7 @@ export class PromptLibrary<TResponse extends IPromptResponseBase = IPromptRespon
     invalidateDescriptor(id: PromptId): void;
     readonly logger: Logging.ILogger;
     get materializedCount(): number;
+    get observationSeam(): IPromptObservationSeam;
     resolve(req: IPromptResolveRequest<TQualifierNames>): Promise<Result<IResolvedPrompt>>;
     resolveFreeTextOutput(req: IPromptResolveRequest<TQualifierNames>, rawOutput: string): Promise<Result<string>>;
     resolveJsonOutput<K extends TResponse['kind']>(req: IPromptResolveRequest<TQualifierNames>, rawOutput: string, expectedKind: K): Promise<Result<Extract<TResponse, {
@@ -769,7 +799,7 @@ export class PromptLibrary<TResponse extends IPromptResponseBase = IPromptRespon
 export type PromptObservationOutputKind = 'free-text' | 'json';
 
 // @public
-export type PromptObservationPhase = 'resolve' | 'json-output' | 'free-text-output';
+export type PromptObservationPhase = 'resolve' | 'json-output' | 'free-text-output' | 'compose';
 
 // @public
 export class PromptObservationStore implements IPromptObserver {

--- a/libraries/ts-prompt-assist/src/packlets/composition/horizontalComposer.ts
+++ b/libraries/ts-prompt-assist/src/packlets/composition/horizontalComposer.ts
@@ -3,18 +3,24 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Result, fail, succeed } from '@fgv/ts-utils';
+import { Hash, Normalizer, Result, captureResult, fail, succeed } from '@fgv/ts-utils';
+import { sanitizeJsonObject } from '@fgv/ts-json-base';
 import {
   IBindingTraceEntry,
   IComposedPrompt,
   IContributorSpec,
-  IHorizontalComposeParams,
   ILogicalSlotConfig,
   IResolvedPromptSlot,
   ISlotProvenanceEntry,
   SlotDirective,
   SlotName
 } from '../types';
+import {
+  IPromptComposeContributorObservation,
+  IPromptComposeObservation,
+  IPromptObservationSeam
+} from '../observe';
+import { IHorizontalComposeParams } from './types';
 import { applySafeguards } from '../safeguards';
 import { MustacheTemplateCache } from '../resolve';
 
@@ -142,11 +148,36 @@ export class HorizontalComposer {
    * merged slot values (with the composed descriptor), renders the composed
    * body template, and returns the {@link IComposedPrompt}.
    *
+   * @remarks
+   * When {@link IHorizontalComposeParams.observation} is supplied, the merge is
+   * timed and a `'compose'` observation record — nesting each contributor's
+   * resolve trace and sharing the library's `seq` space — is built and awaited
+   * through the library's observer fan-out before this returns. When it is
+   * absent, this is the pre-existing fast path: no timing, no record, no
+   * dispatch.
+   *
    * @returns The composed prompt on success; a failure if a merged value
    * violates a hard policy (length cap, disallowed directive, or a screener
    * reject) or rendering fails.
    */
   public async compose(): Promise<Result<IComposedPrompt>> {
+    const observation = this._params.observation;
+    if (observation === undefined) {
+      return this._composeInternal();
+    }
+    const startedAt = observation.now();
+    const result = await this._composeInternal();
+    const durationMs = observation.now() - startedAt;
+    await observation.observe(this._buildComposeObservation(observation, result, durationMs));
+    return result;
+  }
+
+  /**
+   * The directive-aware merge → safeguard boundary → Mustache render pipeline.
+   * Split from {@link HorizontalComposer.compose} so the observation wrapper can
+   * time it without the timing/record machinery leaking into the merge logic.
+   */
+  private async _composeInternal(): Promise<Result<IComposedPrompt>> {
     const mergedSlots = new Map<SlotName, IResolvedPromptSlot>();
     const provenanceTrace = new Map<SlotName, ReadonlyArray<ISlotProvenanceEntry>>();
     const safeguardMap = new Map<SlotName, IBindingTraceEntry>();
@@ -301,5 +332,68 @@ export class HorizontalComposer {
       .getOrParse(this._params.composedDescriptor.id, this._params.composedBody)
       .onSuccess((template) => template.validateAndRender(context))
       .withErrorFormat((msg) => `prompt '${this._params.composedDescriptor.id}': ${msg}`);
+  }
+
+  /**
+   * Builds the `'compose'` observation record from the compose `Result`,
+   * minting a fresh library-global `seq` + `timestamp` through the seam. Nests
+   * each contributor's full resolve trace (the `innerTrace` analogue) on both
+   * success and failure; the merged provenance + safeguard findings surface on
+   * success only. The composed body is deliberately not duplicated (see
+   * {@link IPromptComposeObservation}).
+   */
+  private _buildComposeObservation(
+    seam: IPromptObservationSeam,
+    result: Result<IComposedPrompt>,
+    durationMs: number
+  ): IPromptComposeObservation {
+    const seq = seam.nextSeq();
+    const timestamp = seam.now();
+    const contributors: ReadonlyArray<IPromptComposeContributorObservation> = this._params.contributors.map(
+      (c) => ({
+        provenance: c.provenance,
+        promptId: c.resolved.id,
+        trace: c.resolved.trace
+      })
+    );
+    const common = {
+      seq,
+      contentHash: this._composeContentHash(),
+      timestamp,
+      durationMs,
+      promptId: this._params.composedDescriptor.id,
+      chain: [],
+      contributors
+    };
+    if (result.isSuccess()) {
+      return {
+        ...common,
+        phase: 'compose',
+        outcome: 'success',
+        provenanceTrace: result.value.provenanceTrace,
+        safeguardFindings: result.value.safeguardFindings
+      };
+    }
+    return { ...common, phase: 'compose', outcome: 'failure', error: result.message };
+  }
+
+  /**
+   * CRC32 over the RFC 8785 canonical JSON of the compose identity tuple
+   * (`\{ composedPromptId, contributors: [\{ provenance, promptId \}] \}`).
+   * Best-effort — a canonicalize / hash failure degrades to an empty string
+   * rather than breaking the compose, mirroring the resolve-path content hash.
+   */
+  private _composeContentHash(): string {
+    const identity = {
+      composedPromptId: this._params.composedDescriptor.id,
+      contributors: this._params.contributors.map((c) => ({
+        provenance: c.provenance,
+        promptId: c.resolved.id
+      }))
+    };
+    return sanitizeJsonObject(identity)
+      .onSuccess((sanitized) => new Normalizer().canonicalize(sanitized))
+      .onSuccess((canonical) => captureResult(() => Hash.Crc32Normalizer.crc32Hash([canonical])))
+      .orDefault('');
   }
 }

--- a/libraries/ts-prompt-assist/src/packlets/composition/index.ts
+++ b/libraries/ts-prompt-assist/src/packlets/composition/index.ts
@@ -3,4 +3,5 @@
  * SPDX-License-Identifier: MIT
  */
 
+export * from './types';
 export * from './horizontalComposer';

--- a/libraries/ts-prompt-assist/src/packlets/composition/types.ts
+++ b/libraries/ts-prompt-assist/src/packlets/composition/types.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { IContributorSpec, ILogicalSlotConfig, IPromptDescriptor, IPromptSafetyPolicy } from '../types';
+import { IPromptObservationSeam } from '../observe';
+
+/**
+ * Parameters for {@link HorizontalComposer.create}.
+ *
+ * @remarks
+ * Lives in the `composition` packlet (rather than alongside the other
+ * composition types in the `types` packlet) because its optional
+ * {@link IHorizontalComposeParams.observation | observation} field references
+ * {@link IPromptObservationSeam} from the `observe` packlet — and the `types`
+ * packlet is a leaf that `observe` depends on, so it cannot depend back on
+ * `observe`.
+ *
+ * @public
+ */
+export interface IHorizontalComposeParams {
+  /** Independently-resolved contributors, each tagged with a composer-layer provenance. */
+  readonly contributors: ReadonlyArray<IContributorSpec>;
+  /**
+   * The logical-slot declarations. Declared order is a tiebreaker for
+   * topo-equal slots, **not** the semantic processing order — independent
+   * logical slots may be processed in any order. (Phase B+1 replaces the
+   * declared-order walk with a dependency topo-sort; treating declared order
+   * as the binding processing order would make that a breaking change.)
+   */
+  readonly logicalSlots: ReadonlyArray<ILogicalSlotConfig>;
+  /**
+   * Descriptor for the composed prompt. Mandatory so {@link HorizontalComposer}
+   * can run `applySafeguards` against a first-class composed descriptor (the
+   * composed slots' `maxLength` / `allowedDirectives` / safeguard overrides)
+   * before returning a body — this is the safety closure the consumer-side
+   * external-composer path cannot achieve. Its `slots` are the logical-slot
+   * declarations (keyed by `logicalSlotName`).
+   */
+  readonly composedDescriptor: IPromptDescriptor;
+  /**
+   * Mustache body template for the composed prompt, referencing logical slots
+   * by name (`{{logicalSlotName}}`). {@link IPromptDescriptor} carries slot
+   * declarations but not a body (a body lives on candidate records, not the
+   * descriptor), so the composed body template is supplied here. Rendered with
+   * the merged slot map via the same `MustacheTemplateCache` (`escape: 'none'`)
+   * the resolver uses.
+   */
+  readonly composedBody: string;
+  /** Optional safety policy applied (with the composed descriptor) to the merged slot values. */
+  readonly safetyPolicy?: IPromptSafetyPolicy;
+  /**
+   * Optional observation seam obtained from {@link PromptLibrary.observationSeam}.
+   * When supplied, {@link HorizontalComposer.compose} times the merge, builds a
+   * `'compose'` observation record (nesting each contributor's resolve trace),
+   * and awaits its dispatch through the library's observer fan-out before
+   * returning — so an audit trail correlates the composed output with the N
+   * contributor `'resolve'` records via the shared `seq` space. When omitted,
+   * `compose` behaves exactly as before with zero observation overhead.
+   */
+  readonly observation?: IPromptObservationSeam;
+}

--- a/libraries/ts-prompt-assist/src/packlets/observe/promptObservationStore.ts
+++ b/libraries/ts-prompt-assist/src/packlets/observe/promptObservationStore.ts
@@ -249,6 +249,12 @@ export class PromptObservationStore implements IPromptObserver {
     record: IPromptObservationRecord,
     qualifiers: IPromptObservationQuery['qualifiers'] & object
   ): boolean {
+    // A `'compose'` record has no single resolve request and therefore no
+    // `qualifierContext` to match against — a `qualifiers` criterion never
+    // matches it (the contributor qualifier contexts live on the nested traces).
+    if (record.phase === 'compose') {
+      return false;
+    }
     return this._qualifierResolver.matches(record.qualifierContext, qualifiers);
   }
 
@@ -267,11 +273,16 @@ export class PromptObservationStore implements IPromptObserver {
   }
 
   /**
-   * Safeguard findings live on success resolve records only.
+   * Safeguard findings live on success `'resolve'` records and success
+   * `'compose'` records (both surface their `safeguardFindings` at the top
+   * level; output records and failure records carry none).
    * @internal
    */
   private _safeguardFindings(record: IPromptObservationRecord): ReadonlyArray<ISafeguardFinding> {
-    if (record.phase === 'resolve' && record.safeguardFindings !== undefined) {
+    if (
+      (record.phase === 'resolve' || record.phase === 'compose') &&
+      record.safeguardFindings !== undefined
+    ) {
       return record.safeguardFindings;
     }
     return [];

--- a/libraries/ts-prompt-assist/src/packlets/observe/types.ts
+++ b/libraries/ts-prompt-assist/src/packlets/observe/types.ts
@@ -4,10 +4,10 @@
  */
 
 import { Result } from '@fgv/ts-utils';
-import { PromptId, ScopeKey } from '../types';
+import { PromptId, ScopeKey, SlotName } from '../types';
 import { IQualifierContext } from '../types';
 import { PromptSubstitutions } from '../types';
-import { IPromptResolveTrace, ISafeguardFinding, SafeguardDisposition } from '../types';
+import { IPromptResolveTrace, ISafeguardFinding, ISlotProvenanceEntry, SafeguardDisposition } from '../types';
 
 /**
  * The output-contract kind surfaced on a successful resolve observation — a
@@ -25,53 +25,80 @@ export type PromptObservationOutputKind = 'free-text' | 'json';
  * resolve of an output call). `'json-output'` / `'free-text-output'` records
  * come from {@link PromptLibrary.resolveJsonOutput} /
  * {@link PromptLibrary.resolveFreeTextOutput} respectively and describe the
- * LLM output round-trip, cross-linked to their resolve record.
+ * LLM output round-trip, cross-linked to their resolve record. `'compose'`
+ * records come from {@link HorizontalComposer.compose} (when the composer is
+ * wired to a {@link IPromptObservationSeam}) and describe a multi-contributor
+ * horizontal composition, nesting each contributor's resolve trace.
  *
  * @public
  */
-export type PromptObservationPhase = 'resolve' | 'json-output' | 'free-text-output';
+export type PromptObservationPhase = 'resolve' | 'json-output' | 'free-text-output' | 'compose';
 
 /**
- * Fields common to every {@link IPromptObservationRecord}.
+ * Fields common to every {@link IPromptObservationRecord}, including the
+ * `'compose'` record — which has no single resolve request and therefore
+ * carries none of the request-shaped fields (`qualifierContext` /
+ * `substitutions`) that {@link IPromptObservationBase} adds.
  *
  * @remarks
  * `seq` and `timestamp` are assigned by `PromptLibrary` (a single per-instance
  * authority) before the record is fanned out to observers, so the same record
  * carries the same `seq` across every store it lands in — which is what makes
  * {@link IPromptOutputObservation.linkedResolveSeq | linkedResolveSeq}
- * correlation work consistently across multiple observers.
+ * correlation work consistently across multiple observers. A `'compose'` record
+ * shares this same `seq` space (it is minted through the same authority via the
+ * {@link IPromptObservationSeam}), so a compose record and the contributor
+ * `'resolve'` records it nests order consistently on `seq`.
  *
  * @public
  */
-export interface IPromptObservationBase {
+export interface IPromptObservationCommon {
   /**
    * Monotonic 1-based sequence number assigned by `PromptLibrary`, stable
    * across a store's ring eviction. The ordering / paging key.
    */
   readonly seq: number;
   /**
-   * Dedupe key: CRC32 over RFC 8785 canonical JSON of
-   * `\{ promptId, chain, qualifierContext, substitutions \}` (via
-   * `Hash.Crc32Normalizer`). Side-by-side with `seq` — a consumer picks which
-   * to key a map / dedupe set on. Two resolves of the same request share a
-   * `contentHash` (by design — that is the dedupe signal).
+   * Dedupe key: CRC32 over RFC 8785 canonical JSON of the record's identity
+   * tuple (via `Hash.Crc32Normalizer`). For request-shaped records the tuple is
+   * `\{ promptId, chain, qualifierContext, substitutions \}`; for a `'compose'`
+   * record it is `\{ composedPromptId, contributors \}` (each contributor's
+   * `provenance` + `promptId`). Side-by-side with `seq` — a consumer picks which
+   * to key a map / dedupe set on. Two identical operations share a `contentHash`
+   * (by design — that is the dedupe signal).
    */
   readonly contentHash: string;
   /** Milliseconds since epoch when `PromptLibrary` produced the record. */
   readonly timestamp: number;
   /**
    * Wall-clock milliseconds from the start of the observed call until this
-   * record was built — i.e. the resolve (or output round-trip) computation
-   * itself. It does NOT include the time spent dispatching this record to
-   * observers, so for awaited observers the end-to-end `resolve()` /
-   * `resolveJsonOutput()` / `resolveFreeTextOutput()` latency is slightly
-   * larger than `durationMs`.
+   * record was built — i.e. the resolve (or output round-trip, or compose merge)
+   * computation itself. It does NOT include the time spent dispatching this
+   * record to observers, so for awaited observers the end-to-end call latency is
+   * slightly larger than `durationMs`.
    */
   readonly durationMs: number;
-  /** The prompt id from the request. */
+  /**
+   * The prompt id. For request-shaped records this is the request's prompt id;
+   * for a `'compose'` record it is the composed descriptor's id.
+   */
   readonly promptId: PromptId;
-  /** The request's scope chain (most-specific → most-general), as supplied. */
+  /**
+   * The request's scope chain (most-specific → most-general), as supplied. A
+   * `'compose'` record has no single resolve request and so carries an empty
+   * chain — the contributor chains live on each nested contributor trace.
+   */
   readonly chain: ReadonlyArray<ScopeKey>;
+}
+
+/**
+ * Fields common to the request-shaped observation records
+ * ({@link IPromptResolveObservation} and {@link IPromptOutputObservation}) —
+ * i.e. every record produced by a call carrying a single resolve request.
+ *
+ * @public
+ */
+export interface IPromptObservationBase extends IPromptObservationCommon {
   /**
    * The caller's qualifier context, verbatim. Privacy / redaction is a
    * storage-layer concern — see {@link PromptObservationStore}.
@@ -143,10 +170,114 @@ export interface IPromptOutputObservation extends IPromptObservationBase {
 }
 
 /**
+ * One nested contributor within an {@link IPromptComposeObservation}: the
+ * composer-layer `provenance` a contributor was tagged with, plus the id and
+ * full resolve `trace` of its independently-resolved prompt.
+ *
+ * @remarks
+ * The `trace` is the direct analogue of
+ * {@link IResourceBindingTraceEntry.innerTrace | resourceBindingResolutions[].innerTrace}
+ * — nesting each contributor's full {@link IPromptResolveTrace} is what ties the
+ * composed output back to the N independent contributor resolves an audit trail
+ * would otherwise see disconnected from the composition.
+ *
+ * @public
+ */
+export interface IPromptComposeContributorObservation {
+  /** Composer-layer provenance the contributor was tagged with. */
+  readonly provenance: number;
+  /** Id of the contributor's independently-resolved prompt. */
+  readonly promptId: PromptId;
+  /** The contributor's full resolve trace (the `innerTrace` analogue). */
+  readonly trace: IPromptResolveTrace;
+}
+
+/**
+ * One observation per {@link HorizontalComposer.compose} call, emitted only when
+ * the composer is wired to a {@link IPromptObservationSeam}. Covers both success
+ * and failure, mirroring {@link IPromptResolveObservation}.
+ *
+ * @remarks
+ * A compose operation has no single resolve request, so it carries only the
+ * {@link IPromptObservationCommon} fields — `promptId` is the composed
+ * descriptor's id and `chain` is empty. The per-contributor resolve traces
+ * (each contributor's own `chain` / `qualifierContext` / winning scope) live on
+ * {@link IPromptComposeObservation.contributors | contributors}.
+ *
+ * The composed body is deliberately NOT duplicated here — it is derived from the
+ * merged slot values and is reconstructable from the contributor traces +
+ * `provenanceTrace`, mirroring how {@link IPromptOutputObservation} avoids
+ * re-storing the resolved body.
+ *
+ * @public
+ */
+export interface IPromptComposeObservation extends IPromptObservationCommon {
+  /** Discriminator. */
+  readonly phase: 'compose';
+  /** Whether the composition succeeded. */
+  readonly outcome: 'success' | 'failure';
+  /**
+   * The contributors to this composition, in declared order, each nesting its
+   * full resolve trace. Present on success and failure alike (contributors are
+   * inputs to the compose, available regardless of outcome).
+   */
+  readonly contributors: ReadonlyArray<IPromptComposeContributorObservation>;
+  /**
+   * Present on success: per-composed-logical-slot contribution provenance,
+   * keyed by logical slot name — the same
+   * {@link IComposedPrompt.provenanceTrace} shape, reused rather than a parallel
+   * summary, so "where did this composed slot come from" is answerable directly.
+   */
+  readonly provenanceTrace?: ReadonlyMap<SlotName, ReadonlyArray<ISlotProvenanceEntry>>;
+  /** Present on success: the composed prompt's warn / info safeguard findings. */
+  readonly safeguardFindings?: ReadonlyArray<ISafeguardFinding>;
+  /** Present on failure: the compose failure `Result`'s message. */
+  readonly error?: string;
+}
+
+/**
  * Discriminated union over observation record shapes.
  * @public
  */
-export type IPromptObservationRecord = IPromptResolveObservation | IPromptOutputObservation;
+export type IPromptObservationRecord =
+  | IPromptResolveObservation
+  | IPromptOutputObservation
+  | IPromptComposeObservation;
+
+/**
+ * The narrow observation seam a {@link PromptLibrary} hands out (via
+ * {@link PromptLibrary.observationSeam}) so a {@link HorizontalComposer} can emit
+ * a `'compose'` observation that shares the library's `seq` authority, clock,
+ * and observer fan-out — without the composer taking a dependency on the whole
+ * library or minting its own sequence numbers (which would collide with the
+ * store cursor's `lastSeq`).
+ *
+ * @remarks
+ * The library owns all three because they must be shared: `seq` is a single
+ * per-instance authority so a compose record orders consistently against the
+ * contributor `'resolve'` records; `now` is the library's injected clock so
+ * every record timestamps against the same source; `observe` is the library's
+ * swallow-and-log fan-out so a composer-emitted record reaches every wired
+ * observer under the same "observer errors never affect the caller" contract.
+ *
+ * @public
+ */
+export interface IPromptObservationSeam {
+  /**
+   * Mints the next monotonic 1-based `seq` from the library's single
+   * per-instance authority.
+   */
+  nextSeq(): number;
+  /** Reads the library's injected clock (milliseconds since epoch). */
+  now(): number;
+  /**
+   * Fans a record out to every wired observer under the library's
+   * swallow-and-log contract (observer errors never propagate). Resolves once
+   * awaited observers have completed.
+   * @param record - The observation record to dispatch.
+   */
+  observe(record: IPromptObservationRecord): Promise<void>;
+}
 
 /**
  * Single-method async observer hook. `PromptLibrary` fires `observe` once per

--- a/libraries/ts-prompt-assist/src/packlets/resolve/promptLibrary.ts
+++ b/libraries/ts-prompt-assist/src/packlets/resolve/promptLibrary.ts
@@ -37,6 +37,7 @@ import { IPromptRegistry } from '../registry';
 import {
   IPromptObservationBase,
   IPromptObservationRecord,
+  IPromptObservationSeam,
   IPromptObserver,
   IPromptOutputObservation,
   IPromptResolveObservation
@@ -310,6 +311,14 @@ export class PromptLibrary<
    */
   private readonly _observationNow: () => number;
   /**
+   * The narrow observation seam handed to a {@link HorizontalComposer} via
+   * {@link PromptLibrary.observationSeam}. Built once in the constructor; binds
+   * the `seq` authority, clock, and `_observe` fan-out so a composer can emit a
+   * `'compose'` record into this library's `seq` space without depending on the
+   * library itself.
+   */
+  private readonly _observationSeam: IPromptObservationSeam;
+  /**
    * Set of RFC 8785 canonical-JSON keys for descriptors that have
    * already passed the loader-side compatibility check (see
    * `assertOutputValidationsCompatible` in the `output` packlet).
@@ -367,6 +376,34 @@ export class PromptLibrary<
     this._observers = params.observers;
     this._nextObservationSeq = 0;
     this._observationNow = () => Date.now();
+    this._observationSeam = {
+      nextSeq: () => {
+        this._nextObservationSeq += 1;
+        return this._nextObservationSeq;
+      },
+      now: () => this._observationNow(),
+      observe: (record) => this._observe(record)
+    };
+  }
+
+  /**
+   * A narrow observation seam — `\{ nextSeq, now, observe \}` — bound to this
+   * library's `seq` authority, injected clock, and observer fan-out. Hand it to
+   * {@link HorizontalComposer} via {@link IHorizontalComposeParams.observation}
+   * so a horizontal composition emits a `'compose'` observation that shares this
+   * library's `seq` space (ordering consistently against the contributor
+   * `'resolve'` records) and reaches every wired observer under the same
+   * swallow-and-log contract — without the composer depending on the whole
+   * library or minting its own sequence numbers.
+   *
+   * @remarks
+   * When no observers are wired, `observe` is a no-op fan-out; `nextSeq` still
+   * advances the shared counter (harmless). The composer only reaches for the
+   * seam when {@link IHorizontalComposeParams.observation} is set, so an
+   * unwired composition pays nothing.
+   */
+  public get observationSeam(): IPromptObservationSeam {
+    return this._observationSeam;
   }
 
   /**

--- a/libraries/ts-prompt-assist/src/packlets/types/composition.ts
+++ b/libraries/ts-prompt-assist/src/packlets/types/composition.ts
@@ -6,7 +6,6 @@
 import { SlotName } from './ids';
 import { SlotDirective } from './enums';
 import { IPromptDescriptor } from './descriptor';
-import { IPromptSafetyPolicy } from './safety';
 import { IResolvedPrompt, IResolvedPromptSlot, ISafeguardFinding } from './trace';
 
 /**
@@ -83,44 +82,6 @@ export interface ILogicalSlotConfig {
   readonly strategy: LogicalSlotStrategy;
   /** Separator for the `'concatenate'` strategy (and the constraint block). Default `'\n\n'`. */
   readonly separator?: string;
-}
-
-/**
- * Parameters for {@link HorizontalComposer.create}.
- *
- * @public
- */
-export interface IHorizontalComposeParams {
-  /** Independently-resolved contributors, each tagged with a composer-layer provenance. */
-  readonly contributors: ReadonlyArray<IContributorSpec>;
-  /**
-   * The logical-slot declarations. Declared order is a tiebreaker for
-   * topo-equal slots, **not** the semantic processing order — independent
-   * logical slots may be processed in any order. (Phase B+1 replaces the
-   * declared-order walk with a dependency topo-sort; treating declared order
-   * as the binding processing order would make that a breaking change.)
-   */
-  readonly logicalSlots: ReadonlyArray<ILogicalSlotConfig>;
-  /**
-   * Descriptor for the composed prompt. Mandatory so {@link HorizontalComposer}
-   * can run `applySafeguards` against a first-class composed descriptor (the
-   * composed slots' `maxLength` / `allowedDirectives` / safeguard overrides)
-   * before returning a body — this is the safety closure the consumer-side
-   * external-composer path cannot achieve. Its `slots` are the logical-slot
-   * declarations (keyed by `logicalSlotName`).
-   */
-  readonly composedDescriptor: IPromptDescriptor;
-  /**
-   * Mustache body template for the composed prompt, referencing logical slots
-   * by name (`{{logicalSlotName}}`). {@link IPromptDescriptor} carries slot
-   * declarations but not a body (a body lives on candidate records, not the
-   * descriptor), so the composed body template is supplied here. Rendered with
-   * the merged slot map via the same `MustacheTemplateCache` (`escape: 'none'`)
-   * the resolver uses.
-   */
-  readonly composedBody: string;
-  /** Optional safety policy applied (with the composed descriptor) to the merged slot values. */
-  readonly safetyPolicy?: IPromptSafetyPolicy;
 }
 
 /**

--- a/libraries/ts-prompt-assist/src/test/unit/observe/composeObservation.test.ts
+++ b/libraries/ts-prompt-assist/src/test/unit/observe/composeObservation.test.ts
@@ -1,0 +1,351 @@
+// Copyright (c) 2026 Erik Fortune
+// SPDX-License-Identifier: MIT
+
+import '@fgv/ts-utils-jest';
+import {
+  HorizontalComposer,
+  IContributorSpec,
+  IHorizontalComposeParams,
+  ILogicalSlotConfig,
+  IPromptComposeObservation,
+  IPromptDescriptor,
+  IPromptObservationRecord,
+  IPromptObserver,
+  IPromptSafetyPolicy,
+  IPromptStore,
+  IPromptStoreFixtureSeed,
+  IResolvedPrompt,
+  ISafeguardFinding,
+  IScreener,
+  IStoredPromptRecord,
+  PromptId,
+  PromptLibrary,
+  PromptObservationStore,
+  PromptStoreFixture,
+  ScopeKey,
+  SlotBinding,
+  SlotName
+} from '../../../index';
+import { Logging, Result, fail, succeed } from '@fgv/ts-utils';
+import { QualifierTypes, Qualifiers } from '@fgv/ts-res';
+
+const QUALIFIER_TYPES = QualifierTypes.QualifierTypeCollector.create({
+  qualifierTypes: [QualifierTypes.LiteralQualifierType.create({ name: 'lang' }).orThrow()]
+}).orThrow();
+const QUALIFIERS = Qualifiers.QualifierCollector.create({
+  qualifierTypes: QUALIFIER_TYPES,
+  qualifiers: [{ name: 'lang', typeName: 'lang', defaultPriority: 1000 }]
+}).orThrow();
+
+const SCOPE = 'global' as unknown as ScopeKey;
+
+function promptId(id: string): PromptId {
+  return id as unknown as PromptId;
+}
+function slotName(name: string): SlotName {
+  return name as unknown as SlotName;
+}
+
+/**
+ * A stored prompt with a single slot bound to a literal value. Resolving it
+ * yields an `IResolvedPrompt` whose `slots` map carries the value — the input
+ * a horizontal-composition contributor is built from.
+ */
+function contributorRecord(id: string, slot: string, value: string): IStoredPromptRecord {
+  return {
+    scope: SCOPE,
+    id: promptId(id),
+    descriptor: {
+      id: promptId(id),
+      title: id,
+      schemaVersion: '1',
+      surface: 'chat',
+      slots: [
+        {
+          name: slotName(slot),
+          description: slot,
+          defaultBinding: { kind: 'literal', value, directive: 'hint' } as SlotBinding
+        }
+      ],
+      output: { kind: 'free-text' }
+    },
+    candidates: [{ conditions: {}, body: `{{{${slot}}}}` }]
+  };
+}
+
+function composedDescriptor(slots: ReadonlyArray<{ name: string; maxLength?: number }>): IPromptDescriptor {
+  return {
+    id: promptId('composed'),
+    title: 'composed',
+    schemaVersion: '1',
+    surface: 'chat',
+    slots: slots.map((s) => ({
+      name: slotName(s.name),
+      description: s.name,
+      ...(s.maxLength !== undefined ? { maxLength: s.maxLength } : {})
+    })),
+    output: { kind: 'free-text' }
+  };
+}
+
+const CONTRIBUTORS: ReadonlyArray<IStoredPromptRecord> = [
+  contributorRecord('a', 'sA', 'alpha'),
+  contributorRecord('b', 'sB', 'beta')
+];
+
+async function buildStore(seed: IPromptStoreFixtureSeed): Promise<IPromptStore> {
+  return (await PromptStoreFixture.build(seed)).orThrow();
+}
+
+async function buildLib(options?: {
+  readonly observers?: ReadonlyArray<IPromptObserver>;
+  readonly logger?: Logging.ILogger;
+}): Promise<PromptLibrary> {
+  const store = await buildStore({ records: [...CONTRIBUTORS] });
+  return (
+    await PromptLibrary.create({
+      store,
+      qualifiers: QUALIFIERS,
+      observers: options?.observers,
+      logger: options?.logger
+    })
+  ).orThrow();
+}
+
+async function resolveContributor(lib: PromptLibrary, id: string): Promise<IResolvedPrompt> {
+  return (await lib.resolve({ id: promptId(id), chain: [SCOPE], qualifiers: {} })).orThrow();
+}
+
+/**
+ * Resolves contributors `a` and `b` off `lib` (firing their `'resolve'`
+ * observations) and returns two `IContributorSpec`s tagged provenance 10 / 20.
+ */
+async function twoContributors(lib: PromptLibrary): Promise<ReadonlyArray<IContributorSpec>> {
+  const a = await resolveContributor(lib, 'a');
+  const b = await resolveContributor(lib, 'b');
+  return [
+    { provenance: 10, resolved: a },
+    { provenance: 20, resolved: b }
+  ];
+}
+
+const BODY_SLOT: ILogicalSlotConfig = {
+  logicalSlotName: slotName('body'),
+  contributorSlots: [
+    { contributorProvenance: 10, slotName: slotName('sA') },
+    { contributorProvenance: 20, slotName: slotName('sB') }
+  ],
+  strategy: 'concatenate'
+};
+
+function composeParams(
+  lib: PromptLibrary,
+  contributors: ReadonlyArray<IContributorSpec>,
+  overrides?: {
+    readonly withSeam?: boolean;
+    readonly maxLength?: number;
+    readonly safetyPolicy?: IPromptSafetyPolicy;
+  }
+): IHorizontalComposeParams {
+  return {
+    contributors,
+    logicalSlots: [BODY_SLOT],
+    composedDescriptor: composedDescriptor([{ name: 'body', maxLength: overrides?.maxLength }]),
+    composedBody: '{{body}}',
+    ...(overrides?.safetyPolicy !== undefined ? { safetyPolicy: overrides.safetyPolicy } : {}),
+    ...(overrides?.withSeam !== false ? { observation: lib.observationSeam } : {})
+  };
+}
+
+async function compose(params: IHorizontalComposeParams): Promise<Result<unknown>> {
+  return HorizontalComposer.create(params).orThrow().compose();
+}
+
+function composeRecords(store: PromptObservationStore): ReadonlyArray<IPromptComposeObservation> {
+  return store
+    .query({ phase: 'compose' })
+    .filter((r): r is IPromptComposeObservation => r.phase === 'compose');
+}
+
+describe('HorizontalComposer compose observation', () => {
+  describe('seam present', () => {
+    test('emits one compose record sharing the library seq space', async () => {
+      const store = PromptObservationStore.create().orThrow();
+      const lib = await buildLib({ observers: [store] });
+      const contributors = await twoContributors(lib);
+      // Two resolve records so far, seq 1 and 2.
+      expect(store.query({ phase: 'resolve' }).map((r) => r.seq)).toEqual([1, 2]);
+
+      const result = await compose(composeParams(lib, contributors));
+      expect(result).toSucceed();
+
+      const composed = composeRecords(store);
+      expect(composed).toHaveLength(1);
+      const [record] = composed;
+      // seq continues the same authority the resolve records drew from.
+      expect(record.seq).toBe(3);
+      expect(store.lastSeq).toBe(3);
+      expect(record.phase).toBe('compose');
+      expect(record.outcome).toBe('success');
+      expect(record.promptId).toBe(promptId('composed'));
+      expect(record.chain).toEqual([]);
+      expect(record.contentHash).not.toBe('');
+      expect(record.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    test('nests each contributor resolve trace in declared order', async () => {
+      const store = PromptObservationStore.create().orThrow();
+      const lib = await buildLib({ observers: [store] });
+      const contributors = await twoContributors(lib);
+      expect(await compose(composeParams(lib, contributors))).toSucceed();
+
+      const [record] = composeRecords(store);
+      expect(record.contributors).toHaveLength(2);
+      expect(record.contributors.map((c) => c.provenance)).toEqual([10, 20]);
+      expect(record.contributors.map((c) => c.promptId)).toEqual([promptId('a'), promptId('b')]);
+      // The nested trace is the contributor's own full resolve trace.
+      expect(record.contributors[0].trace).toBe(contributors[0].resolved.trace);
+      expect(record.contributors[0].trace.winningScope).toBe(SCOPE);
+      expect(record.contributors[1].trace).toBe(contributors[1].resolved.trace);
+    });
+
+    test('carries the merged provenance trace and safeguard findings on success', async () => {
+      const store = PromptObservationStore.create().orThrow();
+      const lib = await buildLib({ observers: [store] });
+      const contributors = await twoContributors(lib);
+      expect(await compose(composeParams(lib, contributors))).toSucceed();
+
+      const [record] = composeRecords(store);
+      expect(record.provenanceTrace).toBeDefined();
+      expect(record.provenanceTrace?.get(slotName('body'))?.map((e) => e.value)).toEqual(['alpha', 'beta']);
+      expect(record.safeguardFindings).toEqual([]);
+      expect(record.error).toBeUndefined();
+    });
+
+    test('stores a distinct compose record per compose but a stable contentHash for identical inputs', async () => {
+      const store = PromptObservationStore.create().orThrow();
+      const lib = await buildLib({ observers: [store] });
+      const contributors = await twoContributors(lib);
+      expect(await compose(composeParams(lib, contributors))).toSucceed();
+      expect(await compose(composeParams(lib, contributors))).toSucceed();
+
+      const composed = composeRecords(store);
+      expect(composed).toHaveLength(2);
+      expect(composed[0].seq).toBe(3);
+      expect(composed[1].seq).toBe(4);
+      // Same composed id + same contributor (provenance, promptId) set → same hash.
+      expect(composed[0].contentHash).toBe(composed[1].contentHash);
+    });
+
+    test('records a failure outcome with error and no success-only fields', async () => {
+      const store = PromptObservationStore.create().orThrow();
+      const lib = await buildLib({ observers: [store] });
+      const contributors = await twoContributors(lib);
+      // maxLength 3 rejects the merged 'alpha\n\nbeta' value.
+      const result = await compose(composeParams(lib, contributors, { maxLength: 3 }));
+      expect(result).toFailWith(/max/i);
+
+      const [record] = composeRecords(store);
+      expect(record.outcome).toBe('failure');
+      expect(record.error).toMatch(/max/i);
+      expect(record.provenanceTrace).toBeUndefined();
+      expect(record.safeguardFindings).toBeUndefined();
+      // Contributors (inputs) are present even on failure.
+      expect(record.contributors.map((c) => c.provenance)).toEqual([10, 20]);
+    });
+
+    test('surfaces compose-level warn findings queryable on the store', async () => {
+      const store = PromptObservationStore.create().orThrow();
+      const lib = await buildLib({ observers: [store] });
+      const contributors = await twoContributors(lib);
+      const warnScreener: IScreener = {
+        name: 'warn-once',
+        screen: async () =>
+          succeed<ReadonlyArray<ISafeguardFinding>>([
+            { slot: slotName('body'), kind: 'suspicious-pattern', disposition: 'warn', detail: 'heads up' }
+          ])
+      };
+      const safetyPolicy: IPromptSafetyPolicy = { screeners: [warnScreener] };
+      expect(await compose(composeParams(lib, contributors, { safetyPolicy }))).toSucceed();
+
+      const [record] = composeRecords(store);
+      expect(record.safeguardFindings?.length).toBeGreaterThan(0);
+      expect(record.safeguardFindings?.every((f) => f.disposition === 'warn')).toBe(true);
+      // The store's safeguard filters see compose records.
+      expect(store.query({ phase: 'compose', hasSafeguardFindings: true })).toHaveLength(1);
+      expect(store.query({ phase: 'compose', safeguardDisposition: 'warn' })).toHaveLength(1);
+      expect(store.query({ phase: 'compose', safeguardDisposition: 'reject' })).toHaveLength(0);
+    });
+
+    test('a compose record does not match a qualifiers query and hasSafeguardFindings:false', async () => {
+      const store = PromptObservationStore.create().orThrow();
+      const lib = await buildLib({ observers: [store] });
+      const contributors = await twoContributors(lib);
+      expect(await compose(composeParams(lib, contributors))).toSucceed();
+
+      // No qualifier context on a compose record → excluded, never throws.
+      expect(store.query({ phase: 'compose', qualifiers: { lang: 'en' } })).toHaveLength(0);
+      // Success compose with no findings is hasSafeguardFindings:false.
+      expect(store.query({ phase: 'compose', hasSafeguardFindings: false })).toHaveLength(1);
+      expect(store.query({ phase: 'compose', hasSafeguardFindings: true })).toHaveLength(0);
+    });
+
+    test('an observer error never breaks compose', async () => {
+      const store = PromptObservationStore.create().orThrow();
+      const logger = new Logging.InMemoryLogger('warning');
+      const failing: IPromptObserver = { observe: () => Promise.resolve(fail('nope')) };
+      const throwing: IPromptObserver = {
+        observe: () => {
+          throw new Error('boom');
+        }
+      };
+      const lib = await buildLib({ observers: [failing, throwing, store], logger });
+      const contributors = await twoContributors(lib);
+      expect(await compose(composeParams(lib, contributors))).toSucceed();
+
+      // The healthy sibling still recorded the compose observation.
+      expect(composeRecords(store)).toHaveLength(1);
+      expect(logger.logged.join('\n')).toMatch(/observer (failed|threw)/i);
+    });
+
+    test('a fire-and-forget observer receives the compose record', async () => {
+      const received: IPromptObservationRecord[] = [];
+      const observer: IPromptObserver = {
+        fireAndForget: true,
+        observe: (record) => {
+          received.push(record);
+          return Promise.resolve(succeed(record));
+        }
+      };
+      const lib = await buildLib({ observers: [observer] });
+      const contributors = await twoContributors(lib);
+      expect(await compose(composeParams(lib, contributors))).toSucceed();
+      // Give the detached dispatch a tick to land.
+      await Promise.resolve();
+      expect(received.some((r) => r.phase === 'compose')).toBe(true);
+    });
+  });
+
+  describe('seam absent', () => {
+    test('emits no compose record and mints no seq', async () => {
+      const store = PromptObservationStore.create().orThrow();
+      const lib = await buildLib({ observers: [store] });
+      const contributors = await twoContributors(lib);
+      expect(store.lastSeq).toBe(2);
+
+      const result = await compose(composeParams(lib, contributors, { withSeam: false }));
+      expect(result).toSucceed();
+
+      // No compose record, and the seq authority did not advance.
+      expect(composeRecords(store)).toHaveLength(0);
+      expect(store.lastSeq).toBe(2);
+    });
+
+    test('the seam still works when the library has no observers', async () => {
+      const lib = await buildLib();
+      const contributors = await twoContributors(lib);
+      // seam.observe fans out to zero observers — a no-op — but compose succeeds.
+      expect(await compose(composeParams(lib, contributors))).toSucceed();
+    });
+  });
+});

--- a/libraries/ts-prompt-assist/src/test/unit/observe/observability.test.ts
+++ b/libraries/ts-prompt-assist/src/test/unit/observe/observability.test.ts
@@ -181,7 +181,7 @@ describe('PromptLibrary observability wiring', () => {
       expect(records.map((r) => r.phase)).toEqual(['resolve', 'free-text-output']);
       const [resolveRecord, outputRecord] = records;
       expect(outputRecord.phase).toBe('free-text-output');
-      if (outputRecord.phase !== 'resolve') {
+      if (outputRecord.phase === 'free-text-output' || outputRecord.phase === 'json-output') {
         expect(outputRecord.linkedResolveSeq).toBe(resolveRecord.seq);
         expect(outputRecord.rawOutput).toBe('raw output');
         expect(outputRecord.outcome).toBe('success');
@@ -200,7 +200,7 @@ describe('PromptLibrary observability wiring', () => {
       const records = store.query();
       expect(records.map((r) => r.phase)).toEqual(['resolve', 'json-output']);
       const outputRecord = records[1];
-      if (outputRecord.phase !== 'resolve') {
+      if (outputRecord.phase === 'free-text-output' || outputRecord.phase === 'json-output') {
         expect(outputRecord.linkedResolveSeq).toBe(records[0].seq);
         expect(outputRecord.outcome).toBe('success');
       }
@@ -322,7 +322,10 @@ describe('PromptLibrary observability wiring', () => {
       });
       expect(result).toSucceedAndSatisfy((r) => expect(r.body).toBe('about cats'));
       const [record] = store.query();
-      expect(record.substitutions).toEqual({ topic: 'cats' });
+      expect(record.phase).toBe('resolve');
+      if (record.phase === 'resolve') {
+        expect(record.substitutions).toEqual({ topic: 'cats' });
+      }
       expect(record.contentHash).not.toBe('');
     });
   });


### PR DESCRIPTION
## Summary

`HorizontalComposer.compose()` emitted no observation, so an audit trail saw the N contributor `resolve` records but nothing tying them to the composed output or the merge. This adds a **composer-emitted `'compose'` observation record that nests each contributor's resolve trace**, fanned out through the library's observer authority and sharing the library's `seq` space.

The change is **additive and source-compatible**: `compose()` only emits when wired to an observation seam; when the seam is absent it behaves exactly as before with zero overhead (no timing, no record, no dispatch).

### What changed
- **`observe/types.ts`** — widened `PromptObservationPhase` with `'compose'`; factored `IPromptObservationCommon` out of `IPromptObservationBase` (so the compose record isn't forced to carry request-shaped `qualifierContext`/`substitutions`); added `IPromptComposeObservation` (+ `IPromptComposeContributorObservation`) to the `IPromptObservationRecord` union; added `IPromptObservationSeam`.
- **`resolve/promptLibrary.ts`** — added the public `observationSeam` getter handing out a narrow `{ nextSeq, now, observe }` bundle bound to the library's seq authority, injected clock, and `_observe` fan-out.
- **`composition/horizontalComposer.ts`** — `compose()` splits into an observation wrapper + `_composeInternal()`; when `params.observation` is present it times the merge (like `_resolveObserved` times the resolve), builds the compose record, and awaits its dispatch before returning.
- **`composition/types.ts`** (new) — `IHorizontalComposeParams` moved here from the `types` packlet and gained the optional `observation?: IPromptObservationSeam` field (see judgment call 4 for why it moved).
- **`observe/promptObservationStore.ts`** — `query` handles the new phase: a compose record never matches a `qualifiers` criterion (it has no qualifier context); safeguard filters (`hasSafeguardFindings` / `safeguardDisposition`) see compose findings.

## Judgment calls (as requested)

1. **Base-field mapping for a compose record.** A compose op has no single resolve request, so I factored a slimmer shared `IPromptObservationCommon` (`seq`, `contentHash`, `timestamp`, `durationMs`, `promptId`, `chain`) and kept `qualifierContext`/`substitutions` only on the request-shaped `IPromptObservationBase`. The union stays clean — the compose record extends `IPromptObservationCommon` directly rather than carrying two semantically-empty required fields. Mapping: `promptId` = composed descriptor id; `chain` = `[]`; `contentHash` = CRC32 over canonical `{ composedPromptId, contributors: [{ provenance, promptId }] }`; `qualifierContext`/`substitutions` absent (contributor qualifier contexts live on the nested contributor traces). Best-effort hash degrades to `''`, mirroring the resolve path.
2. **Contributor nesting depth.** Nest each contributor's **full** `IResolvedPrompt.trace` — the direct analogue of `resourceBindingResolutions[].innerTrace`. No slim projection; the full trace is what ties the composed output back to the independent contributor resolves.
3. **Body duplication.** The composed body is **not** stored on the record — it's reconstructable from the contributor traces + `provenanceTrace`, mirroring how `IPromptOutputObservation` avoids re-storing the resolved body. Documented on `IPromptComposeObservation`.
4. **Seam shape + placement.** Chose the narrow bundled `{ nextSeq(): number; now(): number; observe(record): Promise<void> }` (`IPromptObservationSeam`) over handing the composer the whole library. The library owns all three because they must be shared (seq authority, clock, swallow-and-log fan-out). To let `IHorizontalComposeParams.observation` reference the seam without a `types → observe` packlet cycle (`observe` already depends on `types`), I moved **only** `IHorizontalComposeParams` from `types/composition.ts` into the `composition` packlet. Public surface is unchanged (still re-exported via `export * from './packlets/composition'`); all other composition types (`IContributorSpec`, `ILogicalSlotConfig`, `ISlotProvenanceEntry`, `IComposedPrompt`, `LogicalSlotStrategy`) stay in `types` since `observe` needs `ISlotProvenanceEntry`.
5. **Success/failure symmetry.** The compose record fires on both success and failure (mirroring `_buildResolveObservation`). Contributors (inputs) are present on both; `provenanceTrace`/`safeguardFindings` on success only; `error` on failure only.

## Gate results
- `rushx build` ✅ (API report `etc/ts-prompt-assist.api.md` regenerated for the new exports)
- `rushx lint` ✅ (`rushx fixlint` run before commit)
- `rushx test` ✅ **270 passed, 0 failed, 100% coverage** (statements/branches/functions/lines) across the package
- No `any`; all fallible ops return `Result<T>`; Converters/hashing via published primitives (`sanitizeJsonObject` + `Normalizer.canonicalize` + `Hash.Crc32Normalizer`)

## Self-review (layer 1)
Ran a rigorous self-review against `.ai/instructions/CODE_REVIEW_CHECKLIST.md` before coverage closure (no sub-agent per task constraints; the orchestrator will run `code-reviewer` at the gate). **No P1 findings** (no `any`, no unsafe manual type checks, no `Result<void>`, no throwing in business logic). **No P2 findings requiring change** — the compose record build uses direct object literals (declarative), error context flows through `result.message`, and the seam is built once in the constructor. Scenario-driven tests were written first (seam present → record emitted with nested traces + shared seq verified against the store cursor; multiple contributors ordered; failure outcome; observer error swallowed; fire-and-forget delivery; `query({phase:'compose'})`; qualifiers-guard exclusion; safeguard-finding filters; seam-absent no-record/no-seq; seam works with zero observers), then coverage closed to 100%. No `c8 ignore` directives added.

## For the orchestrator to double-check at the gate
- The `IHorizontalComposeParams` packlet move (judgment call 4) — confirm the public surface is unchanged (it re-exports from `composition` now instead of `types`; `git diff` on `etc/*.api.md` shows only additions + the `observation?` field, no removals).
- Compose-record base-field semantics (empty `chain`, absent `qualifierContext`/`substitutions`) and the store's qualifiers-guard for compose records.

Do not merge — gating is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_