### PR TITLE
feat(ts-agent-memory): projection detail tier, offset pagination, kinds-set query axis

### DIFF
--- a/common/changes/@fgv/ts-agent-memory/agent-memory-query-tool-batch_2026-07-12-00-00.json
+++ b/common/changes/@fgv/ts-agent-memory/agent-memory-query-tool-batch_2026-07-12-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add additive query/tool options to @fgv/ts-agent-memory: consumer-owned result projection with a gist/full detail tier on the search/context tools, offset pagination on IMemoryQuery, and a kinds-set query axis. All three are source-compatible and byte-identical for existing consumers when the new options are absent.",
+      "type": "minor",
+      "packageName": "@fgv/ts-agent-memory"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
+++ b/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
@@ -162,6 +162,7 @@ export interface ICreateMemoryToolsParams {
     readonly defaultCodec?: IIdentityCodec;
     readonly handleFor?: (record: IMemoryRecord<unknown>) => string;
     readonly kinds?: ReadonlyArray<Kind>;
+    readonly projectItem?: (record: IMemoryRecord<unknown>, detail: MemoryDetailTier) => IMemoryToolResultItem;
     readonly registry: IBodyConverterRegistry;
     readonly retriever: IMemoryRetriever;
     readonly store: IMemoryStore;
@@ -384,9 +385,11 @@ export interface IMemoryQuery {
     readonly filter?: (record: IMemoryRecord<unknown>) => boolean;
     readonly hops?: number;
     readonly kind?: Kind;
+    readonly kinds?: ReadonlyArray<Kind>;
     readonly limit?: number;
     readonly linkedFrom?: MemoryId;
     readonly linkedTo?: MemoryId;
+    readonly offset?: number;
     readonly scope?: MemoryScopeKey;
     readonly semantic?: string;
     readonly tag?: Tag;
@@ -586,7 +589,7 @@ export class KnowledgeLwwPolicy implements IWritePolicy {
 }
 
 // @public
-export function limitRecords(records: ReadonlyArray<IMemoryRecord<unknown>>, limit?: number): ReadonlyArray<IMemoryRecord<unknown>>;
+export function limitRecords(records: ReadonlyArray<IMemoryRecord<unknown>>, limit?: number, offset?: number): ReadonlyArray<IMemoryRecord<unknown>>;
 
 // @public
 export const LINK_TRAVERSAL_NO_SEED_MESSAGE: string;
@@ -620,6 +623,9 @@ export class MemoryCapCullPolicy implements IWritePolicy {
     readonly dedupScope: DedupScope;
     readonly mutableFields: ReadonlyArray<string>;
 }
+
+// @public
+export type MemoryDetailTier = 'gist' | 'full';
 
 // @public
 export type MemoryEmbedder = (record: IMemoryRecord<unknown>) => Promise<Result<Float32Array>>;

--- a/libraries/ts-agent-memory/src/packlets/retrieve/hybridRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/hybridRetriever.ts
@@ -145,7 +145,7 @@ export class HybridRetriever implements IMemoryRetriever {
       );
       return mapResults(perRetriever)
         .onSuccess((resultSets) => this._mergeStrategy.merge(resultSets))
-        .onSuccess((merged) => succeed(limitRecords(merged, query.limit)));
+        .onSuccess((merged) => succeed(limitRecords(merged, query.limit, query.offset)));
     });
   }
 
@@ -164,6 +164,10 @@ export class HybridRetriever implements IMemoryRetriever {
   private _projectQuery(query: IMemoryQuery, retriever: IMemoryRetriever): IMemoryQuery {
     const projected: { -readonly [K in keyof IMemoryQuery]: IMemoryQuery[K] } = { ...query };
     delete projected.limit;
+    // Offset, like limit, is a post-merge concern: a child that pre-skipped its
+    // own ordered set would drop candidates the merge needs to score correctly.
+    // The hybrid applies the `{ offset, limit }` window once, after merge.
+    delete projected.offset;
     if (!retriever.capabilities.supportsSemanticRecall) {
       delete projected.semantic;
       delete projected.topK;

--- a/libraries/ts-agent-memory/src/packlets/retrieve/linkTraversalRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/linkTraversalRetriever.ts
@@ -117,7 +117,7 @@ export class LinkTraversalRetriever implements IMemoryRetriever {
       .filter((entry) => indexedRecordMatchesQuery(entry, query))
       .map((entry) => entry.record)
       .sort(recencyCompare);
-    return succeed(limitRecords(ordered, query.limit));
+    return succeed(limitRecords(ordered, query.limit, query.offset));
   }
 
   /**

--- a/libraries/ts-agent-memory/src/packlets/retrieve/recencyRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/recencyRetriever.ts
@@ -47,7 +47,7 @@ export class RecencyRetriever implements IMemoryRetriever {
         const ordered: IMemoryRecord<unknown>[] = selectByQuery(this._index.entries(), query).sort(
           recencyCompare
         );
-        return succeed(limitRecords(ordered, query.limit));
+        return succeed(limitRecords(ordered, query.limit, query.offset));
       })
     );
   }

--- a/libraries/ts-agent-memory/src/packlets/retrieve/retriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/retriever.ts
@@ -34,8 +34,20 @@ export interface IMemoryQuery {
   readonly scope?: MemoryScopeKey;
   /** Restrict to records carrying this tag (exact match). */
   readonly tag?: Tag;
-  /** Restrict to records of this kind. */
+  /**
+   * Restrict to records of this kind — the single-kind shorthand for
+   * {@link IMemoryQuery.kinds | kinds}. When both are set they compose as AND
+   * (the record's kind must satisfy both), so `kind` must itself be a member of
+   * `kinds` for anything to match.
+   */
   readonly kind?: Kind;
+  /**
+   * Restrict to records in ANY of these kinds — the general (multi-kind) form of
+   * {@link IMemoryQuery.kind | kind}. Absent → no kind-set constraint (today's
+   * behavior). An explicit empty array `[]` matches NOTHING (mirroring the
+   * non-positive-`limit` "explicit empty" convention), never "match all".
+   */
+  readonly kinds?: ReadonlyArray<Kind>;
   /** Restrict to records linked FROM this id (outbound). */
   readonly linkedFrom?: MemoryId;
   /** Restrict to records linked TO this id (inbound / backlinks). */
@@ -58,6 +70,13 @@ export interface IMemoryQuery {
   readonly asOf?: number;
   /** Maximum records to return. Applied after all other filters. */
   readonly limit?: number;
+  /**
+   * Records to skip after ordering, before `limit` — so `{ offset, limit }` is a
+   * stable page window over the ordered result set. Default 0. A non-positive or
+   * absent offset is today's behavior (no skip); an offset past the end yields an
+   * empty page, never a throw.
+   */
+  readonly offset?: number;
   /** Arbitrary predicate applied after the scope / kind / tag pre-filter. */
   readonly filter?: (record: IMemoryRecord<unknown>) => boolean;
 }
@@ -165,6 +184,9 @@ export function indexedRecordMatchesQuery(entry: IIndexedMemoryRecord, query: IM
   if (query.kind !== undefined && entry.record.envelope.kind !== query.kind) {
     return false;
   }
+  if (query.kinds !== undefined && !query.kinds.includes(entry.record.envelope.kind)) {
+    return false;
+  }
   if (query.tag !== undefined && !entry.record.envelope.tags.includes(query.tag)) {
     return false;
   }
@@ -187,21 +209,32 @@ export function selectByQuery(
 }
 
 /**
- * Truncate to `query.limit` records (a no-op when `limit` is absent). Applied
- * last, after ordering, so it always takes the top-N of the ordered result. A
- * non-positive `limit` is public query input and means "no records" — it returns
- * an empty array rather than letting a negative value slip into `slice`.
+ * Apply the `{ offset, limit }` page window to an ordered record set. Applied
+ * last, after ordering, so it always takes a stable window of the ordered
+ * result. `offset` is applied first (records to skip), then `limit` (top-N of
+ * the remainder).
+ *
+ * @remarks
+ * Both bounds are public query input and are guarded against non-positive
+ * values slipping into `slice`:
+ * - `offset` absent or non-positive → no skip (today's behavior). An offset past
+ *   the end yields an empty page rather than a throw.
+ * - `limit` absent → no truncation; a non-positive `limit` means "no records"
+ *   and returns an empty array.
  * @public
  */
 export function limitRecords(
   records: ReadonlyArray<IMemoryRecord<unknown>>,
-  limit?: number
+  limit?: number,
+  offset?: number
 ): ReadonlyArray<IMemoryRecord<unknown>> {
+  const skip: number = offset !== undefined && offset > 0 ? offset : 0;
+  const windowed: ReadonlyArray<IMemoryRecord<unknown>> = skip > 0 ? records.slice(skip) : records;
   if (limit === undefined) {
-    return records;
+    return windowed;
   }
   if (limit <= 0) {
     return [];
   }
-  return records.length > limit ? records.slice(0, limit) : records;
+  return windowed.length > limit ? windowed.slice(0, limit) : windowed;
 }

--- a/libraries/ts-agent-memory/src/packlets/retrieve/semanticRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/semanticRetriever.ts
@@ -128,7 +128,7 @@ export class SemanticRetriever implements IMemoryRetriever {
         records.push(entry.record);
       }
     }
-    return succeed(limitRecords(records, query.limit));
+    return succeed(limitRecords(records, query.limit, query.offset));
   }
 
   /**

--- a/libraries/ts-agent-memory/src/packlets/retrieve/structuredFilterRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/structuredFilterRetriever.ts
@@ -51,7 +51,7 @@ export class StructuredFilterRetriever implements IMemoryRetriever {
         const ordered: IMemoryRecord<unknown>[] = selectByQuery(this._index.entries(), query).sort(
           recencyCompare
         );
-        return succeed(limitRecords(ordered, query.limit));
+        return succeed(limitRecords(ordered, query.limit, query.offset));
       })
     );
   }

--- a/libraries/ts-agent-memory/src/packlets/retrieve/tagRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/tagRetriever.ts
@@ -51,7 +51,7 @@ export class TagRetriever implements IMemoryRetriever {
         const ordered: IMemoryRecord<unknown>[] = selectByQuery(this._index.entries(), query).sort(
           recencyCompare
         );
-        return succeed(limitRecords(ordered, query.limit));
+        return succeed(limitRecords(ordered, query.limit, query.offset));
       })
     );
   }

--- a/libraries/ts-agent-memory/src/packlets/retrieve/temporalRetrievers.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/temporalRetrievers.ts
@@ -90,7 +90,7 @@ export class CurrentValidRetriever implements IMemoryRetriever {
           }
         }
         selected.sort(recencyCompare);
-        return succeed(limitRecords(selected, query.limit));
+        return succeed(limitRecords(selected, query.limit, query.offset));
       })
     );
   }
@@ -137,7 +137,7 @@ export class AsOfRetriever implements IMemoryRetriever {
           }
         }
         selected.sort(recencyCompare);
-        return succeed(limitRecords(selected, query.limit));
+        return succeed(limitRecords(selected, query.limit, query.offset));
       })
     );
   }
@@ -182,7 +182,7 @@ export class HistoryRetriever implements IMemoryRetriever {
           history.push(...versions);
         }
         history.sort(HistoryRetriever._byValidAtAscending);
-        return succeed(limitRecords(history, query.limit));
+        return succeed(limitRecords(history, query.limit, query.offset));
       })
     );
   }

--- a/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
+++ b/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
@@ -205,7 +205,10 @@ type WriteArgs = JsonSchema.Static<typeof writeSchema>;
 // eslint-disable-next-line @rushstack/typedef-var
 const readSchema = JsonSchema.object({
   kind: JsonSchema.string({ description: 'The record kind.' }),
-  entityId: JsonSchema.string({ description: 'The domain entity id to read.' })
+  entityId: JsonSchema.string({ description: 'The domain entity id to read.' }),
+  detail: JsonSchema.optional(
+    JsonSchema.enumOf(['gist', 'full'] as const, { description: "'gist' | 'full' (default)." })
+  )
 });
 
 // eslint-disable-next-line @rushstack/typedef-var
@@ -225,7 +228,9 @@ const searchSchema = JsonSchema.object({
   offset: JsonSchema.optional(
     JsonSchema.integer({ description: 'Number of results to skip after ordering, before limit. Default 0.' })
   ),
-  detail: JsonSchema.optional(JsonSchema.string({ description: "'gist' (default) | 'full'." }))
+  detail: JsonSchema.optional(
+    JsonSchema.enumOf(['gist', 'full'] as const, { description: "'gist' (default) | 'full'." })
+  )
 });
 
 // eslint-disable-next-line @rushstack/typedef-var
@@ -235,7 +240,9 @@ const contextSchema = JsonSchema.object({
   tag: JsonSchema.optional(JsonSchema.string({ description: 'Restrict reached records carrying this tag.' })),
   hops: JsonSchema.optional(JsonSchema.integer({ description: 'BFS hop count (default 1).' })),
   limit: JsonSchema.optional(JsonSchema.integer({ description: 'Maximum number of results to return.' })),
-  detail: JsonSchema.optional(JsonSchema.string({ description: "'gist' (default) | 'full'." }))
+  detail: JsonSchema.optional(
+    JsonSchema.enumOf(['gist', 'full'] as const, { description: "'gist' (default) | 'full'." })
+  )
 });
 
 // ---------------------------------------------------------------------------
@@ -479,14 +486,19 @@ function buildReadTool(ctx: IToolContext): AiAssist.IAiClientTool {
         .withErrorFormat((msg) => `memory_read: invalid arguments: ${msg}`)
         .onSuccess((typed) =>
           assertKindEnabled(ctx, typed.kind).onSuccess((kind) =>
-            Convert.entityId.convert(typed.entityId).onSuccess((entityId) => succeed({ kind, entityId }))
+            Convert.entityId.convert(typed.entityId).onSuccess((entityId) => {
+              // `memory_read` is the explicit drill-in path, so its detail default is
+              // INVERTED vs search/context: `'full'` unless the caller opts down to `'gist'`.
+              const detail: MemoryDetailTier = typed.detail === 'gist' ? 'gist' : 'full';
+              return succeed({ kind, entityId, detail });
+            })
           )
         )
-        .thenOnSuccess(async ({ kind, entityId }) =>
+        .thenOnSuccess(async ({ kind, entityId, detail }) =>
           (await ctx.store.get(kind, entityId)).onSuccess((record) =>
             record === undefined
               ? succeed({ found: false })
-              : succeed({ found: true, item: projectItem(ctx, record, 'gist') })
+              : succeed({ found: true, item: projectItem(ctx, record, detail) })
           )
         )
   };

--- a/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
+++ b/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
@@ -135,7 +135,32 @@ export interface ICreateMemoryToolsParams {
    * {@link MemoryId} is used.
    */
   readonly handleFor?: (record: IMemoryRecord<unknown>) => string;
+  /**
+   * Optional host projector mapping a record (and the requested detail tier) to
+   * its agent-visible {@link IMemoryToolResultItem}. When supplied, every
+   * `memory_search` / `memory_context` / `memory_read` result item is produced by
+   * this callback — the host owns how much of the body a `'gist'` vs `'full'`
+   * result carries, so it can bound the default (`'gist'`) path.
+   *
+   * When absent, the built-in default projection is used (full body plus the
+   * {@link ICreateMemoryToolsParams.handleFor | handleFor} handle), which ignores
+   * the detail tier — behavior is byte-identical to a build with no projector.
+   *
+   * The callback is guarded exactly like `handleFor`: a throw degrades to the
+   * default full-body projection for that item rather than failing the whole
+   * search.
+   */
+  readonly projectItem?: (record: IMemoryRecord<unknown>, detail: MemoryDetailTier) => IMemoryToolResultItem;
 }
+
+/**
+ * The detail tier a `memory_search` / `memory_context` result is projected at.
+ * `'gist'` is the default (bounded) path; `'full'` is opt-in. Only meaningful
+ * when a host {@link ICreateMemoryToolsParams.projectItem | projectItem} is
+ * supplied — the built-in default projection returns the full body regardless.
+ * @public
+ */
+export type MemoryDetailTier = 'gist' | 'full';
 
 /** The resolved factory context threaded into each tool's `execute`. */
 interface IToolContext {
@@ -146,6 +171,7 @@ interface IToolContext {
   readonly codecs?: ReadonlyMap<Kind, IIdentityCodec>;
   readonly defaultCodec?: IIdentityCodec;
   readonly handleFor?: (record: IMemoryRecord<unknown>) => string;
+  readonly projectItem?: (record: IMemoryRecord<unknown>, detail: MemoryDetailTier) => IMemoryToolResultItem;
 }
 
 // ---------------------------------------------------------------------------
@@ -195,7 +221,11 @@ const searchSchema = JsonSchema.object({
   semantic: JsonSchema.optional(
     JsonSchema.string({ description: 'Semantic query text (requires a semantic-capable retriever).' })
   ),
-  limit: JsonSchema.optional(JsonSchema.integer({ description: 'Maximum number of results to return.' }))
+  limit: JsonSchema.optional(JsonSchema.integer({ description: 'Maximum number of results to return.' })),
+  offset: JsonSchema.optional(
+    JsonSchema.integer({ description: 'Number of results to skip after ordering, before limit. Default 0.' })
+  ),
+  detail: JsonSchema.optional(JsonSchema.string({ description: "'gist' (default) | 'full'." }))
 });
 
 // eslint-disable-next-line @rushstack/typedef-var
@@ -204,7 +234,8 @@ const contextSchema = JsonSchema.object({
   kind: JsonSchema.optional(JsonSchema.string({ description: 'Restrict reached records to this kind.' })),
   tag: JsonSchema.optional(JsonSchema.string({ description: 'Restrict reached records carrying this tag.' })),
   hops: JsonSchema.optional(JsonSchema.integer({ description: 'BFS hop count (default 1).' })),
-  limit: JsonSchema.optional(JsonSchema.integer({ description: 'Maximum number of results to return.' }))
+  limit: JsonSchema.optional(JsonSchema.integer({ description: 'Maximum number of results to return.' })),
+  detail: JsonSchema.optional(JsonSchema.string({ description: "'gist' (default) | 'full'." }))
 });
 
 // ---------------------------------------------------------------------------
@@ -254,8 +285,17 @@ function resolveOptionalKind(ctx: IToolContext, kindStr?: string): Result<Kind |
   return assertKindEnabled(ctx, kindStr);
 }
 
-/** Project a record into an agent-visible result item, applying the host handle hook when present. */
-function projectItem(ctx: IToolContext, record: IMemoryRecord<unknown>): IMemoryToolResultItem {
+/**
+ * Resolve the requested detail tier from the optional tool `detail` string.
+ * `'full'` is the only opt-in value; every other input (absent, or an
+ * unrecognized string) resolves safely to the bounded default `'gist'`.
+ */
+function resolveDetail(detail?: string): MemoryDetailTier {
+  return detail === 'full' ? 'full' : 'gist';
+}
+
+/** The built-in default projection: full body plus the guarded host handle. Ignores the detail tier. */
+function defaultProjectItem(ctx: IToolContext, record: IMemoryRecord<unknown>): IMemoryToolResultItem {
   // `handleFor` is a host callback; guard it so a throw degrades to the raw id rather than
   // escaping the Result chain (and crashing the whole search/context call).
   const handle =
@@ -269,6 +309,27 @@ function projectItem(ctx: IToolContext, record: IMemoryRecord<unknown>): IMemory
     tags: record.envelope.tags,
     body: record.body
   };
+}
+
+/**
+ * Project a record into an agent-visible result item at the requested detail
+ * tier. When a host {@link ICreateMemoryToolsParams.projectItem | projectItem}
+ * is supplied it owns the projection; otherwise the built-in
+ * {@link defaultProjectItem} (full body) is used. The host callback is guarded
+ * like `handleFor` — a throw degrades to the default full-body projection for
+ * that item rather than failing the whole search/context call.
+ */
+function projectItem(
+  ctx: IToolContext,
+  record: IMemoryRecord<unknown>,
+  detail: MemoryDetailTier
+): IMemoryToolResultItem {
+  if (ctx.projectItem === undefined) {
+    return defaultProjectItem(ctx, record);
+  }
+  // Guard the host projector like `handleFor`: a throw degrades to the built-in
+  // full-body projection (itself throw-safe) rather than escaping the chain.
+  return captureResult(() => ctx.projectItem!(record, detail)).orDefault(defaultProjectItem(ctx, record));
 }
 
 /** Resolve the identity codec used by `memory_write` to derive the storage id. */
@@ -425,7 +486,7 @@ function buildReadTool(ctx: IToolContext): AiAssist.IAiClientTool {
           (await ctx.store.get(kind, entityId)).onSuccess((record) =>
             record === undefined
               ? succeed({ found: false })
-              : succeed({ found: true, item: projectItem(ctx, record) })
+              : succeed({ found: true, item: projectItem(ctx, record, 'gist') })
           )
         )
   };
@@ -450,14 +511,16 @@ function buildSearchTool(ctx: IToolContext): AiAssist.IAiClientTool {
           )
         )
         .thenOnSuccess(async ({ typed, kind, tag }) => {
+          const detail: MemoryDetailTier = resolveDetail(typed.detail);
           const query: IMemoryQuery = {
             ...(kind !== undefined ? { kind } : {}),
             ...(tag !== undefined ? { tag } : {}),
             ...(typed.semantic !== undefined ? { semantic: typed.semantic } : {}),
-            ...(typed.limit !== undefined ? { limit: typed.limit } : {})
+            ...(typed.limit !== undefined ? { limit: typed.limit } : {}),
+            ...(typed.offset !== undefined ? { offset: typed.offset } : {})
           };
           return (await ctx.retriever.retrieve(query)).onSuccess((records) =>
-            succeed({ count: records.length, results: records.map((r) => projectItem(ctx, r)) })
+            succeed({ count: records.length, results: records.map((r) => projectItem(ctx, r, detail)) })
           );
         })
   };
@@ -487,6 +550,7 @@ function buildContextTool(ctx: IToolContext): AiAssist.IAiClientTool {
             )
         )
         .thenOnSuccess(async ({ typed, from, kind, tag }) => {
+          const detail: MemoryDetailTier = resolveDetail(typed.detail);
           const query: IMemoryQuery = {
             linkedFrom: from,
             ...(kind !== undefined ? { kind } : {}),
@@ -495,7 +559,11 @@ function buildContextTool(ctx: IToolContext): AiAssist.IAiClientTool {
             ...(typed.limit !== undefined ? { limit: typed.limit } : {})
           };
           return (await ctx.retriever.retrieve(query)).onSuccess((records) =>
-            succeed({ seed: from, count: records.length, results: records.map((r) => projectItem(ctx, r)) })
+            succeed({
+              seed: from,
+              count: records.length,
+              results: records.map((r) => projectItem(ctx, r, detail))
+            })
           );
         })
   };
@@ -572,7 +640,8 @@ export function createMemoryTools(params: ICreateMemoryToolsParams): ReadonlyArr
     kinds: params.kinds,
     codecs: params.codecs,
     defaultCodec: params.defaultCodec,
-    handleFor: params.handleFor
+    handleFor: params.handleFor,
+    projectItem: params.projectItem
   };
   const selected: ReadonlySet<MemoryToolName> = new Set<MemoryToolName>(params.tools ?? DEFAULT_MEMORY_TOOLS);
   return TOOL_BUILDERS.filter((builder) => selected.has(builder.name)).map((builder) => builder.build(ctx));

--- a/libraries/ts-agent-memory/src/test/unit/retrieve/retrievers.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/retrieve/retrievers.test.ts
@@ -135,6 +135,29 @@ describe('retrieve helpers', () => {
       expect(limitRecords(records, 0)).toEqual([]);
       expect(limitRecords(records, -1)).toEqual([]);
     });
+
+    test('an absent offset is a no-op (byte-identical to today) — same reference returned', () => {
+      expect(limitRecords(records, undefined, undefined)).toBe(records);
+      expect(limitRecords(records, 2, undefined)).toHaveLength(2);
+      // A non-positive offset is guarded like a non-positive limit — no skip.
+      expect(limitRecords(records, undefined, 0)).toBe(records);
+      expect(ids(limitRecords(records, undefined, -5))).toEqual(['a', 'b', 'c']);
+    });
+
+    test('offset skips after ordering; { offset, limit } is a stable page window', () => {
+      expect(ids(limitRecords(records, undefined, 1))).toEqual(['b', 'c']);
+      expect(ids(limitRecords(records, 1, 1))).toEqual(['b']);
+      expect(ids(limitRecords(records, 2, 1))).toEqual(['b', 'c']);
+    });
+
+    test('an offset past the end yields an empty page (never a throw)', () => {
+      expect(limitRecords(records, undefined, 3)).toEqual([]);
+      expect(limitRecords(records, 5, 99)).toEqual([]);
+    });
+
+    test('a non-positive limit still wins over an offset window', () => {
+      expect(limitRecords(records, 0, 1)).toEqual([]);
+    });
   });
 });
 
@@ -218,6 +241,104 @@ describe('RecencyRetriever', () => {
   test('degrades loudly on a link-traversal request', async () => {
     const r = RecencyRetriever.create(buildIndex([{ id: 'a' }])).orThrow();
     expect(await r.retrieve({ linkedTo: 'a' as MemoryId })).toFailWith(/link traversal requires/i);
+  });
+});
+
+describe('query axes: kinds (kind-set) and offset', () => {
+  function multiKindRetriever(): RecencyRetriever {
+    return RecencyRetriever.create(
+      buildIndex([
+        { id: 'k1', kind: 'knowledge', updated: 40 },
+        { id: 'n1', kind: 'note', updated: 30 },
+        { id: 'e1', kind: 'event', updated: 20 },
+        { id: 'k2', kind: 'knowledge', updated: 10 }
+      ])
+    ).orThrow();
+  }
+
+  describe('kinds', () => {
+    test("an absent kinds axis imposes no kind constraint (today's behavior)", async () => {
+      expect(await multiKindRetriever().retrieve({})).toSucceedAndSatisfy(
+        (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+          expect([...ids(records)].sort()).toEqual(['e1', 'k1', 'k2', 'n1']);
+        }
+      );
+    });
+
+    test('restricts to records in ANY of the listed kinds', async () => {
+      expect(
+        await multiKindRetriever().retrieve({
+          kinds: ['knowledge', 'event'] as unknown as ReadonlyArray<Kind>
+        })
+      ).toSucceedAndSatisfy((records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+        expect([...ids(records)].sort()).toEqual(['e1', 'k1', 'k2']);
+      });
+    });
+
+    test('an explicit empty kinds array matches NOTHING (not match-all)', async () => {
+      expect(await multiKindRetriever().retrieve({ kinds: [] })).toSucceedWith([]);
+    });
+
+    test('kind and kinds compose as AND (kind must be a member of kinds)', async () => {
+      // kind=knowledge AND kinds includes knowledge → knowledge records only.
+      expect(
+        await multiKindRetriever().retrieve({
+          kind: knowledge,
+          kinds: ['knowledge', 'note'] as unknown as ReadonlyArray<Kind>
+        })
+      ).toSucceedAndSatisfy((records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+        expect([...ids(records)].sort()).toEqual(['k1', 'k2']);
+      });
+      // kind=knowledge but kinds excludes knowledge → nothing can satisfy both.
+      expect(
+        await multiKindRetriever().retrieve({
+          kind: knowledge,
+          kinds: ['note', 'event'] as unknown as ReadonlyArray<Kind>
+        })
+      ).toSucceedWith([]);
+    });
+  });
+
+  describe('offset', () => {
+    function ordered(): RecencyRetriever {
+      return RecencyRetriever.create(
+        buildIndex([
+          { id: 'a', updated: 10 },
+          { id: 'b', updated: 40 },
+          { id: 'c', updated: 30 },
+          { id: 'd', updated: 20 }
+        ])
+      ).orThrow();
+    }
+
+    test('skips after ordering, forming a stable { offset, limit } page window', async () => {
+      // Recency order is [b, c, d, a].
+      expect(await ordered().retrieve({ offset: 1, limit: 2 })).toSucceedAndSatisfy(
+        (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+          expect(ids(records)).toEqual(['c', 'd']);
+        }
+      );
+    });
+
+    test('an absent offset is unchanged from today', async () => {
+      expect(await ordered().retrieve({ limit: 2 })).toSucceedAndSatisfy(
+        (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+          expect(ids(records)).toEqual(['b', 'c']);
+        }
+      );
+    });
+
+    test('an offset past the end yields an empty page', async () => {
+      expect(await ordered().retrieve({ offset: 99 })).toSucceedWith([]);
+    });
+
+    test('a negative offset does not slip into slice (treated as no skip)', async () => {
+      expect(await ordered().retrieve({ offset: -3, limit: 2 })).toSucceedAndSatisfy(
+        (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+          expect(ids(records)).toEqual(['b', 'c']);
+        }
+      );
+    });
   });
 });
 
@@ -658,5 +779,40 @@ describe('HybridRetriever', () => {
         expect(records[0].envelope.id).toBe('b');
       }
     );
+  });
+
+  test('applies the { offset, limit } window after merge', async () => {
+    const { index } = build();
+    const recency = RecencyRetriever.create(index).orThrow();
+    const hybrid = HybridRetriever.create([recency], ScoreUnionMergeStrategy.create().orThrow()).orThrow();
+    // Merged recency order is [b(30), c(20), a(10)]; offset 1 + limit 1 → [c].
+    expect(await hybrid.retrieve({ offset: 1, limit: 1 })).toSucceedAndSatisfy(
+      (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+        expect(ids(records)).toEqual(['c']);
+      }
+    );
+  });
+
+  test('strips offset from child queries (offset is a post-merge concern)', async () => {
+    const child = new RecordingRetriever({
+      supportsSemanticRecall: false,
+      supportsTemporalQuery: false,
+      supportsLinkTraversal: false
+    });
+    const hybrid = HybridRetriever.create([child], ScoreUnionMergeStrategy.create().orThrow()).orThrow();
+    expect(await hybrid.retrieve({ offset: 2, limit: 3 })).toSucceed();
+    expect(child.lastQuery?.offset).toBeUndefined();
+    expect(child.lastQuery?.limit).toBeUndefined();
+  });
+
+  test('passes the kinds axis through to children (a shared pre-filter axis)', async () => {
+    const child = new RecordingRetriever({
+      supportsSemanticRecall: false,
+      supportsTemporalQuery: false,
+      supportsLinkTraversal: false
+    });
+    const hybrid = HybridRetriever.create([child], ScoreUnionMergeStrategy.create().orThrow()).orThrow();
+    expect(await hybrid.retrieve({ kinds: ['knowledge'] as unknown as ReadonlyArray<Kind> })).toSucceed();
+    expect(child.lastQuery?.kinds).toEqual(['knowledge']);
   });
 });

--- a/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
@@ -818,10 +818,18 @@ describe('result projection (projectItem host projector + detail tier)', () => {
       expect(props).toContain('detail');
     });
 
-    test('memory_search accepts detail and offset', () => {
+    test('memory_read declares an optional detail property', () => {
+      const props = schemaProperties(toolByName(allTools(), 'memory_read'));
+      expect(props).toContain('detail');
+    });
+
+    test('memory_search accepts detail and offset, and rejects an out-of-enum detail', () => {
       const schema = toolByName(allTools(), 'memory_search').config.parametersSchema;
       expect(schema.convert({ detail: 'full', offset: 2 })).toSucceed();
+      expect(schema.convert({ detail: 'gist' })).toSucceed();
       expect(schema.convert({ offset: 'nope' })).toFail();
+      // detail is now an enum ('gist' | 'full') at the wire-schema level.
+      expect(schema.convert({ detail: 'verbose' })).toFail();
     });
   });
 
@@ -862,9 +870,16 @@ describe('result projection (projectItem host projector + detail tier)', () => {
       });
     });
 
-    test('an unrecognized detail string resolves safely to gist (bounded)', async () => {
+    test('an out-of-enum detail is rejected at the schema boundary', async () => {
+      // detail is a JsonSchema.enumOf(['gist','full']); the tool re-validates args
+      // on execute, so an out-of-enum value fails loudly rather than reaching the projector.
       const tool = searchToolWith({ projectItem: boundingProjector });
-      expect(await tool.execute({ tag: 'topic', detail: 'verbose' })).toSucceedAndSatisfy((value) => {
+      expect(await tool.execute({ tag: 'topic', detail: 'verbose' })).toFailWith(/invalid arguments/i);
+    });
+
+    test('an explicit detail=gist stays bounded (the non-full branch)', async () => {
+      const tool = searchToolWith({ projectItem: boundingProjector });
+      expect(await tool.execute({ tag: 'topic', detail: 'gist' })).toSucceedAndSatisfy((value) => {
         expect((value as ISearchOut).results[0].body).toBe('<<gist>>');
       });
     });
@@ -933,6 +948,60 @@ describe('result projection (projectItem host projector + detail tier)', () => {
         expect(out.count).toBe(1);
         expect(out.results.map((r) => r.handle)).toEqual(['doc-2']);
       });
+    });
+  });
+
+  describe('memory_read detail (explicit drill-in defaults to FULL)', () => {
+    interface IReadOut {
+      readonly found: boolean;
+      readonly item: IMemoryToolResultItem;
+    }
+
+    async function readToolWith(
+      projector?: (record: IMemoryRecord<unknown>, detail: 'gist' | 'full') => IMemoryToolResultItem
+    ): Promise<AiAssist.IAiClientTool> {
+      const tools = createMemoryTools({
+        store: makeStore(),
+        retriever: makeRetriever([]),
+        registry: registryWith([{ kind: knowledgeKind }]),
+        codecs,
+        tools: ['memory_write', 'memory_read'],
+        ...(projector !== undefined ? { projectItem: projector } : {})
+      });
+      await toolByName(tools, 'memory_write').execute({
+        kind: 'knowledge',
+        entityId: 'doc-1',
+        body: 'FULLBODY'
+      });
+      return toolByName(tools, 'memory_read');
+    }
+
+    test('defaults to the FULL body (drill-in) with a bounding projector', async () => {
+      const tool = await readToolWith(boundingProjector);
+      expect(await tool.execute({ kind: 'knowledge', entityId: 'doc-1' })).toSucceedAndSatisfy((value) => {
+        expect((value as IReadOut).item.body).toBe('FULLBODY');
+      });
+    });
+
+    test('opts down to gist only when detail=gist is requested', async () => {
+      const tool = await readToolWith(boundingProjector);
+      expect(
+        await tool.execute({ kind: 'knowledge', entityId: 'doc-1', detail: 'gist' })
+      ).toSucceedAndSatisfy((value) => {
+        expect((value as IReadOut).item.body).toBe('<<gist>>');
+      });
+    });
+
+    test('is byte-identical for a no-projector consumer (full body regardless of detail)', async () => {
+      const tool = await readToolWith(undefined);
+      for (const args of [
+        { kind: 'knowledge', entityId: 'doc-1' },
+        { kind: 'knowledge', entityId: 'doc-1', detail: 'gist' }
+      ]) {
+        expect(await tool.execute(args)).toSucceedAndSatisfy((value) => {
+          expect((value as IReadOut).item.body).toBe('FULLBODY');
+        });
+      }
     });
   });
 });

--- a/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
@@ -769,3 +769,170 @@ describe('createMemoryTools', () => {
     });
   });
 });
+
+describe('result projection (projectItem host projector + detail tier)', () => {
+  interface ISearchOut {
+    readonly count: number;
+    readonly results: ReadonlyArray<IMemoryToolResultItem>;
+  }
+
+  /**
+   * A host projector that bounds the `'gist'` body to a sentinel and passes the
+   * full body through only for `'full'` — the shape a real host uses to keep the
+   * default (gist) path bounded.
+   */
+  const boundingProjector = (
+    record: IMemoryRecord<unknown>,
+    detail: 'gist' | 'full'
+  ): IMemoryToolResultItem => ({
+    handle: `h:${record.envelope.id}`,
+    kind: record.envelope.kind,
+    entityId: record.envelope.entityId,
+    tags: record.envelope.tags,
+    body: detail === 'full' ? record.body : '<<gist>>'
+  });
+
+  function searchToolWith(
+    overrides: Partial<Parameters<typeof createMemoryTools>[0]>
+  ): AiAssist.IAiClientTool {
+    return toolByName(
+      createMemoryTools({
+        store: makeStore(),
+        retriever: makeRetriever([{ id: 'doc-1', tags: ['topic'] }]),
+        registry: registryWith([{ kind: knowledgeKind }]),
+        ...overrides
+      }),
+      'memory_search'
+    );
+  }
+
+  describe('schema surface', () => {
+    test('memory_search declares optional detail + offset properties', () => {
+      const props = schemaProperties(toolByName(allTools(), 'memory_search'));
+      expect(props).toContain('detail');
+      expect(props).toContain('offset');
+    });
+
+    test('memory_context declares an optional detail property', () => {
+      const props = schemaProperties(toolByName(allTools(), 'memory_context'));
+      expect(props).toContain('detail');
+    });
+
+    test('memory_search accepts detail and offset', () => {
+      const schema = toolByName(allTools(), 'memory_search').config.parametersSchema;
+      expect(schema.convert({ detail: 'full', offset: 2 })).toSucceed();
+      expect(schema.convert({ offset: 'nope' })).toFail();
+    });
+  });
+
+  describe('absent projector = byte-identical default projection', () => {
+    test('returns the full body and the default handle (raw id) when no projector is supplied', async () => {
+      const tool = searchToolWith({});
+      expect(await tool.execute({ tag: 'topic' })).toSucceedAndSatisfy((value) => {
+        const out = value as ISearchOut;
+        expect(out.results[0].handle).toBe('doc-1');
+        expect(out.results[0].body).toBe('body-doc-1');
+      });
+    });
+
+    test('the detail tier is inert without a projector (gist and full both yield the full body)', async () => {
+      const tool = searchToolWith({});
+      for (const detail of ['gist', 'full'] as const) {
+        expect(await tool.execute({ tag: 'topic', detail })).toSucceedAndSatisfy((value) => {
+          expect((value as ISearchOut).results[0].body).toBe('body-doc-1');
+        });
+      }
+    });
+  });
+
+  describe('host projector + detail tier', () => {
+    test('defaults to the bounded gist projection when detail is absent', async () => {
+      const tool = searchToolWith({ projectItem: boundingProjector });
+      expect(await tool.execute({ tag: 'topic' })).toSucceedAndSatisfy((value) => {
+        const out = value as ISearchOut;
+        expect(out.results[0].handle).toBe('h:doc-1');
+        expect(out.results[0].body).toBe('<<gist>>');
+      });
+    });
+
+    test('opts into the full body only when detail=full is requested', async () => {
+      const tool = searchToolWith({ projectItem: boundingProjector });
+      expect(await tool.execute({ tag: 'topic', detail: 'full' })).toSucceedAndSatisfy((value) => {
+        expect((value as ISearchOut).results[0].body).toBe('body-doc-1');
+      });
+    });
+
+    test('an unrecognized detail string resolves safely to gist (bounded)', async () => {
+      const tool = searchToolWith({ projectItem: boundingProjector });
+      expect(await tool.execute({ tag: 'topic', detail: 'verbose' })).toSucceedAndSatisfy((value) => {
+        expect((value as ISearchOut).results[0].body).toBe('<<gist>>');
+      });
+    });
+
+    test('memory_context routes its results through the host projector', async () => {
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever: makeLinkRetriever([{ id: 'a', links: ['b'] }, { id: 'b' }]),
+          registry: registryWith([{ kind: knowledgeKind }]),
+          projectItem: boundingProjector
+        }),
+        'memory_context'
+      );
+      expect(await tool.execute({ from: 'a', detail: 'full' })).toSucceedAndSatisfy((value) => {
+        const out = value as { results: ReadonlyArray<IMemoryToolResultItem> };
+        expect(out.results.map((r) => r.handle)).toEqual(['h:b']);
+        expect(out.results[0].body).toBe('body-b');
+      });
+    });
+
+    test('a throwing host projector degrades to the default full-body projection (does not crash search)', async () => {
+      const tool = searchToolWith({
+        projectItem: () => {
+          throw new Error('host projector blew up');
+        }
+      });
+      expect(await tool.execute({ tag: 'topic' })).toSucceedAndSatisfy((value) => {
+        const out = value as ISearchOut;
+        // Degraded to the built-in default: raw-id handle + full body.
+        expect(out.results[0].handle).toBe('doc-1');
+        expect(out.results[0].body).toBe('body-doc-1');
+      });
+    });
+
+    test('a throwing projector still honors the handleFor hook in the fallback path', async () => {
+      const tool = searchToolWith({
+        handleFor: (r) => `@${r.envelope.id}`,
+        projectItem: () => {
+          throw new Error('nope');
+        }
+      });
+      expect(await tool.execute({ tag: 'topic' })).toSucceedAndSatisfy((value) => {
+        expect((value as ISearchOut).results[0].handle).toBe('@doc-1');
+      });
+    });
+  });
+
+  describe('offset threading (memory_search)', () => {
+    test('threads offset into the query to page the ordered result window', async () => {
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever: makeRetriever([
+            { id: 'doc-1', tags: ['topic'], updated: 30 },
+            { id: 'doc-2', tags: ['topic'], updated: 20 },
+            { id: 'doc-3', tags: ['topic'], updated: 10 }
+          ]),
+          registry: registryWith([{ kind: knowledgeKind }])
+        }),
+        'memory_search'
+      );
+      // Recency-ordered [doc-1, doc-2, doc-3]; offset 1 + limit 1 → [doc-2].
+      expect(await tool.execute({ tag: 'topic', offset: 1, limit: 1 })).toSucceedAndSatisfy((value) => {
+        const out = value as ISearchOut;
+        expect(out.count).toBe(1);
+        expect(out.results.map((r) => r.handle)).toEqual(['doc-2']);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three additive, source-compatible extensions to `@fgv/ts-agent-memory`, requested by the library's first consumer. **Each is byte-identical for existing consumers when the new option is absent** (verified).

### 1. Consumer-owned result projection + detail tier
- New optional `ICreateMemoryToolsParams.projectItem?(record, detail)` host projector.
- `memory_search` / `memory_context` / `memory_read` schemas gain an optional `detail` enum (`'gist' | 'full'`). The tier threads into the projector for every result item.
- **Default detail differs by tool intent:** `memory_search` / `memory_context` (browse) default `'gist'` (bounded); **`memory_read` (explicit drill-in) defaults `'full'`.**
- When `projectItem` is absent, the built-in default projection (full body + guarded `handleFor` handle) is used and the detail tier is inert — byte-identical to today. The default projection is `defaultProjectItem(ctx, record)`; the host callback (no `ctx`) is the sole override.
- Host projector guarded exactly like `handleFor`: wrapped in `captureResult(...)`; a throw degrades to the default full-body projection for that item rather than failing the whole call. `defaultProjectItem` is itself throw-safe.

### 2. `IMemoryQuery.offset` — offset pagination
- New optional `offset?: number`. `limitRecords(records, limit?, offset?)` applies **offset first (after ordering), then limit** — a stable `{ offset, limit }` page window.
- Absent/non-positive offset = no skip (same array reference); offset past the end = empty page, never a throw.
- `HybridRetriever` applies the window post-merge and **strips `offset` from child queries** (like `limit`). Threaded into `searchSchema` as an optional integer; every standalone retriever passes `query.offset` through `limitRecords`.

### 3. `IMemoryQuery.kinds` — kind-set query axis
- New optional `kinds?: ReadonlyArray<Kind>`. Added to `indexedRecordMatchesQuery` **after** the single-`kind` check; rides the existing `entries()` pre-filter — **no new index view, `byKind` untouched.**
- `kind` and `kinds` compose as **AND**; documented as the shorthand/general-form pair. Empty `kinds: []` matches **nothing**; absent = no constraint.

## Gate-round update (addressed the two findings)

**FIX 1 (P2) — `memory_read` detail default corrected to `'full'`.** Originally `buildReadTool` hard-coded `'gist'` and `readSchema` had no `detail` field, so a consumer with a bounding `projectItem` could never get a full body from the explicit drill-in tool. Now `readSchema` carries an optional `detail` (default `full`), and `buildReadTool` resolves with **inverted polarity** vs search/context (`const detail: MemoryDetailTier = typed.detail === 'gist' ? 'gist' : 'full'`). `resolveDetail` stays gist-default (unchanged) for search/context. Added `memory_read` detail tests: default→full, `detail:'gist'`→gist, and the no-projector byte-identity case.

**FIX 2 (P3) — `detail` fields now `JsonSchema.enumOf(['gist','full'] as const)`** (idiomatic per LIBRARY_CAPABILITIES), constraining the wire schema and narrowing the arg type to `'gist' | 'full' | undefined`. Per-tool default preserved in descriptions (search/context `'gist' (default) | 'full'`, read `'gist' | 'full' (default)`). The former execute-level "unknown string → gist" test became a schema-rejection assertion (out-of-enum now fails at the boundary), plus an explicit `detail:'gist'` test to keep the non-full branch covered. `resolveDetail`'s defensive default is retained (harmless with the narrower type).

## Judgment calls
- **`memory_read` polarity is intentionally inverted** vs search/context — the drill-in tool defaults to the full body; browse tools default to the bounded gist. This is the consumer's "gist for a browse, full for a drill-in" model.
- **Default-projector `ctx` reconciliation:** host callback is `(record, detail)` with no `ctx`; the built-in default needs `ctx` for `handleFor`. Kept `defaultProjectItem(ctx, record)` internal; public callback overrides only the projection. Guard uses eager `orDefault(defaultProjectItem(...))` (no `orDefaultLazy` in this repo) — safe because the default is throw-safe.
- **`offset` applied in all standalone retrievers** (recency/tag/structured/link/semantic/temporal), not just the hybrid, so the axis works uniformly whichever retriever a consumer wires directly.

## Gate results
- `rushx build` ✅ (API report regenerated — `etc/ts-agent-memory.api.md` carries the new optional fields + `MemoryDetailTier`; `readSchema`'s `detail` is internal so no public-API delta from FIX 1)
- `rushx fixlint` then `rushx lint` ✅ clean
- `rushx test` ✅ **100% coverage** across every file incl. `memoryTools.ts` and `retriever.ts` (memoryTools 61 tests, retrievers 60, all 25 suites pass)
- No `any`; all fallible ops return `Result<T>`; no `Result<void>`
- Changeset added (**minor**, additive)

## Review-loop discipline
- **Layer 1:** self-reviewed the final diff against `.ai/instructions/CODE_REVIEW_CHECKLIST.md` (P1: none; P2: offset stripped in `_projectQuery` mirroring `limit`, kinds passed through as a shared pre-filter axis, `memory_read` full-body default; P3: enum schema, `??`/naming). Scenario-driven tests written before coverage closure. The `code-reviewer` agent was **not** run by me (sub-agent delegation disallowed for this task) — for the orchestrator to run at the gate.

Do not merge — orchestrator gates and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch