### PR TITLE
feat(ts-agent-memory): store-maintained numeric rank axis for bounded top-M retrieval

### DIFF
--- a/common/changes/@fgv/ts-agent-memory/agent-memory-rank-axis_2026-07-13-00-00.json
+++ b/common/changes/@fgv/ts-agent-memory/agent-memory-rank-axis_2026-07-13-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add an additive, store-maintained numeric ranking axis to @fgv/ts-agent-memory: an optional per-kind host `rankProjectors` map runs on every put AND update (both the non-versioned and temporal write paths) and stamps a numeric `IMemoryEnvelope.rank`, which round-trips through frontmatter; a new `IMemoryIndex.byRank()` view, a `rankCompare` comparator, and an `IMemoryQuery.orderBy: 'recency' | 'rank'` axis serve a bounded top-M rank-ordered page (via the existing limit/offset) with no full-vault scan. Absent-rank records sort last; a throwing projector degrades to rank-absent (warn) without failing the write. Purely additive and byte-identical when the new options are absent.",
+      "type": "minor",
+      "packageName": "@fgv/ts-agent-memory"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
+++ b/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
@@ -214,6 +214,7 @@ export interface IFileTreeMemoryStoreCreateParams {
     readonly embed?: MemoryEmbedder;
     readonly logger?: Logging.ILogger;
     readonly observers?: ReadonlyArray<IMemoryObserver>;
+    readonly rankProjectors?: ReadonlyMap<Kind, RankProjector>;
     readonly registry: IBodyConverterRegistry;
     readonly root: FileTree.IMutableFileTreeDirectoryItem;
     readonly scopeEncoding?: (scope: MemoryScopeKey) => Result<string>;
@@ -295,6 +296,7 @@ export interface IMemoryEnvelope {
     readonly kind: Kind;
     readonly links: ReadonlyArray<IEdge>;
     readonly provenance: IProvenance;
+    readonly rank?: number;
     readonly seq: number;
     readonly tags: ReadonlyArray<Tag>;
     readonly temporal?: ITemporalBlock;
@@ -311,6 +313,7 @@ export interface IMemoryFileParts {
 export interface IMemoryIndex {
     backlinks(target: MemoryId): ReadonlyArray<MemoryId>;
     byKind(kind: Kind): ReadonlyArray<IMemoryRecord<unknown>>;
+    byRank(): ReadonlyArray<IMemoryRecord<unknown>>;
     byRecency(): ReadonlyArray<IMemoryRecord<unknown>>;
     byTag(tag: Tag): ReadonlyArray<IMemoryRecord<unknown>>;
     entries(): ReadonlyArray<IIndexedMemoryRecord>;
@@ -390,6 +393,7 @@ export interface IMemoryQuery {
     readonly linkedFrom?: MemoryId;
     readonly linkedTo?: MemoryId;
     readonly offset?: number;
+    readonly orderBy?: 'recency' | 'rank';
     readonly scope?: MemoryScopeKey;
     readonly semantic?: string;
     readonly tag?: Tag;
@@ -637,6 +641,7 @@ export type MemoryId = Brand<string, 'MemoryId'>;
 export class MemoryIndex implements IMemoryIndex {
     backlinks(target: MemoryId): ReadonlyArray<MemoryId>;
     byKind(kind: Kind): ReadonlyArray<IMemoryRecord<unknown>>;
+    byRank(): ReadonlyArray<IMemoryRecord<unknown>>;
     byRecency(): ReadonlyArray<IMemoryRecord<unknown>>;
     byTag(tag: Tag): ReadonlyArray<IMemoryRecord<unknown>>;
     static create(): Result<MemoryIndex>;
@@ -693,6 +698,9 @@ export class MtmIdentityCodec implements IIdentityCodec {
 export const NON_SEMANTIC_CAPABILITIES: IMemoryRetrieverCapabilities;
 
 // @public
+export function orderingCompare(orderBy?: IMemoryQuery['orderBy']): (a: IMemoryRecord<unknown>, b: IMemoryRecord<unknown>) => number;
+
+// @public
 export function parseMemoryFile(raw: string, registry: IBodyConverterRegistry): Result<IMemoryRecord<unknown>>;
 
 // @public
@@ -703,6 +711,12 @@ export type ProvenanceSource = 'agent' | 'host-ingest' | 'human' | (string & {})
 
 // @public
 export type QueryEmbedder = (text: string) => Promise<Result<Float32Array>>;
+
+// @public
+export function rankCompare(a: IMemoryRecord<unknown>, b: IMemoryRecord<unknown>): number;
+
+// @public
+export type RankProjector = (record: IMemoryRecord<unknown>) => number;
 
 // @public
 export function recencyCompare(a: IMemoryRecord<unknown>, b: IMemoryRecord<unknown>): number;

--- a/libraries/ts-agent-memory/src/packlets/converters/envelopeConverter.ts
+++ b/libraries/ts-agent-memory/src/packlets/converters/envelopeConverter.ts
@@ -105,11 +105,12 @@ export const envelopeConverter: Converter<IMemoryEnvelope> = Converters.object<I
     updated: Converters.number,
     seq: Converters.number,
     contentHash: Converters.string,
+    rank: Converters.number.optional(),
     provenance: provenanceConverter,
     temporal: temporalConverter.optional(),
     embeddingRef: stringOrNull.optional()
   },
-  { optionalFields: ['temporal', 'embeddingRef'] }
+  { optionalFields: ['rank', 'temporal', 'embeddingRef'] }
 );
 
 /**

--- a/libraries/ts-agent-memory/src/packlets/index/memoryIndex.ts
+++ b/libraries/ts-agent-memory/src/packlets/index/memoryIndex.ts
@@ -72,6 +72,15 @@ export interface IMemoryIndex {
   byRecency(): ReadonlyArray<IMemoryRecord<unknown>>;
 
   /**
+   * All records ordered by store-computed {@link IMemoryEnvelope.rank} descending,
+   * with recency (most-recently-updated, then `seq`) as a tiebreak. Records with
+   * an absent `rank` sort LAST (after every ranked record), then by recency among
+   * themselves. Serves a bounded top-M ({@link IMemoryEnvelope.rank}-ordered) page
+   * from the in-memory index with no full-vault (filesystem) scan.
+   */
+  byRank(): ReadonlyArray<IMemoryRecord<unknown>>;
+
+  /**
    * The ids of records whose `links` point AT `target` (inbound edges).
    * The seed map for B2 link-traversal.
    */
@@ -166,6 +175,11 @@ export class MemoryIndex implements IMemoryIndex {
     return this._recencyOrdered(this._byKey.keys());
   }
 
+  /** {@inheritDoc IMemoryIndex.byRank} */
+  public byRank(): ReadonlyArray<IMemoryRecord<unknown>> {
+    return this._rankOrdered(this._byKey.keys());
+  }
+
   /** {@inheritDoc IMemoryIndex.backlinks} */
   public backlinks(target: MemoryId): ReadonlyArray<MemoryId> {
     const sources: Map<string, MemoryId> | undefined = this._backlinks.get(target);
@@ -189,6 +203,49 @@ export class MemoryIndex implements IMemoryIndex {
       const byUpdated: number = b.envelope.updated - a.envelope.updated;
       return byUpdated !== 0 ? byUpdated : b.envelope.seq - a.envelope.seq;
     });
+  }
+
+  /**
+   * Resolve a set of composite keys to their records, ordered by
+   * {@link IMemoryEnvelope.rank} descending with recency (`updated`, then `seq`)
+   * as the tiebreak. Records with an absent `rank` sort LAST, then by recency
+   * among themselves. Computed on call (mirrors {@link MemoryIndex._recencyOrdered}) —
+   * no incremental rank-ordered view is maintained, matching the recency view's
+   * approach; the sort is over the in-memory index, never a filesystem walk.
+   */
+  private _rankOrdered(keys: Iterable<string>): ReadonlyArray<IMemoryRecord<unknown>> {
+    const records: IMemoryRecord<unknown>[] = [];
+    for (const key of keys) {
+      const entry: IIndexedMemoryRecord | undefined = this._byKey.get(key);
+      if (entry !== undefined) {
+        records.push(entry.record);
+      }
+    }
+    return records.sort(MemoryIndex._compareByRank);
+  }
+
+  /**
+   * Rank-descending comparator with an absent-`rank`-last rule and a recency
+   * (`updated`, then `seq`) tiebreak. Duplicated from the retrieve packlet's
+   * `rankCompare` deliberately: the index must not depend on `retrieve` (that
+   * package depends on the index), mirroring how `_recencyOrdered` inlines the
+   * recency ordering rather than importing `recencyCompare`.
+   */
+  private static _compareByRank(a: IMemoryRecord<unknown>, b: IMemoryRecord<unknown>): number {
+    const ra: number | undefined = a.envelope.rank;
+    const rb: number | undefined = b.envelope.rank;
+    // Absent rank sorts last; two absent ranks fall through to the recency tiebreak.
+    if (ra === undefined && rb !== undefined) {
+      return 1;
+    }
+    if (rb === undefined && ra !== undefined) {
+      return -1;
+    }
+    if (ra !== undefined && rb !== undefined && ra !== rb) {
+      return rb - ra;
+    }
+    const byUpdated: number = b.envelope.updated - a.envelope.updated;
+    return byUpdated !== 0 ? byUpdated : b.envelope.seq - a.envelope.seq;
   }
 
   /** Insert an entry and register all its derived associations. */

--- a/libraries/ts-agent-memory/src/packlets/retrieve/hybridRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/hybridRetriever.ts
@@ -11,6 +11,7 @@ import {
   IMemoryRetrieverCapabilities,
   guardRetrieverCapabilities,
   limitRecords,
+  rankCompare,
   recencyCompare
 } from './retriever';
 
@@ -145,7 +146,15 @@ export class HybridRetriever implements IMemoryRetriever {
       );
       return mapResults(perRetriever)
         .onSuccess((resultSets) => this._mergeStrategy.merge(resultSets))
-        .onSuccess((merged) => succeed(limitRecords(merged, query.limit, query.offset)));
+        .onSuccess((merged) => {
+          // `orderBy: 'rank'` re-orders the merged set by rank (descending, absent
+          // last) before the page window, so a rank-ordered hybrid query yields a
+          // rank-ordered page. Absent / `'recency'` preserves the merge strategy's
+          // own ordering (byte-identical to the pre-`orderBy` behavior).
+          const ordered: ReadonlyArray<IMemoryRecord<unknown>> =
+            query.orderBy === 'rank' ? [...merged].sort(rankCompare) : merged;
+          return succeed(limitRecords(ordered, query.limit, query.offset));
+        });
     });
   }
 

--- a/libraries/ts-agent-memory/src/packlets/retrieve/linkTraversalRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/linkTraversalRetriever.ts
@@ -13,7 +13,7 @@ import {
   guardRetrieverCapabilities,
   indexedRecordMatchesQuery,
   limitRecords,
-  recencyCompare
+  orderingCompare
 } from './retriever';
 
 /** The capabilities a link-traversal retriever exposes (link traversal only). */
@@ -116,7 +116,7 @@ export class LinkTraversalRetriever implements IMemoryRetriever {
     const ordered: IMemoryRecord<unknown>[] = entries
       .filter((entry) => indexedRecordMatchesQuery(entry, query))
       .map((entry) => entry.record)
-      .sort(recencyCompare);
+      .sort(orderingCompare(query.orderBy));
     return succeed(limitRecords(ordered, query.limit, query.offset));
   }
 

--- a/libraries/ts-agent-memory/src/packlets/retrieve/recencyRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/recencyRetriever.ts
@@ -13,7 +13,7 @@ import {
   NON_SEMANTIC_CAPABILITIES,
   guardRetrieverCapabilities,
   limitRecords,
-  recencyCompare,
+  orderingCompare,
   selectByQuery
 } from './retriever';
 
@@ -45,7 +45,7 @@ export class RecencyRetriever implements IMemoryRetriever {
     return Promise.resolve(
       guardRetrieverCapabilities(query, this.capabilities).onSuccess(() => {
         const ordered: IMemoryRecord<unknown>[] = selectByQuery(this._index.entries(), query).sort(
-          recencyCompare
+          orderingCompare(query.orderBy)
         );
         return succeed(limitRecords(ordered, query.limit, query.offset));
       })

--- a/libraries/ts-agent-memory/src/packlets/retrieve/retriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/retriever.ts
@@ -68,6 +68,22 @@ export interface IMemoryQuery {
    * `Result.fail` — never a silent empty.
    */
   readonly asOf?: number;
+  /**
+   * Ordering for the result set. `'recency'` (the default when absent — today's
+   * exact behavior) orders most-recently-updated first; `'rank'` orders by the
+   * store-computed {@link IMemoryEnvelope.rank} descending (records with an absent
+   * `rank` last), with recency as the tiebreak. Combined with `{ limit, offset }`
+   * this yields a bounded top-M rank-ordered page with no full-vault scan.
+   *
+   * @remarks
+   * `orderBy` governs the ordered non-semantic retrievers (recency / tag /
+   * structured-filter) and the {@link HybridRetriever}'s post-merge ordering. The
+   * {@link SemanticRetriever} preserves its native vector-similarity order
+   * regardless of `orderBy` — re-sorting semantic hits by `rank` would discard the
+   * similarity ranking that is the whole point of that path; a consumer that wants
+   * rank ordering uses a non-semantic query.
+   */
+  readonly orderBy?: 'recency' | 'rank';
   /** Maximum records to return. Applied after all other filters. */
   readonly limit?: number;
   /**
@@ -169,6 +185,40 @@ export function guardRetrieverCapabilities(
 export function recencyCompare(a: IMemoryRecord<unknown>, b: IMemoryRecord<unknown>): number {
   const byUpdated: number = b.envelope.updated - a.envelope.updated;
   return byUpdated !== 0 ? byUpdated : b.envelope.seq - a.envelope.seq;
+}
+
+/**
+ * Rank comparator: store-computed {@link IMemoryEnvelope.rank} descending, with
+ * {@link recencyCompare} as the tiebreak. Records with an absent `rank` sort LAST
+ * (after every ranked record), then by recency among themselves. Mirrors the
+ * index's rank-view ordering.
+ * @public
+ */
+export function rankCompare(a: IMemoryRecord<unknown>, b: IMemoryRecord<unknown>): number {
+  const ra: number | undefined = a.envelope.rank;
+  const rb: number | undefined = b.envelope.rank;
+  if (ra === undefined && rb !== undefined) {
+    return 1;
+  }
+  if (rb === undefined && ra !== undefined) {
+    return -1;
+  }
+  if (ra !== undefined && rb !== undefined && ra !== rb) {
+    return rb - ra;
+  }
+  return recencyCompare(a, b);
+}
+
+/**
+ * Select the record comparator for a query's {@link IMemoryQuery.orderBy | orderBy}
+ * axis: {@link rankCompare} for `'rank'`, {@link recencyCompare} otherwise (the
+ * default, byte-identical to the pre-`orderBy` behavior).
+ * @public
+ */
+export function orderingCompare(
+  orderBy?: IMemoryQuery['orderBy']
+): (a: IMemoryRecord<unknown>, b: IMemoryRecord<unknown>) => number {
+  return orderBy === 'rank' ? rankCompare : recencyCompare;
 }
 
 /**

--- a/libraries/ts-agent-memory/src/packlets/retrieve/retriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/retriever.ts
@@ -77,11 +77,12 @@ export interface IMemoryQuery {
    *
    * @remarks
    * `orderBy` governs the ordered non-semantic retrievers (recency / tag /
-   * structured-filter) and the {@link HybridRetriever}'s post-merge ordering. The
-   * {@link SemanticRetriever} preserves its native vector-similarity order
-   * regardless of `orderBy` — re-sorting semantic hits by `rank` would discard the
-   * similarity ranking that is the whole point of that path; a consumer that wants
-   * rank ordering uses a non-semantic query.
+   * structured-filter / link-traversal) and the {@link HybridRetriever}'s
+   * post-merge ordering. The {@link SemanticRetriever} is the sole exception: it
+   * preserves its native vector-similarity order regardless of `orderBy` —
+   * re-sorting semantic hits by `rank` would discard the similarity ranking that
+   * is the whole point of that path; a consumer that wants rank ordering uses a
+   * non-semantic query.
    */
   readonly orderBy?: 'recency' | 'rank';
   /** Maximum records to return. Applied after all other filters. */

--- a/libraries/ts-agent-memory/src/packlets/retrieve/structuredFilterRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/structuredFilterRetriever.ts
@@ -13,7 +13,7 @@ import {
   NON_SEMANTIC_CAPABILITIES,
   guardRetrieverCapabilities,
   limitRecords,
-  recencyCompare,
+  orderingCompare,
   selectByQuery
 } from './retriever';
 
@@ -49,7 +49,7 @@ export class StructuredFilterRetriever implements IMemoryRetriever {
           return succeed([]);
         }
         const ordered: IMemoryRecord<unknown>[] = selectByQuery(this._index.entries(), query).sort(
-          recencyCompare
+          orderingCompare(query.orderBy)
         );
         return succeed(limitRecords(ordered, query.limit, query.offset));
       })

--- a/libraries/ts-agent-memory/src/packlets/retrieve/tagRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/tagRetriever.ts
@@ -13,7 +13,7 @@ import {
   NON_SEMANTIC_CAPABILITIES,
   guardRetrieverCapabilities,
   limitRecords,
-  recencyCompare,
+  orderingCompare,
   selectByQuery
 } from './retriever';
 
@@ -49,7 +49,7 @@ export class TagRetriever implements IMemoryRetriever {
           return succeed([]);
         }
         const ordered: IMemoryRecord<unknown>[] = selectByQuery(this._index.entries(), query).sort(
-          recencyCompare
+          orderingCompare(query.orderBy)
         );
         return succeed(limitRecords(ordered, query.limit, query.offset));
       })

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -20,6 +20,7 @@ import {
   KnowledgeLwwPolicy,
   MemoryId,
   MemoryScopeKey,
+  RankProjector,
   Tag,
   isTemporalIdentityCodec,
   isTemporalRecord,
@@ -116,6 +117,19 @@ export interface IFileTreeMemoryStoreCreateParams {
   readonly writePolicies?: ReadonlyMap<Kind, IWritePolicy>;
   /** Per-kind identity codecs. */
   readonly codecs?: ReadonlyMap<Kind, IIdentityCodec>;
+  /**
+   * Optional per-kind host projector map. When a kind has an entry, the store
+   * runs the projector on the fully-resolved (post-merge) record on every put
+   * AND every update — in the same pass that recomputes `contentHash` — and
+   * stamps the numeric result into {@link IMemoryEnvelope.rank}, which the index's
+   * rank view and `orderBy: 'rank'` retrieval sort by (descending, absent last).
+   * Absent for a kind → that kind's records carry no `rank`. Purely additive and
+   * zero-overhead when unwired: an absent map leaves every write byte-identical.
+   * The projector is a host callback — a throw is logged at `warn` and the record
+   * is stamped with no `rank`, never failing the write (mirrors the store's other
+   * guard-host-callbacks conventions).
+   */
+  readonly rankProjectors?: ReadonlyMap<Kind, RankProjector>;
   /** Default codec for kinds without an explicit entry. */
   readonly defaultCodec?: IIdentityCodec;
   /** Scope encoding. Defaults to {@link defaultMemoryScopeEncoding}. */
@@ -182,6 +196,7 @@ interface IInternalParams {
   readonly registry: IRegistry;
   readonly writePolicies: ReadonlyMap<Kind, IWritePolicy>;
   readonly codecs: ReadonlyMap<Kind, IIdentityCodec>;
+  readonly rankProjectors: ReadonlyMap<Kind, RankProjector>;
   readonly defaultCodec?: IIdentityCodec;
   readonly defaultPolicy: IWritePolicy;
   readonly scopeEncoding: (scope: MemoryScopeKey) => Result<string>;
@@ -212,6 +227,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
   private readonly _registry: IRegistry;
   private readonly _writePolicies: ReadonlyMap<Kind, IWritePolicy>;
   private readonly _codecs: ReadonlyMap<Kind, IIdentityCodec>;
+  private readonly _rankProjectors: ReadonlyMap<Kind, RankProjector>;
   private readonly _defaultCodec: IIdentityCodec | undefined;
   private readonly _defaultPolicy: IWritePolicy;
   private readonly _scopeEncoding: (scope: MemoryScopeKey) => Result<string>;
@@ -258,6 +274,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
     this._registry = params.registry;
     this._writePolicies = params.writePolicies;
     this._codecs = params.codecs;
+    this._rankProjectors = params.rankProjectors;
     this._defaultCodec = params.defaultCodec;
     this._defaultPolicy = params.defaultPolicy;
     this._scopeEncoding = params.scopeEncoding;
@@ -286,6 +303,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
           registry: params.registry,
           writePolicies: params.writePolicies ?? new Map<Kind, IWritePolicy>(),
           codecs: params.codecs ?? new Map<Kind, IIdentityCodec>(),
+          rankProjectors: params.rankProjectors ?? new Map<Kind, RankProjector>(),
           defaultCodec: params.defaultCodec,
           defaultPolicy,
           scopeEncoding: params.scopeEncoding ?? defaultMemoryScopeEncoding,
@@ -669,6 +687,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
       return fail(`memory put: rejected by policy: ${decision.reason}`);
     }
     return this._buildRecord(record, body, existing, policy, hash)
+      .onSuccess((built) => succeed(this._stampRank(built)))
       .thenOnSuccess((built) => this._embedOnWrite(built))
       .onSuccess((embeddedBuilt) => this._persist(embeddedBuilt, scope, idStem))
       .thenOnSuccess(async (persisted) => {
@@ -982,6 +1001,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
           .withErrorFormat((msg) => `memory put '${entityId}': ${msg}`)
           .thenOnSuccess((versionStem) =>
             this._buildVersionedRecord(record, body, current, policy, hash, versionStem, validAt, now, seq)
+              .onSuccess((built) => succeed(this._stampRank(built)))
               .thenOnSuccess((built) => this._embedOnWrite(built))
               .onSuccess((embeddedBuilt) => this._persist(embeddedBuilt, scope, versionStem))
               .onSuccess((persisted) =>
@@ -1239,6 +1259,35 @@ export class FileTreeMemoryStore implements IMemoryStore {
 
   private _contentHash(kind: Kind, body: string, links: IMemoryEnvelope['links']): Result<string> {
     return this._hasher.computeHash({ kind, body, links });
+  }
+
+  /**
+   * Stamp the store-computed {@link IMemoryEnvelope.rank} onto a fully-built,
+   * fully-stamped record by running the kind's registered {@link RankProjector}.
+   * Runs on the SAME resolved (post-merge) record whose `contentHash` was just
+   * computed, so `rank` is always consistent with the current body — no separate
+   * write path and no consumer write-discipline rule. A no-op pass-through
+   * (byte-identical record) when the kind has no projector — the additive,
+   * zero-overhead-when-unwired default. The projector is a host callback: a throw
+   * is logged at `warn` and the record is returned with no `rank`, so a ranking
+   * bug never loses an authoritative write.
+   */
+  private _stampRank(record: IMemoryRecord<string>): IMemoryRecord<string> {
+    const projector: RankProjector | undefined = this._rankProjectors.get(record.envelope.kind);
+    if (projector === undefined) {
+      return record;
+    }
+    try {
+      const rank: number = projector(record);
+      return { envelope: { ...record.envelope, rank }, body: record.body };
+    } catch (err) {
+      this._warnSwallowed(
+        `memory put '${record.envelope.id}': rank projector threw (swallowed; rank left absent): ${String(
+          err
+        )}`
+      );
+      return record;
+    }
   }
 
   private _codecFor(kind: Kind): Result<IIdentityCodec> {

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -1269,8 +1269,9 @@ export class FileTreeMemoryStore implements IMemoryStore {
    * write path and no consumer write-discipline rule. A no-op pass-through
    * (byte-identical record) when the kind has no projector — the additive,
    * zero-overhead-when-unwired default. The projector is a host callback: a throw
-   * is logged at `warn` and the record is returned with no `rank`, so a ranking
-   * bug never loses an authoritative write.
+   * is logged at `warn` and the record is stamped with NO `rank` (the field is
+   * explicitly cleared, so a throw on an update drops a now-stale prior rank rather
+   * than preserving it), so a ranking bug never loses an authoritative write.
    */
   private _stampRank(record: IMemoryRecord<string>): IMemoryRecord<string> {
     const projector: RankProjector | undefined = this._rankProjectors.get(record.envelope.kind);
@@ -1282,11 +1283,14 @@ export class FileTreeMemoryStore implements IMemoryStore {
       return { envelope: { ...record.envelope, rank }, body: record.body };
     } catch (err) {
       this._warnSwallowed(
-        `memory put '${record.envelope.id}': rank projector threw (swallowed; rank left absent): ${String(
-          err
-        )}`
+        `memory put '${record.envelope.id}': rank projector threw (swallowed; rank cleared): ${String(err)}`
       );
-      return record;
+      // Explicitly CLEAR `rank` (not `return record`): on an update the merged
+      // envelope carries the prior version's `rank` (the write-policy merge does
+      // not touch `rank`), so returning it verbatim would keep a stale value
+      // inconsistent with the revised body. Clearing honors the staleness
+      // contract — an uncomputable rank means the record sorts last as "unranked".
+      return { envelope: { ...record.envelope, rank: undefined }, body: record.body };
     }
   }
 

--- a/libraries/ts-agent-memory/src/packlets/types/envelope.ts
+++ b/libraries/ts-agent-memory/src/packlets/types/envelope.ts
@@ -108,6 +108,15 @@ export interface IMemoryEnvelope {
    * an exact match is a no-op upsert that returns the existing record.
    */
   readonly contentHash: string;
+  /**
+   * Store-computed host-defined ordering value, produced by the kind's
+   * {@link RankProjector} on every put/update and stamped into the envelope in
+   * the same pass that recomputes {@link IMemoryEnvelope.contentHash | contentHash}.
+   * Absent when the kind has no registered projector (or the projector threw on
+   * this record). Ordered retrieval (`orderBy: 'rank'`) and the index's rank view
+   * sort by this value descending, placing records with an absent `rank` last.
+   */
+  readonly rank?: number;
   /** Structured provenance (never a flat enum). */
   readonly provenance: IProvenance;
 
@@ -136,3 +145,15 @@ export interface IMemoryRecord<TBody = unknown> {
   /** The per-kind, Converter-validated body. */
   readonly body: TBody;
 }
+
+/**
+ * A per-kind host projection from a fully-resolved (post-merge) memory record
+ * to a numeric ordering value. Registered per kind at store construction (see
+ * `rankProjectors`); the store runs it on every put/update over the same
+ * resolved record whose `contentHash` it computes, stamping the result into
+ * {@link IMemoryEnvelope.rank}. The store never interprets the body — the host
+ * owns what the number means. A projector that throws is treated as "no rank
+ * for this record" (logged at `warn`), never failing the write.
+ * @public
+ */
+export type RankProjector = (record: IMemoryRecord<unknown>) => number;

--- a/libraries/ts-agent-memory/src/test/unit/converters/envelopeConverter.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/converters/envelopeConverter.test.ts
@@ -157,6 +157,34 @@ describe('envelopeConverter', () => {
     expect(envelopeConverter.convert({ ...validEnvelopeObject, embeddingRef: 42 })).toFail();
   });
 
+  test('rank is absent when not present', () => {
+    expect(envelopeConverter.convert(validEnvelopeObject)).toSucceedAndSatisfy((envelope) => {
+      expect(envelope.rank).toBeUndefined();
+    });
+  });
+
+  test('validates and preserves a numeric rank', () => {
+    expect(envelopeConverter.convert({ ...validEnvelopeObject, rank: 42 })).toSucceedAndSatisfy(
+      (envelope) => {
+        expect(envelope.rank).toBe(42);
+      }
+    );
+  });
+
+  test('serialize/parse round-trips rank through frontmatter', () => {
+    const registry = BodyConverterRegistry.create().orThrow();
+    registry.register('knowledge' as Kind, Converters.string);
+    const envelope = envelopeConverter.convert({ ...validEnvelopeObject, rank: 7 }).orThrow();
+    const file = serializeMemoryFile(envelope, 'body').orThrow();
+    expect(parseMemoryFile(file, registry)).toSucceedAndSatisfy((record) => {
+      expect(record.envelope.rank).toBe(7);
+    });
+  });
+
+  test('fails when rank is not a number', () => {
+    expect(envelopeConverter.convert({ ...validEnvelopeObject, rank: 'high' })).toFail();
+  });
+
   test('fails when a required field is missing', () => {
     const missing: Record<string, unknown> = { ...validEnvelopeObject };
     delete missing.contentHash;

--- a/libraries/ts-agent-memory/src/test/unit/index/memoryIndex.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/index/memoryIndex.test.ts
@@ -23,6 +23,7 @@ interface IRecordSpec {
   readonly links?: ReadonlyArray<string>;
   readonly updated?: number;
   readonly seq?: number;
+  readonly rank?: number;
 }
 
 function makeEntry(spec: IRecordSpec): IIndexedMemoryRecord {
@@ -38,6 +39,7 @@ function makeEntry(spec: IRecordSpec): IIndexedMemoryRecord {
         updated: spec.updated ?? 0,
         seq: spec.seq ?? 0,
         contentHash: 'h',
+        ...(spec.rank !== undefined ? { rank: spec.rank } : {}),
         provenance: { source: 'agent' }
       })
       .orThrow(),
@@ -142,6 +144,47 @@ describe('MemoryIndex', () => {
         ])
         .orThrow();
       expect(ids(index.byRecency())).toEqual(['newest', 'tie-hi', 'tie-lo', 'old']);
+    });
+  });
+
+  describe('byRank', () => {
+    test('orders by rank descending, absent-rank records last, recency tiebreak', () => {
+      index
+        .rebuild([
+          makeEntry({ id: 'mid', rank: 5, updated: 100, seq: 1 }),
+          makeEntry({ id: 'top', rank: 9, updated: 100, seq: 2 }),
+          makeEntry({ id: 'tie-lo', rank: 3, updated: 200, seq: 4 }),
+          makeEntry({ id: 'tie-hi', rank: 3, updated: 200, seq: 9 }),
+          makeEntry({ id: 'unranked-old', updated: 100, seq: 5 }),
+          makeEntry({ id: 'unranked-new', updated: 400, seq: 6 })
+        ])
+        .orThrow();
+      // ranked (desc): top(9), mid(5), tie-hi(3,seq9), tie-lo(3,seq4);
+      // then unranked by recency: unranked-new(updated400), unranked-old(updated100).
+      expect(ids(index.byRank())).toEqual(['top', 'mid', 'tie-hi', 'tie-lo', 'unranked-new', 'unranked-old']);
+    });
+
+    test('is empty on an empty index', () => {
+      expect(index.byRank()).toHaveLength(0);
+    });
+
+    test('sorts a ranked record ahead of an earlier-listed absent-rank record', () => {
+      // Input lists the absent-rank record first so the sort compares (ranked, absent),
+      // exercising the ranked-before-absent direction of the comparator.
+      index
+        .rebuild([
+          makeEntry({ id: 'unranked', updated: 100, seq: 1 }),
+          makeEntry({ id: 'ranked', rank: 5, updated: 100, seq: 2 })
+        ])
+        .orThrow();
+      expect(ids(index.byRank())).toEqual(['ranked', 'unranked']);
+    });
+
+    test('orders two absent-rank records by recency alone', () => {
+      index
+        .rebuild([makeEntry({ id: 'a', updated: 100, seq: 1 }), makeEntry({ id: 'b', updated: 300, seq: 2 })])
+        .orThrow();
+      expect(ids(index.byRank())).toEqual(['b', 'a']);
     });
   });
 

--- a/libraries/ts-agent-memory/src/test/unit/index/memoryIndex.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/index/memoryIndex.test.ts
@@ -12,7 +12,8 @@ import {
   MemoryIndex,
   MemoryScopeKey,
   Tag,
-  envelopeConverter
+  envelopeConverter,
+  rankCompare
 } from '../../../index';
 
 interface IRecordSpec {
@@ -185,6 +186,26 @@ describe('MemoryIndex', () => {
         .rebuild([makeEntry({ id: 'a', updated: 100, seq: 1 }), makeEntry({ id: 'b', updated: 300, seq: 2 })])
         .orThrow();
       expect(ids(index.byRank())).toEqual(['b', 'a']);
+    });
+
+    test("index byRank agrees pairwise with the retrieve packlet's rankCompare", () => {
+      // Guard against the two hand-duplicated comparators (index `_compareByRank`
+      // and retrieve `rankCompare`) drifting: a future tie-break edit to one that
+      // diverges from the other is caught here on a shared mixed fixture.
+      const fixture = [
+        makeEntry({ id: 'r-top', rank: 9, updated: 100, seq: 1 }),
+        makeEntry({ id: 'r-mid', rank: 5, updated: 400, seq: 2 }),
+        makeEntry({ id: 'r-tie-a', rank: 3, updated: 200, seq: 3 }),
+        makeEntry({ id: 'r-tie-b', rank: 3, updated: 200, seq: 8 }),
+        makeEntry({ id: 'absent-old', updated: 100, seq: 4 }),
+        makeEntry({ id: 'absent-new', updated: 500, seq: 5 })
+      ];
+      index.rebuild(fixture).orThrow();
+      const viaIndex = ids(index.byRank());
+      const viaRankCompare = ids(fixture.map((e) => e.record).sort(rankCompare));
+      expect(viaIndex).toEqual(viaRankCompare);
+      // And the shared expected ordering is what both must produce.
+      expect(viaIndex).toEqual(['r-top', 'r-mid', 'r-tie-b', 'r-tie-a', 'absent-new', 'absent-old']);
     });
   });
 

--- a/libraries/ts-agent-memory/src/test/unit/retrieve/linkTraversalRetriever.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/retrieve/linkTraversalRetriever.test.ts
@@ -25,6 +25,7 @@ interface IEntrySpec {
   readonly updated?: number;
   readonly seq?: number;
   readonly links?: ReadonlyArray<string>;
+  readonly rank?: number;
 }
 
 function makeEntry(spec: IEntrySpec): IIndexedMemoryRecord {
@@ -40,6 +41,7 @@ function makeEntry(spec: IEntrySpec): IIndexedMemoryRecord {
         updated: spec.updated ?? 0,
         seq: spec.seq ?? 0,
         contentHash: 'h',
+        ...(spec.rank !== undefined ? { rank: spec.rank } : {}),
         provenance: { source: 'agent' }
       })
       .orThrow(),
@@ -99,6 +101,46 @@ describe('LinkTraversalRetriever', () => {
           expect(ids(records).sort()).toEqual(['b', 'c']);
         }
       );
+    });
+  });
+
+  describe('orderBy axis', () => {
+    function seedIndex(): MemoryIndex {
+      // Seed 'a' links to three ranked neighbors. `rank` and `updated` are
+      // deliberately INVERTED so the rank order (n3,n2,n1) is the exact reverse of
+      // the recency order (n1,n2,n3) — proving orderBy actually re-sorts.
+      return buildIndex([
+        { id: 'a', links: ['n1', 'n3', 'n2'] },
+        { id: 'n1', rank: 1, updated: 300, seq: 1 },
+        { id: 'n3', rank: 3, updated: 100, seq: 3 },
+        { id: 'n2', rank: 2, updated: 200, seq: 2 }
+      ]);
+    }
+
+    test("orderBy 'rank' orders reached records by rank descending", async () => {
+      const retriever = LinkTraversalRetriever.create(seedIndex()).orThrow();
+      expect(await retriever.retrieve({ linkedFrom: 'a' as MemoryId, orderBy: 'rank' })).toSucceedAndSatisfy(
+        (records) => {
+          expect(ids(records)).toEqual(['n3', 'n2', 'n1']);
+        }
+      );
+    });
+
+    test('orderBy absent is unchanged recency order', async () => {
+      const retriever = LinkTraversalRetriever.create(seedIndex()).orThrow();
+      expect(await retriever.retrieve({ linkedFrom: 'a' as MemoryId })).toSucceedAndSatisfy((records) => {
+        // Recency: most-recently-updated first → n1(300), n2(200), n3(100).
+        expect(ids(records)).toEqual(['n1', 'n2', 'n3']);
+      });
+    });
+
+    test("orderBy 'rank' composes with { limit, offset }", async () => {
+      const retriever = LinkTraversalRetriever.create(seedIndex()).orThrow();
+      expect(
+        await retriever.retrieve({ linkedFrom: 'a' as MemoryId, orderBy: 'rank', limit: 1, offset: 1 })
+      ).toSucceedAndSatisfy((records) => {
+        expect(ids(records)).toEqual(['n2']);
+      });
     });
   });
 

--- a/libraries/ts-agent-memory/src/test/unit/retrieve/retrievers.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/retrieve/retrievers.test.ts
@@ -26,7 +26,10 @@ import {
   TagRetriever,
   envelopeConverter,
   guardRetrieverCapabilities,
-  limitRecords
+  limitRecords,
+  orderingCompare,
+  rankCompare,
+  recencyCompare
 } from '../../../index';
 
 interface IRecordSpec {
@@ -36,6 +39,7 @@ interface IRecordSpec {
   readonly tags?: ReadonlyArray<string>;
   readonly updated?: number;
   readonly seq?: number;
+  readonly rank?: number;
 }
 
 function makeEntry(spec: IRecordSpec): IIndexedMemoryRecord {
@@ -51,6 +55,7 @@ function makeEntry(spec: IRecordSpec): IIndexedMemoryRecord {
         updated: spec.updated ?? 0,
         seq: spec.seq ?? 0,
         contentHash: 'h',
+        ...(spec.rank !== undefined ? { rank: spec.rank } : {}),
         provenance: { source: 'agent' }
       })
       .orThrow(),
@@ -241,6 +246,167 @@ describe('RecencyRetriever', () => {
   test('degrades loudly on a link-traversal request', async () => {
     const r = RecencyRetriever.create(buildIndex([{ id: 'a' }])).orThrow();
     expect(await r.retrieve({ linkedTo: 'a' as MemoryId })).toFailWith(/link traversal requires/i);
+  });
+});
+
+describe('orderBy: rank axis', () => {
+  const a1 = makeEntry({ id: 'a', rank: 1, updated: 100, seq: 1 }).record;
+  const b3 = makeEntry({ id: 'b', rank: 3, updated: 100, seq: 2 }).record;
+  const c2 = makeEntry({ id: 'c', rank: 2, updated: 100, seq: 3 }).record;
+  const unranked = makeEntry({ id: 'z', updated: 999, seq: 4 }).record;
+
+  describe('rankCompare', () => {
+    test('orders by rank descending', () => {
+      expect(
+        [a1, b3, c2]
+          .slice()
+          .sort(rankCompare)
+          .map((r) => r.envelope.id)
+      ).toEqual(['b', 'c', 'a']);
+    });
+
+    test('places an absent-rank record last regardless of recency', () => {
+      // `unranked` has the newest `updated`, but an absent rank sorts after every ranked record.
+      expect(
+        [unranked, a1, b3]
+          .slice()
+          .sort(rankCompare)
+          .map((r) => r.envelope.id)
+      ).toEqual(['b', 'a', 'z']);
+      // Symmetric: absent on the left side of the compare too.
+      expect(
+        [a1, unranked]
+          .slice()
+          .sort(rankCompare)
+          .map((r) => r.envelope.id)
+      ).toEqual(['a', 'z']);
+    });
+
+    test('breaks an equal-rank tie by recency', () => {
+      const b3b = makeEntry({ id: 'b2', rank: 3, updated: 50, seq: 9 }).record;
+      // Equal rank 3 → newer `updated` (b3 at 100) first.
+      expect(
+        [b3b, b3]
+          .slice()
+          .sort(rankCompare)
+          .map((r) => r.envelope.id)
+      ).toEqual(['b', 'b2']);
+    });
+  });
+
+  describe('orderingCompare', () => {
+    test("returns recencyCompare for absent orderBy and 'recency'", () => {
+      expect(orderingCompare()).toBe(recencyCompare);
+      expect(orderingCompare('recency')).toBe(recencyCompare);
+    });
+
+    test("returns rankCompare for 'rank'", () => {
+      expect(orderingCompare('rank')).toBe(rankCompare);
+    });
+  });
+
+  describe.each([
+    ['RecencyRetriever', (index: MemoryIndex): IMemoryRetriever => RecencyRetriever.create(index).orThrow()],
+    ['TagRetriever', (index: MemoryIndex): IMemoryRetriever => TagRetriever.create(index).orThrow()],
+    [
+      'StructuredFilterRetriever',
+      (index: MemoryIndex): IMemoryRetriever => StructuredFilterRetriever.create(index).orThrow()
+    ]
+  ])('%s honors orderBy', (name, make) => {
+    // Tag / structured-filter need their axis present to return anything.
+    const axis: IMemoryQuery =
+      name === 'TagRetriever'
+        ? { tag: 'x' as Tag }
+        : name === 'StructuredFilterRetriever'
+        ? { filter: () => true }
+        : {};
+
+    function orderedIndex(): MemoryIndex {
+      return buildIndex([
+        { id: 'a', rank: 1, tags: ['x'], updated: 100, seq: 1 },
+        { id: 'b', rank: 3, tags: ['x'], updated: 100, seq: 2 },
+        { id: 'c', rank: 2, tags: ['x'], updated: 100, seq: 3 },
+        { id: 'z', tags: ['x'], updated: 999, seq: 4 }
+      ]);
+    }
+
+    test("orderBy 'rank' orders by rank descending, absent last", async () => {
+      const r = make(orderedIndex());
+      expect(await r.retrieve({ ...axis, orderBy: 'rank' })).toSucceedAndSatisfy(
+        (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+          expect(ids(records)).toEqual(['b', 'c', 'a', 'z']);
+        }
+      );
+    });
+
+    test('orderBy absent is unchanged recency order', async () => {
+      const r = make(orderedIndex());
+      expect(await r.retrieve({ ...axis })).toSucceedAndSatisfy(
+        (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+          // `z` has the newest `updated`; the rest tie on `updated` and break by
+          // seq descending (c=3, b=2, a=1) — recency order regardless of rank.
+          expect(ids(records)).toEqual(['z', 'c', 'b', 'a']);
+        }
+      );
+    });
+
+    test('rank ordering composes with { limit, offset } for a bounded top-M page', async () => {
+      const r = make(orderedIndex());
+      expect(await r.retrieve({ ...axis, orderBy: 'rank', limit: 1, offset: 1 })).toSucceedAndSatisfy(
+        (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+          expect(ids(records)).toEqual(['c']);
+        }
+      );
+    });
+  });
+
+  test("HybridRetriever re-orders the merged set by rank for orderBy 'rank'", async () => {
+    const index = buildIndex([
+      { id: 'a', rank: 1, tags: ['x'], updated: 100, seq: 1 },
+      { id: 'b', rank: 3, tags: ['x'], updated: 100, seq: 2 },
+      { id: 'c', rank: 2, tags: ['x'], updated: 100, seq: 3 }
+    ]);
+    const hybrid = HybridRetriever.create(
+      [RecencyRetriever.create(index).orThrow(), TagRetriever.create(index).orThrow()],
+      ScoreUnionMergeStrategy.create().orThrow()
+    ).orThrow();
+    expect(await hybrid.retrieve({ tag: 'x' as Tag, orderBy: 'rank' })).toSucceedAndSatisfy(
+      (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+        // All three score 2 (surfaced by both children); orderBy rank re-sorts the merge.
+        expect(ids(records)).toEqual(['b', 'c', 'a']);
+      }
+    );
+  });
+
+  test("SemanticRetriever preserves vector-similarity order regardless of orderBy 'rank'", async () => {
+    const index = buildIndex([
+      { id: 'a', rank: 9, updated: 1 },
+      { id: 'b', rank: 1, updated: 1 }
+    ]);
+    const vectorIndex: IVectorIndex = {
+      add: (id: MemoryId) => Promise.resolve(succeed(`ref-${id}`)),
+      remove: (id: MemoryId) => Promise.resolve(succeed(id)),
+      query: () =>
+        Promise.resolve(
+          succeed([
+            { id: 'b' as MemoryId, score: 0.9 },
+            { id: 'a' as MemoryId, score: 0.5 }
+          ])
+        )
+    };
+    const r = SemanticRetriever.create({
+      index,
+      backend: {
+        vectorIndex,
+        embedQuery: () => Promise.resolve(succeed(Float32Array.from([0.1])))
+      }
+    }).orThrow();
+    // Even though `a` has the higher rank, semantic keeps the similarity order (b before a).
+    expect(await r.retrieve({ semantic: 'q', orderBy: 'rank' })).toSucceedAndSatisfy(
+      (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+        expect(ids(records)).toEqual(['b', 'a']);
+      }
+    );
   });
 });
 

--- a/libraries/ts-agent-memory/src/test/unit/store/rankAxis.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/rankAxis.test.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converters, Logging, Result } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
+import {
+  BodyConverterRegistry,
+  EntityId,
+  FileTreeMemoryStore,
+  IBodyConverterRegistry,
+  IIdentityCodec,
+  IMemoryRecord,
+  IWritePolicy,
+  Kind,
+  KnowledgeIdentityCodec,
+  MemoryIndex,
+  MemoryScopeKey,
+  RankProjector,
+  RecencyRetriever,
+  TemporalIdentityCodec,
+  TemporalVersionedPolicy,
+  parseMemoryFile
+} from '../../../index';
+
+const knowledgeKind: Kind = 'knowledge' as Kind;
+const plainKind: Kind = 'plain' as Kind;
+const factKind: Kind = 'fact' as Kind;
+
+/** Host projector: rank = body length. Generic numeric ordering — the store never interprets meaning. */
+const lengthProjector: RankProjector = (record) => (record.body as string).length;
+
+/** A projector that always throws — exercises the guard-host-callback path. */
+const throwingProjector: RankProjector = () => {
+  throw new Error('projector boom');
+};
+
+function mutableRoot(
+  files: ReadonlyArray<{ path: string; contents: string }> = []
+): FileTree.IMutableFileTreeDirectoryItem {
+  const tree = FileTree.inMemory([...files], { mutable: true }).orThrow();
+  const root = tree.getDirectory('/').orThrow();
+  if (!FileTree.isMutableDirectoryItem(root)) {
+    throw new Error('expected a mutable root directory');
+  }
+  return root;
+}
+
+function registry(): IBodyConverterRegistry {
+  const reg = BodyConverterRegistry.create().orThrow();
+  reg.register(knowledgeKind, Converters.string);
+  reg.register(plainKind, Converters.string);
+  reg.register(factKind, Converters.string);
+  return reg;
+}
+
+const codecs: ReadonlyMap<Kind, IIdentityCodec> = new Map<Kind, IIdentityCodec>([
+  [knowledgeKind, new KnowledgeIdentityCodec()],
+  [plainKind, new KnowledgeIdentityCodec()],
+  [factKind, TemporalIdentityCodec.create('facts').orThrow()]
+]);
+
+const temporalPolicies: ReadonlyMap<Kind, IWritePolicy> = new Map<Kind, IWritePolicy>([
+  [factKind, TemporalVersionedPolicy.create().orThrow()]
+]);
+
+interface IRecordSpec {
+  readonly id: string;
+  readonly entityId?: string;
+  readonly kind?: Kind;
+  readonly body: string;
+  readonly tags?: ReadonlyArray<string>;
+}
+
+function makeRecord(spec: IRecordSpec): IMemoryRecord<unknown> {
+  return {
+    envelope: {
+      id: spec.id as unknown as IMemoryRecord<unknown>['envelope']['id'],
+      entityId: (spec.entityId ?? spec.id) as EntityId,
+      kind: spec.kind ?? knowledgeKind,
+      tags: (spec.tags ?? []) as unknown as IMemoryRecord<unknown>['envelope']['tags'],
+      links: [],
+      created: 0,
+      updated: 0,
+      seq: 0,
+      contentHash: '',
+      provenance: { source: 'agent' }
+    },
+    body: spec.body
+  };
+}
+
+describe('FileTreeMemoryStore rank axis', () => {
+  let clockValue: number;
+  const clock = (): number => clockValue;
+
+  beforeEach(() => {
+    clockValue = 1000;
+  });
+
+  function createStore(
+    params: {
+      root?: FileTree.IMutableFileTreeDirectoryItem;
+      rankProjectors?: ReadonlyMap<Kind, RankProjector>;
+      writePolicies?: ReadonlyMap<Kind, IWritePolicy>;
+      logger?: Logging.ILogger;
+    } = {}
+  ): Result<FileTreeMemoryStore> {
+    return FileTreeMemoryStore.create({
+      root: params.root ?? mutableRoot(),
+      registry: registry(),
+      codecs,
+      writePolicies: params.writePolicies,
+      rankProjectors: params.rankProjectors,
+      logger: params.logger,
+      clock
+    });
+  }
+
+  const knowledgeProjectors: ReadonlyMap<Kind, RankProjector> = new Map<Kind, RankProjector>([
+    [knowledgeKind, lengthProjector]
+  ]);
+
+  describe('put stamps rank (flat / non-versioned path)', () => {
+    test('runs the kind projector and stamps the numeric result', async () => {
+      const store = createStore({ rankProjectors: knowledgeProjectors }).orThrow();
+      expect(await store.put(makeRecord({ id: 'doc-a', body: 'abcd' }))).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown>) => {
+          expect(rec.envelope.rank).toBe(4);
+        }
+      );
+    });
+
+    test('leaves rank absent for a kind with no projector', async () => {
+      const store = createStore({ rankProjectors: knowledgeProjectors }).orThrow();
+      expect(
+        await store.put(makeRecord({ id: 'p-1', kind: plainKind, body: 'anything' }))
+      ).toSucceedAndSatisfy((rec: IMemoryRecord<unknown>) => {
+        expect(rec.envelope.rank).toBeUndefined();
+      });
+    });
+
+    test('is byte-identical (rank absent) when no projector map is wired', async () => {
+      const store = createStore().orThrow();
+      expect(await store.put(makeRecord({ id: 'doc-a', body: 'abcd' }))).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown>) => {
+          expect(rec.envelope.rank).toBeUndefined();
+        }
+      );
+    });
+  });
+
+  describe('body revision re-stamps rank (staleness contract)', () => {
+    test('a body-only revision recomputes rank against the current body', async () => {
+      const store = createStore({ rankProjectors: knowledgeProjectors }).orThrow();
+      expect(await store.put(makeRecord({ id: 'doc-a', body: 'ab' }))).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown>) => {
+          expect(rec.envelope.rank).toBe(2);
+        }
+      );
+      clockValue = 2000;
+      expect(await store.put(makeRecord({ id: 'doc-a', body: 'abcdef' }))).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown>) => {
+          expect(rec.envelope.rank).toBe(6);
+          expect(rec.envelope.updated).toBe(2000);
+        }
+      );
+    });
+  });
+
+  describe('throwing projector degrades to rank-absent', () => {
+    test('logs a warn and leaves rank absent without failing the write', async () => {
+      const logger = new Logging.InMemoryLogger();
+      const store = createStore({
+        rankProjectors: new Map<Kind, RankProjector>([[knowledgeKind, throwingProjector]]),
+        logger
+      }).orThrow();
+      expect(await store.put(makeRecord({ id: 'doc-a', body: 'abcd' }))).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown>) => {
+          expect(rec.envelope.rank).toBeUndefined();
+        }
+      );
+      expect(logger.logged.some((m) => /rank projector threw/i.test(m))).toBe(true);
+    });
+  });
+
+  describe('put stamps rank (versioned / temporal path)', () => {
+    const factProjectors: ReadonlyMap<Kind, RankProjector> = new Map<Kind, RankProjector>([
+      [factKind, lengthProjector]
+    ]);
+
+    test('stamps rank on the first version and re-stamps on a subsequent version', async () => {
+      const store = createStore({
+        rankProjectors: factProjectors,
+        writePolicies: temporalPolicies
+      }).orThrow();
+      expect(await store.put(makeRecord({ id: 'fact-1', kind: factKind, body: 'aa' }))).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown>) => {
+          expect(rec.envelope.rank).toBe(2);
+        }
+      );
+      clockValue = 2000;
+      expect(
+        await store.put(makeRecord({ id: 'fact-1', kind: factKind, body: 'aaaaa' }))
+      ).toSucceedAndSatisfy((rec: IMemoryRecord<unknown>) => {
+        expect(rec.envelope.rank).toBe(5);
+      });
+    });
+
+    test('leaves rank absent on the versioned path when the kind has no projector', async () => {
+      const store = createStore({ writePolicies: temporalPolicies }).orThrow();
+      expect(await store.put(makeRecord({ id: 'fact-1', kind: factKind, body: 'aa' }))).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown>) => {
+          expect(rec.envelope.rank).toBeUndefined();
+        }
+      );
+    });
+  });
+
+  describe('persistence round-trip', () => {
+    test('rank serializes to frontmatter and reloads on rebuild (no recompute-on-load)', async () => {
+      const root = mutableRoot();
+      const store = createStore({ root, rankProjectors: knowledgeProjectors }).orThrow();
+      await store.put(makeRecord({ id: 'doc-a', body: 'abcd' }));
+
+      // Read the raw persisted file and confirm rank is in the frontmatter.
+      const scopeDir = root
+        .getChildren()
+        .orThrow()
+        .find((c): c is FileTree.IFileTreeDirectoryItem => c.type === 'directory' && c.name === 'knowledge');
+      expect(scopeDir).toBeDefined();
+      const file = scopeDir!
+        .getChildren()
+        .orThrow()
+        .find((c): c is FileTree.IFileTreeFileItem => c.type === 'file' && c.name === 'doc-a.md');
+      expect(file).toBeDefined();
+      const raw = file!.getRawContents().orThrow();
+      expect(parseMemoryFile(raw, registry())).toSucceedAndSatisfy((rec: IMemoryRecord<unknown>) => {
+        expect(rec.envelope.rank).toBe(4);
+      });
+
+      // A brand-new store over the same root reloads rank from frontmatter WITHOUT any projector wired.
+      const reloaded = createStore({ root }).orThrow();
+      expect(await reloaded.getById('knowledge' as MemoryScopeKey, 'doc-a' as never)).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown> | undefined) => {
+          expect(rec?.envelope.rank).toBe(4);
+        }
+      );
+    });
+  });
+
+  describe('orderBy: rank retrieval (store-stamped ranks flow end-to-end)', () => {
+    async function indexFromStore(store: FileTreeMemoryStore): Promise<MemoryIndex> {
+      const records = (await store.list()).orThrow();
+      const index = MemoryIndex.create().orThrow();
+      // Scope is not returned by `list`; a per-id synthetic scope keeps the
+      // (scope, id) index keys distinct, which is all ordering needs here.
+      index
+        .rebuild(
+          records.map((record) => ({ scope: record.envelope.id as unknown as MemoryScopeKey, record }))
+        )
+        .orThrow();
+      return index;
+    }
+
+    test('orders by store-stamped rank descending, honoring kinds + limit + offset', async () => {
+      const store = createStore({ rankProjectors: knowledgeProjectors }).orThrow();
+      // ranks: a=1, bbb=3, cc=2 (by body length)
+      await store.put(makeRecord({ id: 'a', body: 'a' }));
+      await store.put(makeRecord({ id: 'bbb', body: 'bbb' }));
+      await store.put(makeRecord({ id: 'cc', body: 'cc' }));
+      // A plain-kind record has no projector → rank absent → sorts last.
+      await store.put(makeRecord({ id: 'p', kind: plainKind, body: 'zzzz' }));
+
+      const retriever = RecencyRetriever.create(await indexFromStore(store)).orThrow();
+      expect(await retriever.retrieve({ orderBy: 'rank' })).toSucceedAndSatisfy(
+        (records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+          expect(records.map((r) => r.envelope.id)).toEqual(['bbb', 'cc', 'a', 'p']);
+        }
+      );
+
+      // Kind-set scoped, rank-ordered, paged: skip the top, take one.
+      expect(
+        await retriever.retrieve({ kinds: [knowledgeKind], orderBy: 'rank', limit: 1, offset: 1 })
+      ).toSucceedAndSatisfy((records: ReadonlyArray<IMemoryRecord<unknown>>) => {
+        expect(records.map((r) => r.envelope.id)).toEqual(['cc']);
+      });
+    });
+  });
+});

--- a/libraries/ts-agent-memory/src/test/unit/store/rankAxis.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/rankAxis.test.ts
@@ -184,6 +184,63 @@ describe('FileTreeMemoryStore rank axis', () => {
       );
       expect(logger.logged.some((m) => /rank projector threw/i.test(m))).toBe(true);
     });
+
+    test('an UPDATE whose projector throws CLEARS the prior rank (flat path staleness contract)', async () => {
+      let shouldThrow: boolean = false;
+      const flakyProjector: RankProjector = (record) => {
+        if (shouldThrow) {
+          throw new Error('projector boom');
+        }
+        return (record.body as string).length;
+      };
+      const store = createStore({
+        rankProjectors: new Map<Kind, RankProjector>([[knowledgeKind, flakyProjector]])
+      }).orThrow();
+      // First write succeeds → rank stamped to a nonzero value.
+      expect(await store.put(makeRecord({ id: 'doc-a', body: 'abcd' }))).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown>) => {
+          expect(rec.envelope.rank).toBe(4);
+        }
+      );
+      // Update with a body revision while the projector now throws → the prior
+      // rank (4) must NOT survive; the record is stamped rank-absent.
+      shouldThrow = true;
+      clockValue = 2000;
+      expect(await store.put(makeRecord({ id: 'doc-a', body: 'abcdefgh' }))).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown>) => {
+          expect(rec.envelope.rank).toBeUndefined();
+          expect(rec.envelope.updated).toBe(2000);
+        }
+      );
+    });
+
+    test('an UPDATE whose projector throws CLEARS the prior rank (versioned path staleness contract)', async () => {
+      let shouldThrow: boolean = false;
+      const flakyProjector: RankProjector = (record) => {
+        if (shouldThrow) {
+          throw new Error('projector boom');
+        }
+        return (record.body as string).length;
+      };
+      const store = createStore({
+        rankProjectors: new Map<Kind, RankProjector>([[factKind, flakyProjector]]),
+        writePolicies: temporalPolicies
+      }).orThrow();
+      expect(await store.put(makeRecord({ id: 'fact-1', kind: factKind, body: 'aa' }))).toSucceedAndSatisfy(
+        (rec: IMemoryRecord<unknown>) => {
+          expect(rec.envelope.rank).toBe(2);
+        }
+      );
+      shouldThrow = true;
+      clockValue = 2000;
+      // The new version merges over the current version (which carried rank 2);
+      // the throwing projector must clear it so the new version is rank-absent.
+      expect(
+        await store.put(makeRecord({ id: 'fact-1', kind: factKind, body: 'aaaaa' }))
+      ).toSucceedAndSatisfy((rec: IMemoryRecord<unknown>) => {
+        expect(rec.envelope.rank).toBeUndefined();
+      });
+    });
   });
 
   describe('put stamps rank (versioned / temporal path)', () => {


### PR DESCRIPTION
## Summary

Adds an additive, **store-maintained numeric ranking axis** (host-populated) to `@fgv/ts-agent-memory`, so a consumer can retrieve a bounded top-M ordered by a per-record numeric value **without a full-vault scan**. Three composing pieces:

1. **Per-kind host projector** — optional `rankProjectors?: ReadonlyMap<Kind, RankProjector>` on `IFileTreeMemoryStoreCreateParams`. `RankProjector = (record: IMemoryRecord<unknown>) => number`. Absent for a kind → that kind's records carry no rank.
2. **Store-maintained envelope field** — `IMemoryEnvelope.rank?: number`, computed on the fully-resolved (post-merge) record in the same pass that recomputes `contentHash`, round-tripped through the YAML frontmatter serializer/converter.
3. **Rank-ordered retrieval** — `IMemoryIndex.byRank()` (descending, absent-last, recency tiebreak), a `rankCompare` comparator + `orderingCompare` selector, and an `IMemoryQuery.orderBy: 'recency' | 'rank'` axis wired into the non-semantic retrievers (recency / tag / structured-filter / **link-traversal**) and the hybrid post-merge ordering. Reuses the existing `{ limit, offset }` window for the bounded top-M page.

## Additive / byte-identical when absent

An absent `rankProjectors` map leaves every write byte-identical (no `rank` stamped); an absent/`'recency'` `orderBy` produces today's exact ordering (`orderingCompare` returns `recencyCompare`); the hybrid only re-sorts when `orderBy: 'rank'`. `rank` is an optional envelope field, so existing persisted files load unchanged.

## Both write paths stamp rank (load-bearing)

A single `_stampRank` helper is invoked with `.onSuccess((built) => succeed(this._stampRank(built)))` on the fully-built, fully-hashed record on **both** paths: `_admitWrite` (non-versioned `_writeResolved`) and `_putVersioned` (temporal). Because a body revision changes `contentHash`, it is always a real update that reaches the stamp pass, so `rank` is always consistent with the current body. The serializer round-trips `rank` (raw-frontmatter assertion + fresh-store reload test, no recompute-on-load).

## Judgment calls (decided + documented)

- **Public naming:** `rankProjectors` map of `RankProjector`, stamping `IMemoryEnvelope.rank`.
- **Throwing projector:** logged at `warn`, treated as **rank-absent**, write still succeeds. Kept as `(record) => number` + throw-guard (NOT `Result<number>`) — consistent with the package's tool-layer host-callback convention (`handleFor` / `projectItem` use the same throw + guard shape) and the consumer's sketch.
- **`orderBy: 'rank'` × semantic retriever:** `orderBy` governs the ordered non-semantic retrievers (recency / tag / structured-filter / link-traversal) and the hybrid post-merge ordering. The `SemanticRetriever` is the **sole documented exception** — it preserves its native vector-similarity order.
- **`byRank()` maintenance:** computed-on-call, mirroring `byRecency`/`_recencyOrdered`.
- **Comparator duplication:** `rankCompare` lives in `retrieve`; the index inlines an equivalent private `_compareByRank` (the index must not depend on `retrieve`). A cross-reference test asserts the two agree pairwise on a shared fixture, guarding against tie-break drift.
- **Projector change between sessions:** old records keep their persisted `rank` until their next write (v1 "revises on next write").

## Gate round (code-reviewer) — three fixes applied

Second commit (`910d334f4`) addresses the gate findings:

- **FIX 1 (P2, real bug — stale rank on a throwing UPDATE).** `_stampRank`'s catch branch previously returned the record verbatim. On an update the merged envelope carries the prior version's `rank` (the write-policy merge does not touch `rank`), so a throwing projector kept a value now inconsistent with the revised body — violating the staleness contract and the documented "throw → rank absent". The catch branch now stamps `rank: undefined`, so a throw ALWAYS yields the documented no-rank state. Regression tests added on **both** write paths (flat + versioned): working projector sets a nonzero rank, then an update with a throwing projector asserts `rank` is `undefined`.
- **FIX 2 (P2, completeness — LinkTraversalRetriever ignored `orderBy`).** It was still hard-coding `.sort(recencyCompare)`; its final sort now uses `orderingCompare(query.orderBy)` for parity with the other non-semantic retrievers. Added orderBy coverage (default recency, `orderBy: 'rank'`, `+limit/offset`); the `IMemoryQuery.orderBy` TSDoc now lists link-traversal in the governed set, semantic as the sole exception.
- **FIX 3 (P3, robustness — comparator drift guard).** Added a cross-reference test asserting the index's `_compareByRank` (via `byRank()`) and the retrieve packlet's `rankCompare` agree pairwise on a shared mixed fixture (ranked / absent / equal-rank-different-recency).

## Gate results (in `libraries/ts-agent-memory`)

- `rushx build` — passes; `etc/ts-agent-memory.api.md` regenerated (round 1); **unchanged in the fix round** (internal wiring + docs + tests only).
- `rushx fixlint` + `rushx lint` — clean.
- `rushx test` — all suites pass, **100% coverage** (statements / branches / functions / lines) in both rounds.
- Changeset added (**minor**, additive).

## Review-loop note

Self-reviewed against `.ai/instructions/CODE_REVIEW_CHECKLIST.md`. Gate `code-reviewer` findings addressed in one consolidated round (FIX 1–3 above); the `RankProjector` `Result`-vs-throw disposition is retained per the gate note.

## For the orchestrator to double-check at the gate

- `_stampRank` composition order relative to `_embedOnWrite` (rank stamped first; embed spreads the envelope preserving `rank`) on both paths — and the new clear-on-throw behavior on the update path specifically.
- The absent-rank-last invariant across both comparator implementations (`rankCompare` in `retriever.ts` and `_compareByRank` in `memoryIndex.ts`), now backed by the cross-reference test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch