### PR TITLE
feat(ts-agent-memory)!: scope-qualified edge targets (IEdge.target -> IEdgeTarget)

### DIFF
--- a/common/changes/@fgv/ts-agent-memory/agent-memory-scoped-edges_2026-07-13-00-00.json
+++ b/common/changes/@fgv/ts-agent-memory/agent-memory-scoped-edges_2026-07-13-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "BREAKING: scope-qualified edge targets. IEdge.target is now IEdgeTarget ({ scope, id }) instead of a bare MemoryId, so edges/backlinks/link-traversal/ingest-validation are unambiguous across scopes that reuse a filename stem (e.g. the MTM codec's turn-<n> stems). Adds IEdgeTarget + edgeTargetKey + edgeTargetConverter; IMemoryIndex.backlinks, IMemoryQuery.linkedFrom/linkedTo, ICandidateEdge.source, IRelationCandidate.id, and ICycleGuardEdge source/target all become scope-qualified. The memory_write link input and memory_context from seed adopt a nested { id, scope? } shape (write defaults an omitted scope to the writing record's own scope; context requires it). No back-compat shim; the frontmatter edge format now serializes target as a nested object.",
+      "type": "minor",
+      "packageName": "@fgv/ts-agent-memory"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory",
+  "email": "noreply@anthropic.com"
+}

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -35,6 +35,19 @@ opportunistically when the right surface area is touched.
 
 ## P2 — Fix before next major feature in affected area
 
+- **[P3] `@fgv/ts-agent-memory` `IProvenance.derivedFrom` carries the same latent bare-id ambiguity that scope-qualified edges just fixed.**
+  The scoped-edge-targets change (`IEdge.target: MemoryId → IEdgeTarget`) made every attributed edge unambiguous across scopes, and threaded the same `(scope, id)` fix through backlinks, link traversal, the ingest cycle guard, and the ingest edge-validation path. `IProvenance.derivedFrom` (`libraries/ts-agent-memory/src/packlets/types/envelope.ts`) remains a bare `MemoryId` and shares the identical root cause: per-scope codecs (e.g. the MTM codec's `turn-<n>` stems) legally reuse a stem across scopes, so a bare `derivedFrom` id is ambiguous. It is **not dereferenced anywhere today** — the ingest pipeline only stamps it from `IIngestItem.sourceId` and never resolves it back to a record — so there is no live correctness bug, only a latent one that would surface the moment a consumer tries to walk the provenance spine by id.
+
+  Also left bare in the same stream (a separate, larger follow-on): the vector/similarity path — `IVectorIndex` / `InMemoryCosineIndex._vectors`, `IEntityResolutionCandidate.id`, and `ResolutionVerdict`'s `target: MemoryId` arms + their `_indexById`/`byId` bare lookups in the orchestrator. Those share the root cause but were deliberately scoped out (the ingest verdict/similarity path still keys on a bare `byId` snapshot index).
+
+  **Trigger**: when a consumer needs to dereference `derivedFrom` (or the vector/verdict path) back to a specific record, or when the vector-path scoping is picked up as its own stream.
+
+  **Scope sketch**: promote `derivedFrom` to `IEdgeTarget` (or a `{ scope, id }` pair) and fix the ingest stamping site; for the vector path, scope `IVectorIndex` keys and the verdict target arms together (they interlock through `_indexById`).
+
+  **Not a P2**: `derivedFrom` is never dereferenced today, so there is no functional gap — purely latent.
+
+  **Reference**: the `agent-memory-scoped-edges` stream (scope-qualified `IEdge.target`). The design explicitly deferred both `derivedFrom` and the vector/verdict path as out-of-scope.
+
 - **[P2] `ts-prompt-assist` (and adjacent `ts-res` qualifier surface) needs an API documentation pass once the v0.1 surface settles.**
   PR #380 review surfaced that the recently-extended `ts-prompt-assist` surface — `PromptLibrary` + `IPromptLibraryCreateParams` + `IPromptResolveRequest` + the related fixture / resource-binding / resolve-output types — carries minimal TSDoc on individual methods, parameters, and return shapes. The v0.1 surface has been moving fast (Phase B sub-phases + post-merge cleanups + surface-tidy + round-1 ergonomics absorption), so documenting heavily during churn was the right call; with v0.1 effectively settled now, the next concern is consumer-facing TSDoc quality on the public surface.
 

--- a/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
+++ b/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
@@ -97,6 +97,12 @@ export function defaultMemoryScopeEncoding(scope: MemoryScopeKey): Result<string
 export const edgeConverter: Converter<IEdge>;
 
 // @public
+export const edgeTargetConverter: Converter<IEdgeTarget>;
+
+// @public
+export function edgeTargetKey(target: IEdgeTarget): string;
+
+// @public
 export type EntityId = Brand<string, 'EntityId'>;
 
 // @public
@@ -147,7 +153,7 @@ export interface IBodyConverterRegistry {
 // @public
 export interface ICandidateEdge {
     readonly edge: IEdge;
-    readonly source: MemoryId;
+    readonly source: IEdgeTarget;
 }
 
 // @public
@@ -172,9 +178,9 @@ export interface ICreateMemoryToolsParams {
 // @public
 export interface ICycleGuardEdge {
     // (undocumented)
-    readonly source: MemoryId;
+    readonly source: IEdgeTarget;
     // (undocumented)
-    readonly target: MemoryId;
+    readonly target: IEdgeTarget;
     // (undocumented)
     readonly type: LinkType;
 }
@@ -184,9 +190,15 @@ export interface IEdge {
     readonly confidence?: number;
     readonly invalid_at?: number | null;
     readonly provenance?: IProvenance;
-    readonly target: MemoryId;
+    readonly target: IEdgeTarget;
     readonly type: LinkType;
     readonly valid_at?: number;
+}
+
+// @public
+export interface IEdgeTarget {
+    readonly id: MemoryId;
+    readonly scope: MemoryScopeKey;
 }
 
 // @public
@@ -311,7 +323,7 @@ export interface IMemoryFileParts {
 
 // @public
 export interface IMemoryIndex {
-    backlinks(target: MemoryId): ReadonlyArray<MemoryId>;
+    backlinks(target: IEdgeTarget): ReadonlyArray<IEdgeTarget>;
     byKind(kind: Kind): ReadonlyArray<IMemoryRecord<unknown>>;
     byRank(): ReadonlyArray<IMemoryRecord<unknown>>;
     byRecency(): ReadonlyArray<IMemoryRecord<unknown>>;
@@ -390,8 +402,8 @@ export interface IMemoryQuery {
     readonly kind?: Kind;
     readonly kinds?: ReadonlyArray<Kind>;
     readonly limit?: number;
-    readonly linkedFrom?: MemoryId;
-    readonly linkedTo?: MemoryId;
+    readonly linkedFrom?: IEdgeTarget;
+    readonly linkedTo?: IEdgeTarget;
     readonly offset?: number;
     readonly orderBy?: 'recency' | 'rank';
     readonly scope?: MemoryScopeKey;
@@ -492,7 +504,7 @@ export interface IProvenance {
 // @public
 export interface IRelationCandidate {
     readonly candidate: ICandidateRecord;
-    readonly id: MemoryId;
+    readonly id: IEdgeTarget;
 }
 
 // @public
@@ -639,7 +651,7 @@ export type MemoryId = Brand<string, 'MemoryId'>;
 
 // @public
 export class MemoryIndex implements IMemoryIndex {
-    backlinks(target: MemoryId): ReadonlyArray<MemoryId>;
+    backlinks(target: IEdgeTarget): ReadonlyArray<IEdgeTarget>;
     byKind(kind: Kind): ReadonlyArray<IMemoryRecord<unknown>>;
     byRank(): ReadonlyArray<IMemoryRecord<unknown>>;
     byRecency(): ReadonlyArray<IMemoryRecord<unknown>>;

--- a/libraries/ts-agent-memory/src/packlets/converters/envelopeConverter.ts
+++ b/libraries/ts-agent-memory/src/packlets/converters/envelopeConverter.ts
@@ -5,7 +5,15 @@
 
 import { Converter, Converters, Result, fail, succeed } from '@fgv/ts-utils';
 import { Yaml } from '@fgv/ts-extras';
-import { Convert, IEdge, IMemoryEnvelope, IMemoryRecord, IProvenance, ITemporalBlock } from '../types';
+import {
+  Convert,
+  IEdge,
+  IEdgeTarget,
+  IMemoryEnvelope,
+  IMemoryRecord,
+  IProvenance,
+  ITemporalBlock
+} from '../types';
 import { IBodyConverterRegistry } from './bodyConverterRegistry';
 
 /** Matches exactly the JSON `null` literal. */
@@ -62,13 +70,24 @@ export const provenanceConverter: Converter<IProvenance> = Converters.generic<IP
 );
 
 /**
+ * Converter for a scope-qualified {@link IEdgeTarget}. Both `scope` and `id`
+ * are required — the whole point of the scoped target is that a bare id is
+ * ambiguous across scopes.
+ * @public
+ */
+export const edgeTargetConverter: Converter<IEdgeTarget> = Converters.object<IEdgeTarget>({
+  scope: Convert.scopeKey,
+  id: Convert.memoryId
+});
+
+/**
  * Converter for an attributed {@link IEdge}.
  * @public
  */
 export const edgeConverter: Converter<IEdge> = Converters.object<IEdge>(
   {
     type: Convert.linkType,
-    target: Convert.memoryId,
+    target: edgeTargetConverter,
     confidence: Converters.number.optional(),
     provenance: provenanceConverter.optional(),
     valid_at: Converters.number.optional(),

--- a/libraries/ts-agent-memory/src/packlets/index/memoryIndex.ts
+++ b/libraries/ts-agent-memory/src/packlets/index/memoryIndex.ts
@@ -4,7 +4,7 @@
  */
 
 import { Result, succeed } from '@fgv/ts-utils';
-import { IMemoryRecord, Kind, MemoryId, MemoryScopeKey, Tag } from '../types';
+import { IEdgeTarget, IMemoryRecord, Kind, MemoryId, MemoryScopeKey, Tag, edgeTargetKey } from '../types';
 
 /**
  * The mutation a {@link IMemoryIndex.patch | patch} applies: a record was
@@ -81,10 +81,12 @@ export interface IMemoryIndex {
   byRank(): ReadonlyArray<IMemoryRecord<unknown>>;
 
   /**
-   * The ids of records whose `links` point AT `target` (inbound edges).
-   * The seed map for B2 link-traversal.
+   * The scope-qualified sources of records whose `links` point AT `target`
+   * (inbound edges), keyed on the target's `(scope, id)` address. The seed map
+   * for B2 link-traversal; results are {@link IEdgeTarget}s so a caller can feed
+   * them straight back in as further traversal seeds.
    */
-  backlinks(target: MemoryId): ReadonlyArray<MemoryId>;
+  backlinks(target: IEdgeTarget): ReadonlyArray<IEdgeTarget>;
 }
 
 /**
@@ -102,18 +104,21 @@ export class MemoryIndex implements IMemoryIndex {
   /** tag → set of composite keys. */
   private readonly _byTag: Map<Tag, Set<string>>;
   /**
-   * link target id → (source composite key → source id). Keyed by the source's
-   * `(scope, id)` composite — NOT its bare id — so two distinct source records
-   * that share an id across scopes (e.g. `turn-0` in different conversations)
-   * are tracked independently and removing one never drops the other's edge.
+   * canonical target key (`edgeTargetKey`) → (source composite key → source
+   * {@link IEdgeTarget}). The OUTER map is keyed on the scope-qualified target's
+   * canonical `(scope, id)` string — NOT the target's bare id — so an edge to
+   * `turn-3` in one conversation is tracked separately from `turn-3` in another.
+   * The INNER map is keyed by the source's `(scope, id)` composite so two distinct
+   * source records that share an id across scopes are tracked independently and
+   * removing one never drops the other's edge.
    */
-  private readonly _backlinks: Map<MemoryId, Map<string, MemoryId>>;
+  private readonly _backlinks: Map<string, Map<string, IEdgeTarget>>;
 
   private constructor() {
     this._byKey = new Map<string, IIndexedMemoryRecord>();
     this._byKind = new Map<Kind, Set<string>>();
     this._byTag = new Map<Tag, Set<string>>();
-    this._backlinks = new Map<MemoryId, Map<string, MemoryId>>();
+    this._backlinks = new Map<string, Map<string, IEdgeTarget>>();
   }
 
   /** Family-convention factory. */
@@ -128,7 +133,7 @@ export class MemoryIndex implements IMemoryIndex {
    * is a collision-proof separator across every scope/id pair the codecs produce.
    */
   private static _keyOf(scope: MemoryScopeKey, id: MemoryId): string {
-    return `${scope}\0${id}`;
+    return edgeTargetKey({ scope, id });
   }
 
   /** {@inheritDoc IMemoryIndex.rebuild} */
@@ -181,8 +186,8 @@ export class MemoryIndex implements IMemoryIndex {
   }
 
   /** {@inheritDoc IMemoryIndex.backlinks} */
-  public backlinks(target: MemoryId): ReadonlyArray<MemoryId> {
-    const sources: Map<string, MemoryId> | undefined = this._backlinks.get(target);
+  public backlinks(target: IEdgeTarget): ReadonlyArray<IEdgeTarget> {
+    const sources: Map<string, IEdgeTarget> | undefined = this._backlinks.get(edgeTargetKey(target));
     return sources === undefined ? [] : Array.from(sources.values());
   }
 
@@ -258,7 +263,7 @@ export class MemoryIndex implements IMemoryIndex {
       this._addToSetMap(this._byTag, tag, key);
     }
     for (const edge of envelope.links) {
-      this._addBacklink(edge.target, key, envelope.id);
+      this._addBacklink(edge.target, key, { scope: entry.scope, id: envelope.id });
     }
   }
 
@@ -279,25 +284,27 @@ export class MemoryIndex implements IMemoryIndex {
     }
   }
 
-  /** Register `sourceId` (keyed by its composite `sourceKey`) as linking at `target`. */
-  private _addBacklink(target: MemoryId, sourceKey: string, sourceId: MemoryId): void {
-    const existing: Map<string, MemoryId> | undefined = this._backlinks.get(target);
+  /** Register `source` (keyed by its composite `sourceKey`) as linking at `target`. */
+  private _addBacklink(target: IEdgeTarget, sourceKey: string, source: IEdgeTarget): void {
+    const targetKey: string = edgeTargetKey(target);
+    const existing: Map<string, IEdgeTarget> | undefined = this._backlinks.get(targetKey);
     if (existing === undefined) {
-      this._backlinks.set(target, new Map<string, MemoryId>([[sourceKey, sourceId]]));
+      this._backlinks.set(targetKey, new Map<string, IEdgeTarget>([[sourceKey, source]]));
     } else {
-      existing.set(sourceKey, sourceId);
+      existing.set(sourceKey, source);
     }
   }
 
   /** Drop the backlink from `sourceKey` to `target`, removing the target map when empty. */
-  private _removeBacklink(target: MemoryId, sourceKey: string): void {
-    const existing: Map<string, MemoryId> | undefined = this._backlinks.get(target);
+  private _removeBacklink(target: IEdgeTarget, sourceKey: string): void {
+    const targetKey: string = edgeTargetKey(target);
+    const existing: Map<string, IEdgeTarget> | undefined = this._backlinks.get(targetKey);
     if (existing === undefined) {
       return;
     }
     existing.delete(sourceKey);
     if (existing.size === 0) {
-      this._backlinks.delete(target);
+      this._backlinks.delete(targetKey);
     }
   }
 

--- a/libraries/ts-agent-memory/src/packlets/ingest/cycleGuard.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/cycleGuard.ts
@@ -4,17 +4,22 @@
  */
 
 import { Hash, Result, fail, mapResults, succeed } from '@fgv/ts-utils';
-import { LinkType, MemoryId } from '../types';
+import { IEdgeTarget, LinkType, edgeTargetKey } from '../types';
 
 /**
- * A directed edge in the link graph the cycle guard reasons over: `source` links
- * to `target` under relation `type`.
+ * A directed edge in the link graph the cycle guard reasons over: scope-qualified
+ * `source` links to scope-qualified `target` under relation `type`.
  * @public
  */
 export interface ICycleGuardEdge {
-  readonly source: MemoryId;
-  readonly target: MemoryId;
+  readonly source: IEdgeTarget;
+  readonly target: IEdgeTarget;
   readonly type: LinkType;
+}
+
+/** Human-readable `scope/id` rendering of a scoped node, for cycle-guard diagnostics. */
+function formatNode(node: IEdgeTarget): string {
+  return `${node.scope}/${node.id}`;
 }
 
 /**
@@ -69,17 +74,23 @@ export function assertNoCycles(
       }
       for (const keyed of proposedKeyed) {
         const edge: ICycleGuardEdge = keyed.edge;
+        const sourceKey: string = edgeTargetKey(edge.source);
+        const targetKey: string = edgeTargetKey(edge.target);
         // A self-loop is the degenerate one-node cycle.
-        if (edge.source === edge.target) {
+        if (sourceKey === targetKey) {
           return fail(
-            `ingest cycle guard: edge '${edge.source}' -${edge.type}-> '${edge.target}' is a self-loop`
+            `ingest cycle guard: edge '${formatNode(edge.source)}' -${edge.type}-> '${formatNode(
+              edge.target
+            )}' is a self-loop`
           );
         }
         // Reachability: does `target` already reach `source`? If so, adding
         // `source -> target` closes a directed cycle.
-        if (reaches(adjacency, edge.target, edge.source)) {
+        if (reaches(adjacency, targetKey, sourceKey)) {
           return fail(
-            `ingest cycle guard: edge '${edge.source}' -${edge.type}-> '${edge.target}' would create a cycle`
+            `ingest cycle guard: edge '${formatNode(edge.source)}' -${edge.type}-> '${formatNode(
+              edge.target
+            )}' would create a cycle`
           );
         }
         addEdge(adjacency, seenKeys, keyed);
@@ -106,8 +117,8 @@ function addEdge(adjacency: Map<string, Set<string>>, seenKeys: Set<string>, key
     return;
   }
   seenKeys.add(keyed.key);
-  const source: string = keyed.edge.source;
-  const target: string = keyed.edge.target;
+  const source: string = edgeTargetKey(keyed.edge.source);
+  const target: string = edgeTargetKey(keyed.edge.target);
   const targets: Set<string> | undefined = adjacency.get(source);
   if (targets === undefined) {
     adjacency.set(source, new Set<string>([target]));

--- a/libraries/ts-agent-memory/src/packlets/ingest/hostStages.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/hostStages.ts
@@ -4,7 +4,7 @@
  */
 
 import { Result } from '@fgv/ts-utils';
-import { MemoryId } from '../types';
+import { IEdgeTarget } from '../types';
 import {
   ICandidateEdge,
   ICandidateRecord,
@@ -90,8 +90,8 @@ export interface IRelationContext {
 export interface IRelationCandidate {
   /** The candidate about to be written. */
   readonly candidate: ICandidateRecord;
-  /** Its resolved reference id (codec `idStem` — the stable entity reference). */
-  readonly id: MemoryId;
+  /** Its resolved scope-qualified reference (codec `(scope, idStem)` — the stable entity address). */
+  readonly id: IEdgeTarget;
 }
 
 /**

--- a/libraries/ts-agent-memory/src/packlets/ingest/model.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/model.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { IEdge, IMemoryEnvelope, IMemoryRecord, Kind, MemoryId, Tag } from '../types';
+import { IEdge, IEdgeTarget, IMemoryEnvelope, IMemoryRecord, Kind, MemoryId, Tag } from '../types';
 
 /**
  * A single unit of raw source material handed to the ingest pipeline. The host
@@ -129,8 +129,8 @@ export type IngestDisposition = 'written' | 'deduped' | 'merged';
  * @public
  */
 export interface ICandidateEdge {
-  /** The reference id (codec `idStem`) of the candidate the edge originates from. */
-  readonly source: MemoryId;
+  /** The scope-qualified reference (codec `(scope, idStem)`) of the candidate the edge originates from. */
+  readonly source: IEdgeTarget;
   /** The attributed edge (type / target / optional confidence / provenance). */
   readonly edge: IEdge;
 }

--- a/libraries/ts-agent-memory/src/packlets/ingest/orchestrator.ts
+++ b/libraries/ts-agent-memory/src/packlets/ingest/orchestrator.ts
@@ -8,6 +8,7 @@ import {
   Convert,
   EntityId,
   IEdge,
+  IEdgeTarget,
   IIdentityCodec,
   IIdentityCodecResult,
   IMemoryEnvelope,
@@ -18,6 +19,7 @@ import {
   MemoryId,
   MemoryScopeKey,
   Tag,
+  edgeTargetKey,
   isTemporalRecord,
   isVersionCurrent
 } from '../types';
@@ -156,6 +158,12 @@ interface ISimilarityWiring {
   readonly embed: MemoryEmbedder;
 }
 
+/** A snapshot record paired with its resolved scope-qualified `(scope, id)` address. */
+interface IScopedRecord {
+  readonly address: IEdgeTarget;
+  readonly record: IMemoryRecord<unknown>;
+}
+
 /** Internal per-candidate plan threaded through the pipeline. */
 interface ICandidatePlan {
   readonly candidate: ICandidateRecord;
@@ -165,6 +173,12 @@ interface ICandidatePlan {
   readonly writeEntityId: EntityId;
   /** The reference id used in stage-5 edges (the write target's `idStem`). */
   readonly refId: MemoryId;
+  /**
+   * The scope-qualified reference used in stage-5 edges: the write target's
+   * `(scope, idStem)`. Stage-5 sources / dedup all key on this scoped address so
+   * two candidates that share a stem across scopes never collide.
+   */
+  readonly refTarget: IEdgeTarget;
   /** The resolution verdict; carries the target id on its target-bearing arms. */
   readonly verdict: ResolutionVerdict;
   /**
@@ -269,6 +283,14 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     }
     const snapshot: ReadonlyArray<IMemoryRecord<unknown>> = snapshotResult.value;
     const byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>> = MemoryIngestOrchestrator._indexById(snapshot);
+    // Resolve every snapshot record's scope-qualified address ONCE. The scoped
+    // view drives the edge path (validation + cycle guard); the bare `byId` above
+    // still serves the verdict/similarity target lookups (those stay bare).
+    const scopedResult: Result<ReadonlyArray<IScopedRecord>> = this._scopeRecords(snapshot);
+    if (scopedResult.isFailure()) {
+      return fail(`ingest '${item.id}': ${scopedResult.message}`);
+    }
+    const scoped: ReadonlyArray<IScopedRecord> = scopedResult.value;
 
     // Stage 3b + 4: validate each body and resolve a verdict/plan.
     const plans: ICandidatePlan[] = [];
@@ -285,8 +307,7 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     const edgesResult: Result<ReadonlyArray<ICandidateEdge>> = await this._relate(
       item,
       writablePlans,
-      snapshot,
-      byId
+      scoped
     );
     if (edgesResult.isFailure()) {
       return fail(edgesResult.message);
@@ -357,6 +378,7 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
           writeAddress: addr,
           writeEntityId: candidate.envelope.entityId,
           refId,
+          refTarget: { scope: addr.scope, id: refId },
           verdict
         })
       );
@@ -378,20 +400,24 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
       // Re-address the write to the target's entity, carrying the target record so
       // stage 6 can UNION its existing tags/links (never overwrite them).
       const targetEntityId: EntityId = target.envelope.entityId;
-      return this._resolveAddress(targetEntityId, target.envelope.kind)
-        .withErrorFormat((msg) => `ingest '${item.id}': ${msg}`)
-        .onSuccess((targetAddr) =>
-          Convert.memoryId.convert(targetAddr.idStem).onSuccess((refId) =>
-            succeed({
-              candidate,
-              writeAddress: targetAddr,
-              writeEntityId: targetEntityId,
-              refId,
-              verdict,
-              mergeTarget: target
-            })
-          )
-        );
+      // The merge target is a snapshot record, and `_scopeRecords` already proved
+      // every snapshot record's address resolves before planning runs — so this
+      // re-resolve (needed for the full codec result: scope + idStem + isVersioned)
+      // cannot fail. No error-context wrap is warranted; a failure here would be a
+      // logic contradiction, not a user-facing condition.
+      return this._resolveAddress(targetEntityId, target.envelope.kind).onSuccess((targetAddr) =>
+        Convert.memoryId.convert(targetAddr.idStem).onSuccess((refId) =>
+          succeed({
+            candidate,
+            writeAddress: targetAddr,
+            writeEntityId: targetEntityId,
+            refId,
+            refTarget: { scope: targetAddr.scope, id: refId },
+            verdict,
+            mergeTarget: target
+          })
+        )
+      );
     }
     // duplicate-of | supersede: write under the candidate's own address.
     return Convert.memoryId.convert(addr.idStem).onSuccess((refId) =>
@@ -400,6 +426,7 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
         writeAddress: addr,
         writeEntityId: candidate.envelope.entityId,
         refId,
+        refTarget: { scope: addr.scope, id: refId },
         verdict
       })
     );
@@ -546,12 +573,11 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
   private async _relate(
     item: IIngestItem,
     writablePlans: ReadonlyArray<ICandidatePlan>,
-    snapshot: ReadonlyArray<IMemoryRecord<unknown>>,
-    byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>>
+    scoped: ReadonlyArray<IScopedRecord>
   ): Promise<Result<ReadonlyArray<ICandidateEdge>>> {
     const relationCandidates: IRelationCandidate[] = writablePlans.map((plan) => ({
       candidate: plan.candidate,
-      id: plan.refId
+      id: plan.refTarget
     }));
     const proposed: Result<ReadonlyArray<ICandidateEdge>> = await this._capture(
       () => this._relationExtractor.relate({ item, candidates: relationCandidates }),
@@ -560,14 +586,21 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     if (proposed.isFailure()) {
       return proposed;
     }
-    const refIds: ReadonlySet<string> = new Set<string>(writablePlans.map((plan) => plan.refId));
-    const validation: Result<true> = this._validateEdges(item, proposed.value, refIds, byId);
+    // refIds and the existing-record view both key on the canonical scoped
+    // address, so a stem reused across scopes never aliases.
+    const refIds: ReadonlySet<string> = new Set<string>(
+      writablePlans.map((plan) => edgeTargetKey(plan.refTarget))
+    );
+    const byKey: ReadonlyMap<string, IMemoryRecord<unknown>> = new Map<string, IMemoryRecord<unknown>>(
+      scoped.map((s) => [edgeTargetKey(s.address), s.record])
+    );
+    const validation: Result<true> = this._validateEdges(item, proposed.value, refIds, byKey);
     if (validation.isFailure()) {
       return fail(validation.message);
     }
     if (this._cycleGuard === 'reject') {
       const guard: Result<true> = assertNoCycles(
-        MemoryIngestOrchestrator._existingEdges(snapshot),
+        MemoryIngestOrchestrator._existingEdges(scoped),
         proposed.value.map((e) => ({ source: e.source, target: e.edge.target, type: e.edge.type }))
       );
       if (guard.isFailure()) {
@@ -579,22 +612,30 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
 
   /**
    * Validate stage-5 edges: each `source` must be a candidate being written; each
-   * `target` must resolve to a sibling candidate or an existing store record.
+   * `target` must resolve to a sibling candidate or an existing store record. All
+   * matching is on the canonical scope-qualified address.
    */
   private _validateEdges(
     item: IIngestItem,
     edges: ReadonlyArray<ICandidateEdge>,
     refIds: ReadonlySet<string>,
-    byId: ReadonlyMap<MemoryId, IMemoryRecord<unknown>>
+    byKey: ReadonlyMap<string, IMemoryRecord<unknown>>
   ): Result<true> {
     return mapResults(
       edges.map((edge) => {
-        if (!refIds.has(edge.source)) {
-          return fail(`ingest '${item.id}': edge source '${edge.source}' is not a candidate being written`);
-        }
-        if (!refIds.has(edge.edge.target) && byId.get(edge.edge.target) === undefined) {
+        if (!refIds.has(edgeTargetKey(edge.source))) {
           return fail(
-            `ingest '${item.id}': edge target '${edge.edge.target}' resolves to neither a sibling candidate nor an existing record`
+            `ingest '${item.id}': edge source '${MemoryIngestOrchestrator._formatTarget(
+              edge.source
+            )}' is not a candidate being written`
+          );
+        }
+        const targetKey: string = edgeTargetKey(edge.edge.target);
+        if (!refIds.has(targetKey) && byKey.get(targetKey) === undefined) {
+          return fail(
+            `ingest '${item.id}': edge target '${MemoryIngestOrchestrator._formatTarget(
+              edge.edge.target
+            )}' resolves to neither a sibling candidate nor an existing record`
           );
         }
         return succeed(true);
@@ -608,7 +649,8 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     plan: ICandidatePlan,
     allEdges: ReadonlyArray<ICandidateEdge>
   ): Promise<Result<IIngestedRecordResult>> {
-    const myEdges: ReadonlyArray<ICandidateEdge> = allEdges.filter((e) => e.source === plan.refId);
+    const refKey: string = edgeTargetKey(plan.refTarget);
+    const myEdges: ReadonlyArray<ICandidateEdge> = allEdges.filter((e) => edgeTargetKey(e.source) === refKey);
     if (plan.verdict.verdict === 'duplicate-of') {
       // No write: the existing target satisfied the candidate. The target id is a
       // typed field of the narrowed `duplicate-of` verdict — no cast, no guard.
@@ -751,17 +793,44 @@ export class MemoryIngestOrchestrator implements IMemoryIngestOrchestrator {
     return byId;
   }
 
-  /** Every existing outbound edge in the snapshot, as cycle-guard edges. */
-  private static _existingEdges(
-    records: ReadonlyArray<IMemoryRecord<unknown>>
-  ): ReadonlyArray<ICycleGuardEdge> {
+  /**
+   * Every existing outbound edge in the snapshot, as cycle-guard edges. The
+   * source is the record's own scope-qualified address (already resolved by
+   * {@link MemoryIngestOrchestrator._scopeRecords}); the target is the edge's
+   * own scoped target. Both ends are scoped so the guard never conflates a stem
+   * shared across scopes into one graph node.
+   */
+  private static _existingEdges(scoped: ReadonlyArray<IScopedRecord>): ReadonlyArray<ICycleGuardEdge> {
     const edges: ICycleGuardEdge[] = [];
-    for (const record of records) {
-      for (const edge of record.envelope.links) {
-        edges.push({ source: record.envelope.id, target: edge.target, type: edge.type });
+    for (const s of scoped) {
+      for (const edge of s.record.envelope.links) {
+        edges.push({ source: s.address, target: edge.target, type: edge.type });
       }
     }
     return edges;
+  }
+
+  /**
+   * Resolve every snapshot record's scope-qualified `(scope, id)` address via its
+   * registered codec. Fails loudly if a record's kind has no resolvable codec —
+   * the edge path cannot place an un-scopeable record in the graph, and a missing
+   * codec for a stored kind is a real misconfiguration, not something to paper over.
+   */
+  private _scopeRecords(
+    records: ReadonlyArray<IMemoryRecord<unknown>>
+  ): Result<ReadonlyArray<IScopedRecord>> {
+    return mapResults(
+      records.map((record) =>
+        this._resolveAddress(record.envelope.entityId, record.envelope.kind)
+          .withErrorFormat((msg) => `cannot resolve scope for stored record '${record.envelope.id}': ${msg}`)
+          .onSuccess((addr) => succeed({ address: { scope: addr.scope, id: record.envelope.id }, record }))
+      )
+    );
+  }
+
+  /** Human-readable `scope/id` rendering of a scoped target for edge-validation diagnostics. */
+  private static _formatTarget(target: IEdgeTarget): string {
+    return `${target.scope}/${target.id}`;
   }
 
   /** A provisional record for embedding a candidate (placeholder txn-time fields). */

--- a/libraries/ts-agent-memory/src/packlets/retrieve/linkTraversalRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/linkTraversalRetriever.ts
@@ -4,7 +4,7 @@
  */
 
 import { Result, fail, succeed } from '@fgv/ts-utils';
-import { IMemoryRecord, MemoryId } from '../types';
+import { IEdgeTarget, IMemoryRecord, edgeTargetKey } from '../types';
 import { IIndexedMemoryRecord, IMemoryIndex } from '../index';
 import {
   IMemoryQuery,
@@ -35,20 +35,23 @@ export const LINK_TRAVERSAL_NO_SEED_MESSAGE: string =
   'link traversal requires a seed id (linkedFrom or linkedTo)';
 
 /**
- * Breadth-first link-traversal retriever. From a seed {@link MemoryId} it walks
- * the link graph up to `query.hops` levels and returns the records reached
- * (excluding the seed), recency-ordered and limited.
+ * Breadth-first link-traversal retriever. From a scope-qualified
+ * {@link IEdgeTarget} seed it walks the link graph up to `query.hops` levels and
+ * returns the records reached (excluding the seed), recency-ordered and limited.
  *
  * @remarks
  * - **Direction.** `linkedFrom` walks OUTBOUND edges (each record's
  *   `envelope.links[].target`); `linkedTo` walks INBOUND edges (the index's
  *   `backlinks`). Exactly one is the seed; `linkedFrom` wins if both are set.
+ * - **Scope-qualified nodes.** Every graph node is an {@link IEdgeTarget}
+ *   `(scope, id)` pair, so following an edge to `turn-3` reaches ONLY the record
+ *   in the edge's own scope — never a same-stem record in another scope.
  * - **Bound + cycle safety.** Traversal is bounded by `hops` (default `1` — a
- *   single hop) and a visited-set guard. The graph is keyed by bare
- *   string {@link MemoryId}s, so a `Set<string>` visited-set is the exact,
- *   collision-free cycle key — no structural hashing (e.g. `Crc32Normalizer`) is
- *   needed. A self-loop or any multi-hop cycle terminates because a revisited id
- *   is never re-expanded.
+ *   single hop) and a visited-set guard. Nodes are canonicalized to their
+ *   `(scope, id)` string via {@link edgeTargetKey}, so a `Set<string>` visited-set
+ *   is the exact, collision-free cycle key — no structural hashing (e.g.
+ *   `Crc32Normalizer`) is needed. A self-loop or any multi-hop cycle terminates
+ *   because a revisited node is never re-expanded.
  * - **Post-filter.** The scope / kind / tag / predicate axes of the query are
  *   applied to the reached records (the link axes are the traversal itself).
  * @public
@@ -80,24 +83,26 @@ export class LinkTraversalRetriever implements IMemoryRetriever {
   /** Run the bounded, cycle-safe BFS and post-filter the reached records. */
   private _traverse(query: IMemoryQuery): Result<ReadonlyArray<IMemoryRecord<unknown>>> {
     const outbound: boolean = query.linkedFrom !== undefined;
-    const seed: MemoryId | undefined = query.linkedFrom ?? query.linkedTo;
+    const seed: IEdgeTarget | undefined = query.linkedFrom ?? query.linkedTo;
     if (seed === undefined) {
       return fail(LINK_TRAVERSAL_NO_SEED_MESSAGE);
     }
     const hops: number = query.hops ?? DEFAULT_HOPS;
-    const byId: ReadonlyMap<MemoryId, IIndexedMemoryRecord[]> = this._indexById();
+    const byKey: ReadonlyMap<string, IIndexedMemoryRecord> = this._indexByKey();
 
-    // The visited-set IS the cycle guard: ids are strings, so set membership is
-    // an exact identity check. The seed is pre-marked so it is never re-added.
-    const visited: Set<string> = new Set<string>([seed]);
-    const reached: MemoryId[] = [];
-    let frontier: MemoryId[] = [seed];
+    // The visited-set IS the cycle guard: nodes are canonicalized to their
+    // `(scope, id)` string, so set membership is an exact identity check. The
+    // seed is pre-marked so it is never re-added.
+    const visited: Set<string> = new Set<string>([edgeTargetKey(seed)]);
+    const reached: IEdgeTarget[] = [];
+    let frontier: IEdgeTarget[] = [seed];
     for (let hop = 0; hop < hops && frontier.length > 0; hop++) {
-      const next: MemoryId[] = [];
-      for (const id of frontier) {
-        for (const neighbor of outbound ? this._outbound(id, byId) : this._inbound(id)) {
-          if (!visited.has(neighbor)) {
-            visited.add(neighbor);
+      const next: IEdgeTarget[] = [];
+      for (const node of frontier) {
+        for (const neighbor of outbound ? this._outbound(node, byKey) : this._inbound(node)) {
+          const neighborKey: string = edgeTargetKey(neighbor);
+          if (!visited.has(neighborKey)) {
+            visited.add(neighborKey);
             reached.push(neighbor);
             next.push(neighbor);
           }
@@ -107,10 +112,10 @@ export class LinkTraversalRetriever implements IMemoryRetriever {
     }
 
     const entries: IIndexedMemoryRecord[] = [];
-    for (const id of reached) {
-      const matches: IIndexedMemoryRecord[] | undefined = byId.get(id);
-      if (matches !== undefined) {
-        entries.push(...matches);
+    for (const node of reached) {
+      const match: IIndexedMemoryRecord | undefined = byKey.get(edgeTargetKey(node));
+      if (match !== undefined) {
+        entries.push(match);
       }
     }
     const ordered: IMemoryRecord<unknown>[] = entries
@@ -121,49 +126,33 @@ export class LinkTraversalRetriever implements IMemoryRetriever {
   }
 
   /**
-   * Group the index's entries by bare {@link MemoryId}. An id can map to more
-   * than one entry when distinct scopes reuse a filename stem (e.g. `turn-0` in
-   * two conversations), so the value is an array.
-   *
-   * @remarks
-   * **Design note (links are globally-scoped identifiers in this phase).** An
-   * {@link IEdge.target} is a bare `MemoryId`, not a `(scope, id)` pair, so
-   * traversal resolves a target across ALL scopes that hold that id. When two
-   * scopes reuse a stem, following an edge to it reaches every match. This
-   * mirrors the `backlinks` index, which is also keyed by bare id. Scope-
-   * qualified link resolution is intentionally out of scope for Phase C and
-   * would be an additive change here (and to {@link IEdge} / the index).
+   * Group the index's entries by their scope-qualified {@link edgeTargetKey}
+   * `(scope, id)` composite. Each composite is the index's primary key, so it maps
+   * to exactly one entry — two records that reuse a filename stem across scopes
+   * (e.g. `turn-0` in two conversations) get distinct keys and never collide.
    */
-  private _indexById(): ReadonlyMap<MemoryId, IIndexedMemoryRecord[]> {
-    const byId: Map<MemoryId, IIndexedMemoryRecord[]> = new Map<MemoryId, IIndexedMemoryRecord[]>();
+  private _indexByKey(): ReadonlyMap<string, IIndexedMemoryRecord> {
+    const byKey: Map<string, IIndexedMemoryRecord> = new Map<string, IIndexedMemoryRecord>();
     for (const entry of this._index.entries()) {
-      const id: MemoryId = entry.record.envelope.id;
-      const existing: IIndexedMemoryRecord[] | undefined = byId.get(id);
-      if (existing === undefined) {
-        byId.set(id, [entry]);
-      } else {
-        existing.push(entry);
-      }
+      byKey.set(edgeTargetKey({ scope: entry.scope, id: entry.record.envelope.id }), entry);
     }
-    return byId;
+    return byKey;
   }
 
-  /** Outbound neighbors: the targets of every edge on the records with this id. */
-  private _outbound(id: MemoryId, byId: ReadonlyMap<MemoryId, IIndexedMemoryRecord[]>): MemoryId[] {
-    const targets: MemoryId[] = [];
-    const matches: IIndexedMemoryRecord[] | undefined = byId.get(id);
-    if (matches !== undefined) {
-      for (const entry of matches) {
-        for (const edge of entry.record.envelope.links) {
-          targets.push(edge.target);
-        }
+  /** Outbound neighbors: the scope-qualified targets of every edge on the record at `node`. */
+  private _outbound(node: IEdgeTarget, byKey: ReadonlyMap<string, IIndexedMemoryRecord>): IEdgeTarget[] {
+    const targets: IEdgeTarget[] = [];
+    const match: IIndexedMemoryRecord | undefined = byKey.get(edgeTargetKey(node));
+    if (match !== undefined) {
+      for (const edge of match.record.envelope.links) {
+        targets.push(edge.target);
       }
     }
     return targets;
   }
 
-  /** Inbound neighbors: the ids whose edges point AT this id (the backlinks). */
-  private _inbound(id: MemoryId): ReadonlyArray<MemoryId> {
-    return this._index.backlinks(id);
+  /** Inbound neighbors: the scope-qualified sources whose edges point AT `node` (the backlinks). */
+  private _inbound(node: IEdgeTarget): ReadonlyArray<IEdgeTarget> {
+    return this._index.backlinks(node);
   }
 }

--- a/libraries/ts-agent-memory/src/packlets/retrieve/retriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/retriever.ts
@@ -4,7 +4,7 @@
  */
 
 import { Result, fail, succeed } from '@fgv/ts-utils';
-import { IMemoryRecord, Kind, MemoryId, MemoryScopeKey, Tag } from '../types';
+import { IEdgeTarget, IMemoryRecord, Kind, MemoryScopeKey, Tag } from '../types';
 import { IIndexedMemoryRecord } from '../index';
 
 /**
@@ -48,10 +48,10 @@ export interface IMemoryQuery {
    * non-positive-`limit` "explicit empty" convention), never "match all".
    */
   readonly kinds?: ReadonlyArray<Kind>;
-  /** Restrict to records linked FROM this id (outbound). */
-  readonly linkedFrom?: MemoryId;
-  /** Restrict to records linked TO this id (inbound / backlinks). */
-  readonly linkedTo?: MemoryId;
+  /** Restrict to records linked FROM this scope-qualified seed (outbound). */
+  readonly linkedFrom?: IEdgeTarget;
+  /** Restrict to records linked TO this scope-qualified seed (inbound / backlinks). */
+  readonly linkedTo?: IEdgeTarget;
   /** BFS hop count for link traversal. Default: 1. */
   readonly hops?: number;
   /**

--- a/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
+++ b/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
@@ -6,7 +6,7 @@
 import { Result, captureResult, fail, succeed } from '@fgv/ts-utils';
 import { JsonSchema } from '@fgv/ts-json-base';
 import { AiAssist } from '@fgv/ts-extras';
-import { Convert, EntityId, IIdentityCodec, IMemoryRecord, Kind, MemoryId, Tag } from '../types';
+import { Convert, EntityId, IEdgeTarget, IIdentityCodec, IMemoryRecord, Kind, MemoryId, Tag } from '../types';
 import { IBodyConverterRegistry, envelopeConverter } from '../converters';
 import { IMemoryStore } from '../store';
 import { IMemoryQuery, IMemoryRetriever } from '../retrieve';
@@ -181,11 +181,27 @@ interface IToolContext {
 // gate is enforced structurally and asserted in the tests.
 // ---------------------------------------------------------------------------
 
+/**
+ * The scope-qualified target of a link edge authored by the agent on a write.
+ * `scope` is optional: when omitted it defaults to the writing record's OWN
+ * resolved scope (the common same-conversation case); supply it explicitly to
+ * point an edge at a record in a different scope.
+ */
+// eslint-disable-next-line @rushstack/typedef-var
+const linkTargetSchema = JsonSchema.object({
+  id: JsonSchema.string({ description: 'The MemoryId of the record this edge points at.' }),
+  scope: JsonSchema.optional(
+    JsonSchema.string({
+      description: "The target record's scope. Defaults to the writing record's own scope when omitted."
+    })
+  )
+});
+
 /** A single attributed link edge as authored by the agent on a write. */
 // eslint-disable-next-line @rushstack/typedef-var
 const linkEdgeSchema = JsonSchema.object({
   type: JsonSchema.string({ description: 'The relation type of the link.' }),
-  target: JsonSchema.string({ description: 'The MemoryId this edge points at.' }),
+  target: linkTargetSchema,
   confidence: JsonSchema.optional(JsonSchema.number({ description: 'Optional confidence in [0, 1].' }))
 });
 
@@ -233,9 +249,24 @@ const searchSchema = JsonSchema.object({
   )
 });
 
+/**
+ * The scope-qualified seed a `memory_context` traversal starts from. Same nested
+ * `{ id, scope? }` shape as a link target, but — unlike a write edge — there is no
+ * writing record to default the scope from, so `scope` MUST be supplied to
+ * disambiguate the seed across scopes (a bare stem like `turn-3` is otherwise
+ * ambiguous). The traversal fails loudly if it is omitted.
+ */
+// eslint-disable-next-line @rushstack/typedef-var
+const contextSeedSchema = JsonSchema.object({
+  id: JsonSchema.string({ description: 'The MemoryId of the seed record to traverse links from.' }),
+  scope: JsonSchema.optional(
+    JsonSchema.string({ description: 'The scope of the seed record. Required — omitting it fails the call.' })
+  )
+});
+
 // eslint-disable-next-line @rushstack/typedef-var
 const contextSchema = JsonSchema.object({
-  from: JsonSchema.string({ description: 'The seed MemoryId to traverse links from.' }),
+  from: contextSeedSchema,
   kind: JsonSchema.optional(JsonSchema.string({ description: 'Restrict reached records to this kind.' })),
   tag: JsonSchema.optional(JsonSchema.string({ description: 'Restrict reached records carrying this tag.' })),
   hops: JsonSchema.optional(JsonSchema.integer({ description: 'BFS hop count (default 1).' })),
@@ -353,13 +384,16 @@ function buildWriteRecord(
   typed: WriteArgs,
   kind: Kind,
   entityId: EntityId,
-  idStem: string
+  idStem: string,
+  sourceScope: string
 ): Result<IMemoryRecord<unknown>> {
   // Plain shapes handed to `envelopeConverter`, which validates each field
-  // (type → LinkType, target → MemoryId) and produces the branded IEdge[].
+  // (type → LinkType, target → { scope, id }) and produces the branded IEdge[].
+  // An edge target with no explicit `scope` defaults to the writing record's own
+  // resolved scope — the same-conversation case authors just an id.
   const links: ReadonlyArray<Record<string, unknown>> = (typed.links ?? []).map((link) => ({
     type: link.type,
-    target: link.target,
+    target: { scope: link.target.scope ?? sourceScope, id: link.target.id },
     ...(link.confidence !== undefined ? { confidence: link.confidence } : {})
   }));
   return envelopeConverter
@@ -391,7 +425,7 @@ function prepareWrite(
           if (addr.isVersioned) {
             return fail(`memory_write: versioned/temporal kind '${kind}' is not supported`);
           }
-          return buildWriteRecord(typed, kind, entityId, addr.idStem).onSuccess((record) =>
+          return buildWriteRecord(typed, kind, entityId, addr.idStem, addr.scope).onSuccess((record) =>
             succeed({ kind, entityId, record })
           );
         })
@@ -553,13 +587,11 @@ function buildContextTool(ctx: IToolContext): AiAssist.IAiClientTool {
         .convert(args)
         .withErrorFormat((msg) => `memory_context: invalid arguments: ${msg}`)
         .onSuccess((typed) =>
-          Convert.memoryId
-            .convert(typed.from)
-            .onSuccess((from) =>
-              resolveOptionalKind(ctx, typed.kind).onSuccess((kind) =>
-                resolveOptionalTag(typed.tag).onSuccess((tag) => succeed({ typed, from, kind, tag }))
-              )
+          resolveContextSeed(typed.from).onSuccess((from) =>
+            resolveOptionalKind(ctx, typed.kind).onSuccess((kind) =>
+              resolveOptionalTag(typed.tag).onSuccess((tag) => succeed({ typed, from, kind, tag }))
             )
+          )
         )
         .thenOnSuccess(async ({ typed, from, kind, tag }) => {
           const detail: MemoryDetailTier = resolveDetail(typed.detail);
@@ -605,6 +637,25 @@ function buildDeleteTool(ctx: IToolContext): AiAssist.IAiClientTool {
           )
         )
   };
+}
+
+/**
+ * Resolve a `memory_context` seed argument into a scope-qualified
+ * {@link IEdgeTarget}. `scope` is structurally optional (the seed shares the edge
+ * target shape) but semantically required here — unlike a write edge there is no
+ * writing record to default it from, and a bare stem is ambiguous across scopes —
+ * so an omitted scope fails loudly rather than guessing.
+ */
+function resolveContextSeed(from: { readonly id: string; readonly scope?: string }): Result<IEdgeTarget> {
+  if (from.scope === undefined) {
+    return fail(
+      "memory_context: 'from.scope' is required — a bare seed id is ambiguous across scopes and cannot be defaulted"
+    );
+  }
+  const scopeStr: string = from.scope;
+  return Convert.memoryId
+    .convert(from.id)
+    .onSuccess((id) => Convert.scopeKey.convert(scopeStr).onSuccess((scope) => succeed({ scope, id })));
 }
 
 /** Validate an optional `tag` string (`undefined` passes through). */

--- a/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
+++ b/libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts
@@ -250,18 +250,19 @@ const searchSchema = JsonSchema.object({
 });
 
 /**
- * The scope-qualified seed a `memory_context` traversal starts from. Same nested
- * `{ id, scope? }` shape as a link target, but — unlike a write edge — there is no
- * writing record to default the scope from, so `scope` MUST be supplied to
+ * The scope-qualified seed a `memory_context` traversal starts from. Nested
+ * `{ id, scope }` shape like a link target, but — unlike a write edge — there is
+ * no writing record to default the scope from, so `scope` is REQUIRED to
  * disambiguate the seed across scopes (a bare stem like `turn-3` is otherwise
- * ambiguous). The traversal fails loudly if it is omitted.
+ * ambiguous). It is schema-required (not just runtime-required) so the wire
+ * schema an LLM reads never advertises an optionality the tool does not honor.
  */
 // eslint-disable-next-line @rushstack/typedef-var
 const contextSeedSchema = JsonSchema.object({
   id: JsonSchema.string({ description: 'The MemoryId of the seed record to traverse links from.' }),
-  scope: JsonSchema.optional(
-    JsonSchema.string({ description: 'The scope of the seed record. Required — omitting it fails the call.' })
-  )
+  scope: JsonSchema.string({
+    description: 'The scope of the seed record (required — a bare seed id is ambiguous across scopes).'
+  })
 });
 
 // eslint-disable-next-line @rushstack/typedef-var
@@ -641,21 +642,15 @@ function buildDeleteTool(ctx: IToolContext): AiAssist.IAiClientTool {
 
 /**
  * Resolve a `memory_context` seed argument into a scope-qualified
- * {@link IEdgeTarget}. `scope` is structurally optional (the seed shares the edge
- * target shape) but semantically required here — unlike a write edge there is no
- * writing record to default it from, and a bare stem is ambiguous across scopes —
- * so an omitted scope fails loudly rather than guessing.
+ * {@link IEdgeTarget}. Both `id` and `scope` are present here — the tool's
+ * `parametersSchema` ({@link contextSeedSchema}) makes `scope` schema-required —
+ * so this only brands the two fields; a malformed value fails via the branded
+ * converters (e.g. a path-unsafe seed id).
  */
-function resolveContextSeed(from: { readonly id: string; readonly scope?: string }): Result<IEdgeTarget> {
-  if (from.scope === undefined) {
-    return fail(
-      "memory_context: 'from.scope' is required — a bare seed id is ambiguous across scopes and cannot be defaulted"
-    );
-  }
-  const scopeStr: string = from.scope;
+function resolveContextSeed(from: { readonly id: string; readonly scope: string }): Result<IEdgeTarget> {
   return Convert.memoryId
     .convert(from.id)
-    .onSuccess((id) => Convert.scopeKey.convert(scopeStr).onSuccess((scope) => succeed({ scope, id })));
+    .onSuccess((id) => Convert.scopeKey.convert(from.scope).onSuccess((scope) => succeed({ scope, id })));
 }
 
 /** Validate an optional `tag` string (`undefined` passes through). */

--- a/libraries/ts-agent-memory/src/packlets/types/envelope.ts
+++ b/libraries/ts-agent-memory/src/packlets/types/envelope.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { EntityId, Kind, LinkType, MemoryId, Tag } from './ids';
+import { EntityId, Kind, LinkType, MemoryId, MemoryScopeKey, Tag } from './ids';
 
 /**
  * Origin of a provenance attribution. Open vocabulary: the three named
@@ -36,17 +36,48 @@ export interface IProvenance {
 }
 
 /**
+ * The physical address of a linked-to record: the `(scope, id)` pair that
+ * uniquely identifies it. Both components are required because a bare
+ * {@link MemoryId} is NOT unique across scopes — per-scope codecs (e.g. the
+ * medium-term codec's `turn-<n>` stems) legally mint the same stem under
+ * different scopes, so an edge that carried only the id would be ambiguous.
+ * `(scope, id)` matches the store's `getById(scope, id)` addressing and the
+ * index's composite primary key.
+ * @public
+ */
+export interface IEdgeTarget {
+  /** The scope the target record lives under. */
+  readonly scope: MemoryScopeKey;
+  /** The target record's stable file-stem id (unique WITHIN {@link IEdgeTarget.scope}). */
+  readonly id: MemoryId;
+}
+
+/**
+ * The canonical composite-key string for an {@link IEdgeTarget}: scope + id,
+ * NUL-separated. NUL is excluded from both components (scope segments are
+ * filename-safe; {@link MemoryId} is portable-filename-safe), so it is a
+ * collision-proof separator. This is the ONE canonicalization every consumer
+ * that keys on a scoped target uses — the backlink index, the cycle guard, and
+ * the ingest edge-validation path all route through it so their notions of
+ * "same target" cannot drift.
+ * @public
+ */
+export function edgeTargetKey(target: IEdgeTarget): string {
+  return `${target.scope}\0${target.id}`;
+}
+
+/**
  * An attributed link between two records. Carries the relation type, the
- * target id, and optional confidence / provenance / world-truth validity.
- * Replaces bare string references (e.g. PersonAIlity's `IMtmRef` becomes an
- * `IEdge` with `type: LinkType('mtm-ref')`).
+ * scope-qualified {@link IEdgeTarget | target}, and optional confidence /
+ * provenance / world-truth validity. Replaces bare string references (e.g.
+ * PersonAIlity's `IMtmRef` becomes an `IEdge` with `type: LinkType('mtm-ref')`).
  * @public
  */
 export interface IEdge {
   /** Open-vocabulary relation type. */
   readonly type: LinkType;
-  /** The linked-to record. */
-  readonly target: MemoryId;
+  /** The scope-qualified address of the linked-to record. */
+  readonly target: IEdgeTarget;
   /** Optional confidence in `[0, 1]`. */
   readonly confidence?: number;
   /** Optional structured provenance for the link itself. */

--- a/libraries/ts-agent-memory/src/test/unit/converters/antagonistRoundTrip.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/converters/antagonistRoundTrip.test.ts
@@ -46,7 +46,7 @@ describe('antagonist — full on-disk round-trip preserves every optional field'
       links: [
         {
           type: 'rel' as never,
-          target: 'doc-2' as never,
+          target: { scope: 'knowledge', id: 'doc-2' } as never,
           confidence: 0.42,
           provenance: { source: 'agent', by: 'curator', extra: { nested: true } },
           valid_at: 111,
@@ -89,7 +89,7 @@ describe('antagonist — full on-disk round-trip preserves every optional field'
       entityId: 'doc-2' as IMemoryEnvelope['entityId'],
       kind,
       tags: [],
-      links: [{ type: 'rel' as never, target: 'doc-3' as never }],
+      links: [{ type: 'rel' as never, target: { scope: 'knowledge', id: 'doc-3' } as never }],
       created: 0,
       updated: 0,
       seq: 0,

--- a/libraries/ts-agent-memory/src/test/unit/converters/envelopeConverter.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/converters/envelopeConverter.test.ts
@@ -8,6 +8,7 @@ import { Converters } from '@fgv/ts-utils';
 import {
   BodyConverterRegistry,
   edgeConverter,
+  edgeTargetConverter,
   envelopeConverter,
   envelopeYamlConverter,
   joinFrontmatter,
@@ -24,7 +25,7 @@ const validEnvelopeObject: Record<string, unknown> = {
   entityId: 'intro-to-rust',
   kind: 'knowledge',
   tags: ['rust', 'systems'],
-  links: [{ type: 'related', target: 'ownership' }],
+  links: [{ type: 'related', target: { scope: 'knowledge', id: 'ownership' } }],
   created: 1000,
   updated: 2000,
   seq: 5,
@@ -62,12 +63,34 @@ describe('provenanceConverter', () => {
   });
 });
 
+describe('edgeTargetConverter', () => {
+  test('validates a scope-qualified target', () => {
+    expect(edgeTargetConverter.convert({ scope: 'conversations/conv-a', id: 'turn-3' })).toSucceedAndSatisfy(
+      (t) => {
+        expect(t).toEqual({ scope: 'conversations/conv-a', id: 'turn-3' });
+      }
+    );
+  });
+
+  test('rejects a target missing scope', () => {
+    expect(edgeTargetConverter.convert({ id: 'turn-3' })).toFailWith(/scope/i);
+  });
+
+  test('rejects a target missing id', () => {
+    expect(edgeTargetConverter.convert({ scope: 'conversations/conv-a' })).toFailWith(/id/i);
+  });
+
+  test('rejects a bare-string target (the pre-scoped format)', () => {
+    expect(edgeTargetConverter.convert('turn-3')).toFail();
+  });
+});
+
 describe('edgeConverter', () => {
   test('validates a full attributed edge', () => {
     expect(
       edgeConverter.convert({
         type: 'mtm-ref',
-        target: 'turn-3',
+        target: { scope: 'conversations/conv-a', id: 'turn-3' },
         confidence: 0.8,
         provenance: { source: 'agent' },
         valid_at: 100,
@@ -75,7 +98,7 @@ describe('edgeConverter', () => {
       })
     ).toSucceedAndSatisfy((edge) => {
       expect(edge.type).toBe('mtm-ref');
-      expect(edge.target).toBe('turn-3');
+      expect(edge.target).toEqual({ scope: 'conversations/conv-a', id: 'turn-3' });
       expect(edge.confidence).toBe(0.8);
       expect(edge.provenance).toEqual({ source: 'agent' });
       expect(edge.valid_at).toBe(100);
@@ -84,27 +107,35 @@ describe('edgeConverter', () => {
   });
 
   test('validates a minimal edge', () => {
-    expect(edgeConverter.convert({ type: 'related', target: 'ownership' })).toSucceedAndSatisfy((edge) => {
+    expect(
+      edgeConverter.convert({ type: 'related', target: { scope: 'knowledge', id: 'ownership' } })
+    ).toSucceedAndSatisfy((edge) => {
       expect(edge.type).toBe('related');
-      expect(edge.target).toBe('ownership');
+      expect(edge.target).toEqual({ scope: 'knowledge', id: 'ownership' });
       expect(edge.confidence).toBeUndefined();
     });
   });
 
   test('accepts a null invalid_at (still valid)', () => {
-    expect(edgeConverter.convert({ type: 'related', target: 'x', invalid_at: null })).toSucceedAndSatisfy(
-      (edge) => {
-        expect(edge.invalid_at).toBeNull();
-      }
-    );
+    expect(
+      edgeConverter.convert({ type: 'related', target: { scope: 'knowledge', id: 'x' }, invalid_at: null })
+    ).toSucceedAndSatisfy((edge) => {
+      expect(edge.invalid_at).toBeNull();
+    });
   });
 
   test('fails when invalid_at is neither a number nor null', () => {
-    expect(edgeConverter.convert({ type: 'related', target: 'x', invalid_at: 'soon' })).toFail();
+    expect(
+      edgeConverter.convert({ type: 'related', target: { scope: 'knowledge', id: 'x' }, invalid_at: 'soon' })
+    ).toFail();
   });
 
   test('fails when target is missing', () => {
     expect(edgeConverter.convert({ type: 'related' })).toFail();
+  });
+
+  test('fails when target is a bare string (rejects the pre-scoped format)', () => {
+    expect(edgeConverter.convert({ type: 'related', target: 'ownership' })).toFail();
   });
 });
 
@@ -264,6 +295,26 @@ describe('parseMemoryFile / serializeMemoryFile', () => {
     expect(parseMemoryFile(file, registry)).toSucceedAndSatisfy((record) => {
       expect(record.envelope.id).toBe('intro-to-rust');
       expect(record.body).toBe('The knowledge body.');
+    });
+  });
+
+  test('round-trips a scope-qualified edge target through the frontmatter intact', () => {
+    const envelope = envelopeConverter
+      .convert({
+        ...validEnvelopeObject,
+        links: [{ type: 'mtm-ref', target: { scope: 'conversations/conv-a', id: 'turn-3' } }]
+      })
+      .orThrow();
+    const file = serializeMemoryFile(envelope, 'body').orThrow();
+    // On-wire the target is a nested object, NOT a bare scalar.
+    expect(file).toMatch(/scope: conversations\/conv-a/);
+    expect(file).toMatch(/id: turn-3/);
+    expect(parseMemoryFile(file, registry)).toSucceedAndSatisfy((record) => {
+      expect(record.envelope.links).toEqual([
+        { type: 'mtm-ref', target: { scope: 'conversations/conv-a', id: 'turn-3' } }
+      ]);
+      // Serializing the reparsed record reproduces byte-identical output.
+      expect(serializeMemoryFile(record.envelope, record.body as string)).toSucceedWith(file);
     });
   });
 

--- a/libraries/ts-agent-memory/src/test/unit/index/memoryIndex.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/index/memoryIndex.test.ts
@@ -5,6 +5,7 @@
 
 import '@fgv/ts-utils-jest';
 import {
+  IEdgeTarget,
   IIndexedMemoryRecord,
   IMemoryRecord,
   Kind,
@@ -15,6 +16,23 @@ import {
   envelopeConverter,
   rankCompare
 } from '../../../index';
+
+/**
+ * The scope every link target in this fixture lives under. Links are authored as
+ * bare id strings and resolved to `{ scope: LINK_TARGET_SCOPE, id }`, so the
+ * cross-scope source tests can share one target while their sources differ.
+ */
+const LINK_TARGET_SCOPE: string = 'knowledge';
+
+/** A scope-qualified backlink-target query for the fixed link-target scope. */
+function bt(id: string): IEdgeTarget {
+  return { scope: LINK_TARGET_SCOPE as MemoryScopeKey, id: id as MemoryId };
+}
+
+/** Extract the bare ids from a set of scope-qualified targets (backlink results). */
+function targetIds(targets: ReadonlyArray<IEdgeTarget>): string[] {
+  return targets.map((t) => t.id as string);
+}
 
 interface IRecordSpec {
   readonly id: string;
@@ -35,7 +53,10 @@ function makeEntry(spec: IRecordSpec): IIndexedMemoryRecord {
         entityId: spec.id,
         kind: spec.kind ?? 'knowledge',
         tags: spec.tags ?? [],
-        links: (spec.links ?? []).map((target) => ({ type: 'rel', target })),
+        links: (spec.links ?? []).map((target) => ({
+          type: 'rel',
+          target: { scope: LINK_TARGET_SCOPE, id: target }
+        })),
         created: 0,
         updated: spec.updated ?? 0,
         seq: spec.seq ?? 0,
@@ -66,7 +87,7 @@ describe('MemoryIndex', () => {
       expect(index.byKind('knowledge' as Kind)).toHaveLength(0);
       expect(index.byTag('any' as Tag)).toHaveLength(0);
       expect(index.byRecency()).toHaveLength(0);
-      expect(index.backlinks('none' as MemoryId)).toHaveLength(0);
+      expect(index.backlinks(bt('none'))).toHaveLength(0);
     });
   });
 
@@ -81,7 +102,7 @@ describe('MemoryIndex', () => {
       expect([...ids(index.byKind('knowledge' as Kind))].sort()).toEqual(['a', 'b']);
       expect([...ids(index.byTag('x' as Tag))].sort()).toEqual(['a', 'b']);
       expect(ids(index.byTag('y' as Tag))).toEqual(['b']);
-      expect(index.backlinks('b' as MemoryId)).toEqual(['a']);
+      expect(targetIds(index.backlinks(bt('b')))).toEqual(['a']);
     });
 
     test('clears prior state', () => {
@@ -97,7 +118,7 @@ describe('MemoryIndex', () => {
       const entry = makeEntry({ id: 'a', tags: ['x'], links: ['b'] });
       expect(index.patch('put', entry)).toSucceedWith(entry);
       expect(ids(index.byKind('knowledge' as Kind))).toEqual(['a']);
-      expect(index.backlinks('b' as MemoryId)).toEqual(['a']);
+      expect(targetIds(index.backlinks(bt('b')))).toEqual(['a']);
     });
 
     test('put on an existing key replaces stale associations', () => {
@@ -108,8 +129,8 @@ describe('MemoryIndex', () => {
       expect(ids(index.byTag('new' as Tag))).toEqual(['a']);
       expect(index.byKind('knowledge' as Kind)).toHaveLength(0);
       expect(ids(index.byKind('note' as Kind))).toEqual(['a']);
-      expect(index.backlinks('b' as MemoryId)).toHaveLength(0);
-      expect(index.backlinks('c' as MemoryId)).toEqual(['a']);
+      expect(index.backlinks(bt('b'))).toHaveLength(0);
+      expect(targetIds(index.backlinks(bt('c')))).toEqual(['a']);
     });
 
     test('delete removes the entry and its associations', () => {
@@ -118,7 +139,7 @@ describe('MemoryIndex', () => {
       expect(index.patch('delete', entry)).toSucceedWith(entry);
       expect(index.entries()).toHaveLength(0);
       expect(index.byTag('x' as Tag)).toHaveLength(0);
-      expect(index.backlinks('b' as MemoryId)).toHaveLength(0);
+      expect(index.backlinks(bt('b'))).toHaveLength(0);
     });
 
     test('delete of an absent key is a no-op that still succeeds', () => {
@@ -214,14 +235,14 @@ describe('MemoryIndex', () => {
       index
         .rebuild([makeEntry({ id: 'a', links: ['target'] }), makeEntry({ id: 'b', links: ['target'] })])
         .orThrow();
-      expect([...index.backlinks('target' as MemoryId)].sort()).toEqual(['a', 'b']);
+      expect(targetIds(index.backlinks(bt('target'))).sort()).toEqual(['a', 'b']);
     });
 
     test('drops the target set once the last source is removed', () => {
       const a = makeEntry({ id: 'a', links: ['target'] });
       index.patch('put', a).orThrow();
       index.patch('delete', a).orThrow();
-      expect(index.backlinks('target' as MemoryId)).toHaveLength(0);
+      expect(index.backlinks(bt('target'))).toHaveLength(0);
     });
 
     test('tracks same-id sources across scopes independently', () => {
@@ -231,9 +252,9 @@ describe('MemoryIndex', () => {
       const a2 = makeEntry({ id: 'a', scope: 'conversations/c2', links: ['target'] });
       index.patch('put', a1).orThrow();
       index.patch('put', a2).orThrow();
-      expect(index.backlinks('target' as MemoryId)).toEqual(['a', 'a']);
+      expect(targetIds(index.backlinks(bt('target')))).toEqual(['a', 'a']);
       index.patch('delete', a1).orThrow();
-      expect(index.backlinks('target' as MemoryId)).toEqual(['a']);
+      expect(targetIds(index.backlinks(bt('target')))).toEqual(['a']);
     });
   });
 
@@ -242,10 +263,10 @@ describe('MemoryIndex', () => {
       const entry = makeEntry({ id: 'a', tags: ['dup', 'dup'], links: ['t', 't'] });
       index.patch('put', entry).orThrow();
       expect(ids(index.byTag('dup' as Tag))).toEqual(['a']);
-      expect(index.backlinks('t' as MemoryId)).toEqual(['a']);
+      expect(targetIds(index.backlinks(bt('t')))).toEqual(['a']);
       index.patch('delete', entry).orThrow();
       expect(index.byTag('dup' as Tag)).toHaveLength(0);
-      expect(index.backlinks('t' as MemoryId)).toHaveLength(0);
+      expect(index.backlinks(bt('t'))).toHaveLength(0);
     });
   });
 });

--- a/libraries/ts-agent-memory/src/test/unit/ingest/antagonistCycleAndParity.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/ingest/antagonistCycleAndParity.test.ts
@@ -21,6 +21,7 @@ import {
   IBodyConverterRegistry,
   ICandidateEdge,
   ICandidateRecord,
+  IEdgeTarget,
   IEntityResolutionCandidate,
   IEntityResolver,
   IFactExtractor,
@@ -38,11 +39,17 @@ import {
   KnowledgeIdentityCodec,
   MemoryId,
   MemoryIngestOrchestrator,
+  MemoryScopeKey,
   ResolutionVerdict,
   Tag
 } from '../../../index';
 
 const noteKind: Kind = 'note' as Kind;
+
+/** A scope-qualified target for the note fixtures (all under the knowledge scope). */
+function kt(id: string): IEdgeTarget {
+  return { scope: 'knowledge' as MemoryScopeKey, id: id as MemoryId };
+}
 
 function mutableRoot(): FileTree.IMutableFileTreeDirectoryItem {
   const tree = FileTree.inMemory([], { mutable: true }).orThrow();
@@ -131,7 +138,7 @@ function candidate(
 }
 
 function candEdge(source: string, type: string, target: string): ICandidateEdge {
-  return { source: source as MemoryId, edge: { type: type as never, target: target as MemoryId } };
+  return { source: kt(source), edge: { type: type as never, target: kt(target) } };
 }
 
 function buildOrchestrator(params: {
@@ -159,7 +166,7 @@ describe('antagonist — cycle guard through EXISTING store edges (integration)'
   test('a proposed edge that closes a cycle through a pre-existing on-disk edge is rejected', async () => {
     const store = buildStore();
     // Existing on-disk edge: doc-a -> doc-b (persisted before this ingest runs).
-    await putFull(store, 'doc-a', 'anchor-a', [{ type: 'rel' as never, target: 'doc-b' as MemoryId }]);
+    await putFull(store, 'doc-a', 'anchor-a', [{ type: 'rel' as never, target: kt('doc-b') }]);
     await putFull(store, 'doc-b', 'anchor-b');
 
     // This ingest re-writes doc-b (a 'new'-verdict same-id update, since no
@@ -183,9 +190,9 @@ describe('antagonist — cycle guard through EXISTING store edges (integration)'
     const store = buildStore();
     // Existing chain: a -> b -> c -> d (four pre-existing on-disk edges spanning
     // three hops), persisted before this ingest.
-    await putFull(store, 'chain-a', 'a', [{ type: 'rel' as never, target: 'chain-b' as MemoryId }]);
-    await putFull(store, 'chain-b', 'b', [{ type: 'rel' as never, target: 'chain-c' as MemoryId }]);
-    await putFull(store, 'chain-c', 'c', [{ type: 'rel' as never, target: 'chain-d' as MemoryId }]);
+    await putFull(store, 'chain-a', 'a', [{ type: 'rel' as never, target: kt('chain-b') }]);
+    await putFull(store, 'chain-b', 'b', [{ type: 'rel' as never, target: kt('chain-c') }]);
+    await putFull(store, 'chain-c', 'c', [{ type: 'rel' as never, target: kt('chain-d') }]);
     await putFull(store, 'chain-d', 'd');
 
     // Proposed: chain-d -> chain-a, closing the whole loop through the existing chain.
@@ -199,7 +206,7 @@ describe('antagonist — cycle guard through EXISTING store edges (integration)'
 
   test('cycleGuard "off" admits a cycle that closes through an existing edge', async () => {
     const store = buildStore();
-    await putFull(store, 'doc-a', 'anchor-a', [{ type: 'rel' as never, target: 'doc-b' as MemoryId }]);
+    await putFull(store, 'doc-a', 'anchor-a', [{ type: 'rel' as never, target: kt('doc-b') }]);
     await putFull(store, 'doc-b', 'anchor-b');
     const orch = MemoryIngestOrchestrator.create({
       store,
@@ -211,7 +218,7 @@ describe('antagonist — cycle guard through EXISTING store edges (integration)'
       cycleGuard: 'off'
     }).orThrow();
     expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
-      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: 'doc-a' }]);
+      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: kt('doc-a') }]);
     });
   });
 });

--- a/libraries/ts-agent-memory/src/test/unit/ingest/cycleGuard.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/ingest/cycleGuard.test.ts
@@ -4,12 +4,29 @@
  */
 
 import '@fgv/ts-utils-jest';
-import { ICycleGuardEdge, LinkType, MemoryId, assertNoCycles, buildCycleKey } from '../../../index';
+import {
+  ICycleGuardEdge,
+  IEdgeTarget,
+  LinkType,
+  MemoryId,
+  MemoryScopeKey,
+  assertNoCycles,
+  buildCycleKey
+} from '../../../index';
 
 const rel: LinkType = 'rel' as LinkType;
+const DEFAULT_SCOPE: string = 'exp';
+
+/** A scope-qualified node, `scope#id` or a bare id defaulting to {@link DEFAULT_SCOPE}. */
+function node(spec: string): IEdgeTarget {
+  const hash: number = spec.indexOf('#');
+  const scope: string = hash >= 0 ? spec.slice(0, hash) : DEFAULT_SCOPE;
+  const id: string = hash >= 0 ? spec.slice(hash + 1) : spec;
+  return { scope: scope as MemoryScopeKey, id: id as MemoryId };
+}
 
 function edge(source: string, target: string, type: LinkType = rel): ICycleGuardEdge {
-  return { source: source as MemoryId, target: target as MemoryId, type };
+  return { source: node(source), target: node(target), type };
 }
 
 describe('buildCycleKey', () => {
@@ -64,5 +81,30 @@ describe('assertNoCycles', () => {
     // from `a`, whose DFS pushes `c` twice before it is visited — exercising the
     // visited-node skip in the traversal.
     expect(assertNoCycles([edge('a', 'c'), edge('a', 'b'), edge('b', 'c')], [edge('z', 'a')])).toSucceed();
+  });
+
+  describe('scope-qualified nodes', () => {
+    test('does NOT conflate a stem shared across scopes into one node', () => {
+      // ca#x -> cb#y and cb#x -> ca#z reuse the stem `x` across scopes ca/cb.
+      // If the guard keyed on bare id, the two `x` nodes would merge and a false
+      // cycle could appear; with scoped keys they are distinct and the graph is acyclic.
+      expect(assertNoCycles([], [edge('ca#x', 'cb#y'), edge('cb#x', 'ca#z')])).toSucceed();
+    });
+
+    test('still rejects a genuine within-scope cycle across the same stems', () => {
+      expect(assertNoCycles([], [edge('ca#x', 'ca#y'), edge('ca#y', 'ca#x')])).toFailWith(
+        /would create a cycle/
+      );
+    });
+
+    test('a self-loop is detected on the full scoped identity', () => {
+      expect(assertNoCycles([], [edge('ca#x', 'ca#x')])).toFailWith(/self-loop/);
+      // Same stem, different scope is NOT a self-loop.
+      expect(assertNoCycles([], [edge('ca#x', 'cb#x')])).toSucceed();
+    });
+
+    test('names the scope in the diagnostic', () => {
+      expect(assertNoCycles([], [edge('ca#x', 'ca#x')])).toFailWith(/ca\/x/);
+    });
   });
 });

--- a/libraries/ts-agent-memory/src/test/unit/ingest/orchestrator.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/ingest/orchestrator.test.ts
@@ -41,6 +41,7 @@ import {
   LinkType,
   LtmIdentityCodec,
   MemoryEmbedder,
+  MtmIdentityCodec,
   MemoryId,
   MemoryIngestOrchestrator,
   MemoryScopeKey,
@@ -846,6 +847,110 @@ describe('MemoryIngestOrchestrator — stage 5 relate + cycle guard', () => {
     expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
       expect(r.records[0].interlock).toBeUndefined();
       expect(r.records[0].record?.envelope.links).toEqual([{ type: 'contradicts', target: kt('doc-a') }]);
+    });
+  });
+
+  describe('_validateEdges cross-scope target disambiguation', () => {
+    // Two EXISTING records share the idStem 'turn-3' across two conversations
+    // (the MTM codec mints per-scope stems). A stage-5 edge target must resolve
+    // to the CORRECT (scope, id) — with bare-id keying both would alias and a
+    // wrong-scope target would silently validate. Guards the ingest-validation seam.
+    const mtmKind: Kind = 'mtm' as Kind;
+
+    function mtmRegistry(): IBodyConverterRegistry {
+      const reg = registry();
+      reg.register(mtmKind, Converters.string);
+      return reg;
+    }
+
+    const mtmCodecs: ReadonlyMap<Kind, IIdentityCodec> = new Map<Kind, IIdentityCodec>([
+      [mtmKind, new MtmIdentityCodec()]
+    ]);
+
+    async function seedTurn(store: FileTreeMemoryStore, entityId: string, body: string): Promise<void> {
+      const addr = new MtmIdentityCodec().encode(entityId as EntityId).orThrow();
+      const rec: IMemoryRecord<unknown> = {
+        envelope: {
+          id: addr.idStem as MemoryId,
+          entityId: entityId as EntityId,
+          kind: mtmKind,
+          tags: [],
+          links: [],
+          created: 0,
+          updated: 0,
+          seq: 0,
+          contentHash: '',
+          provenance: { source: 'agent' }
+        },
+        body
+      };
+      (await store.put(rec)).orThrow();
+    }
+
+    function buildMtmOrchestrator(
+      store: FileTreeMemoryStore,
+      relationExtractor: IRelationExtractor
+    ): MemoryIngestOrchestrator {
+      return MemoryIngestOrchestrator.create({
+        store,
+        registry: mtmRegistry(),
+        codecs: mtmCodecs,
+        classifier: classifier(() => succeed({ kind: mtmKind })),
+        // The candidate is a fresh turn-5 under conv-a (distinct stem from the seeds).
+        extractor: extractor(() => succeed([candidate(mtmKind, 'conv-a:5', 'a new turn')])),
+        relationExtractor
+      }).orThrow();
+    }
+
+    async function seededStore(): Promise<FileTreeMemoryStore> {
+      const store = FileTreeMemoryStore.create({
+        root: mutableRoot(),
+        registry: mtmRegistry(),
+        codecs: mtmCodecs,
+        clock
+      }).orThrow();
+      await seedTurn(store, 'conv-a:3', 'anchor in conversation a');
+      await seedTurn(store, 'conv-b:3', 'anchor in conversation b');
+      return store;
+    }
+
+    test('accepts a same-stem edge target that resolves to the correct scope', async () => {
+      const store = await seededStore();
+      const orch = buildMtmOrchestrator(
+        store,
+        relater((ctx) =>
+          succeed([
+            {
+              source: srcOf(ctx, 'conv-a:5'),
+              edge: { type: 'rel' as LinkType, target: kt('turn-3', 'conversations/conv-a') }
+            }
+          ])
+        )
+      );
+      expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
+        expect(r.records[0].record?.envelope.links).toEqual([
+          { type: 'rel', target: kt('turn-3', 'conversations/conv-a') }
+        ]);
+      });
+    });
+
+    test('rejects a same-stem edge target whose scope has no matching record', async () => {
+      const store = await seededStore();
+      const orch = buildMtmOrchestrator(
+        store,
+        relater((ctx) =>
+          succeed([
+            {
+              source: srcOf(ctx, 'conv-a:5'),
+              // turn-3 exists under conv-a and conv-b, but NOT conv-z.
+              edge: { type: 'rel' as LinkType, target: kt('turn-3', 'conversations/conv-z') }
+            }
+          ])
+        )
+      );
+      expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
+        /edge target 'conversations\/conv-z\/turn-3' resolves to neither a sibling candidate nor an existing record/
+      );
     });
   });
 });

--- a/libraries/ts-agent-memory/src/test/unit/ingest/orchestrator.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/ingest/orchestrator.test.ts
@@ -17,6 +17,7 @@ import {
   IBodyConverterRegistry,
   ICandidateEdge,
   ICandidateRecord,
+  IEdgeTarget,
   IEntityResolutionCandidate,
   IEntityResolver,
   IFactExtractor,
@@ -168,12 +169,36 @@ function candidate(
   };
 }
 
+/**
+ * A scope-qualified target, authored as `scope#id` or a bare id defaulting to the
+ * knowledge scope (where the note/num fixtures live). `kt` is the assertion-side
+ * spelling of the same helper.
+ */
+function scopedTarget(spec: string): IEdgeTarget {
+  const hash: number = spec.indexOf('#');
+  const scope: string = hash >= 0 ? spec.slice(0, hash) : 'knowledge';
+  const id: string = hash >= 0 ? spec.slice(hash + 1) : spec;
+  return { scope: scope as MemoryScopeKey, id: id as MemoryId };
+}
+function kt(id: string, scope: string = 'knowledge'): IEdgeTarget {
+  return { scope: scope as MemoryScopeKey, id: id as MemoryId };
+}
+
+/** The scope-qualified reference of a candidate about to be written, by its entityId. */
+function srcOf(ctx: IRelationContext, entityId: string): IEdgeTarget {
+  const found = ctx.candidates.find((rc) => rc.candidate.envelope.entityId === (entityId as EntityId));
+  if (found === undefined) {
+    throw new Error(`test relater: no candidate with entityId '${entityId}'`);
+  }
+  return found.id;
+}
+
 function candEdge(source: string, type: string, target: string, confidence?: number): ICandidateEdge {
   return {
-    source: source as MemoryId,
+    source: scopedTarget(source),
     edge: {
       type: type as LinkType,
-      target: target as MemoryId,
+      target: scopedTarget(target),
       ...(confidence !== undefined ? { confidence } : {})
     }
   };
@@ -380,6 +405,28 @@ describe('MemoryIngestOrchestrator', () => {
         extractor: extractor(() => succeed([candidate(orphanKind, 'o-1', 'body')]))
       });
       expect(await orch.ingestItem({ id: 'o-1', content: 'x' })).toFailWith(/no identity codec/);
+    });
+
+    test('fails loudly when a pre-existing snapshot record cannot be scoped (no codec for its kind)', async () => {
+      // The store can persist a note (it has the note codec), but the orchestrator
+      // below is wired WITHOUT a note codec — so when it snapshots the store to run
+      // the edge path, it cannot resolve the seeded note's scope and fails loudly
+      // (never silently drops it from the cycle graph). This is the branch the
+      // scope-qualified edge change added.
+      const store = buildStore();
+      await putNote(store, 'legacy', 'anchor');
+      const orch = MemoryIngestOrchestrator.create({
+        store,
+        registry: registry(),
+        // Deliberately omit the note codec (and any default) that the seeded record needs.
+        codecs: new Map<Kind, IIdentityCodec>([[numKind, new KnowledgeIdentityCodec()]]),
+        classifier: classifier(() => succeed({ kind: numKind })),
+        extractor: extractor(() => succeed([candidate(numKind, 'n-1', 7)])),
+        relationExtractor: noEdges
+      }).orThrow();
+      expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
+        /cannot resolve scope for stored record 'legacy'.*no identity codec registered for kind 'note'/i
+      );
     });
   });
 
@@ -716,7 +763,7 @@ describe('MemoryIngestOrchestrator — stage 5 relate + cycle guard', () => {
     expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
       expect(r.records[0].edges).toHaveLength(1);
       expect(r.records[0].record?.envelope.links).toEqual([
-        { type: 'mentions', target: 'doc-a', confidence: 0.7 }
+        { type: 'mentions', target: kt('doc-a'), confidence: 0.7 }
       ]);
     });
   });
@@ -731,7 +778,7 @@ describe('MemoryIngestOrchestrator — stage 5 relate + cycle guard', () => {
     });
     expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
       expect(r.records).toHaveLength(2);
-      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: 'doc-c' }]);
+      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: kt('doc-c') }]);
       expect(r.records[1].edges).toEqual([]);
     });
   });
@@ -743,7 +790,7 @@ describe('MemoryIngestOrchestrator — stage 5 relate + cycle guard', () => {
       relationExtractor: relater(() => succeed([candEdge('ghost', 'rel', 'doc-b')]))
     });
     expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
-      /edge source 'ghost' is not a candidate being written/
+      /edge source 'knowledge\/ghost' is not a candidate being written/
     );
   });
 
@@ -754,7 +801,7 @@ describe('MemoryIngestOrchestrator — stage 5 relate + cycle guard', () => {
       relationExtractor: relater(() => succeed([candEdge('doc-b', 'rel', 'ghost')]))
     });
     expect(await orch.ingestItem({ id: 'i', content: 'x' })).toFailWith(
-      /edge target 'ghost' resolves to neither/
+      /edge target 'knowledge\/ghost' resolves to neither/
     );
   });
 
@@ -783,8 +830,8 @@ describe('MemoryIngestOrchestrator — stage 5 relate + cycle guard', () => {
       )
     });
     expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
-      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: 'doc-c' }]);
-      expect(r.records[1].record?.envelope.links).toEqual([{ type: 'rel', target: 'doc-b' }]);
+      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: kt('doc-c') }]);
+      expect(r.records[1].record?.envelope.links).toEqual([{ type: 'rel', target: kt('doc-b') }]);
     });
   });
 
@@ -798,7 +845,7 @@ describe('MemoryIngestOrchestrator — stage 5 relate + cycle guard', () => {
     });
     expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
       expect(r.records[0].interlock).toBeUndefined();
-      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'contradicts', target: 'doc-a' }]);
+      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'contradicts', target: kt('doc-a') }]);
     });
   });
 });
@@ -821,13 +868,22 @@ describe('MemoryIngestOrchestrator — contradicts→temporal interlock', () => 
       store,
       classifier: classifyFact,
       extractor: extractor(() => succeed([candidate(factKind, 'fact-1', 'the sky is grey')])),
-      relationExtractor: relater(() => succeed([candEdge('fact-1', 'contradicts', v1Id)]))
+      relationExtractor: relater((ctx) =>
+        succeed([
+          {
+            source: srcOf(ctx, 'fact-1'),
+            edge: { type: CONTRADICTS_LINK_TYPE, target: kt(v1Id, 'facts/entities/fact-1') }
+          }
+        ])
+      )
     });
     expect(await secondOrch.ingestItem({ id: 'fact-1', content: 'the sky is grey' })).toSucceedAndSatisfy(
       (r: IIngestItemResult) => {
         expect(r.records[0].interlock).toBe('temporal-versioned');
         expect(r.records[0].disposition).toBe('written');
-        expect(r.records[0].record?.envelope.links).toEqual([{ type: CONTRADICTS_LINK_TYPE, target: v1Id }]);
+        expect(r.records[0].record?.envelope.links).toEqual([
+          { type: CONTRADICTS_LINK_TYPE, target: kt(v1Id, 'facts/entities/fact-1') }
+        ]);
       }
     );
 
@@ -854,7 +910,14 @@ describe('MemoryIngestOrchestrator — contradicts→temporal interlock', () => 
       store,
       classifier: classifyFact,
       extractor: extractor(() => succeed([candidate(factKind, 'fact-1', 'grey')])),
-      relationExtractor: relater(() => succeed([candEdge('fact-1', 'contradicts', v1Id)]))
+      relationExtractor: relater((ctx) =>
+        succeed([
+          {
+            source: srcOf(ctx, 'fact-1'),
+            edge: { type: CONTRADICTS_LINK_TYPE, target: kt(v1Id, 'facts/entities/fact-1') }
+          }
+        ])
+      )
     });
     (await o2.ingestItem({ id: 'fact-1', content: 'grey' })).orThrow();
 
@@ -1012,7 +1075,7 @@ describe('MemoryIngestOrchestrator — review-punch-list fixes', () => {
       )
     });
     expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceedAndSatisfy((r: IIngestItemResult) => {
-      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: 'doc-a' }]);
+      expect(r.records[0].record?.envelope.links).toEqual([{ type: 'rel', target: kt('doc-a') }]);
     });
   });
 
@@ -1034,7 +1097,7 @@ describe('MemoryIngestOrchestrator — review-punch-list fixes', () => {
     expect(await orch.ingestItem({ id: 'i', content: 'x' })).toSucceed();
     expect(await store.get(noteKind, 'doc-a' as EntityId)).toSucceedAndSatisfy(
       (rec: IMemoryRecord<unknown> | undefined) => {
-        expect(rec?.envelope.links).toEqual([{ type: 'rel', target: 'doc-x' }]);
+        expect(rec?.envelope.links).toEqual([{ type: 'rel', target: kt('doc-x') }]);
       }
     );
   });
@@ -1072,7 +1135,7 @@ describe('MemoryIngestOrchestrator — merge-into safety (second review)', () =>
     const store = buildStore({ vectorIndex, embed });
     await putFull(store, noteKind, 'doc-a', 'apple pie', {
       tags: ['old-tag'],
-      links: [{ type: 'existing' as LinkType, target: 'doc-z' as MemoryId }]
+      links: [{ type: 'existing' as LinkType, target: kt('doc-z') }]
     });
     await putFull(store, noteKind, 'doc-x', 'target of stage-5');
     const orch = buildOrchestrator({
@@ -1084,7 +1147,7 @@ describe('MemoryIngestOrchestrator — merge-into safety (second review)', () =>
         succeed([
           candidate(noteKind, 'doc-b', 'apple tart', {
             tags: ['new-tag'],
-            links: [{ type: 'candlink' as LinkType, target: 'doc-z' as MemoryId }]
+            links: [{ type: 'candlink' as LinkType, target: kt('doc-z') }]
           })
         ])
       ),
@@ -1099,9 +1162,9 @@ describe('MemoryIngestOrchestrator — merge-into safety (second review)', () =>
         expect([...(rec?.envelope.tags ?? [])].sort()).toEqual(['new-tag', 'old-tag']);
         // Original link + candidate link + stage-5 edge, each exactly once.
         expect(rec?.envelope.links).toEqual([
-          { type: 'existing', target: 'doc-z' },
-          { type: 'candlink', target: 'doc-z' },
-          { type: 'stage5', target: 'doc-x' }
+          { type: 'existing', target: kt('doc-z') },
+          { type: 'candlink', target: kt('doc-z') },
+          { type: 'stage5', target: kt('doc-x') }
         ]);
       }
     );

--- a/libraries/ts-agent-memory/src/test/unit/retrieve/linkTraversalRetriever.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/retrieve/linkTraversalRetriever.test.ts
@@ -172,6 +172,28 @@ describe('LinkTraversalRetriever', () => {
         expect(ids(records)).toEqual(['a', 'b']);
       });
     });
+
+    test('reaches ONLY the same-scope inbound source when a TARGET stem is reused across scopes', async () => {
+      // 'shared' exists in scope a and scope b; src-a@a links {a, shared} and
+      // src-b@b links {b, shared}. Seeding linkedTo {a, shared} must reach ONLY
+      // src-a — backlinks disambiguate on the target's (scope, id), not a bare id.
+      const index = buildIndex([
+        { id: 'src-a', scope: 'a', links: ['shared'], tags: ['src-a'] },
+        { id: 'src-b', scope: 'b', links: ['shared'], tags: ['src-b'] },
+        { id: 'shared', scope: 'a' },
+        { id: 'shared', scope: 'b' }
+      ]);
+      const retriever = LinkTraversalRetriever.create(index).orThrow();
+      expect(await retriever.retrieve({ linkedTo: seed('shared', 'a') })).toSucceedAndSatisfy((records) => {
+        expect(records).toHaveLength(1);
+        expect(records[0].envelope.tags).toEqual(['src-a']);
+      });
+      // Symmetric: seeding the b-scope target reaches only src-b.
+      expect(await retriever.retrieve({ linkedTo: seed('shared', 'b') })).toSucceedAndSatisfy((records) => {
+        expect(records).toHaveLength(1);
+        expect(records[0].envelope.tags).toEqual(['src-b']);
+      });
+    });
   });
 
   describe('cycle safety', () => {

--- a/libraries/ts-agent-memory/src/test/unit/retrieve/linkTraversalRetriever.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/retrieve/linkTraversalRetriever.test.ts
@@ -5,6 +5,7 @@
 
 import '@fgv/ts-utils-jest';
 import {
+  IEdgeTarget,
   IIndexedMemoryRecord,
   IMemoryRecord,
   Kind,
@@ -17,6 +18,11 @@ import {
   envelopeConverter
 } from '../../../index';
 
+const DEFAULT_SCOPE: string = 'experience';
+
+/** A link target authored either as a bare id (same-scope) or an explicit `(scope, id)`. */
+type LinkSpec = string | { readonly id: string; readonly scope: string };
+
 interface IEntrySpec {
   readonly id: string;
   readonly scope?: string;
@@ -24,11 +30,17 @@ interface IEntrySpec {
   readonly tags?: ReadonlyArray<string>;
   readonly updated?: number;
   readonly seq?: number;
-  readonly links?: ReadonlyArray<string>;
+  readonly links?: ReadonlyArray<LinkSpec>;
   readonly rank?: number;
 }
 
+/** A scope-qualified traversal seed (defaults to the fixture's default scope). */
+function seed(id: string, scope: string = DEFAULT_SCOPE): IEdgeTarget {
+  return { scope: scope as MemoryScopeKey, id: id as MemoryId };
+}
+
 function makeEntry(spec: IEntrySpec): IIndexedMemoryRecord {
+  const scope: string = spec.scope ?? DEFAULT_SCOPE;
   const record: IMemoryRecord<unknown> = {
     envelope: envelopeConverter
       .convert({
@@ -36,7 +48,13 @@ function makeEntry(spec: IEntrySpec): IIndexedMemoryRecord {
         entityId: spec.id,
         kind: spec.kind ?? 'experience',
         tags: spec.tags ?? [],
-        links: (spec.links ?? []).map((target) => ({ type: 'rel', target })),
+        // A bare link id defaults its target scope to the source record's own
+        // scope (the same-conversation case); an object carries an explicit scope.
+        links: (spec.links ?? []).map((l) =>
+          typeof l === 'string'
+            ? { type: 'rel', target: { scope, id: l } }
+            : { type: 'rel', target: { scope: l.scope, id: l.id } }
+        ),
         created: 0,
         updated: spec.updated ?? 0,
         seq: spec.seq ?? 0,
@@ -47,7 +65,7 @@ function makeEntry(spec: IEntrySpec): IIndexedMemoryRecord {
       .orThrow(),
     body: `body-${spec.id}`
   };
-  return { scope: (spec.scope ?? 'experience') as MemoryScopeKey, record };
+  return { scope: scope as MemoryScopeKey, record };
 }
 
 function buildIndex(specs: ReadonlyArray<IEntrySpec>): MemoryIndex {
@@ -79,7 +97,7 @@ describe('LinkTraversalRetriever', () => {
         { id: 'c', updated: 10 }
       ]);
       const retriever = LinkTraversalRetriever.create(index).orThrow();
-      expect(await retriever.retrieve({ linkedFrom: 'a' as MemoryId })).toSucceedAndSatisfy((records) => {
+      expect(await retriever.retrieve({ linkedFrom: seed('a') })).toSucceedAndSatisfy((records) => {
         // Recency-ordered: b (updated 20) before c (updated 10). 'a' (the seed) excluded.
         expect(ids(records)).toEqual(['b', 'c']);
       });
@@ -88,7 +106,7 @@ describe('LinkTraversalRetriever', () => {
     test('stops at the default single hop (does not reach 2-hop neighbors)', async () => {
       const index = buildIndex([{ id: 'a', links: ['b'] }, { id: 'b', links: ['c'] }, { id: 'c' }]);
       const retriever = LinkTraversalRetriever.create(index).orThrow();
-      expect(await retriever.retrieve({ linkedFrom: 'a' as MemoryId })).toSucceedAndSatisfy((records) => {
+      expect(await retriever.retrieve({ linkedFrom: seed('a') })).toSucceedAndSatisfy((records) => {
         expect(ids(records)).toEqual(['b']);
       });
     });
@@ -96,11 +114,9 @@ describe('LinkTraversalRetriever', () => {
     test('follows multiple hops when hops is raised', async () => {
       const index = buildIndex([{ id: 'a', links: ['b'] }, { id: 'b', links: ['c'] }, { id: 'c' }]);
       const retriever = LinkTraversalRetriever.create(index).orThrow();
-      expect(await retriever.retrieve({ linkedFrom: 'a' as MemoryId, hops: 2 })).toSucceedAndSatisfy(
-        (records) => {
-          expect(ids(records).sort()).toEqual(['b', 'c']);
-        }
-      );
+      expect(await retriever.retrieve({ linkedFrom: seed('a'), hops: 2 })).toSucceedAndSatisfy((records) => {
+        expect(ids(records).sort()).toEqual(['b', 'c']);
+      });
     });
   });
 
@@ -119,7 +135,7 @@ describe('LinkTraversalRetriever', () => {
 
     test("orderBy 'rank' orders reached records by rank descending", async () => {
       const retriever = LinkTraversalRetriever.create(seedIndex()).orThrow();
-      expect(await retriever.retrieve({ linkedFrom: 'a' as MemoryId, orderBy: 'rank' })).toSucceedAndSatisfy(
+      expect(await retriever.retrieve({ linkedFrom: seed('a'), orderBy: 'rank' })).toSucceedAndSatisfy(
         (records) => {
           expect(ids(records)).toEqual(['n3', 'n2', 'n1']);
         }
@@ -128,7 +144,7 @@ describe('LinkTraversalRetriever', () => {
 
     test('orderBy absent is unchanged recency order', async () => {
       const retriever = LinkTraversalRetriever.create(seedIndex()).orThrow();
-      expect(await retriever.retrieve({ linkedFrom: 'a' as MemoryId })).toSucceedAndSatisfy((records) => {
+      expect(await retriever.retrieve({ linkedFrom: seed('a') })).toSucceedAndSatisfy((records) => {
         // Recency: most-recently-updated first → n1(300), n2(200), n3(100).
         expect(ids(records)).toEqual(['n1', 'n2', 'n3']);
       });
@@ -137,7 +153,7 @@ describe('LinkTraversalRetriever', () => {
     test("orderBy 'rank' composes with { limit, offset }", async () => {
       const retriever = LinkTraversalRetriever.create(seedIndex()).orThrow();
       expect(
-        await retriever.retrieve({ linkedFrom: 'a' as MemoryId, orderBy: 'rank', limit: 1, offset: 1 })
+        await retriever.retrieve({ linkedFrom: seed('a'), orderBy: 'rank', limit: 1, offset: 1 })
       ).toSucceedAndSatisfy((records) => {
         expect(ids(records)).toEqual(['n2']);
       });
@@ -152,7 +168,7 @@ describe('LinkTraversalRetriever', () => {
         { id: 'target' }
       ]);
       const retriever = LinkTraversalRetriever.create(index).orThrow();
-      expect(await retriever.retrieve({ linkedTo: 'target' as MemoryId })).toSucceedAndSatisfy((records) => {
+      expect(await retriever.retrieve({ linkedTo: seed('target') })).toSucceedAndSatisfy((records) => {
         expect(ids(records)).toEqual(['a', 'b']);
       });
     });
@@ -162,11 +178,9 @@ describe('LinkTraversalRetriever', () => {
     test('terminates on a self-loop and excludes the seed', async () => {
       const index = buildIndex([{ id: 'a', links: ['a'] }]);
       const retriever = LinkTraversalRetriever.create(index).orThrow();
-      expect(await retriever.retrieve({ linkedFrom: 'a' as MemoryId, hops: 5 })).toSucceedAndSatisfy(
-        (records) => {
-          expect(records).toHaveLength(0);
-        }
-      );
+      expect(await retriever.retrieve({ linkedFrom: seed('a'), hops: 5 })).toSucceedAndSatisfy((records) => {
+        expect(records).toHaveLength(0);
+      });
     });
 
     test('terminates on a multi-hop cycle without revisiting', async () => {
@@ -176,22 +190,27 @@ describe('LinkTraversalRetriever', () => {
         { id: 'c', links: ['a'] }
       ]);
       const retriever = LinkTraversalRetriever.create(index).orThrow();
-      expect(await retriever.retrieve({ linkedFrom: 'a' as MemoryId, hops: 10 })).toSucceedAndSatisfy(
-        (records) => {
-          // a→b→c→a: reaches b and c, then the edge back to the seed is pruned.
-          expect(ids(records).sort()).toEqual(['b', 'c']);
-        }
-      );
+      expect(await retriever.retrieve({ linkedFrom: seed('a'), hops: 10 })).toSucceedAndSatisfy((records) => {
+        // a→b→c→a: reaches b and c, then the edge back to the seed is pruned.
+        expect(ids(records).sort()).toEqual(['b', 'c']);
+      });
     });
   });
 
   test('traverses a cross-kind edge (experience derivedFrom a knowledge doc)', async () => {
     const index = buildIndex([
-      { id: 'turn-5', scope: 'conversations/conv-1', kind: 'summarized-turn', links: ['doc-1'] },
+      {
+        id: 'turn-5',
+        scope: 'conversations/conv-1',
+        kind: 'summarized-turn',
+        links: [{ id: 'doc-1', scope: 'knowledge' }]
+      },
       { id: 'doc-1', scope: 'knowledge', kind: 'knowledge' }
     ]);
     const retriever = LinkTraversalRetriever.create(index).orThrow();
-    expect(await retriever.retrieve({ linkedFrom: 'turn-5' as MemoryId })).toSucceedAndSatisfy((records) => {
+    expect(
+      await retriever.retrieve({ linkedFrom: seed('turn-5', 'conversations/conv-1') })
+    ).toSucceedAndSatisfy((records) => {
       expect(ids(records)).toEqual(['doc-1']);
       expect(records[0].envelope.kind).toBe('knowledge');
     });
@@ -206,7 +225,7 @@ describe('LinkTraversalRetriever', () => {
       ]);
       const retriever = LinkTraversalRetriever.create(index).orThrow();
       expect(
-        await retriever.retrieve({ linkedFrom: 'a' as MemoryId, kind: 'keep' as unknown as Kind })
+        await retriever.retrieve({ linkedFrom: seed('a'), kind: 'keep' as unknown as Kind })
       ).toSucceedAndSatisfy((records) => {
         expect(ids(records)).toEqual(['b']);
       });
@@ -220,29 +239,45 @@ describe('LinkTraversalRetriever', () => {
         { id: 'd', updated: 10 }
       ]);
       const retriever = LinkTraversalRetriever.create(index).orThrow();
-      expect(await retriever.retrieve({ linkedFrom: 'a' as MemoryId, limit: 2 })).toSucceedAndSatisfy(
-        (records) => {
-          expect(ids(records)).toEqual(['b', 'c']);
-        }
-      );
+      expect(await retriever.retrieve({ linkedFrom: seed('a'), limit: 2 })).toSucceedAndSatisfy((records) => {
+        expect(ids(records)).toEqual(['b', 'c']);
+      });
     });
 
     test('returns empty when the seed is not in the index', async () => {
       const index = buildIndex([{ id: 'a', links: ['b'] }, { id: 'b' }]);
       const retriever = LinkTraversalRetriever.create(index).orThrow();
-      expect(await retriever.retrieve({ linkedFrom: 'missing' as MemoryId })).toSucceedWith([]);
+      expect(await retriever.retrieve({ linkedFrom: seed('missing') })).toSucceedWith([]);
     });
 
-    test('resolves every record sharing a reached id (cross-scope id reuse)', async () => {
+    test('reaches ONLY the same-scope target when an id is reused across scopes', async () => {
+      // 'seed' (scope a) links a bare 'dup' → the edge target is {scope a, id dup}.
+      // Two records share the stem 'dup' (scopes a and b); the scoped edge must
+      // reach ONLY dup@a, never dup@b — the whole point of scope-qualified targets.
       const index = buildIndex([
         { id: 'seed', scope: 'a', links: ['dup'] },
-        { id: 'dup', scope: 'a' },
-        { id: 'dup', scope: 'b' }
+        { id: 'dup', scope: 'a', tags: ['in-a'] },
+        { id: 'dup', scope: 'b', tags: ['in-b'] }
       ]);
       const retriever = LinkTraversalRetriever.create(index).orThrow();
-      expect(await retriever.retrieve({ linkedFrom: 'seed' as MemoryId })).toSucceedAndSatisfy((records) => {
-        expect(records).toHaveLength(2);
-        expect(ids(records)).toEqual(['dup', 'dup']);
+      expect(await retriever.retrieve({ linkedFrom: seed('seed', 'a') })).toSucceedAndSatisfy((records) => {
+        expect(records).toHaveLength(1);
+        expect(records[0].envelope.tags).toEqual(['in-a']);
+      });
+    });
+
+    test('an explicit cross-scope edge reaches the other scope', async () => {
+      // The same fixture, but the edge names dup@b explicitly → traversal follows
+      // it to the b-scope record, proving explicit scope is honored verbatim.
+      const index = buildIndex([
+        { id: 'seed', scope: 'a', links: [{ id: 'dup', scope: 'b' }] },
+        { id: 'dup', scope: 'a', tags: ['in-a'] },
+        { id: 'dup', scope: 'b', tags: ['in-b'] }
+      ]);
+      const retriever = LinkTraversalRetriever.create(index).orThrow();
+      expect(await retriever.retrieve({ linkedFrom: seed('seed', 'a') })).toSucceedAndSatisfy((records) => {
+        expect(records).toHaveLength(1);
+        expect(records[0].envelope.tags).toEqual(['in-b']);
       });
     });
   });
@@ -267,6 +302,6 @@ describe('LINK_TRAVERSAL_UNWIRED_MESSAGE constant', () => {
   test('a link query against the link-capable retriever still succeeds', async () => {
     const index = buildIndex([{ id: 'a', links: ['b'] }, { id: 'b' }]);
     const retriever = LinkTraversalRetriever.create(index).orThrow();
-    expect(await retriever.retrieve({ linkedFrom: 'a' as MemoryId })).toSucceed();
+    expect(await retriever.retrieve({ linkedFrom: seed('a') })).toSucceed();
   });
 });

--- a/libraries/ts-agent-memory/src/test/unit/retrieve/retrievers.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/retrieve/retrievers.test.ts
@@ -7,6 +7,7 @@ import '@fgv/ts-utils-jest';
 import { Result, fail, succeed } from '@fgv/ts-utils';
 import {
   HybridRetriever,
+  IEdgeTarget,
   IIndexedMemoryRecord,
   IMemoryQuery,
   IMemoryRecord,
@@ -31,6 +32,11 @@ import {
   rankCompare,
   recencyCompare
 } from '../../../index';
+
+/** A scope-qualified link-traversal seed for the retriever tests. */
+function et(id: string, scope: string = 'knowledge'): IEdgeTarget {
+  return { scope: scope as MemoryScopeKey, id: id as MemoryId };
+}
 
 interface IRecordSpec {
   readonly id: string;
@@ -107,10 +113,10 @@ describe('retrieve helpers', () => {
     });
 
     test('fails loudly when a link-traversal axis is requested but unsupported', () => {
-      expect(guardRetrieverCapabilities({ linkedTo: 'x' as MemoryId }, noCaps)).toFailWith(
+      expect(guardRetrieverCapabilities({ linkedTo: et('x') }, noCaps)).toFailWith(
         /link traversal requires a backlink index; none configured/i
       );
-      expect(guardRetrieverCapabilities({ linkedFrom: 'x' as MemoryId }, noCaps)).toFailWith(
+      expect(guardRetrieverCapabilities({ linkedFrom: et('x') }, noCaps)).toFailWith(
         /link traversal requires/i
       );
       expect(guardRetrieverCapabilities({ hops: 2 }, noCaps)).toFailWith(/link traversal requires/i);
@@ -118,7 +124,7 @@ describe('retrieve helpers', () => {
 
     test('passes a link-traversal axis when the capability is supported', () => {
       expect(
-        guardRetrieverCapabilities({ linkedTo: 'x' as MemoryId }, { ...noCaps, supportsLinkTraversal: true })
+        guardRetrieverCapabilities({ linkedTo: et('x') }, { ...noCaps, supportsLinkTraversal: true })
       ).toSucceed();
     });
   });
@@ -245,7 +251,7 @@ describe('RecencyRetriever', () => {
 
   test('degrades loudly on a link-traversal request', async () => {
     const r = RecencyRetriever.create(buildIndex([{ id: 'a' }])).orThrow();
-    expect(await r.retrieve({ linkedTo: 'a' as MemoryId })).toFailWith(/link traversal requires/i);
+    expect(await r.retrieve({ linkedTo: et('a') })).toFailWith(/link traversal requires/i);
   });
 });
 
@@ -873,9 +879,9 @@ describe('HybridRetriever', () => {
     ).orThrow();
     expect(hybrid.capabilities.supportsLinkTraversal).toBe(true);
     // Union supports link traversal, so the hybrid does NOT loud-fail.
-    expect(await hybrid.retrieve({ linkedTo: 'a' as MemoryId, hops: 2 })).toSucceed();
+    expect(await hybrid.retrieve({ linkedTo: et('a'), hops: 2 })).toSucceed();
     // The link-capable child keeps the axes; the plain child has them stripped.
-    expect(linkChild.lastQuery?.linkedTo).toBe('a');
+    expect(linkChild.lastQuery?.linkedTo).toEqual(et('a'));
     expect(linkChild.lastQuery?.hops).toBe(2);
     expect(plainChild.lastQuery?.linkedTo).toBeUndefined();
     expect(plainChild.lastQuery?.hops).toBeUndefined();

--- a/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
@@ -328,14 +328,25 @@ describe('createMemoryTools', () => {
       expect(schema.convert({ limit: 'three' })).toFail();
     });
 
-    test('memory_context requires a from seed (nested { id, scope? })', () => {
+    test('memory_context requires a from seed with a REQUIRED scope (nested { id, scope })', () => {
       const schema = toolByName(allTools(), 'memory_context').config.parametersSchema;
       expect(schema.convert({ from: { id: 'doc-1', scope: 'knowledge' } })).toSucceed();
-      // scope is structurally optional on the seed shape (parity with an edge target).
-      expect(schema.convert({ from: { id: 'doc-1' } })).toSucceed();
+      // scope is schema-REQUIRED (unlike a write link target) — the wire schema must
+      // not advertise an optionality the tool does not honor. Omitting it fails.
+      expect(schema.convert({ from: { id: 'doc-1' } })).toFail();
       expect(schema.convert({ hops: 2 })).toFail();
       // A bare-string seed (the pre-scoped format) is rejected at the schema.
       expect(schema.convert({ from: 'doc-1' })).toFail();
+    });
+
+    test('the memory_context wire schema marks from.scope as required', () => {
+      // Guards the schema-accuracy contract at the wire level: an LLM reading the
+      // tool's `parameters` sees scope in the seed's `required` array.
+      const schema = toolByName(allTools(), 'memory_context').config.parametersSchema;
+      const wire = schema.toJson() as unknown as {
+        properties: { from: { required?: ReadonlyArray<string> } };
+      };
+      expect(wire.properties.from.required).toContain('scope');
     });
   });
 
@@ -793,9 +804,11 @@ describe('createMemoryTools', () => {
       expect(await tool.execute({ from: { id: 'a/b', scope: 'knowledge' } })).toFail();
     });
 
-    test('fails loudly when the seed omits its scope (no source to default from)', async () => {
+    test('fails at the schema when the seed omits its required scope', async () => {
+      // scope is schema-required, so an omitted scope is rejected as an invalid
+      // argument (the wire schema and the runtime contract agree — no lie).
       const tool = toolByName(allTools(), 'memory_context');
-      expect(await tool.execute({ from: { id: 'a' } })).toFailWith(/'from\.scope' is required/i);
+      expect(await tool.execute({ from: { id: 'a' } })).toFailWith(/invalid arguments/i);
     });
 
     test('a scoped seed reaches ONLY the correctly-scoped graph', async () => {

--- a/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/tools/memoryTools.test.ts
@@ -11,9 +11,11 @@ import {
   AdmissionDecision,
   BodyConverterRegistry,
   DEFAULT_MEMORY_TOOLS,
+  EntityId,
   FileTreeMemoryStore,
   HybridRetriever,
   IBodyConverterRegistry,
+  IEdgeTarget,
   IIdentityCodec,
   IIndexedMemoryRecord,
   IMemoryRecord,
@@ -111,7 +113,10 @@ function makeEntry(spec: IEntrySpec): IIndexedMemoryRecord {
         entityId: spec.entityId ?? spec.id,
         kind: spec.kind ?? 'knowledge',
         tags: spec.tags ?? [],
-        links: (spec.links ?? []).map((target) => ({ type: 'rel', target })),
+        links: (spec.links ?? []).map((target) => ({
+          type: 'rel',
+          target: { scope: spec.scope ?? 'knowledge', id: target }
+        })),
         created: 0,
         updated: spec.updated ?? 0,
         seq: 0,
@@ -285,10 +290,27 @@ describe('createMemoryTools', () => {
           entityId: 'doc-1',
           body: 'hello',
           tags: ['a'],
-          links: [{ type: 'rel', target: 'doc-2', confidence: 0.5 }]
+          links: [{ type: 'rel', target: { id: 'doc-2' }, confidence: 0.5 }]
+        })
+      ).toSucceed();
+      expect(
+        schema.convert({
+          kind: 'knowledge',
+          entityId: 'doc-1',
+          body: 'hello',
+          links: [{ type: 'rel', target: { scope: 'conversations/other', id: 'turn-1' } }]
         })
       ).toSucceed();
       expect(schema.convert({ kind: 'knowledge', entityId: 'doc-1' })).toFail();
+      // A bare-string target (the pre-scoped format) is rejected at the schema.
+      expect(
+        schema.convert({
+          kind: 'knowledge',
+          entityId: 'doc-1',
+          body: 'x',
+          links: [{ type: 'rel', target: 'doc-2' }]
+        })
+      ).toFail();
     });
 
     test('memory_read / memory_delete require kind and entityId', () => {
@@ -306,10 +328,14 @@ describe('createMemoryTools', () => {
       expect(schema.convert({ limit: 'three' })).toFail();
     });
 
-    test('memory_context requires a from seed', () => {
+    test('memory_context requires a from seed (nested { id, scope? })', () => {
       const schema = toolByName(allTools(), 'memory_context').config.parametersSchema;
-      expect(schema.convert({ from: 'doc-1' })).toSucceed();
+      expect(schema.convert({ from: { id: 'doc-1', scope: 'knowledge' } })).toSucceed();
+      // scope is structurally optional on the seed shape (parity with an edge target).
+      expect(schema.convert({ from: { id: 'doc-1' } })).toSucceed();
       expect(schema.convert({ hops: 2 })).toFail();
+      // A bare-string seed (the pre-scoped format) is rejected at the schema.
+      expect(schema.convert({ from: 'doc-1' })).toFail();
     });
   });
 
@@ -364,14 +390,43 @@ describe('createMemoryTools', () => {
           entityId: 'doc-1',
           body: 'linked',
           links: [
-            { type: 'rel', target: 'doc-2', confidence: 0.9 },
-            { type: 'rel', target: 'doc-3' }
+            // scope omitted → defaults to the writing record's own scope (knowledge)
+            { type: 'rel', target: { id: 'doc-2' }, confidence: 0.9 },
+            { type: 'rel', target: { id: 'doc-3' } }
           ]
         })
       ).toSucceedAndSatisfy((v) => expect((v as IMemoryWriteResult).outcome).toBe('written'));
+      // The persisted links carry the writing record's scope on each target.
+      expect(await store.get(knowledgeKind, 'doc-1' as EntityId)).toSucceedAndSatisfy((rec) => {
+        expect(rec?.envelope.links).toEqual([
+          { type: 'rel', target: { scope: 'knowledge', id: 'doc-2' }, confidence: 0.9 },
+          { type: 'rel', target: { scope: 'knowledge', id: 'doc-3' } }
+        ]);
+      });
+    });
+
+    test('an authored link with an EXPLICIT scope is honored verbatim (cross-scope edge)', async () => {
+      const store = makeStore();
+      const tools = createMemoryTools({
+        store,
+        retriever: makeRetriever([]),
+        registry: registryWith([{ kind: knowledgeKind }]),
+        codecs,
+        tools: ['memory_write']
+      });
       expect(
-        await toolByName(tools, 'memory_read').execute({ kind: 'knowledge', entityId: 'doc-1' })
-      ).toSucceedAndSatisfy(() => undefined);
+        await toolByName(tools, 'memory_write').execute({
+          kind: 'knowledge',
+          entityId: 'doc-1',
+          body: 'cross',
+          links: [{ type: 'mtm-ref', target: { scope: 'conversations/conv-a', id: 'turn-3' } }]
+        })
+      ).toSucceed();
+      expect(await store.get(knowledgeKind, 'doc-1' as EntityId)).toSucceedAndSatisfy((rec) => {
+        expect(rec?.envelope.links).toEqual([
+          { type: 'mtm-ref', target: { scope: 'conversations/conv-a', id: 'turn-3' } }
+        ]);
+      });
     });
 
     test('an identical re-put of the same entity is a dedup no-op (outcome: deduped)', async () => {
@@ -694,9 +749,13 @@ describe('createMemoryTools', () => {
         }),
         'memory_context'
       );
-      expect(await tool.execute({ from: 'a' })).toSucceedAndSatisfy((value) => {
-        const out = value as { seed: string; count: number; results: ReadonlyArray<IMemoryToolResultItem> };
-        expect(out.seed).toBe('a');
+      expect(await tool.execute({ from: { id: 'a', scope: 'knowledge' } })).toSucceedAndSatisfy((value) => {
+        const out = value as {
+          seed: IEdgeTarget;
+          count: number;
+          results: ReadonlyArray<IMemoryToolResultItem>;
+        };
+        expect(out.seed).toEqual({ scope: 'knowledge', id: 'a' });
         expect(out.results.map((r) => r.handle)).toEqual(['b', 'c']);
       });
     });
@@ -716,7 +775,13 @@ describe('createMemoryTools', () => {
         'memory_context'
       );
       expect(
-        await tool.execute({ from: 'a', hops: 2, tag: 'keep', kind: 'knowledge', limit: 5 })
+        await tool.execute({
+          from: { id: 'a', scope: 'knowledge' },
+          hops: 2,
+          tag: 'keep',
+          kind: 'knowledge',
+          limit: 5
+        })
       ).toSucceedAndSatisfy((value) => {
         const out = value as { results: ReadonlyArray<IMemoryToolResultItem> };
         expect(out.results.map((r) => r.handle).sort()).toEqual(['b', 'c']);
@@ -725,7 +790,38 @@ describe('createMemoryTools', () => {
 
     test('rejects an invalid seed id', async () => {
       const tool = toolByName(allTools(), 'memory_context');
-      expect(await tool.execute({ from: 'a/b' })).toFail();
+      expect(await tool.execute({ from: { id: 'a/b', scope: 'knowledge' } })).toFail();
+    });
+
+    test('fails loudly when the seed omits its scope (no source to default from)', async () => {
+      const tool = toolByName(allTools(), 'memory_context');
+      expect(await tool.execute({ from: { id: 'a' } })).toFailWith(/'from\.scope' is required/i);
+    });
+
+    test('a scoped seed reaches ONLY the correctly-scoped graph', async () => {
+      // Two conversations reuse the stem `turn-0`; each links a same-scope `turn-1`.
+      // Seeding conv-a must reach conv-a's turn-1 and NEVER conv-b's.
+      const retriever = makeLinkRetriever([
+        { id: 'turn-0', scope: 'conversations/conv-a', links: ['turn-1'] },
+        { id: 'turn-1', scope: 'conversations/conv-a', tags: ['in-a'] },
+        { id: 'turn-0', scope: 'conversations/conv-b', links: ['turn-1'] },
+        { id: 'turn-1', scope: 'conversations/conv-b', tags: ['in-b'] }
+      ]);
+      const tool = toolByName(
+        createMemoryTools({
+          store: makeStore(),
+          retriever,
+          registry: registryWith([{ kind: knowledgeKind }])
+        }),
+        'memory_context'
+      );
+      expect(
+        await tool.execute({ from: { id: 'turn-0', scope: 'conversations/conv-a' } })
+      ).toSucceedAndSatisfy((value) => {
+        const out = value as { results: ReadonlyArray<IMemoryToolResultItem> };
+        expect(out.results).toHaveLength(1);
+        expect(out.results[0].tags).toEqual(['in-a']);
+      });
     });
 
     test('rejects malformed arguments', async () => {
@@ -894,7 +990,9 @@ describe('result projection (projectItem host projector + detail tier)', () => {
         }),
         'memory_context'
       );
-      expect(await tool.execute({ from: 'a', detail: 'full' })).toSucceedAndSatisfy((value) => {
+      expect(
+        await tool.execute({ from: { id: 'a', scope: 'knowledge' }, detail: 'full' })
+      ).toSucceedAndSatisfy((value) => {
         const out = value as { results: ReadonlyArray<IMemoryToolResultItem> };
         expect(out.results.map((r) => r.handle)).toEqual(['h:b']);
         expect(out.results[0].body).toBe('body-b');

--- a/libraries/ts-agent-memory/src/test/unit/types/writePolicy.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/types/writePolicy.test.ts
@@ -6,6 +6,7 @@
 import '@fgv/ts-utils-jest';
 import {
   EntityId,
+  IEdgeTarget,
   IMemoryEnvelope,
   IMemoryRecord,
   IProvenance,
@@ -13,6 +14,7 @@ import {
   KnowledgeLwwPolicy,
   MemoryCapCullPolicy,
   MemoryId,
+  MemoryScopeKey,
   Tag
 } from '../../../packlets/types';
 
@@ -275,13 +277,20 @@ describe('MemoryCapCullPolicy', () => {
         {
           id: 'turn-0' as MemoryId,
           kind: 'summarized-turn' as Kind,
-          links: [{ type: 'derived-from' as never, target: 'doc-1' as MemoryId }]
+          links: [
+            {
+              type: 'derived-from' as never,
+              target: { scope: 'knowledge' as MemoryScopeKey, id: 'doc-1' as MemoryId } as IEdgeTarget
+            }
+          ]
         },
         { summary: 'old' }
       );
       expect(narrow.applyUpdate(existing, { body: { summary: 'x' }, links: [] })).toSucceedAndSatisfy(
         (updated) => {
-          expect(updated.envelope.links).toEqual([{ type: 'derived-from', target: 'doc-1' }]);
+          expect(updated.envelope.links).toEqual([
+            { type: 'derived-from', target: { scope: 'knowledge', id: 'doc-1' } }
+          ]);
           expect(updated.body).toEqual({ summary: 'x' });
         }
       );


### PR DESCRIPTION
## Summary

**BREAKING** core-type change in `@fgv/ts-agent-memory`: **scope-qualified edge targets**. `IEdge.target` changes from a bare `MemoryId` to a new `IEdgeTarget` (`{ scope, id }`).

**Problem fixed.** The bundled `MtmIdentityCodec` mints per-scope stems (`turn-<n>`) with the store enforcing `envelope.id === idStem`, so `MemoryId`s collide across scopes. Edges / backlinks / traversal / ingest-validation all keyed on a bare id, so an edge to `turn-3` was ambiguous across conversations. Edges now carry scope and are unambiguous by construction; per-scope stems stay legal (the MTM codec is unchanged).

`(scope, id)` is the physical record address — it matches `getById(scope, id)` and the index's composite primary key. There is no `kind` on the target (ingest resolves the target then checks the resolved record's own kind, so kind on the edge would be a redundant second source of truth).

## Surface changes (all threaded through one canonical composite key, `edgeTargetKey`)

- **`types/envelope.ts`** — new `IEdgeTarget` + `edgeTargetKey(target)`; `IEdge.target: MemoryId → IEdgeTarget`.
- **`converters`** — new `edgeTargetConverter`; `edgeConverter.target` → nested-object converter. On-wire YAML frontmatter now serializes `target: { scope, id }`.
- **`index/memoryIndex.ts`** — `backlinks(target: IEdgeTarget): ReadonlyArray<IEdgeTarget>`; `_backlinks` outer map keyed by the canonical `${scope}\0${id}` string, inner values scope-qualified.
- **`retrieve`** — `IMemoryQuery.linkedFrom/linkedTo → IEdgeTarget`; link-traversal BFS walks `IEdgeTarget` nodes with a canonical-string visited guard and resolves each node to exactly one `(scope, id)` record.
- **`ingest`** — `ICandidateEdge.source`, `IRelationCandidate.id`, and `ICycleGuardEdge` source+target become `IEdgeTarget`. Cycle guard self-loop + adjacency keys switch to the composite key. The orchestrator resolves every snapshot record's scoped address once (`_scopeRecords`) to drive cycle-guard + edge validation — fixing the last-write-wins bug on the edge path. The bare `byId` snapshot index is retained only for the out-of-scope verdict/similarity lookups.
- **`tools`** — `memory_write` link input and `memory_context` seed adopt a nested object shape. **Same-scope-default ergonomics (write):** on a write, an omitted `scope` defaults to the *writing record's own resolved scope* (the common same-conversation case authors just an id); an explicit scope is honored verbatim (cross-scope edge) — so the write link target's `scope` is a **true optional**. **`memory_context` seed:** the seed has no writing record to default from, so its `scope` is **schema-required** (see Review round 1, FIX 1 below) — the wire schema and the runtime contract agree.

## Fork 6 rationale — no back-compat shim

Per the approved design (Fork 6): this is a clean break with **no migration shim**. `@fgv/ts-agent-memory` is a new, actively-developed library; the frontier posture (`ACTIVE_DEVELOPMENT.md`) is "break compatibility and fix consumers rather than accumulating cruft." Verified: no checked-in `.md` fixtures depend on the bare-target format (all test data is in-memory). The consumer re-emits.

## Explicitly out of scope (deferred follow-on)

- The **vector/similarity path** (`IVectorIndex` / `InMemoryCosineIndex`, `IEntityResolutionCandidate.id`, `ResolutionVerdict`'s `target` arms + their bare `byId` lookups). These share the root cause but interlock through the ingest verdict path and are a distinct stream. Left bare deliberately; the orchestrator keeps a bare `byId` snapshot index specifically for them.
- **`IProvenance.derivedFrom`** — left bare (never dereferenced today). A `TECH_DEBT.md` entry was added noting the same latent ambiguity.

## Review — round 1 (code-reviewer gate: SOUND, no P1s; three P2s fixed)

The code-reviewer gate verified the implementation sound — canonical-key invariant holds, the out-of-scope boundary held, and the merge-arm dead-code removal is confirmed unreachable. Three P2s were raised and fixed in the follow-up commit:

- **FIX 1 (schema-accuracy footgun).** `memory_context`'s seed `scope` was schema-*optional* but runtime-*required* — the wire schema lied to an LLM caller. Made `contextSeedSchema.scope` **schema-required** (dropped `JsonSchema.optional`), simplified `resolveContextSeed` (scope guaranteed present post-convert), and added a wire-schema assertion (`from.required` contains `scope`). The `memory_write` link target's optional scope is untouched — that one is a genuine optional (defaults to the source record's scope).
- **FIX 2 (test gap at the ingest-validation seam).** Added orchestrator `_validateEdges` cross-scope disambiguation tests using `MtmIdentityCodec`'s per-scope stems: two existing `turn-3` records under different conversations, a stage-5 edge to the correct scope validates, and a same-stem *wrong*-scope target is rejected with the existing "resolves to neither a sibling candidate nor an existing record" failure.
- **FIX 3 (test gap).** Added a `linkedTo` cross-scope disambiguation pair (same-stem TARGET reused across scopes; backlinks reach only the correctly-scoped source), mirroring the existing `linkedFrom` coverage.

## Self-review (layer 1, pre-first-push)

Ran against `CODE_REVIEW_CHECKLIST.md`. **P1**: none — no `any` in production; all fallible ops return `Result<T>`; `edgeTargetConverter` uses `Converters.object`; no `Result<void>`. **Canonical-key consistency** (the key risk): the single `edgeTargetKey` helper is the *only* canonicalization — index (`_keyOf` delegates to it), cycle guard, ingest edge-validation/`_existingEdges`, and link-traversal all route through it. **Simplification during coverage closure:** removed the now-unreachable merge-arm re-resolve error-wrap rather than masking with a `c8 ignore`.

## Gate results (after round-1 fixes)

- `rushx build` ✅ — `etc/ts-agent-memory.api.md` regenerated (round-1 fixes touch only the internal `contextSeedSchema`, so no further api.md movement).
- `rushx fixlint` run before each commit; `rushx lint` ✅.
- `rushx test` ✅ — **100% coverage** (statements/branches/functions/lines) across every file in the package.

## Changeset

`minor` bump — a breaking type change on a new, pre-1.0, actively-developed library ships as `minor` under the lockstep-version policy (consistent with the recent `l2-tools` / `l3-ingest` / query-tool-batch changesets for this package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch