### PR TITLE
docs: reconcile agent-memory scoped-addressing docs after #542/#543

### DIFF
--- a/.ai/instructions/ACTIVE_DEVELOPMENT.md
+++ b/.ai/instructions/ACTIVE_DEVELOPMENT.md
@@ -17,6 +17,7 @@ The active/production split is therefore **per-surface, not per-library**. A lib
 | `ts-http-storage` | All | New library |
 | `ts-web-extras` | All | New library |
 | `ts-prompt-assist` | All | New library (v0.1; design + initial implementation in flight via the `ts-prompt-assist` workstream) |
+| `ts-agent-memory` | All | New library (v1 shipped, one close consumer coordinating adoption; treated as still pre-1.0/malleable — breaking changes land freely with no shim, e.g. the 2026-07 rank-axis, scope-qualified-edge, and vector-scoping streams) |
 
 Anything not listed above — including production libraries like `ts-utils`, `ts-res`, `ts-bcp47`, `ts-json`, `ts-json-base`, `ts-random`, `ts-utils-jest`, `ts-res-ui-components` — carries stability obligations. See [Compatibility Rules](#compatibility-rules).
 

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -377,18 +377,29 @@ chunk-granular vector entries + in-result offsets — only if we ever want one s
 semantic retriever to serve **both** record-level memory and sub-document knowledge at
 fragment granularity. Recorded so the shape is visible; no action requested.
 
-### Scope-qualified edge targets — dormant, recorded
+### Scope-qualified edge targets — SHIPPED (2026-07-13)
 
-`IEdge.target` is a bare `MemoryId` with no scope qualifier (`types/envelope.ts`).
-Under the current per-agent-store design (memory and knowledge alike), no two records
-share an id stem across a scope boundary, so bare targets are correct. This would only
-matter if a future **hub-level shared entity table** or **cross-hub federation** scheme
-introduced stem collisions across scopes. Dormant; recorded so the constraint is
-visible if that day comes. No action requested.
+> **SHIPPED** — `IEdge.target: MemoryId → IEdgeTarget` (`{ scope, id }`), via the
+> `agent-memory-scoped-edges` stream (PR #542) plus the `agent-memory-scoped-vectors`
+> follow-on (PR #543). The original "dormant, recorded" framing rested on a premise that
+> turned out to be **wrong**: it assumed no two records share an id stem across a scope
+> boundary. In fact the bundled `MtmIdentityCodec` mints per-scope stems (`turn-<n>`), so
+> two conversations' `turn-3` records collide on a bare `MemoryId` — an edge, backlink,
+> traversal seed, cycle-guard node, ingest-validation target, or vector-index key of
+> `turn-3` was ambiguous across conversations. The consumer surfaced this as a live footgun
+> in the *default* codec; the maintainer adjudicated the deep fix (scope-qualified targets,
+> making per-scope stems legal by construction) over the two lighter options (globally-unique
+> bundled stems; a registration guard). #542 scope-qualified the link graph (edges, backlinks,
+> traversal, cycle guard, ingest edge-validation, edge serialization, the `memory_write` /
+> `memory_context` tool schemas) behind a single collision-proof `edgeTargetKey` helper; #543
+> completed the migration across the vector/similarity + entity-resolution path (breaking the
+> pre-1.0 `IEntityResolver` host contract, no shim). Residual latent item: `IProvenance.derivedFrom`
+> stays a bare `MemoryId` (never dereferenced today) — tracked in `TECH_DEBT.md`.
 
-**Reference:** consumer orchestrator's forwarded 2026-07 agent-memory batch; the four
-firm asks from the same batch shipped via the `agent-memory-query-tool-batch` and
-`agent-memory-rank-axis` streams.
+**Reference:** consumer orchestrator's forwarded 2026-07 agent-memory batch (the id-stem
+uniqueness vs. bare-MemoryId-links friction report); PRs #542, #543; the four firm asks from
+the same batch shipped via the `agent-memory-query-tool-batch` and `agent-memory-rank-axis`
+streams.
 
 ## RFC 9421 HTTP-message-signature packlet (prospective `@fgv/ts-extras`)
 


### PR DESCRIPTION
## Summary

Docs-only reconciliation after the scope-qualified-addressing streams merged (#542 link graph, #543 vector/entity-resolution). **No code change.**

- **`docs/FUTURE.md`** — flips the "scope-qualified edge targets" entry from *dormant, recorded* to **SHIPPED**, and corrects the record: the original premise ("no two records share an id stem across a scope boundary, so bare targets are correct") was wrong. The bundled `MtmIdentityCodec` mints per-scope `turn-<n>` stems, so two conversations' `turn-3` records collided on a bare `MemoryId` — the live footgun the consumer surfaced. Notes the deep fix was adjudicated over the two lighter options, and that `IProvenance.derivedFrom` stays a tracked latent item.
- **`.ai/instructions/ACTIVE_DEVELOPMENT.md`** — adds `ts-agent-memory` to the active-development surfaces table, making explicit the pre-1.0/malleable governance the recent breaking streams already relied on (rank axis, scoped edges, vector scoping — all breaking, no shim). This resolves the governance ambiguity the `code-reviewer` flagged on #543 (the library was being treated as malleable but wasn't listed as an active surface). No contradiction with the stability-obligations list, which doesn't name it.

`TECH_DEBT.md` was already reconciled within the stream PRs (vector half marked resolved; the `derivedFrom` half and the store scoped-`list()` gap remain deferred), so it needs no change here.

## Gate

Docs-only; no build/lint/test impact. Merging without waiting on CI per standing docs-merge policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_