### PR TITLE
feat(crypto-utils): raw-byte AES-256-GCM encryptBytes/decryptBytes (caller nonce + AAD)

### DIFF
--- a/common/changes/@fgv/ts-extras/crypto-encrypt-bytes_2026-07-13-00-00.json
+++ b/common/changes/@fgv/ts-extras/crypto-encrypt-bytes_2026-07-13-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add raw-byte AES-256-GCM encryptBytes/decryptBytes (caller-supplied nonce + optional AAD) to ICryptoProvider and NodeCryptoProvider",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/common/changes/@fgv/ts-web-extras/crypto-encrypt-bytes_2026-07-13-00-00.json
+++ b/common/changes/@fgv/ts-web-extras/crypto-encrypt-bytes_2026-07-13-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-web-extras",
+      "comment": "Implement raw-byte AES-256-GCM encryptBytes/decryptBytes (caller-supplied nonce + optional AAD) on BrowserCryptoProvider; byte-identical to NodeCryptoProvider",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -471,6 +471,7 @@ declare namespace CryptoUtils {
         EncryptedFileFormat,
         INamedSecret,
         IEncryptionResult,
+        IEncryptBytesResult,
         KeyPairAlgorithm,
         IWrapBytesOptions,
         IWrappedBytes,
@@ -1195,8 +1196,14 @@ interface ICreateZipOptions {
 // @public
 interface ICryptoProvider {
     decrypt(encryptedData: Uint8Array, key: Uint8Array, iv: Uint8Array, authTag: Uint8Array): Promise<Result<string>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    decryptBytes(key: Uint8Array, nonce: Uint8Array, ciphertext: Uint8Array, authTag: Uint8Array, aad?: Uint8Array): Promise<Result<Uint8Array>>;
     deriveKey(password: string, salt: Uint8Array, iterations: number): Promise<Result<Uint8Array>>;
     encrypt(plaintext: string, key: Uint8Array): Promise<Result<IEncryptionResult>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    encryptBytes(key: Uint8Array, nonce: Uint8Array, plaintext: Uint8Array, aad?: Uint8Array): Promise<Result<IEncryptBytesResult>>;
     exportPublicKeyJwk(publicKey: CryptoKey): Promise<Result<JsonWebKey>>;
     exportPublicKeySpki(publicKey: CryptoKey): Promise<Result<Uint8Array>>;
     fromBase64(base64: string): Result<Uint8Array>;
@@ -1238,6 +1245,16 @@ interface IDirectEncryptionProviderParams {
     readonly boundSecretName?: string;
     readonly cryptoProvider: ICryptoProvider;
     readonly key: Uint8Array;
+}
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+interface IEncryptBytesResult {
+    readonly authTag: Uint8Array;
+    readonly ciphertext: Uint8Array;
 }
 
 // @public
@@ -2211,8 +2228,13 @@ const namedSecret: Converter<INamedSecret>;
 // @public
 class NodeCryptoProvider implements ICryptoProvider {
     decrypt(encryptedData: Uint8Array, key: Uint8Array, iv: Uint8Array, authTag: Uint8Array): Promise<Result<string>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "NodeCryptoProvider"
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    decryptBytes(key: Uint8Array, nonce: Uint8Array, ciphertext: Uint8Array, authTag: Uint8Array, aad?: Uint8Array): Promise<Result<Uint8Array>>;
     deriveKey(password: string, salt: Uint8Array, iterations: number): Promise<Result<Uint8Array>>;
     encrypt(plaintext: string, key: Uint8Array): Promise<Result<IEncryptionResult>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    encryptBytes(key: Uint8Array, nonce: Uint8Array, plaintext: Uint8Array, aad?: Uint8Array): Promise<Result<IEncryptBytesResult>>;
     exportPublicKeyJwk(publicKey: CryptoKey): Promise<Result<JsonWebKey>>;
     exportPublicKeySpki(publicKey: CryptoKey): Promise<Result<Uint8Array>>;
     fromBase64(base64: string): Result<Uint8Array>;

--- a/libraries/ts-extras/src/packlets/crypto-utils/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/model.ts
@@ -93,6 +93,35 @@ export interface IEncryptionResult {
 }
 
 /**
+ * Result of a raw-byte AES-256-GCM encryption via
+ * {@link CryptoUtils.ICryptoProvider.encryptBytes | encryptBytes}. The
+ * authentication tag is returned separately from the ciphertext, mirroring the
+ * separated-tag convention of {@link CryptoUtils.IEncryptionResult}. The exact
+ * byte layout is:
+ * - `ciphertext`: the AES-GCM ciphertext, byte-for-byte the same length as the
+ *   input plaintext (GCM is a stream cipher — no padding). Empty plaintext
+ *   yields an empty `ciphertext`.
+ * - `authTag`: the 16-byte (128-bit) GCM authentication tag, computed over the
+ *   ciphertext, the nonce, and any `aad`.
+ *
+ * The caller persists both fields alongside the (caller-owned) nonce and feeds
+ * them back to {@link CryptoUtils.ICryptoProvider.decryptBytes | decryptBytes}.
+ * @public
+ */
+export interface IEncryptBytesResult {
+  /**
+   * The AES-256-GCM ciphertext. Same length as the input plaintext (no tag
+   * appended — the tag is carried separately in the `authTag` field).
+   */
+  readonly ciphertext: Uint8Array;
+
+  /**
+   * The 16-byte (128-bit) GCM authentication tag.
+   */
+  readonly authTag: Uint8Array;
+}
+
+/**
  * Asymmetric keypair algorithms supported by the crypto provider.
  * - `'ecdsa-p256'`: ECDSA over the P-256 curve, for signing.
  * - `'rsa-oaep-2048'`: RSA-OAEP, 2048-bit modulus with SHA-256, for encryption.
@@ -398,6 +427,81 @@ export interface ICryptoProvider {
     iv: Uint8Array,
     authTag: Uint8Array
   ): Promise<Result<string>>;
+
+  /**
+   * Encrypts raw bytes using AES-256-GCM with a **caller-supplied nonce** and
+   * optional additional authenticated data (AAD).
+   *
+   * This is the raw-byte sibling of {@link CryptoUtils.ICryptoProvider.encrypt | encrypt}.
+   * Unlike `encrypt`, it takes and returns `Uint8Array` (no UTF-8 coding), the
+   * caller owns the nonce (rather than the provider generating one), and it
+   * binds optional `aad` into the GCM authentication. Use it when you need to
+   * bind context (e.g. an actor id, key version, or row kind) into the
+   * authentication so a wrapped secret cannot be replayed across
+   * users/versions/kinds, or when you manage nonces yourself.
+   *
+   * @remarks
+   * **⚠️ NONCE UNIQUENESS IS THE CALLER'S RESPONSIBILITY AND IS CRITICAL.**
+   * Because the caller supplies the nonce, this primitive cannot guarantee
+   * uniqueness. Reusing a `(key, nonce)` pair for two different messages is
+   * **catastrophic** for AES-GCM: it breaks confidentiality (the XOR of the two
+   * plaintexts leaks) AND authentication (the GCM authentication key can be
+   * recovered, letting an attacker forge tags for arbitrary messages under that
+   * key). The caller MUST use a unique nonce for every message encrypted under a
+   * given key — draw it from {@link CryptoUtils.ICryptoProvider.generateRandomBytes | generateRandomBytes(12)}
+   * (12 random bytes has negligible collision probability well within a single
+   * key's message budget) or from a strictly-increasing counter. Never hardcode
+   * a nonce and never reuse one.
+   *
+   * @param key - 32-byte AES-256 key. Wrong lengths fail with error context.
+   * @param nonce - 12-byte (96-bit) GCM nonce. MUST be unique per message under
+   * `key` (see the nonce-uniqueness warning above). Wrong lengths fail with
+   * error context.
+   * @param plaintext - The bytes to encrypt. Empty plaintext is permitted and
+   * round-trips (GCM produces a valid tag over zero-length plaintext).
+   * @param aad - Optional additional authenticated data bound into the GCM tag
+   * but NOT encrypted. If provided at encrypt time, the identical bytes must be
+   * supplied to `decryptBytes` or decryption fails authentication. Absent means
+   * no AAD.
+   * @returns `Success` with the {@link CryptoUtils.IEncryptBytesResult | ciphertext and 16-byte auth tag},
+   * or `Failure` with error context.
+   */
+  encryptBytes(
+    key: Uint8Array,
+    nonce: Uint8Array,
+    plaintext: Uint8Array,
+    aad?: Uint8Array
+  ): Promise<Result<IEncryptBytesResult>>;
+
+  /**
+   * Decrypts raw bytes produced by
+   * {@link CryptoUtils.ICryptoProvider.encryptBytes | encryptBytes} using
+   * AES-256-GCM. The inverse of `encryptBytes`: the `ciphertext` and `authTag`
+   * from an `encryptBytes` result, together with the same `key`, `nonce`, and
+   * `aad`, recover the original plaintext.
+   *
+   * Fails (never throws) on any authentication failure: a tampered ciphertext
+   * or tag, the wrong key or nonce, or an `aad` that differs from the one used
+   * at encrypt time. AES-GCM authentication is fail-closed — a mismatched `aad`
+   * fails exactly as a tampered ciphertext does.
+   *
+   * @param key - 32-byte AES-256 key (the same key used to encrypt).
+   * @param nonce - 12-byte (96-bit) GCM nonce (the same nonce used to encrypt).
+   * @param ciphertext - The ciphertext from the `encryptBytes` result.
+   * @param authTag - The 16-byte (128-bit) GCM authentication tag from the
+   * `encryptBytes` result.
+   * @param aad - The identical additional authenticated data supplied at encrypt
+   * time (or absent if none was supplied). A mismatch fails authentication.
+   * @returns `Success` with the decrypted plaintext bytes, or `Failure` with
+   * error context (including all authentication failures).
+   */
+  decryptBytes(
+    key: Uint8Array,
+    nonce: Uint8Array,
+    ciphertext: Uint8Array,
+    authTag: Uint8Array,
+    aad?: Uint8Array
+  ): Promise<Result<Uint8Array>>;
 
   /**
    * Generates a random 32-byte key suitable for AES-256.

--- a/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/nodeCryptoProvider.ts
@@ -34,6 +34,7 @@ import * as Constants from './constants';
 import { keyPairAlgorithmParams } from './keyPairAlgorithmParams';
 import {
   ICryptoProvider,
+  IEncryptBytesResult,
   IEncryptionResult,
   IWrapBytesOptions,
   IWrappedBytes,
@@ -114,6 +115,89 @@ export class NodeCryptoProvider implements ICryptoProvider {
 
       return decrypted.toString('utf8');
     }).withErrorFormat((e) => `Decryption failed: ${e}`);
+  }
+
+  /**
+   * Encrypts raw bytes using AES-256-GCM with a caller-supplied nonce and
+   * optional AAD. See {@link CryptoUtils.ICryptoProvider.encryptBytes | ICryptoProvider.encryptBytes}
+   * — in particular the caller's responsibility to use a unique `nonce` per
+   * message under a given `key`.
+   * @param key - 32-byte AES-256 key.
+   * @param nonce - 12-byte GCM nonce (must be unique per message under `key`).
+   * @param plaintext - The bytes to encrypt (empty permitted).
+   * @param aad - Optional additional authenticated data bound into the tag.
+   * @returns `Success` with the ciphertext and 16-byte auth tag, or `Failure` with an error.
+   */
+  public async encryptBytes(
+    key: Uint8Array,
+    nonce: Uint8Array,
+    plaintext: Uint8Array,
+    aad?: Uint8Array
+  ): Promise<Result<IEncryptBytesResult>> {
+    if (key.length !== Constants.AES_256_KEY_SIZE) {
+      return fail(`encryptBytes: key must be ${Constants.AES_256_KEY_SIZE} bytes, got ${key.length}`);
+    }
+    if (nonce.length !== Constants.GCM_IV_SIZE) {
+      return fail(`encryptBytes: nonce must be ${Constants.GCM_IV_SIZE} bytes, got ${nonce.length}`);
+    }
+
+    return captureResult(() => {
+      const cipher = crypto.createCipheriv('aes-256-gcm', Buffer.from(key), Buffer.from(nonce), {
+        authTagLength: Constants.GCM_AUTH_TAG_SIZE
+      });
+      if (aad !== undefined) {
+        cipher.setAAD(Buffer.from(aad));
+      }
+      const encrypted = Buffer.concat([cipher.update(Buffer.from(plaintext)), cipher.final()]);
+      const authTag = cipher.getAuthTag();
+      return {
+        ciphertext: new Uint8Array(encrypted),
+        authTag: new Uint8Array(authTag)
+      };
+    });
+  }
+
+  /**
+   * Decrypts raw bytes produced by {@link NodeCryptoProvider.encryptBytes} using
+   * AES-256-GCM. See {@link CryptoUtils.ICryptoProvider.decryptBytes | ICryptoProvider.decryptBytes}.
+   * Fails (never throws) on any authentication failure, including a mismatched `aad`.
+   * @param key - 32-byte AES-256 key.
+   * @param nonce - 12-byte GCM nonce (the same one used to encrypt).
+   * @param ciphertext - The ciphertext from the `encryptBytes` result.
+   * @param authTag - The 16-byte GCM auth tag from the `encryptBytes` result.
+   * @param aad - The identical AAD supplied at encrypt time (or absent).
+   * @returns `Success` with the decrypted plaintext bytes, or `Failure` with an error.
+   */
+  public async decryptBytes(
+    key: Uint8Array,
+    nonce: Uint8Array,
+    ciphertext: Uint8Array,
+    authTag: Uint8Array,
+    aad?: Uint8Array
+  ): Promise<Result<Uint8Array>> {
+    if (key.length !== Constants.AES_256_KEY_SIZE) {
+      return fail(`decryptBytes: key must be ${Constants.AES_256_KEY_SIZE} bytes, got ${key.length}`);
+    }
+    if (nonce.length !== Constants.GCM_IV_SIZE) {
+      return fail(`decryptBytes: nonce must be ${Constants.GCM_IV_SIZE} bytes, got ${nonce.length}`);
+    }
+    if (authTag.length !== Constants.GCM_AUTH_TAG_SIZE) {
+      return fail(
+        `decryptBytes: auth tag must be ${Constants.GCM_AUTH_TAG_SIZE} bytes, got ${authTag.length}`
+      );
+    }
+
+    return captureResult(() => {
+      const decipher = crypto.createDecipheriv('aes-256-gcm', Buffer.from(key), Buffer.from(nonce), {
+        authTagLength: Constants.GCM_AUTH_TAG_SIZE
+      });
+      if (aad !== undefined) {
+        decipher.setAAD(Buffer.from(aad));
+      }
+      decipher.setAuthTag(Buffer.from(authTag));
+      const decrypted = Buffer.concat([decipher.update(Buffer.from(ciphertext)), decipher.final()]);
+      return new Uint8Array(decrypted);
+    }).withErrorFormat((e) => `decryptBytes failed: ${e}`);
   }
 
   /**

--- a/libraries/ts-extras/src/test/unit/crypto/nodeCryptoProvider.encryptBytes.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/nodeCryptoProvider.encryptBytes.test.ts
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import * as CryptoUtils from '../../../packlets/crypto-utils';
+
+describe('NodeCryptoProvider — encryptBytes/decryptBytes', () => {
+  const provider = CryptoUtils.nodeCryptoProvider;
+
+  // In-memory fixtures only — never logged, exposed, or persisted.
+  const key = new Uint8Array(Array.from({ length: 32 }, (__unused, i) => i));
+  const nonce = new Uint8Array(Array.from({ length: 12 }, (__unused, i) => 0xa0 + i));
+  const aad = new TextEncoder().encode('actor-1|v3|secret');
+  const plaintext = new TextEncoder().encode('known-answer-plaintext');
+
+  // Known-answer vectors precomputed with node:crypto for the fixtures above.
+  const KAT_CIPHERTEXT_HEX = '8d76135a2be663d11112e2a12a0aacbf19c22d75eac3';
+  const KAT_TAG_WITH_AAD_HEX = '314d44a2486673fb3cfda154798aea1e';
+  const KAT_TAG_NO_AAD_HEX = '6e31ae1dd502488285776c15d36e3b9a';
+
+  function toHex(bytes: Uint8Array): string {
+    return Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+
+  describe('round-trip', () => {
+    test('round-trips without AAD', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(encrypted.authTag.length).toBe(CryptoUtils.Constants.GCM_AUTH_TAG_SIZE);
+      // GCM is a stream cipher: ciphertext length equals plaintext length.
+      expect(encrypted.ciphertext.length).toBe(plaintext.length);
+      const recovered = await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag);
+      expect(recovered).toSucceedWith(plaintext);
+    });
+
+    test('round-trips with AAD', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      const recovered = await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag, aad);
+      expect(recovered).toSucceedWith(plaintext);
+    });
+
+    test('round-trips empty plaintext (0 bytes) with a valid tag', async () => {
+      const empty = new Uint8Array(0);
+      const encrypted = (await provider.encryptBytes(key, nonce, empty)).orThrow();
+      expect(encrypted.ciphertext.length).toBe(0);
+      expect(encrypted.authTag.length).toBe(CryptoUtils.Constants.GCM_AUTH_TAG_SIZE);
+      const recovered = await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag);
+      expect(recovered).toSucceedWith(empty);
+    });
+
+    test('round-trips empty plaintext with AAD', async () => {
+      const empty = new Uint8Array(0);
+      const encrypted = (await provider.encryptBytes(key, nonce, empty, aad)).orThrow();
+      const recovered = await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag, aad);
+      expect(recovered).toSucceedWith(empty);
+    });
+  });
+
+  describe('known-answer vectors', () => {
+    test('produces the documented ciphertext/tag layout with AAD', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      expect(toHex(encrypted.ciphertext)).toBe(KAT_CIPHERTEXT_HEX);
+      expect(toHex(encrypted.authTag)).toBe(KAT_TAG_WITH_AAD_HEX);
+    });
+
+    test('produces the documented ciphertext/tag layout without AAD', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(toHex(encrypted.ciphertext)).toBe(KAT_CIPHERTEXT_HEX);
+      expect(toHex(encrypted.authTag)).toBe(KAT_TAG_NO_AAD_HEX);
+    });
+  });
+
+  describe('AAD binding', () => {
+    test('decrypt with a different AAD fails authentication', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      const wrongAad = new TextEncoder().encode('actor-2|v3|secret');
+      expect(
+        await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag, wrongAad)
+      ).toFailWith(/decryptBytes failed/i);
+    });
+
+    test('decrypt without AAD fails when AAD was used at encrypt time', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      expect(await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag)).toFailWith(
+        /decryptBytes failed/i
+      );
+    });
+
+    test('decrypt with AAD fails when none was used at encrypt time', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(
+        await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag, aad)
+      ).toFailWith(/decryptBytes failed/i);
+    });
+  });
+
+  describe('tampering', () => {
+    test('flipping a ciphertext byte fails authentication', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      const tampered = Uint8Array.from(encrypted.ciphertext);
+      tampered[0] ^= 0x01;
+      expect(await provider.decryptBytes(key, nonce, tampered, encrypted.authTag, aad)).toFailWith(
+        /decryptBytes failed/i
+      );
+    });
+
+    test('flipping a tag byte fails authentication', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      const tamperedTag = Uint8Array.from(encrypted.authTag);
+      tamperedTag[0] ^= 0xff;
+      expect(await provider.decryptBytes(key, nonce, encrypted.ciphertext, tamperedTag, aad)).toFailWith(
+        /decryptBytes failed/i
+      );
+    });
+  });
+
+  describe('wrong key / wrong nonce', () => {
+    test('decrypt with a different key fails', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      const wrongKey = new Uint8Array(32).fill(0xff);
+      expect(
+        await provider.decryptBytes(wrongKey, nonce, encrypted.ciphertext, encrypted.authTag)
+      ).toFailWith(/decryptBytes failed/i);
+    });
+
+    test('decrypt with a different nonce fails', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      const wrongNonce = new Uint8Array(12).fill(0x00);
+      expect(
+        await provider.decryptBytes(key, wrongNonce, encrypted.ciphertext, encrypted.authTag)
+      ).toFailWith(/decryptBytes failed/i);
+    });
+  });
+
+  describe('validation', () => {
+    test('encryptBytes fails on wrong key length', async () => {
+      expect(await provider.encryptBytes(new Uint8Array(16), nonce, plaintext)).toFailWith(
+        /encryptBytes: key must be 32 bytes, got 16/i
+      );
+    });
+
+    test('encryptBytes fails on wrong nonce length', async () => {
+      expect(await provider.encryptBytes(key, new Uint8Array(16), plaintext)).toFailWith(
+        /encryptBytes: nonce must be 12 bytes, got 16/i
+      );
+    });
+
+    test('decryptBytes fails on wrong key length', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(
+        await provider.decryptBytes(new Uint8Array(31), nonce, encrypted.ciphertext, encrypted.authTag)
+      ).toFailWith(/decryptBytes: key must be 32 bytes, got 31/i);
+    });
+
+    test('decryptBytes fails on wrong nonce length', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(
+        await provider.decryptBytes(key, new Uint8Array(8), encrypted.ciphertext, encrypted.authTag)
+      ).toFailWith(/decryptBytes: nonce must be 12 bytes, got 8/i);
+    });
+
+    test('decryptBytes fails on wrong auth tag length', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(await provider.decryptBytes(key, nonce, encrypted.ciphertext, new Uint8Array(8))).toFailWith(
+        /decryptBytes: auth tag must be 16 bytes, got 8/i
+      );
+    });
+  });
+});

--- a/libraries/ts-web-extras/etc/ts-web-extras.api.md
+++ b/libraries/ts-web-extras/etc/ts-web-extras.api.md
@@ -16,8 +16,14 @@ class BrowserCryptoProvider implements CryptoUtils_2.ICryptoProvider {
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     constructor(cryptoApi?: Crypto);
     decrypt(encryptedData: Uint8Array, key: Uint8Array, iv: Uint8Array, authTag: Uint8Array): Promise<Result<string>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-web-extras" does not have an export "BrowserCryptoProvider"
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    decryptBytes(key: Uint8Array, nonce: Uint8Array, ciphertext: Uint8Array, authTag: Uint8Array, aad?: Uint8Array): Promise<Result<Uint8Array>>;
     deriveKey(password: string, salt: Uint8Array, iterations: number): Promise<Result<Uint8Array>>;
     encrypt(plaintext: string, key: Uint8Array): Promise<Result<CryptoUtils_2.IEncryptionResult>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    encryptBytes(key: Uint8Array, nonce: Uint8Array, plaintext: Uint8Array, aad?: Uint8Array): Promise<Result<CryptoUtils_2.IEncryptBytesResult>>;
     exportPublicKeyJwk(publicKey: CryptoKey): Promise<Result<JsonWebKey>>;
     exportPublicKeySpki(publicKey: CryptoKey): Promise<Result<Uint8Array>>;
     fromBase64(base64: string): Result<Uint8Array>;

--- a/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
+++ b/libraries/ts-web-extras/src/packlets/crypto-utils/browserCryptoProvider.ts
@@ -562,6 +562,126 @@ export class BrowserCryptoProvider implements CryptoUtils.ICryptoProvider {
   }
 
   /**
+   * Encrypts raw bytes using AES-256-GCM with a caller-supplied nonce and
+   * optional AAD. See {@link CryptoUtils.ICryptoProvider.encryptBytes | ICryptoProvider.encryptBytes}
+   * — in particular the caller's responsibility to use a unique `nonce` per
+   * message under a given `key`.
+   *
+   * Byte-identical to {@link CryptoUtils.NodeCryptoProvider.encryptBytes} for
+   * identical `(key, nonce, plaintext, aad)`: Web Crypto appends the 16-byte tag
+   * to the ciphertext, and this method splits it off so the returned
+   * `ciphertext`/`authTag` match Node's separated-tag layout exactly.
+   * @param key - 32-byte AES-256 key.
+   * @param nonce - 12-byte GCM nonce (must be unique per message under `key`).
+   * @param plaintext - The bytes to encrypt (empty permitted).
+   * @param aad - Optional additional authenticated data bound into the tag.
+   * @returns `Success` with the ciphertext and 16-byte auth tag, or `Failure` with an error.
+   */
+  public async encryptBytes(
+    key: Uint8Array,
+    nonce: Uint8Array,
+    plaintext: Uint8Array,
+    aad?: Uint8Array
+  ): Promise<Result<CryptoUtils.IEncryptBytesResult>> {
+    if (key.length !== CryptoUtils.Constants.AES_256_KEY_SIZE) {
+      return Failure.with(
+        `encryptBytes: key must be ${CryptoUtils.Constants.AES_256_KEY_SIZE} bytes, got ${key.length}`
+      );
+    }
+    if (nonce.length !== CryptoUtils.Constants.GCM_IV_SIZE) {
+      return Failure.with(
+        `encryptBytes: nonce must be ${CryptoUtils.Constants.GCM_IV_SIZE} bytes, got ${nonce.length}`
+      );
+    }
+    const result = await captureAsyncResult(async () => {
+      const cryptoKey = await this._crypto.subtle.importKey(
+        'raw',
+        toBufferView(key),
+        { name: 'AES-GCM' },
+        false,
+        ['encrypt']
+      );
+      const algorithm: AesGcmParams = {
+        name: 'AES-GCM',
+        iv: toBufferView(nonce),
+        tagLength: CryptoUtils.Constants.GCM_AUTH_TAG_SIZE * 8 // bits
+      };
+      if (aad !== undefined) {
+        algorithm.additionalData = toBufferView(aad);
+      }
+      const encryptedWithTag = new Uint8Array(
+        await this._crypto.subtle.encrypt(algorithm, cryptoKey, toBufferView(plaintext))
+      );
+      const tagStart = encryptedWithTag.length - CryptoUtils.Constants.GCM_AUTH_TAG_SIZE;
+      return {
+        ciphertext: encryptedWithTag.slice(0, tagStart),
+        authTag: encryptedWithTag.slice(tagStart)
+      };
+    });
+    return result.withErrorFormat((e) => `encryptBytes failed: ${e}`);
+  }
+
+  /**
+   * Decrypts raw bytes produced by {@link BrowserCryptoProvider.encryptBytes}
+   * using AES-256-GCM. See
+   * {@link CryptoUtils.ICryptoProvider.decryptBytes | ICryptoProvider.decryptBytes}.
+   * Fails (never throws) on any authentication failure, including a mismatched `aad`.
+   * @param key - 32-byte AES-256 key.
+   * @param nonce - 12-byte GCM nonce (the same one used to encrypt).
+   * @param ciphertext - The ciphertext from the `encryptBytes` result.
+   * @param authTag - The 16-byte GCM auth tag from the `encryptBytes` result.
+   * @param aad - The identical AAD supplied at encrypt time (or absent).
+   * @returns `Success` with the decrypted plaintext bytes, or `Failure` with an error.
+   */
+  public async decryptBytes(
+    key: Uint8Array,
+    nonce: Uint8Array,
+    ciphertext: Uint8Array,
+    authTag: Uint8Array,
+    aad?: Uint8Array
+  ): Promise<Result<Uint8Array>> {
+    if (key.length !== CryptoUtils.Constants.AES_256_KEY_SIZE) {
+      return Failure.with(
+        `decryptBytes: key must be ${CryptoUtils.Constants.AES_256_KEY_SIZE} bytes, got ${key.length}`
+      );
+    }
+    if (nonce.length !== CryptoUtils.Constants.GCM_IV_SIZE) {
+      return Failure.with(
+        `decryptBytes: nonce must be ${CryptoUtils.Constants.GCM_IV_SIZE} bytes, got ${nonce.length}`
+      );
+    }
+    if (authTag.length !== CryptoUtils.Constants.GCM_AUTH_TAG_SIZE) {
+      return Failure.with(
+        `decryptBytes: auth tag must be ${CryptoUtils.Constants.GCM_AUTH_TAG_SIZE} bytes, got ${authTag.length}`
+      );
+    }
+    const result = await captureAsyncResult(async () => {
+      const cryptoKey = await this._crypto.subtle.importKey(
+        'raw',
+        toBufferView(key),
+        { name: 'AES-GCM' },
+        false,
+        ['decrypt']
+      );
+      // Web Crypto expects ciphertext + auth tag concatenated.
+      const encryptedWithTag = new Uint8Array(ciphertext.length + authTag.length);
+      encryptedWithTag.set(ciphertext);
+      encryptedWithTag.set(authTag, ciphertext.length);
+      const algorithm: AesGcmParams = {
+        name: 'AES-GCM',
+        iv: toBufferView(nonce),
+        tagLength: CryptoUtils.Constants.GCM_AUTH_TAG_SIZE * 8 // bits
+      };
+      if (aad !== undefined) {
+        algorithm.additionalData = toBufferView(aad);
+      }
+      const decrypted = await this._crypto.subtle.decrypt(algorithm, cryptoKey, encryptedWithTag);
+      return new Uint8Array(decrypted);
+    });
+    return result.withErrorFormat((e) => `decryptBytes failed: ${e}`);
+  }
+
+  /**
    * Wraps `plaintext` for the holder of `recipientPublicKey` using
    * ECIES (ECDH P-256 + HKDF-SHA256 + AES-GCM-256). See
    * {@link CryptoUtils.ICryptoProvider.wrapBytes | ICryptoProvider.wrapBytes}.

--- a/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.encryptBytes.test.ts
+++ b/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.encryptBytes.test.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import '@fgv/ts-utils-jest';
+
+import { CryptoUtils } from '@fgv/ts-extras';
+import { BrowserCryptoProvider } from '../../packlets/crypto-utils';
+
+const provider = new BrowserCryptoProvider();
+const nodeProvider = CryptoUtils.nodeCryptoProvider;
+
+// In-memory fixtures only — never logged, exposed, or persisted.
+const key = new Uint8Array(Array.from({ length: 32 }, (__unused, i) => i));
+const nonce = new Uint8Array(Array.from({ length: 12 }, (__unused, i) => 0xa0 + i));
+const aad = new TextEncoder().encode('actor-1|v3|secret');
+const plaintext = new TextEncoder().encode('known-answer-plaintext');
+
+// Known-answer vectors precomputed with node:crypto for the fixtures above.
+const KAT_CIPHERTEXT_HEX = '8d76135a2be663d11112e2a12a0aacbf19c22d75eac3';
+const KAT_TAG_WITH_AAD_HEX = '314d44a2486673fb3cfda154798aea1e';
+const KAT_TAG_NO_AAD_HEX = '6e31ae1dd502488285776c15d36e3b9a';
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+describe('BrowserCryptoProvider — encryptBytes/decryptBytes', () => {
+  describe('round-trip', () => {
+    test.each<[string, Uint8Array]>([
+      ['32-byte plaintext', new Uint8Array(32).fill(0x11)],
+      ['1-byte plaintext', new Uint8Array([0x42])],
+      ['1KB plaintext', new Uint8Array(Array.from({ length: 1024 }, (__unused, i) => i % 256))],
+      ['empty plaintext', new Uint8Array(0)],
+      ['high-bit-set bytes', new Uint8Array(64).fill(0xff)]
+    ])('round-trips %s without AAD', async (__label, pt) => {
+      const encrypted = (await provider.encryptBytes(key, nonce, pt)).orThrow();
+      expect(encrypted.ciphertext.length).toBe(pt.length);
+      expect(encrypted.authTag.length).toBe(CryptoUtils.Constants.GCM_AUTH_TAG_SIZE);
+      const recovered = await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag);
+      expect(recovered).toSucceedWith(pt);
+    });
+
+    test('round-trips with AAD', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      const recovered = await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag, aad);
+      expect(recovered).toSucceedWith(plaintext);
+    });
+
+    test('round-trips empty plaintext with AAD', async () => {
+      const empty = new Uint8Array(0);
+      const encrypted = (await provider.encryptBytes(key, nonce, empty, aad)).orThrow();
+      expect(encrypted.ciphertext.length).toBe(0);
+      const recovered = await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag, aad);
+      expect(recovered).toSucceedWith(empty);
+    });
+  });
+
+  describe('known-answer vectors', () => {
+    test('produces the documented ciphertext/tag layout with AAD', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      expect(toHex(encrypted.ciphertext)).toBe(KAT_CIPHERTEXT_HEX);
+      expect(toHex(encrypted.authTag)).toBe(KAT_TAG_WITH_AAD_HEX);
+    });
+
+    test('produces the documented ciphertext/tag layout without AAD', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(toHex(encrypted.ciphertext)).toBe(KAT_CIPHERTEXT_HEX);
+      expect(toHex(encrypted.authTag)).toBe(KAT_TAG_NO_AAD_HEX);
+    });
+  });
+
+  describe('cross-runtime byte-identity with NodeCryptoProvider', () => {
+    test('Browser and Node produce byte-identical ciphertext+tag (with AAD)', async () => {
+      const browserOut = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      const nodeOut = (await nodeProvider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      expect(toHex(browserOut.ciphertext)).toBe(toHex(nodeOut.ciphertext));
+      expect(toHex(browserOut.authTag)).toBe(toHex(nodeOut.authTag));
+    });
+
+    test('Browser and Node produce byte-identical ciphertext+tag (no AAD)', async () => {
+      const browserOut = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      const nodeOut = (await nodeProvider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(toHex(browserOut.ciphertext)).toBe(toHex(nodeOut.ciphertext));
+      expect(toHex(browserOut.authTag)).toBe(toHex(nodeOut.authTag));
+    });
+
+    test('Node-encrypted bytes decrypt on the Browser provider', async () => {
+      const nodeOut = (await nodeProvider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      const recovered = await provider.decryptBytes(key, nonce, nodeOut.ciphertext, nodeOut.authTag, aad);
+      expect(recovered).toSucceedWith(plaintext);
+    });
+
+    test('Browser-encrypted bytes decrypt on the Node provider', async () => {
+      const browserOut = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      const recovered = await nodeProvider.decryptBytes(
+        key,
+        nonce,
+        browserOut.ciphertext,
+        browserOut.authTag,
+        aad
+      );
+      expect(recovered).toSucceedWith(plaintext);
+    });
+  });
+
+  describe('AAD binding', () => {
+    test('decrypt with a different AAD fails authentication', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      const wrongAad = new TextEncoder().encode('actor-2|v3|secret');
+      expect(
+        await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag, wrongAad)
+      ).toFailWith(/decryptBytes failed/i);
+    });
+
+    test('decrypt without AAD fails when AAD was used at encrypt time', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      expect(await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag)).toFailWith(
+        /decryptBytes failed/i
+      );
+    });
+
+    test('decrypt with AAD fails when none was used at encrypt time', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(
+        await provider.decryptBytes(key, nonce, encrypted.ciphertext, encrypted.authTag, aad)
+      ).toFailWith(/decryptBytes failed/i);
+    });
+  });
+
+  describe('tampering', () => {
+    test('flipping a ciphertext byte fails authentication', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      const tampered = Uint8Array.from(encrypted.ciphertext);
+      tampered[0] ^= 0x01;
+      expect(await provider.decryptBytes(key, nonce, tampered, encrypted.authTag, aad)).toFailWith(
+        /decryptBytes failed/i
+      );
+    });
+
+    test('flipping a tag byte fails authentication', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext, aad)).orThrow();
+      const tamperedTag = Uint8Array.from(encrypted.authTag);
+      tamperedTag[0] ^= 0xff;
+      expect(await provider.decryptBytes(key, nonce, encrypted.ciphertext, tamperedTag, aad)).toFailWith(
+        /decryptBytes failed/i
+      );
+    });
+  });
+
+  describe('wrong key / wrong nonce', () => {
+    test('decrypt with a different key fails', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      const wrongKey = new Uint8Array(32).fill(0xff);
+      expect(
+        await provider.decryptBytes(wrongKey, nonce, encrypted.ciphertext, encrypted.authTag)
+      ).toFailWith(/decryptBytes failed/i);
+    });
+
+    test('decrypt with a different nonce fails', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      const wrongNonce = new Uint8Array(12).fill(0x00);
+      expect(
+        await provider.decryptBytes(key, wrongNonce, encrypted.ciphertext, encrypted.authTag)
+      ).toFailWith(/decryptBytes failed/i);
+    });
+  });
+
+  describe('validation', () => {
+    test('encryptBytes fails on wrong key length', async () => {
+      expect(await provider.encryptBytes(new Uint8Array(16), nonce, plaintext)).toFailWith(
+        /encryptBytes: key must be 32 bytes, got 16/i
+      );
+    });
+
+    test('encryptBytes fails on wrong nonce length', async () => {
+      expect(await provider.encryptBytes(key, new Uint8Array(16), plaintext)).toFailWith(
+        /encryptBytes: nonce must be 12 bytes, got 16/i
+      );
+    });
+
+    test('decryptBytes fails on wrong key length', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(
+        await provider.decryptBytes(new Uint8Array(31), nonce, encrypted.ciphertext, encrypted.authTag)
+      ).toFailWith(/decryptBytes: key must be 32 bytes, got 31/i);
+    });
+
+    test('decryptBytes fails on wrong nonce length', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(
+        await provider.decryptBytes(key, new Uint8Array(8), encrypted.ciphertext, encrypted.authTag)
+      ).toFailWith(/decryptBytes: nonce must be 12 bytes, got 8/i);
+    });
+
+    test('decryptBytes fails on wrong auth tag length', async () => {
+      const encrypted = (await provider.encryptBytes(key, nonce, plaintext)).orThrow();
+      expect(await provider.decryptBytes(key, nonce, encrypted.ciphertext, new Uint8Array(8))).toFailWith(
+        /decryptBytes: auth tag must be 16 bytes, got 8/i
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a raw-byte symmetric **AES-256-GCM** primitive to `ICryptoProvider` — a sibling to the existing string-based `encrypt`/`decrypt` — for consumers that today call `crypto.subtle.encrypt/decrypt` directly to encrypt bytes under a symmetric key with a specific nonce and AAD.

```ts
encryptBytes(key, nonce, plaintext, aad?): Promise<Result<IEncryptBytesResult>>   // { ciphertext, authTag }
decryptBytes(key, nonce, ciphertext, authTag, aad?): Promise<Result<Uint8Array>>
```

The existing `encrypt`/`decrypt` take/return a UTF-8 string, generate the nonce internally, and support no AAD. The new methods are structurally different (bytes in/out, caller-owned nonce, AAD), so per the repo's "new sibling primitive" guidance they are added as siblings rather than options on `encrypt`.

Implemented in **both** providers, byte-identical for identical inputs:
- `NodeCryptoProvider` (`@fgv/ts-extras`) via `node:crypto` `createCipheriv('aes-256-gcm', …)` + `setAAD`/`getAuthTag`.
- `BrowserCryptoProvider` (`@fgv/ts-web-extras`) via `crypto.subtle` `{ name: 'AES-GCM', iv, additionalData, tagLength: 128 }`.

## Tag / byte layout

**Separated-tag convention**, mirroring the existing `IEncryptionResult` (iv/authTag/encryptedData) and `decrypt`'s separate `authTag` param:
- `ciphertext`: AES-GCM ciphertext, same length as plaintext (stream cipher, no padding; empty plaintext → empty ciphertext).
- `authTag`: 16-byte (128-bit) GCM tag, over ciphertext + nonce + any AAD.

WebCrypto appends the 16-byte tag to the ciphertext; the browser impl splits it off so both runtimes emit the identical separated `{ ciphertext, authTag }`. `encryptBytes` output feeds `decryptBytes` input symmetrically. The consumer matches its persistence format to this layout.

## Nonce-safety contract (load-bearing)

The caller supplies the nonce, so the primitive cannot guarantee uniqueness. The TSDoc warns **prominently** that AES-GCM `(key, nonce)` reuse across two messages is catastrophic (breaks confidentiality AND authentication), and that callers MUST use a unique nonce per `(key, message)` — e.g. from `generateRandomBytes(12)` or a strictly-increasing counter.

## AAD (fail-closed)

`aad` is optional and bound into the GCM tag but not encrypted. Absent → no AAD. A `decryptBytes` call whose `aad` differs from the encrypt-time `aad` fails GCM authentication exactly like a tampered ciphertext — proven by tests (different aad, aad-present-vs-absent both directions). This lets a consumer bind e.g. `actorId || masterVersion || rowKind` so wrapped secrets can't be replayed across users/versions/kinds.

## Node/Browser parity

Both impls produce byte-identical `ciphertext + authTag` for identical `(key, nonce, plaintext, aad)`. Verified three ways: a fixed **known-answer vector** (asserted in both packages), direct **Browser-vs-Node byte-equality** assertions, and **cross-decryption** (Node-encrypted → Browser-decrypted and vice-versa) — all run in the Node webcrypto test env.

## Test matrix (100% coverage, both packages)

Round-trip (with/without AAD, incl. empty plaintext); AAD binding (mismatch fails, present/absent both ways); tamper (ciphertext byte, tag byte); wrong key / wrong nonce; validation (wrong key len, wrong nonce len, wrong tag len — fail loudly with context); known-answer + cross-runtime byte-identity + cross-decryption. Key/nonce/plaintext are in-memory fixtures only (never logged/persisted).

## Gate results

**`@fgv/ts-extras`** — `rushx build` ✅ · `rushx fixlint` + `rushx lint` ✅ · `rushx test` ✅ 100% (`model.ts`, `nodeCryptoProvider.ts` at 100/100/100/100).
**`@fgv/ts-web-extras`** — `rushx build` ✅ · `rushx fixlint` + `rushx lint` ✅ · `rushx test` ✅ 100% (`browserCryptoProvider.ts` at 100/100/100/100).

`etc/*.api.md` regenerated in both packages (two new methods + `IEncryptBytesResult`). Changesets added (minor, additive) for both packages.

## Review notes

- **Self-review (layer 1):** ran the CODE_REVIEW_CHECKLIST myself (no `code-reviewer` sub-agent available in this run). No `any`; all fallible ops return `Result<T>` (no `Result<void>`); validation failures carry context; `decryptBytes` wraps auth failures with `withErrorFormat`; `encryptBytes` omits an error-format wrapper because its only failure mode is the up-front length validation (the crypto op can't fail on validated inputs) — this keeps the success-only path fully covered without an unreachable lambda. Additive interface change on the active `crypto-utils` surface.
- **For the gate to double-check:** (1) Node/Browser byte-identity / tag placement (the KAT + cross-decryption tests are the evidence); (2) the nonce-reuse safety TSDoc is prominent and accurate.

Copilot review loop: not yet run (implementer will drive post-open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_