### PR TITLE
feat(crypto-utils): opt-in private-key escrow for cross-device KeyStore recovery

### DIFF
--- a/common/changes/@fgv/ts-extras/keystore-private-key-escrow_2026-07-14-00-00.json
+++ b/common/changes/@fgv/ts-extras/keystore-private-key-escrow_2026-07-14-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "crypto-utils/KeyStore: add opt-in per-keypair private-key escrow for cross-device recovery. `addKeyPair(name, { escrow: true })` carries an encrypted private-key JWK inside the vault ciphertext (new optional `escrowedPrivateKeyJwk` on asymmetric entries); `getKeyPair(name, { rehydrate: true })` reconstitutes the private key on a fresh device from the vault file plus master password (fill-a-gap only, never overwrites an existing storage blob). `escrow` is orthogonal to `extractable` — the live stored key's extractability is unchanged; only a recovery copy is retained. The bare private key never leaves `addKeyPair` (transient extractable key, exported JWK, and re-imported non-extractable key are the only artifacts; none is returned or logged). Vault format bumped to `keystore-v2` (strict superset: a v2 reader opens v1 vaults; a re-saved v1 vault upgrades silently). Additive/back-compatible.",
+      "type": "minor",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -275,6 +275,9 @@ const allKeyPairAlgorithms: ReadonlyArray<KeyPairAlgorithm>;
 const allKeyStoreAsymmetricSecretTypes: ReadonlyArray<KeyStoreAsymmetricSecretType>;
 
 // @public
+const allKeyStoreFormats: ReadonlyArray<KeyStoreFormat>;
+
+// @public
 const allKeyStoreSecretTypes: ReadonlyArray<KeyStoreSecretType>;
 
 // @public
@@ -763,6 +766,8 @@ class HpkeProvider {
 interface IAddKeyPairOptions {
     readonly algorithm: KeyPairAlgorithm;
     readonly description?: string;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly escrow?: boolean;
     readonly extractable?: boolean;
     readonly replace?: boolean;
 }
@@ -1404,6 +1409,13 @@ interface IGenerateJsonCompletionResult<T> {
     readonly value: T;
 }
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+interface IGetKeyPairOptions {
+    readonly rehydrate?: boolean;
+}
+
 // @public
 interface IGptImageGenerationConfig {
     readonly background?: 'transparent' | 'opaque' | 'auto';
@@ -1497,6 +1509,8 @@ interface IKeyStoreAsymmetricEntry {
     readonly createdAt: string;
     readonly description?: string;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly escrowedPrivateKeyJwk?: JsonWebKey;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     readonly id: string;
     readonly name: string;
     readonly publicKeyJwk: JsonWebKey;
@@ -1510,6 +1524,7 @@ interface IKeyStoreAsymmetricEntryJson {
     readonly algorithm: KeyPairAlgorithm;
     readonly createdAt: string;
     readonly description?: string;
+    readonly escrowedPrivateKeyJwk?: JsonWebKey;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     readonly id: string;
     readonly name: string;
@@ -1963,6 +1978,7 @@ declare namespace KeyStore {
         allKeyPairAlgorithms,
         KeyPairAlgorithm,
         KeyStoreFormat,
+        allKeyStoreFormats,
         KEYSTORE_FORMAT,
         DEFAULT_KEYSTORE_ITERATIONS,
         MIN_SALT_LENGTH,
@@ -1994,12 +2010,15 @@ declare namespace KeyStore {
         IAddSecretFromPasswordResult,
         IAddSecretFromPasswordArgon2idOptions,
         IAddKeyPairOptions,
+        IGetKeyPairOptions,
         IAddKeyPairResult,
         IRemoveSecretResult,
         IPrivateKeyStorage
     }
 }
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
 // @public
 class KeyStore_2 implements IEncryptionProvider {
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -2018,7 +2037,8 @@ class KeyStore_2 implements IEncryptionProvider {
     getApiKey(name: string): Result<string>;
     getEncryptionConfig(): Result<Pick<IEncryptionConfig, 'secretProvider' | 'cryptoProvider'>>;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-    getKeyPair(name: string): Promise<Result<{
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    getKeyPair(name: string, options?: IGetKeyPairOptions): Promise<Result<{
         publicKey: CryptoKey;
         privateKey: CryptoKey;
     }>>;
@@ -2077,7 +2097,7 @@ const keystoreAsymmetricSecretType: Converter<KeyStoreAsymmetricSecretType>;
 const keystoreFile: Converter<IKeyStoreFile>;
 
 // @public
-type KeyStoreFormat = 'keystore-v1';
+type KeyStoreFormat = 'keystore-v1' | 'keystore-v2';
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
@@ -2526,8 +2546,9 @@ class ZipFileTreeAccessors<TCT extends string = string> implements FileTree.IFil
 
 // Warnings were encountered during analysis:
 //
-// src/packlets/crypto-utils/keystore/keyStore.ts:1479:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// src/packlets/crypto-utils/keystore/keyStore.ts:1518:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/crypto-utils/keystore/keyStore.ts:1562:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/crypto-utils/keystore/keyStore.ts:1599:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "KeyStore"
+// src/packlets/crypto-utils/keystore/keyStore.ts:1693:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 
 // (No @packageDocumentation comment for this package)
 

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -2546,9 +2546,9 @@ class ZipFileTreeAccessors<TCT extends string = string> implements FileTree.IFil
 
 // Warnings were encountered during analysis:
 //
-// src/packlets/crypto-utils/keystore/keyStore.ts:1562:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// src/packlets/crypto-utils/keystore/keyStore.ts:1599:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "KeyStore"
-// src/packlets/crypto-utils/keystore/keyStore.ts:1693:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/crypto-utils/keystore/keyStore.ts:1558:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/crypto-utils/keystore/keyStore.ts:1595:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "KeyStore"
+// src/packlets/crypto-utils/keystore/keyStore.ts:1689:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 
 // (No @packageDocumentation comment for this package)
 

--- a/libraries/ts-extras/src/packlets/crypto-utils/keystore/converters.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/keystore/converters.ts
@@ -22,6 +22,7 @@ import { Converter, Converters, succeed, Validation, Validator, Validators } fro
 import { base64String, encryptionAlgorithm, pbkdf2KeyDerivationParams } from '../converters';
 import {
   allKeyPairAlgorithms,
+  allKeyStoreFormats,
   allKeyStoreSecretTypes,
   allKeyStoreSymmetricSecretTypes,
   IKeyStoreAsymmetricEntryJson,
@@ -29,7 +30,6 @@ import {
   IKeyStoreFile,
   IKeyStoreSymmetricEntryJson,
   IKeyStoreVaultContents,
-  KEYSTORE_FORMAT,
   KeyPairAlgorithm,
   KeyStoreAsymmetricSecretType,
   KeyStoreFormat,
@@ -46,9 +46,8 @@ import {
  * Converter for {@link CryptoUtils.KeyStore.KeyStoreFormat | key store format} version.
  * @public
  */
-export const keystoreFormat: Converter<KeyStoreFormat> = Converters.enumeratedValue<KeyStoreFormat>([
-  KEYSTORE_FORMAT
-]);
+export const keystoreFormat: Converter<KeyStoreFormat> =
+  Converters.enumeratedValue<KeyStoreFormat>(allKeyStoreFormats);
 
 // ============================================================================
 // Secret Type Converters
@@ -171,6 +170,7 @@ export const keystoreAsymmetricEntryJson: Converter<IKeyStoreAsymmetricEntryJson
     id: Converters.string,
     algorithm: keyPairAlgorithm,
     publicKeyJwk: jsonWebKeyShape,
+    escrowedPrivateKeyJwk: jsonWebKeyShape.optional(),
     description: Converters.string.optional(),
     createdAt: Converters.string
   });

--- a/libraries/ts-extras/src/packlets/crypto-utils/keystore/keyStore.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/keystore/keyStore.ts
@@ -19,9 +19,10 @@
 // SOFTWARE.
 
 import { JsonValue } from '@fgv/ts-json-base';
-import { captureResult, fail, Result, succeed } from '@fgv/ts-utils';
+import { captureAsyncResult, captureResult, fail, Result, succeed } from '@fgv/ts-utils';
 import * as Constants from '../constants';
 import { createEncryptedFile } from '../encryptedFile';
+import { IKeyPairAlgorithmParams, keyPairAlgorithmParams } from '../keyPairAlgorithmParams';
 import {
   ICryptoProvider,
   IEncryptedFile,
@@ -32,6 +33,7 @@ import {
   IArgon2idParams,
   IKeyDerivationParams,
   ARGON2ID_OWASP_MIN,
+  KeyPairAlgorithm,
   SecretProvider
 } from '../model';
 import {
@@ -44,6 +46,7 @@ import {
   IAddSecretFromPasswordResult,
   IAddSecretOptions,
   IAddSecretResult,
+  IGetKeyPairOptions,
   IImportKeyOptions,
   IImportSecretOptions,
   IKeyStoreAsymmetricEntry,
@@ -69,6 +72,12 @@ import { keystoreFile, keystoreVaultContents } from './converters';
 function getCurrentTimestamp(): string {
   return new Date().toISOString();
 }
+
+// WebCrypto key usages that only ever apply to a public key. Filtering these
+// out of the keypair usages yields the usages valid for the private half, which
+// `crypto.subtle.importKey` requires when re-importing a private JWK. Mirrors
+// the same list in `EncryptedFilePrivateKeyStorage`.
+const PUBLIC_ONLY_USAGES: ReadonlyArray<KeyUsage> = ['verify', 'encrypt', 'wrapKey'];
 
 // ============================================================================
 // KeyStore Class
@@ -102,6 +111,20 @@ function getCurrentTimestamp(): string {
  * // Use as secret provider for encrypted file loading
  * const encryptionConfig = keystore2.getEncryptionConfig().orThrow();
  * ```
+ *
+ * @remarks
+ * SECURITY — private-key escrow. By default an asymmetric keypair's private
+ * key lives only in the per-device {@link CryptoUtils.KeyStore.IPrivateKeyStorage}
+ * backend; the vault carries only the public JWK, so a vault recovered on a new
+ * device reconstitutes with no private keys (a lost device is a lost identity).
+ * `addKeyPair(name, { escrow: true })` opts into carrying an encrypted private-key
+ * copy inside the vault ciphertext, so the vault file plus the master password can
+ * recover the identity on a fresh device via `getKeyPair(name, { rehydrate: true })`.
+ *
+ * When escrow is used, **the master password becomes the sole gate** protecting a
+ * private signing/decryption key that was previously unrecoverable from the vault.
+ * Configure escrow-bearing stores with a strong KDF — an Argon2id-derived master
+ * key or a high-iteration PBKDF2 count — and treat the vault file accordingly.
  *
  * @public
  */
@@ -947,8 +970,17 @@ export class KeyStore implements IEncryptionProvider {
         `Cannot create non-extractable keypair for '${name}': storage backend does not support non-extractable keys`
       );
     }
-    const extractable = options.extractable ?? backendExtractable;
-    const keyPairResult = await this._cryptoProvider.generateKeyPair(options.algorithm, extractable);
+    // Extractability of the LIVE stored key. Escrow is orthogonal — it never
+    // changes this; the escrow copy is captured separately from a transient
+    // extractable key.
+    const liveExtractable = options.extractable ?? backendExtractable;
+
+    // For escrow we must be able to export the private key to JWK, which only
+    // works on an extractable key, so the transient keypair is generated
+    // extractable regardless of `liveExtractable`. Without escrow it is
+    // generated directly at the live setting.
+    const generateExtractable = options.escrow === true ? true : liveExtractable;
+    const keyPairResult = await this._cryptoProvider.generateKeyPair(options.algorithm, generateExtractable);
     /* c8 ignore next 3 - crypto provider errors covered in nodeCryptoProvider tests; cannot be triggered here without mocking */
     if (keyPairResult.isFailure()) {
       return fail(`Failed to generate keypair for '${name}': ${keyPairResult.message}`);
@@ -961,6 +993,37 @@ export class KeyStore implements IEncryptionProvider {
       return fail(`Failed to export public key for '${name}': ${jwkResult.message}`);
     }
 
+    // Escrow (opt-in). The bare private key exists only as three local
+    // artifacts, none of which is returned or logged: (1) the transient
+    // extractable `privateKey` above; (2) the exported `escrowedPrivateKeyJwk`,
+    // which is carried in the vault entry (same custody class as the public
+    // JWK); (3) a freshly re-imported non-extractable key handed to `store()`
+    // when the live copy must be non-extractable. When the live copy is
+    // extractable the transient key IS the live copy and is stored directly.
+    let escrowedPrivateKeyJwk: JsonWebKey | undefined;
+    let keyToStore: CryptoKey = privateKey;
+    if (options.escrow === true) {
+      const escrowResult = await this._exportPrivateKeyJwk(privateKey, name);
+      /* c8 ignore next 3 - export('jwk') of a freshly-generated extractable private key does not fail with a healthy provider (analogous to the exportPublicKeyJwk ignore above) */
+      if (escrowResult.isFailure()) {
+        return fail(escrowResult.message);
+      }
+      escrowedPrivateKeyJwk = escrowResult.value;
+
+      if (!liveExtractable) {
+        const reimportResult = await this._importEscrowedPrivateKey(
+          escrowedPrivateKeyJwk,
+          options.algorithm,
+          false
+        );
+        /* c8 ignore next 3 - re-importing a JWK we just exported from a valid key cannot fail; the import-failure path itself is covered via getKeyPair rehydration of a malformed escrow JWK */
+        if (reimportResult.isFailure()) {
+          return fail(`Failed to prepare non-extractable key for '${name}': ${reimportResult.message}`);
+        }
+        keyToStore = reimportResult.value;
+      }
+    }
+
     const idResult = this._generateId();
     /* c8 ignore next 3 - random-bytes failure is hard to trigger with a healthy provider */
     if (idResult.isFailure()) {
@@ -969,7 +1032,7 @@ export class KeyStore implements IEncryptionProvider {
     const id = idResult.value;
 
     // Storage-first: write the private key before committing the vault entry.
-    const storeResult = await this._privateKeyStorage.store(id, privateKey);
+    const storeResult = await this._privateKeyStorage.store(id, keyToStore);
     if (storeResult.isFailure()) {
       return fail(`Failed to persist private key for '${name}': ${storeResult.message}`);
     }
@@ -980,6 +1043,7 @@ export class KeyStore implements IEncryptionProvider {
       id,
       algorithm: options.algorithm,
       publicKeyJwk: jwkResult.value,
+      escrowedPrivateKeyJwk,
       description: options.description,
       createdAt: getCurrentTimestamp()
     };
@@ -997,12 +1061,26 @@ export class KeyStore implements IEncryptionProvider {
    * the keystore never caches private `CryptoKey` references between calls.
    * The public key is re-imported from the vault's JWK so callers always
    * receive a `CryptoKey` rather than the JWK form.
+   *
+   * With `options.rehydrate: true`, if the storage backend holds no blob for
+   * the entry's `id` and the entry carries an `escrowedPrivateKeyJwk` (see
+   * `addKeyPair(name, { escrow: true })`), the escrowed JWK is imported and
+   * stored under the entry's `id` before being returned — recovering the
+   * private key on a fresh device from the vault plus master password. This is
+   * fill-a-gap only: an existing storage blob is never overwritten.
+   *
    * @param name - Name of the entry
+   * @param options - Optional {@link CryptoUtils.KeyStore.IGetKeyPairOptions}
+   * (currently the `rehydrate` escrow-recovery flag).
    * @returns Success with `{ publicKey, privateKey }`, Failure if not found,
-   * locked, wrong type, no provider, or storage load failed.
+   * locked, wrong type, no provider, or storage load (and any escrow
+   * rehydration) failed.
    * @public
    */
-  public async getKeyPair(name: string): Promise<Result<{ publicKey: CryptoKey; privateKey: CryptoKey }>> {
+  public async getKeyPair(
+    name: string,
+    options?: IGetKeyPairOptions
+  ): Promise<Result<{ publicKey: CryptoKey; privateKey: CryptoKey }>> {
     if (!this._secrets) {
       return fail('Key store is locked');
     }
@@ -1017,9 +1095,9 @@ export class KeyStore implements IEncryptionProvider {
       return fail('No private key storage configured');
     }
 
-    const privateResult = await this._privateKeyStorage.load(entry.id);
+    const privateResult = await this._loadOrRehydratePrivateKey(name, entry, options);
     if (privateResult.isFailure()) {
-      return fail(`Failed to load private key for '${name}': ${privateResult.message}`);
+      return fail(privateResult.message);
     }
 
     const publicResult = await this._cryptoProvider.importPublicKeyJwk(entry.publicKeyJwk, entry.algorithm);
@@ -1315,6 +1393,7 @@ export class KeyStore implements IEncryptionProvider {
           id: entry.id,
           algorithm: entry.algorithm,
           publicKeyJwk: entry.publicKeyJwk,
+          escrowedPrivateKeyJwk: entry.escrowedPrivateKeyJwk,
           description: entry.description,
           createdAt: entry.createdAt
         };
@@ -1432,6 +1511,7 @@ export class KeyStore implements IEncryptionProvider {
           id: jsonEntry.id,
           algorithm: jsonEntry.algorithm,
           publicKeyJwk: jsonEntry.publicKeyJwk,
+          escrowedPrivateKeyJwk: jsonEntry.escrowedPrivateKeyJwk,
           description: jsonEntry.description,
           createdAt: jsonEntry.createdAt
         };
@@ -1489,6 +1569,98 @@ export class KeyStore implements IEncryptionProvider {
     }
     entry.key.fill(0);
     return undefined;
+  }
+
+  /**
+   * Exports the transient extractable private `CryptoKey` to a JWK for escrow,
+   * via WebCrypto's `exportKey('jwk', ...)` (cross-runtime through
+   * `globalThis.crypto.subtle`). The result is carried in the vault entry — the
+   * same custody class as the public JWK — and is never returned from a public
+   * method nor logged.
+   */
+  private async _exportPrivateKeyJwk(privateKey: CryptoKey, name: string): Promise<Result<JsonWebKey>> {
+    return captureAsyncResult(() => globalThis.crypto.subtle.exportKey('jwk', privateKey)).withErrorFormat(
+      (msg) => `Failed to export private key for escrow of '${name}': ${msg}`
+    );
+  }
+
+  /**
+   * Re-imports an escrowed private-key JWK as a `CryptoKey` for `algorithm`
+   * with the requested extractability. The WebCrypto JWK-import descriptor is
+   * shared between the public and private halves for every supported algorithm,
+   * so `IKeyPairAlgorithmParams.importPublicKey` is reused; the private/public
+   * distinction is carried by the requested usages (see
+   * {@link KeyStore._privateKeyUsagesFor}). Cross-runtime through
+   * `globalThis.crypto.subtle`.
+   */
+  private async _importEscrowedPrivateKey(
+    jwk: JsonWebKey,
+    algorithm: KeyPairAlgorithm,
+    extractable: boolean
+  ): Promise<Result<CryptoKey>> {
+    const params = keyPairAlgorithmParams[algorithm];
+    const usages = KeyStore._privateKeyUsagesFor(jwk, params);
+    return captureAsyncResult(() =>
+      globalThis.crypto.subtle.importKey('jwk', jwk, params.importPublicKey, extractable, usages)
+    ).withErrorFormat((msg) => `Failed to import escrowed private key: ${msg}`);
+  }
+
+  /**
+   * Loads the private key for `entry` from storage, or — when
+   * `options.rehydrate` is set, storage holds no blob, and the entry carries an
+   * escrowed JWK — imports the escrowed key, persists it under the entry's `id`
+   * (fill-a-gap; never overwrites an existing blob), and returns it.
+   */
+  private async _loadOrRehydratePrivateKey(
+    name: string,
+    entry: IKeyStoreAsymmetricEntry,
+    options: IGetKeyPairOptions | undefined
+  ): Promise<Result<CryptoKey>> {
+    // Non-undefined by getKeyPair's precondition check.
+    const storage = this._privateKeyStorage!;
+    const loadResult = await storage.load(entry.id);
+    if (loadResult.isSuccess()) {
+      return succeed(loadResult.value);
+    }
+    if (options?.rehydrate !== true || entry.escrowedPrivateKeyJwk === undefined) {
+      return fail(`Failed to load private key for '${name}': ${loadResult.message}`);
+    }
+
+    // Fill-a-gap recovery: import the escrowed key non-extractable where the
+    // backend supports it (extractable otherwise, since a JWK-round-tripping
+    // backend cannot store a non-extractable key), then persist it.
+    const backendExtractable = !storage.supportsNonExtractable;
+    const importResult = await this._importEscrowedPrivateKey(
+      entry.escrowedPrivateKeyJwk,
+      entry.algorithm,
+      backendExtractable
+    );
+    if (importResult.isFailure()) {
+      return fail(`Failed to rehydrate private key for '${name}' from escrow: ${importResult.message}`);
+    }
+
+    const storeResult = await storage.store(entry.id, importResult.value);
+    if (storeResult.isFailure()) {
+      return fail(`Failed to persist rehydrated private key for '${name}': ${storeResult.message}`);
+    }
+    return succeed(importResult.value);
+  }
+
+  /**
+   * Computes the key usages to request when importing an escrowed private JWK.
+   * Mirrors `EncryptedFilePrivateKeyStorage`: intersect the algorithm's private
+   * usages (its keypair usages minus the public-only ones) with the JWK's
+   * recorded `key_ops` so we request exactly the operations the stored key
+   * supports; fall back to the algorithm's private usages when `key_ops` is
+   * absent.
+   */
+  private static _privateKeyUsagesFor(jwk: JsonWebKey, params: IKeyPairAlgorithmParams): KeyUsage[] {
+    const privateUsages = params.keyPairUsages.filter((usage) => !PUBLIC_ONLY_USAGES.includes(usage));
+    const keyOps = jwk.key_ops;
+    if (keyOps === undefined) {
+      return [...privateUsages];
+    }
+    return privateUsages.filter((usage) => keyOps.includes(usage));
   }
 
   /**

--- a/libraries/ts-extras/src/packlets/crypto-utils/keystore/keyStore.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/keystore/keyStore.ts
@@ -398,6 +398,12 @@ export class KeyStore implements IEncryptionProvider {
    * Gets a secret by name. Returns the {@link CryptoUtils.KeyStore.IKeyStoreEntry | discriminated union}
    * — callers must check `entry.type` before accessing `key`/`id` since asymmetric
    * entries carry no raw key material.
+   *
+   * SECURITY: for an escrow-enabled asymmetric-keypair entry the returned object
+   * carries `escrowedPrivateKeyJwk` in cleartext (same custody class as
+   * `publicKeyJwk`, gated by the same unlock) — do not log or serialize a
+   * `getSecret()` result casually.
+   *
    * @param name - Name of the secret
    * @returns Success with secret entry, Failure if not found or locked
    * @public
@@ -1003,25 +1009,25 @@ export class KeyStore implements IEncryptionProvider {
     let escrowedPrivateKeyJwk: JsonWebKey | undefined;
     let keyToStore: CryptoKey = privateKey;
     if (options.escrow === true) {
-      const escrowResult = await this._exportPrivateKeyJwk(privateKey, name);
-      /* c8 ignore next 3 - export('jwk') of a freshly-generated extractable private key does not fail with a healthy provider (analogous to the exportPublicKeyJwk ignore above) */
-      if (escrowResult.isFailure()) {
-        return fail(escrowResult.message);
-      }
-      escrowedPrivateKeyJwk = escrowResult.value;
-
-      if (!liveExtractable) {
-        const reimportResult = await this._importEscrowedPrivateKey(
-          escrowedPrivateKeyJwk,
-          options.algorithm,
-          false
-        );
-        /* c8 ignore next 3 - re-importing a JWK we just exported from a valid key cannot fail; the import-failure path itself is covered via getKeyPair rehydration of a malformed escrow JWK */
-        if (reimportResult.isFailure()) {
-          return fail(`Failed to prepare non-extractable key for '${name}': ${reimportResult.message}`);
+      // Chain the export → (conditional) non-extractable re-import so the
+      // failure dispatch lives in ts-utils rather than in local branch nodes.
+      // When the live copy is extractable the transient key IS the live copy;
+      // otherwise a freshly re-imported non-extractable key is stored instead.
+      const escrowPrepResult = await (
+        await this._exportPrivateKeyJwk(privateKey, name)
+      ).thenOnSuccess(async (jwk): Promise<Result<{ jwk: JsonWebKey; keyToStore: CryptoKey }>> => {
+        if (liveExtractable) {
+          return succeed({ jwk, keyToStore: privateKey });
         }
-        keyToStore = reimportResult.value;
+        return (await this._importEscrowedPrivateKey(jwk, options.algorithm, false))
+          .withErrorFormat((msg) => `Failed to prepare non-extractable key for '${name}': ${msg}`)
+          .onSuccess((reimported) => succeed({ jwk, keyToStore: reimported }));
+      });
+      /* c8 ignore next 3 - escrowPrepResult only fails if exporting or re-importing a freshly-generated valid key fails, which a healthy provider cannot do (same untestable class as the keyPairResult/jwkResult/idResult guards); the import-failure path itself is covered via getKeyPair rehydration of a malformed escrow JWK */
+      if (escrowPrepResult.isFailure()) {
+        return fail(escrowPrepResult.message);
       }
+      ({ jwk: escrowedPrivateKeyJwk, keyToStore } = escrowPrepResult.value);
     }
 
     const idResult = this._generateId();
@@ -1095,18 +1101,11 @@ export class KeyStore implements IEncryptionProvider {
       return fail('No private key storage configured');
     }
 
-    const privateResult = await this._loadOrRehydratePrivateKey(name, entry, options);
-    if (privateResult.isFailure()) {
-      return fail(privateResult.message);
-    }
-
-    const publicResult = await this._cryptoProvider.importPublicKeyJwk(entry.publicKeyJwk, entry.algorithm);
-    /* c8 ignore next 3 - vault JWKs that previously exported cleanly are extremely unlikely to fail re-import */
-    if (publicResult.isFailure()) {
-      return fail(`Failed to re-import public key for '${name}': ${publicResult.message}`);
-    }
-
-    return succeed({ publicKey: publicResult.value, privateKey: privateResult.value });
+    return (await this._loadOrRehydratePrivateKey(name, entry, options)).thenOnSuccess(async (privateKey) =>
+      (await this._cryptoProvider.importPublicKeyJwk(entry.publicKeyJwk, entry.algorithm))
+        .withErrorFormat((msg) => `Failed to re-import public key for '${name}': ${msg}`)
+        .onSuccess((publicKey) => succeed({ publicKey, privateKey }))
+    );
   }
 
   /**

--- a/libraries/ts-extras/src/packlets/crypto-utils/keystore/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/keystore/model.ts
@@ -38,15 +38,27 @@ export { allKeyPairAlgorithms, KeyPairAlgorithm } from '../model';
 
 /**
  * Format version for key store files.
+ *
+ * - `'keystore-v1'`: the original format (no private-key escrow).
+ * - `'keystore-v2'`: adds the optional `escrowedPrivateKeyJwk` field on
+ *   asymmetric-keypair entries. A strict superset of v1 — the field is
+ *   optional, so a v2 reader opens a v1 vault with no special-casing, and a
+ *   v1 vault opened and re-saved is silently upgraded to v2.
  * @public
  */
-export type KeyStoreFormat = 'keystore-v1';
+export type KeyStoreFormat = 'keystore-v1' | 'keystore-v2';
 
 /**
- * Current format version constant.
+ * All recognized key store format versions (readable by the current library).
  * @public
  */
-export const KEYSTORE_FORMAT: KeyStoreFormat = 'keystore-v1';
+export const allKeyStoreFormats: ReadonlyArray<KeyStoreFormat> = ['keystore-v1', 'keystore-v2'];
+
+/**
+ * Current format version constant. New vaults are written as `'keystore-v2'`.
+ * @public
+ */
+export const KEYSTORE_FORMAT: KeyStoreFormat = 'keystore-v2';
 
 /**
  * Default PBKDF2 iterations for key store encryption.
@@ -183,6 +195,22 @@ export interface IKeyStoreAsymmetricEntry {
   readonly publicKeyJwk: JsonWebKey;
 
   /**
+   * Optional escrowed copy of the private key, as a JSON Web Key. Present only
+   * when the entry was created with `addKeyPair(name, { escrow: true })`.
+   *
+   * This is an opt-in cross-device recovery affordance: the private key is
+   * carried inside the vault's AES-GCM ciphertext (same custody class as
+   * `publicKeyJwk`), so a recovered vault plus the master password can
+   * reconstitute the signing/decryption identity on a fresh device via
+   * `getKeyPair(name, { rehydrate: true })`.
+   *
+   * SECURITY: when present, the master password becomes the sole gate
+   * protecting this private key. Use a strong KDF for escrow-bearing stores.
+   * See the {@link CryptoUtils.KeyStore.KeyStore} class docs.
+   */
+  readonly escrowedPrivateKeyJwk?: JsonWebKey;
+
+  /**
    * Optional description for this entry.
    */
   readonly description?: string;
@@ -286,6 +314,13 @@ export interface IKeyStoreAsymmetricEntryJson {
    * The public key as a JSON Web Key.
    */
   readonly publicKeyJwk: JsonWebKey;
+
+  /**
+   * Optional escrowed copy of the private key, as a JSON Web Key. Present only
+   * on `'keystore-v2'` vaults whose entry was created with escrow enabled. A
+   * v1 vault omits the field; a v2 reader treats its absence as "no escrow".
+   */
+  readonly escrowedPrivateKeyJwk?: JsonWebKey;
 
   /**
    * Optional description.
@@ -572,6 +607,49 @@ export interface IAddKeyPairOptions {
    * downgrading.
    */
   readonly extractable?: boolean;
+
+  /**
+   * Opt in to private-key escrow. When `true`, an encrypted copy of the
+   * private key (as a JWK) is carried inside the vault entry
+   * (`escrowedPrivateKeyJwk`), enabling cross-device recovery from the vault
+   * file plus the master password alone via
+   * `getKeyPair(name, { rehydrate: true })`.
+   *
+   * Orthogonal to `extractable`: the escrow copy is always captured (the
+   * transient keypair is generated extractable so it can be exported to JWK),
+   * while the LIVE stored key's extractability still follows the normal rule
+   * (`extractable` override, else the backend default). So escrow does not
+   * change how extractable the day-to-day key is — only whether a recovery
+   * copy is retained in the vault.
+   *
+   * @defaultValue false — no escrow copy is written (today's behavior).
+   *
+   * SECURITY: escrow makes the master password the sole gate protecting a
+   * private key that would otherwise be unrecoverable from the vault. Use a
+   * strong KDF (Argon2id-derived or high-iteration PBKDF2) for escrow-bearing
+   * stores. See the {@link CryptoUtils.KeyStore.KeyStore} class docs.
+   */
+  readonly escrow?: boolean;
+}
+
+/**
+ * Options for retrieving an asymmetric keypair via {@link CryptoUtils.KeyStore.KeyStore.getKeyPair}.
+ * @public
+ */
+export interface IGetKeyPairOptions {
+  /**
+   * Opt in to escrow rehydration. When `true` AND no private-key blob exists
+   * under the entry's storage `id` AND the entry carries an
+   * `escrowedPrivateKeyJwk`, the escrowed JWK is imported (non-extractable
+   * where the backend supports it) and stored under the entry's `id` before
+   * being returned — filling a gap on a fresh device from the recovered vault.
+   *
+   * Fill-a-gap only: an existing storage blob is never overwritten. When a
+   * blob is present it is loaded as usual and the escrow copy is ignored.
+   *
+   * @defaultValue false — today's behavior: load from storage or fail.
+   */
+  readonly rehydrate?: boolean;
 }
 
 /**
@@ -634,5 +712,5 @@ export function isKeyStoreFile(json: unknown): boolean {
     return false;
   }
   const obj = json as Record<string, unknown>;
-  return obj.format === KEYSTORE_FORMAT;
+  return typeof obj.format === 'string' && (allKeyStoreFormats as ReadonlyArray<string>).includes(obj.format);
 }

--- a/libraries/ts-extras/src/test/unit/crypto/keystore/converters.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/keystore/converters.test.ts
@@ -24,14 +24,17 @@ import * as CryptoUtils from '../../../../packlets/crypto-utils';
 
 describe('Key Store Converters', () => {
   describe('keystoreFormat', () => {
-    test('accepts valid format', () => {
+    test('accepts valid formats (v1 and v2)', () => {
       expect(CryptoUtils.KeyStore.Converters.keystoreFormat.convert('keystore-v1')).toSucceedWith(
         'keystore-v1'
+      );
+      expect(CryptoUtils.KeyStore.Converters.keystoreFormat.convert('keystore-v2')).toSucceedWith(
+        'keystore-v2'
       );
     });
 
     test('rejects invalid format', () => {
-      expect(CryptoUtils.KeyStore.Converters.keystoreFormat.convert('keystore-v2')).toFail();
+      expect(CryptoUtils.KeyStore.Converters.keystoreFormat.convert('keystore-v3')).toFail();
     });
 
     test('rejects non-string', () => {

--- a/libraries/ts-extras/src/test/unit/crypto/keystore/keyStoreEscrow.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/keystore/keyStoreEscrow.test.ts
@@ -1,0 +1,456 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import { FileTree } from '@fgv/ts-json-base';
+import * as CryptoUtils from '../../../../packlets/crypto-utils';
+import { InMemoryPrivateKeyStorage } from './inMemoryPrivateKeyStorage';
+
+const KeyStore = CryptoUtils.KeyStore.KeyStore;
+const EncryptedFilePrivateKeyStorage = CryptoUtils.KeyStore.EncryptedFilePrivateKeyStorage;
+const provider = CryptoUtils.nodeCryptoProvider;
+const subtle = globalThis.crypto.subtle;
+const testPassword = 'escrow-master-password-123';
+
+type KeyStoreType = CryptoUtils.KeyStore.KeyStore;
+type IKeyStoreFile = CryptoUtils.KeyStore.IKeyStoreFile;
+type KeyPairAlgorithm = CryptoUtils.KeyStore.KeyPairAlgorithm;
+
+const allAlgorithms: ReadonlyArray<KeyPairAlgorithm> = [
+  'ecdsa-p256',
+  'rsa-oaep-2048',
+  'ecdh-p256',
+  'ed25519',
+  'x25519'
+];
+
+function makeTree(): FileTree.IFileTreeDirectoryItem {
+  return FileTree.inMemory([], { mutable: true })
+    .onSuccess((tree) => tree.getDirectory('/'))
+    .orThrow();
+}
+
+function makeEncFileStorage(): CryptoUtils.KeyStore.EncryptedFilePrivateKeyStorage {
+  return EncryptedFilePrivateKeyStorage.create({
+    directory: '/keys',
+    encryptionKey: provider.generateRandomBytes(32).orThrow(),
+    cryptoProvider: provider,
+    tree: makeTree()
+  }).orThrow();
+}
+
+async function newDeviceKeystore(storage: CryptoUtils.KeyStore.IPrivateKeyStorage): Promise<KeyStoreType> {
+  const ks = KeyStore.create({ cryptoProvider: provider, privateKeyStorage: storage }).orThrow();
+  (await ks.initialize(testPassword)).orThrow();
+  return ks;
+}
+
+async function openDeviceKeystore(
+  file: IKeyStoreFile,
+  storage: CryptoUtils.KeyStore.IPrivateKeyStorage,
+  password: string = testPassword
+): Promise<KeyStoreType> {
+  const ks = KeyStore.open({
+    cryptoProvider: provider,
+    keystoreFile: file,
+    privateKeyStorage: storage
+  }).orThrow();
+  (await ks.unlock(password)).orThrow();
+  return ks;
+}
+
+// The decrypted vault shape we manipulate for back-compat / negative fixtures.
+interface IVaultShape {
+  version: string;
+  secrets: Record<string, { escrowedPrivateKeyJwk?: JsonWebKey; [key: string]: unknown }>;
+}
+
+// Decrypt a saved vault, let the caller mutate it, then re-encrypt with the same
+// derived key so the same password still unlocks. Used to synthesize a v1 file
+// and to inject crafted escrow material for negative tests (rather than
+// corrupting ciphertext, which GCM would reject before the code under test runs).
+async function rewriteVault(
+  file: IKeyStoreFile,
+  password: string,
+  mutate: (vault: IVaultShape) => void
+): Promise<IKeyStoreFile> {
+  const salt = provider.fromBase64(file.keyDerivation.salt).orThrow();
+  const key = (await provider.deriveKey(password, salt, file.keyDerivation.iterations)).orThrow();
+  const iv = provider.fromBase64(file.iv).orThrow();
+  const authTag = provider.fromBase64(file.authTag).orThrow();
+  const ciphertext = provider.fromBase64(file.encryptedData).orThrow();
+  const json = (await provider.decrypt(ciphertext, key, iv, authTag)).orThrow();
+  const vault = JSON.parse(json) as unknown as IVaultShape;
+  mutate(vault);
+  const encrypted = (await provider.encrypt(JSON.stringify(vault), key)).orThrow();
+  return {
+    ...file,
+    iv: provider.toBase64(encrypted.iv),
+    authTag: provider.toBase64(encrypted.authTag),
+    encryptedData: provider.toBase64(encrypted.encryptedData)
+  };
+}
+
+// Proves that `privateKey` is the counterpart of `publicJwk` using the operation
+// natural to the algorithm — a same-identity check that works for signing,
+// encryption, and key-agreement keys alike.
+async function assertSameIdentity(
+  algorithm: KeyPairAlgorithm,
+  privateKey: CryptoKey,
+  publicJwk: JsonWebKey
+): Promise<void> {
+  const data = new TextEncoder().encode('escrow-recovery-identity-proof');
+  if (algorithm === 'ecdsa-p256' || algorithm === 'ed25519') {
+    const importAlg =
+      algorithm === 'ecdsa-p256' ? { name: 'ECDSA', namedCurve: 'P-256' } : { name: 'Ed25519' };
+    const signAlg = algorithm === 'ecdsa-p256' ? { name: 'ECDSA', hash: 'SHA-256' } : { name: 'Ed25519' };
+    const publicKey = await subtle.importKey('jwk', publicJwk, importAlg, true, ['verify']);
+    const signature = await subtle.sign(signAlg, privateKey, data);
+    expect(await subtle.verify(signAlg, publicKey, signature, data)).toBe(true);
+    return;
+  }
+  if (algorithm === 'rsa-oaep-2048') {
+    const publicKey = await subtle.importKey('jwk', publicJwk, { name: 'RSA-OAEP', hash: 'SHA-256' }, true, [
+      'encrypt'
+    ]);
+    const ciphertext = await subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, data);
+    const recovered = await subtle.decrypt({ name: 'RSA-OAEP' }, privateKey, ciphertext);
+    expect(new Uint8Array(recovered)).toEqual(data);
+    return;
+  }
+  // ecdh-p256 / x25519: ECDH symmetry — deriving with (privateKey, ephemeralPub)
+  // must equal deriving with (ephemeralPriv, originalPub) iff privateKey is the
+  // counterpart of publicJwk.
+  const derive = algorithm === 'ecdh-p256' ? 'ECDH' : 'X25519';
+  const genAlg = algorithm === 'ecdh-p256' ? { name: 'ECDH', namedCurve: 'P-256' } : { name: 'X25519' };
+  const originalPublic = await subtle.importKey('jwk', publicJwk, genAlg, true, []);
+  const ephemeral = (await subtle.generateKey(genAlg, true, ['deriveBits'])) as CryptoKeyPair;
+  const derived1 = new Uint8Array(
+    await subtle.deriveBits({ name: derive, public: ephemeral.publicKey }, privateKey, 256)
+  );
+  const derived2 = new Uint8Array(
+    await subtle.deriveBits({ name: derive, public: originalPublic }, ephemeral.privateKey, 256)
+  );
+  expect(derived1).toEqual(derived2);
+}
+
+describe('KeyStore private-key escrow', () => {
+  describe('end-to-end cross-device recovery (per algorithm)', () => {
+    test.each(allAlgorithms)('recovers a %s identity on a fresh device', async (algorithm) => {
+      // Device A: create, escrow-enabled keypair, save.
+      const deviceA = await newDeviceKeystore(new InMemoryPrivateKeyStorage());
+      const added = await deviceA.addKeyPair('identity', { algorithm, escrow: true });
+      const publicJwk = added.orThrow().entry.publicKeyJwk;
+      expect(added.orThrow().entry.escrowedPrivateKeyJwk).toBeDefined();
+      const file = (await deviceA.save(testPassword)).orThrow();
+      expect(file.format).toBe('keystore-v2');
+
+      // Device B: fresh empty backend + the recovered vault file.
+      const deviceBStorage = new InMemoryPrivateKeyStorage();
+      const deviceB = await openDeviceKeystore(file, deviceBStorage);
+
+      const recovered = await deviceB.getKeyPair('identity', { rehydrate: true });
+      expect(recovered).toSucceedAndSatisfy(({ privateKey }) => {
+        expect(privateKey.type).toBe('private');
+      });
+      await assertSameIdentity(algorithm, recovered.orThrow().privateKey, publicJwk);
+
+      // Rehydration filled the gap: the blob is now stored and a plain
+      // (non-rehydrating) getKeyPair works.
+      expect(deviceBStorage.entries.has(added.orThrow().entry.id)).toBe(true);
+      expect(await deviceB.getKeyPair('identity')).toSucceed();
+    });
+  });
+
+  test('getKeyPair without rehydrate fails on a fresh device despite escrow material', async () => {
+    const deviceA = await newDeviceKeystore(new InMemoryPrivateKeyStorage());
+    (await deviceA.addKeyPair('identity', { algorithm: 'ed25519', escrow: true })).orThrow();
+    const file = (await deviceA.save(testPassword)).orThrow();
+
+    const deviceB = await openDeviceKeystore(file, new InMemoryPrivateKeyStorage());
+    expect(await deviceB.getKeyPair('identity')).toFailWith(/Failed to load private key/i);
+  });
+
+  describe('escrow-window invariant', () => {
+    test('the live stored key is non-extractable on a supportsNonExtractable backend', async () => {
+      const storage = new InMemoryPrivateKeyStorage();
+      const keystore = await newDeviceKeystore(storage);
+      (await keystore.addKeyPair('signing', { algorithm: 'ed25519', escrow: true })).orThrow();
+
+      // The transient extractable key never becomes the live copy.
+      expect(await keystore.getKeyPair('signing')).toSucceedAndSatisfy(({ privateKey }) => {
+        expect(privateKey.extractable).toBe(false);
+      });
+    });
+
+    test('escrow with extractable:true yields an extractable live key (explicit, legal)', async () => {
+      const storage = new InMemoryPrivateKeyStorage();
+      const keystore = await newDeviceKeystore(storage);
+      const added = await keystore.addKeyPair('signing', {
+        algorithm: 'ed25519',
+        escrow: true,
+        extractable: true
+      });
+      expect(added.orThrow().entry.escrowedPrivateKeyJwk).toBeDefined();
+      expect(await keystore.getKeyPair('signing')).toSucceedAndSatisfy(({ privateKey }) => {
+        expect(privateKey.extractable).toBe(true);
+      });
+    });
+  });
+
+  test('tampering with the ciphertext fails unlock (GCM covers the escrow field)', async () => {
+    const deviceA = await newDeviceKeystore(new InMemoryPrivateKeyStorage());
+    (await deviceA.addKeyPair('identity', { algorithm: 'ecdsa-p256', escrow: true })).orThrow();
+    const file = (await deviceA.save(testPassword)).orThrow();
+
+    const rawData = provider.fromBase64(file.encryptedData).orThrow();
+    rawData[0] ^= 0xff;
+    const tampered: IKeyStoreFile = { ...file, encryptedData: provider.toBase64(rawData) };
+
+    const reopened = KeyStore.open({
+      cryptoProvider: provider,
+      keystoreFile: tampered,
+      privateKeyStorage: new InMemoryPrivateKeyStorage()
+    }).orThrow();
+    expect(await reopened.unlock(testPassword)).toFailWith(/Incorrect password or corrupted key store/i);
+  });
+
+  test('changing the master password re-wraps escrow and still recovers', async () => {
+    const newPassword = 'rotated-master-password-456';
+    const deviceA = await newDeviceKeystore(new InMemoryPrivateKeyStorage());
+    const added = await deviceA.addKeyPair('identity', { algorithm: 'ed25519', escrow: true });
+    const publicJwk = added.orThrow().entry.publicKeyJwk;
+    (await deviceA.changePassword(testPassword, newPassword)).orThrow();
+    const file = (await deviceA.save(newPassword)).orThrow();
+
+    const deviceC = await openDeviceKeystore(file, new InMemoryPrivateKeyStorage(), newPassword);
+    const recovered = await deviceC.getKeyPair('identity', { rehydrate: true });
+    expect(recovered).toSucceed();
+    await assertSameIdentity('ed25519', recovered.orThrow().privateKey, publicJwk);
+  });
+
+  describe('keystore-v1 back-compat', () => {
+    async function makeV1File(): Promise<IKeyStoreFile> {
+      const deviceA = await newDeviceKeystore(new InMemoryPrivateKeyStorage());
+      (await deviceA.addKeyPair('identity', { algorithm: 'ed25519' })).orThrow(); // no escrow
+      const v2 = (await deviceA.save(testPassword)).orThrow();
+      const rewritten = await rewriteVault(v2, testPassword, (vault) => {
+        vault.version = 'keystore-v1';
+      });
+      return { ...rewritten, format: 'keystore-v1' };
+    }
+
+    test('opens and unlocks; rehydrate fails cleanly with no escrow material', async () => {
+      const v1 = await makeV1File();
+      expect(v1.format).toBe('keystore-v1');
+
+      const keystore = await openDeviceKeystore(v1, new InMemoryPrivateKeyStorage());
+      expect(await keystore.getKeyPair('identity', { rehydrate: true })).toFailWith(
+        /Failed to load private key/i
+      );
+    });
+
+    test('re-saving a v1 vault silently upgrades the file to keystore-v2', async () => {
+      const v1 = await makeV1File();
+      const keystore = await openDeviceKeystore(v1, new InMemoryPrivateKeyStorage());
+      const resaved = (await keystore.save(testPassword)).orThrow();
+      expect(resaved.format).toBe('keystore-v2');
+    });
+
+    test('isKeyStoreFile recognizes both v1 and v2 files', async () => {
+      const v1 = await makeV1File();
+      const deviceA = await newDeviceKeystore(new InMemoryPrivateKeyStorage());
+      const v2 = (await deviceA.save(testPassword)).orThrow();
+      expect(CryptoUtils.KeyStore.isKeyStoreFile(v1)).toBe(true);
+      expect(CryptoUtils.KeyStore.isKeyStoreFile(v2)).toBe(true);
+      expect(CryptoUtils.KeyStore.isKeyStoreFile({ format: 'not-a-keystore' })).toBe(false);
+    });
+  });
+
+  describe('both storage backends', () => {
+    test('EncryptedFilePrivateKeyStorage (extractable) escrows and recovers', async () => {
+      const deviceA = KeyStore.create({
+        cryptoProvider: provider,
+        privateKeyStorage: makeEncFileStorage()
+      }).orThrow();
+      (await deviceA.initialize(testPassword)).orThrow();
+      const added = await deviceA.addKeyPair('identity', { algorithm: 'ecdsa-p256', escrow: true });
+      const publicJwk = added.orThrow().entry.publicKeyJwk;
+      const file = (await deviceA.save(testPassword)).orThrow();
+
+      // Live copy is extractable on this backend (round-trips via JWK).
+      expect(await deviceA.getKeyPair('identity')).toSucceedAndSatisfy(({ privateKey }) => {
+        expect(privateKey.extractable).toBe(true);
+      });
+
+      // Fresh EncryptedFile backend on device B — rehydrate from escrow.
+      const deviceB = KeyStore.open({
+        cryptoProvider: provider,
+        keystoreFile: file,
+        privateKeyStorage: makeEncFileStorage()
+      }).orThrow();
+      (await deviceB.unlock(testPassword)).orThrow();
+      const recovered = await deviceB.getKeyPair('identity', { rehydrate: true });
+      expect(recovered).toSucceed();
+      await assertSameIdentity('ecdsa-p256', recovered.orThrow().privateKey, publicJwk);
+    });
+
+    test('supportsNonExtractable backend keeps the live copy non-extractable', async () => {
+      const storage = new InMemoryPrivateKeyStorage();
+      const keystore = await newDeviceKeystore(storage);
+      (await keystore.addKeyPair('identity', { algorithm: 'ecdsa-p256', escrow: true })).orThrow();
+      expect(await keystore.getKeyPair('identity')).toSucceedAndSatisfy(({ privateKey }) => {
+        expect(privateKey.extractable).toBe(false);
+      });
+    });
+  });
+
+  describe('rehydration edge cases', () => {
+    test('does not overwrite an existing storage blob (fill-a-gap only)', async () => {
+      const storage = new InMemoryPrivateKeyStorage();
+      const keystore = await newDeviceKeystore(storage);
+      const added = await keystore.addKeyPair('identity', { algorithm: 'ed25519', escrow: true });
+      const id = added.orThrow().entry.id;
+      const storedKey = storage.entries.get(id);
+
+      // rehydrate:true with a blob present must load, not re-import.
+      const result = await keystore.getKeyPair('identity', { rehydrate: true });
+      expect(result).toSucceedAndSatisfy(({ privateKey }) => {
+        expect(privateKey).toBe(storedKey);
+      });
+    });
+
+    test('rehydrate succeeds when the escrowed JWK omits key_ops', async () => {
+      const deviceA = await newDeviceKeystore(new InMemoryPrivateKeyStorage());
+      const added = await deviceA.addKeyPair('identity', { algorithm: 'ed25519', escrow: true });
+      const publicJwk = added.orThrow().entry.publicKeyJwk;
+      const file = (await deviceA.save(testPassword)).orThrow();
+
+      const stripped = await rewriteVault(file, testPassword, (vault) => {
+        const jwk = vault.secrets.identity.escrowedPrivateKeyJwk;
+        if (jwk) {
+          delete jwk.key_ops;
+        }
+      });
+
+      const deviceB = await openDeviceKeystore(stripped, new InMemoryPrivateKeyStorage());
+      const recovered = await deviceB.getKeyPair('identity', { rehydrate: true });
+      expect(recovered).toSucceed();
+      await assertSameIdentity('ed25519', recovered.orThrow().privateKey, publicJwk);
+    });
+
+    test('rehydrate fails cleanly when the escrowed JWK is malformed', async () => {
+      const deviceA = await newDeviceKeystore(new InMemoryPrivateKeyStorage());
+      (await deviceA.addKeyPair('identity', { algorithm: 'ed25519', escrow: true })).orThrow();
+      const file = (await deviceA.save(testPassword)).orThrow();
+
+      const corrupted = await rewriteVault(file, testPassword, (vault) => {
+        // Valid JWK *shape* (kty present) but invalid key material — passes the
+        // converter's shape check, fails at crypto.subtle.importKey.
+        vault.secrets.identity.escrowedPrivateKeyJwk = {
+          kty: 'OKP',
+          crv: 'Ed25519',
+          x: 'AAAA'
+        };
+      });
+
+      const deviceB = await openDeviceKeystore(corrupted, new InMemoryPrivateKeyStorage());
+      expect(await deviceB.getKeyPair('identity', { rehydrate: true })).toFailWith(
+        /rehydrate private key.*from escrow/i
+      );
+    });
+
+    test('rehydrate surfaces a storage store() failure', async () => {
+      const deviceA = await newDeviceKeystore(new InMemoryPrivateKeyStorage());
+      (await deviceA.addKeyPair('identity', { algorithm: 'ed25519', escrow: true })).orThrow();
+      const file = (await deviceA.save(testPassword)).orThrow();
+
+      // Empty backend whose store() fails: load misses, import succeeds, persist fails.
+      const failingStorage = new InMemoryPrivateKeyStorage({ failOn: { store: 'disk full' } });
+      const deviceB = await openDeviceKeystore(file, failingStorage);
+      expect(await deviceB.getKeyPair('identity', { rehydrate: true })).toFailWith(
+        /persist rehydrated private key.*disk full/i
+      );
+    });
+  });
+
+  describe('escrow x extractable x backend matrix', () => {
+    interface IMatrixCase {
+      readonly escrow?: boolean;
+      readonly extractable?: boolean;
+      readonly supportsNonExtractable: boolean;
+      readonly expectEscrow: boolean;
+      readonly expectLiveExtractable: boolean;
+    }
+
+    const cases: ReadonlyArray<IMatrixCase> = [
+      // escrow absent → unchanged behavior (no escrow copy; backend-default extractability).
+      { supportsNonExtractable: true, expectEscrow: false, expectLiveExtractable: false },
+      { supportsNonExtractable: false, expectEscrow: false, expectLiveExtractable: true },
+      // escrow, extractable unset → escrow present; live follows backend default.
+      { escrow: true, supportsNonExtractable: true, expectEscrow: true, expectLiveExtractable: false },
+      { escrow: true, supportsNonExtractable: false, expectEscrow: true, expectLiveExtractable: true },
+      // escrow, extractable: true → escrow present; live extractable (explicit).
+      {
+        escrow: true,
+        extractable: true,
+        supportsNonExtractable: true,
+        expectEscrow: true,
+        expectLiveExtractable: true
+      },
+      // escrow, extractable: false on a capable backend → escrow present; live non-extractable.
+      {
+        escrow: true,
+        extractable: false,
+        supportsNonExtractable: true,
+        expectEscrow: true,
+        expectLiveExtractable: false
+      }
+    ];
+
+    test.each(cases)(
+      'escrow=$escrow extractable=$extractable supportsNonExtractable=$supportsNonExtractable',
+      async ({ escrow, extractable, supportsNonExtractable, expectEscrow, expectLiveExtractable }) => {
+        const storage = new InMemoryPrivateKeyStorage({ supportsNonExtractable });
+        const keystore = await newDeviceKeystore(storage);
+        const result = await keystore.addKeyPair('identity', { algorithm: 'ed25519', escrow, extractable });
+
+        expect(result).toSucceedAndSatisfy(({ entry }) => {
+          expect(entry.escrowedPrivateKeyJwk !== undefined).toBe(expectEscrow);
+          expect(storage.entries.get(entry.id)?.extractable).toBe(expectLiveExtractable);
+        });
+      }
+    );
+
+    test('escrow with extractable:false fails loudly on an incapable backend', async () => {
+      const storage = new InMemoryPrivateKeyStorage({ supportsNonExtractable: false });
+      const keystore = await newDeviceKeystore(storage);
+      const result = await keystore.addKeyPair('identity', {
+        algorithm: 'ed25519',
+        escrow: true,
+        extractable: false
+      });
+      expect(result).toFailWith(/does not support non-extractable keys/i);
+      expect(keystore.hasSecret('identity')).toSucceedWith(false);
+      expect(storage.entries.size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds **opt-in, per-keypair private-key escrow** to `@fgv/ts-extras` crypto-utils `KeyStore`, so a client-held (potentially non-extractable) signing/decryption identity can be recovered on a new device from **the vault file + master password alone**.

Previously an asymmetric keypair's private key lived only in the per-device `IPrivateKeyStorage` backend; the vault carried only the public JWK. A recovered vault reconstituted with no private keys — a lost device meant a lost identity. Escrow carries an encrypted private-key copy inside the vault ciphertext (already AES-256-GCM under the master-password key), enabling cross-device recovery.

Additive and back-compatible. Changeset: **minor**.

## What changed

- **`addKeyPair(name, { escrow: true })`** — captures an encrypted private-key JWK (new optional `escrowedPrivateKeyJwk` on asymmetric entries) inside the vault, same custody class as the public JWK.
- **`getKeyPair(name, { rehydrate: true })`** — new options parameter. When storage holds no blob for the entry's `id` and the entry carries `escrowedPrivateKeyJwk`, imports the escrowed JWK (non-extractable where the backend supports it), stores it, and returns it. **Fill-a-gap only — never overwrites an existing blob.**
- **`escrow` × `extractable` are orthogonal.** The transient keypair is always generated extractable so it can be exported to JWK, but the LIVE stored key's extractability follows the normal rule (`extractable` override, else backend default). Escrow does not change how extractable the day-to-day key is — only whether a recovery copy is retained. The existing `extractable: false` + incapable-backend loud failure is unchanged.
- **Vault format bumped to `keystore-v2`** — `KeyStoreFormat` widened to `'keystore-v1' | 'keystore-v2'`; the converter accepts both; `escrowedPrivateKeyJwk` is optional, so v2 opens v1 vaults with no special-casing and a re-saved v1 vault upgrades silently. `isKeyStoreFile` recognizes both. Old-reader-new-file is out of scope (lockstep policy).
- Reuses the proven `EncryptedFilePrivateKeyStorage` JWK export/import path: `keyPairAlgorithmParams[algorithm].importPublicKey` as the private-half re-import descriptor and `jsonWebKeyShape` as the wire validator. Works for all five algorithms (ecdsa-p256, rsa-oaep-2048, ecdh-p256, ed25519, x25519). No change to `ICryptoProvider`, `IPrivateKeyStorage`, `EncryptedFilePrivateKeyStorage`, `keyPairAlgorithmParams`, or the browser `IdbPrivateKeyStorage`. The private-JWK round-trip in `KeyStore` uses `globalThis.crypto.subtle` (cross-runtime, same pattern as the repo's `generateUuid`).

## Escrow-window invariant (the security core)

The bare private key exists **only inside `addKeyPair`** as three local artifacts, none returned or logged: (1) the transient extractable `CryptoKey` from `generateKeyPair(algorithm, true)`; (2) the exported `JsonWebKey` assigned into the vault entry; (3) a freshly re-imported non-extractable `CryptoKey` handed straight to `store()` (when the live copy must be non-extractable). On a `supportsNonExtractable: true` backend the transient extractable key never becomes the live/stored copy.

Verified in code (self-audit: no path returns/logs the transient key or JWK) **and by test**: `escrow-window invariant › the live stored key is non-extractable on a supportsNonExtractable backend` asserts `getKeyPair(...).privateKey.extractable === false` immediately after `addKeyPair({ escrow: true })`.

## Tests (26 new, scenario-first)

- **E2E cross-device recovery per algorithm** (all five): device A create+addKeyPair(escrow)+save → device B fresh empty backend + open+unlock+`getKeyPair({ rehydrate: true })` → **same-identity proof** using the operation natural to each algorithm (sign/verify for ecdsa/ed25519, encrypt/decrypt for rsa-oaep, ECDH-symmetry derive for ecdh-p256/x25519).
- `getKeyPair` without `rehydrate` fails on a fresh device even with escrow material present.
- Ciphertext tamper → `unlock` fails via the existing corrupt/incorrect-password path (GCM covers the new field for free).
- Master-password change re-wraps escrow → reopen on a third empty backend recovers.
- `keystore-v1` back-compat: open+unlock succeed; `rehydrate` fails cleanly (no material); re-save writes `keystore-v2`; `isKeyStoreFile` accepts both.
- Both backends: `EncryptedFilePrivateKeyStorage` (extractable live copy) and a `supportsNonExtractable` fake (non-extractable live copy) — escrow + rehydration identical, live extractability differs per the fork-3 table.
- Rehydration edges: fill-gap-only (existing blob not overwritten), escrow JWK missing `key_ops`, malformed escrow JWK import failure, storage `store()` failure surfaced.
- Option matrix: table-driven `{escrow}×{extractable}×{supportsNonExtractable}` asserting live-copy extractability + escrow presence, incl. the unchanged loud failure.

## Doc callout

Added to the `escrow` option TSDoc, the `escrowedPrivateKeyJwk` field, and the `KeyStore` class docs: escrow makes the master password the **sole gate** protecting a private key that was previously unrecoverable from the vault — recommend a strong KDF (Argon2id-derived or high-iteration PBKDF2) for escrow-bearing stores. Plus a `getSecret()` SECURITY note (fix round below).

## Fix round (post-approval, layer-1 follow-ups)

**FIX 1 — chaining hygiene.** The escrow export → conditional non-extractable re-import in `addKeyPair` is now a `thenOnSuccess` chain, moving the two inner failure-guard branch nodes (and their `c8 ignore` directives) into ts-utils. `getKeyPair`'s public-key re-import tail is likewise chained (`withErrorFormat` + `onSuccess`), eliminating a pre-existing directive. Behavior is byte-identical (same error messages, control flow, return values); 26 escrow tests + 100% coverage unchanged.

**FIX 2 — `getSecret()` custody doc note.** Added a SECURITY line: a `getSecret()` result for an escrow-enabled entry carries `escrowedPrivateKeyJwk` in cleartext (same custody class as `publicKeyJwk`, same unlock gate) — do not log/serialize casually.

**`c8 ignore` directive count in `keyStore.ts`: 28 (baseline `origin/release`) → 28 (now). Net new directives from the whole feature: 0.** The feature's escrow logic carries exactly **one** consolidated directive (the outer `escrowPrepResult` guard — genuinely untestable: a freshly-generated valid key cannot fail to export/re-import without mocking; the import-failure path itself is covered via the malformed-escrow rehydrate test), and this round chained away one pre-existing directive in `getKeyPair`, netting to the original baseline.

**Scope decision on the file-wide `c8 ignore` sweep (STOPPED per the ~2x guard).** A full sweep of `keyStore.ts` is **29→28** counting the escrow work; the remaining 28 break down as:
- **~25 chain-eliminable** `if (result.isFailure()) return fail(...)` guards spread across ~13 methods **unrelated to escrow** (`initialize`, `unlock`, `addSecret`, `addSecretFromPassword`, `verifySecretFromPassword`, `addSecretFromPasswordArgon2id`, `addKeyPair` [3 pre-existing: `keyPairResult`/`jwkResult`/`idResult`], `save`, `changePassword` [5], `_encryptVault` [2], `_decryptVault` [~4]). Eliminating these means folding multi-statement, instance-mutating crypto flows into chains — a full-file refactor of **security-critical control flow**, ~4–6x the escrow diff, which would obscure the feature and carries real "preserve exact behavior" risk.
- **3 genuinely-defensive — KEEP** per instruction: `unlockWithKey` no-file (unreachable via public API), `_decryptVault` no-file, `_timingSafeEqual` equal-length.

Per the explicit "if it balloons past ~2x, STOP and report so I can decide whether to split" instruction, I did the **low-risk, in-feature-method** eliminations (escrow block + `getKeyPair`) and **stopped** the file-wide sweep. Recommend it as a **dedicated hygiene PR** so the security-critical control-flow rewrites get reviewed on their own, not bundled with the feature.

## Review notes (layer 1)

- **Self-review** against `CODE_REVIEW_CHECKLIST.md` performed before coverage closure (the `code-reviewer` agent could not be spawned in this run — flagging for the orchestrator to run at the gate). No `any`; all fallible ops return `Result`; converters/validators (not manual checks) for the new field; error messages carry context.
- **Coverage: 100%** (statements/branches/functions/lines) across `ts-extras`.

## Gate results (both rounds)

- `rushx build` ✅ (regenerated `etc/ts-extras.api.md`)
- `rushx fixlint` + `rushx lint` ✅
- `rushx test` ✅ — all suites pass, **100% coverage**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_