### PR TITLE
feat(ts-agent-memory): lenient vault open via onRecordError: 'skip'

### DIFF
--- a/common/changes/@fgv/ts-agent-memory/claude-agent-memory-lenient-open_2026-07-19-00-45.json
+++ b/common/changes/@fgv/ts-agent-memory/claude-agent-memory-lenient-open_2026-07-19-00-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add optional onRecordError: 'skip' | 'fail' to FileTreeMemoryStore.create (default 'fail', byte-identical to the historical load path); 'skip' mode quarantines unreadable records instead of failing the whole open, surfacing each on the new FileTreeMemoryStore.skippedRecords getter and warn-logging it, so a required-field migration on one kind no longer makes every other record in the vault unreadable.",
+      "type": "none",
+      "packageName": "@fgv/ts-agent-memory"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
+++ b/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
@@ -121,6 +121,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
     list(filter?: IMemoryStoreListFilter): Promise<Result<ReadonlyArray<IMemoryRecord<unknown>>>>;
     listScoped(): Promise<Result<ReadonlyArray<IScopedMemoryRecord>>>;
     put(record: IMemoryRecord<unknown>): Promise<Result<IMemoryRecord<unknown>>>;
+    get skippedRecords(): ReadonlyArray<ISkippedRecord>;
 }
 
 // @public
@@ -228,6 +229,7 @@ export interface IFileTreeMemoryStoreCreateParams {
     readonly embed?: MemoryEmbedder;
     readonly logger?: Logging.ILogger;
     readonly observers?: ReadonlyArray<IMemoryObserver>;
+    readonly onRecordError?: MemoryRecordErrorMode;
     readonly rankProjectors?: ReadonlyMap<Kind, RankProjector>;
     readonly registry: IBodyConverterRegistry;
     readonly root: FileTree.IMutableFileTreeDirectoryItem;
@@ -541,6 +543,13 @@ export interface ISemanticRetrieverCreateParams {
 }
 
 // @public
+export interface ISkippedRecord {
+    readonly error: string;
+    readonly path: string;
+    readonly scope: MemoryScopeKey;
+}
+
+// @public
 export function isTemporalIdentityCodec(codec: IIdentityCodec): codec is ITemporalIdentityCodec;
 
 // @public
@@ -697,6 +706,9 @@ export class MemoryObservationStore implements IMemoryObserver {
     query(criteria?: IMemoryObservationQuery): ReadonlyArray<IMemoryObservationRecord>;
     get size(): number;
 }
+
+// @public
+export type MemoryRecordErrorMode = 'skip' | 'fail';
 
 // @public
 export type MemoryScopeKey = Brand<string, 'MemoryScopeKey'>;

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Hash, Logging, Result, fail, mapResults, succeed } from '@fgv/ts-utils';
+import { Hash, Logging, Result, fail, mapResults, mapSuccess, succeed } from '@fgv/ts-utils';
 import { FileTree } from '@fgv/ts-json-base';
 import {
   AdmissionDecision,
@@ -60,6 +60,39 @@ export interface IMemoryStoreListFilter {
    * unchanged. Absent = no temporal projection (every version is returned).
    */
   readonly asOf?: number;
+}
+
+/**
+ * Policy for how {@link FileTreeMemoryStore.create}'s initial vault walk reacts
+ * to a record that fails to parse or validate.
+ *
+ * - `'fail'` (the default) — one unreadable record fails the whole open. The
+ *   walk collapses per-record results with `mapResults`, so any single failure
+ *   aborts `create()`. This is the historical behavior, preserved byte-for-byte.
+ * - `'skip'` — an unreadable record is quarantined (not indexed) rather than
+ *   failing the open. Every record that DOES parse loads normally; each skip is
+ *   logged at `warn` and surfaced structurally on
+ *   {@link FileTreeMemoryStore.skippedRecords}. The offending file is never
+ *   deleted or mutated, so a later open (after the body converter is fixed)
+ *   re-indexes it. A vault holds every kind in one store, so a required-field
+ *   migration on one kind must not make every other record unreadable.
+ * @public
+ */
+export type MemoryRecordErrorMode = 'skip' | 'fail';
+
+/**
+ * A record that {@link FileTreeMemoryStore.create} could not load and
+ * quarantined (only produced in {@link MemoryRecordErrorMode | `'skip'` mode}).
+ * The `path` identifies WHICH record was skipped so a host can repair it.
+ * @public
+ */
+export interface ISkippedRecord {
+  /** The record file's path within the vault (`<scope>/<filename>.md`). */
+  readonly path: string;
+  /** The scope the record lives under (its parent directory path). */
+  readonly scope: MemoryScopeKey;
+  /** The parse/validation failure message (includes the record path). */
+  readonly error: string;
 }
 
 /**
@@ -196,6 +229,16 @@ export interface IFileTreeMemoryStoreCreateParams {
    * `rebuild` reconciles, so a vector failure never fails an authoritative write.
    */
   readonly embed?: MemoryEmbedder;
+  /**
+   * How the initial vault walk reacts to a record that fails to parse or
+   * validate. Defaults to `'fail'` — one bad record fails the whole open, the
+   * historical behavior, preserved byte-for-byte. Set `'skip'` to quarantine
+   * unreadable records instead: valid records still load, each skip is logged
+   * at `warn` and surfaced on {@link FileTreeMemoryStore.skippedRecords}, and
+   * the offending file is left untouched for a later (post-fix) re-index. See
+   * {@link MemoryRecordErrorMode}.
+   */
+  readonly onRecordError?: MemoryRecordErrorMode;
 }
 
 /**
@@ -259,6 +302,11 @@ export class FileTreeMemoryStore implements IMemoryStore {
   private readonly _logger: Logging.ILogger;
   private readonly _vectorIndex: IVectorIndex | undefined;
   private readonly _embed: MemoryEmbedder | undefined;
+  /**
+   * Records the initial walk could not load. Populated during `create()` in
+   * {@link MemoryRecordErrorMode | `'skip'` mode}; empty otherwise.
+   */
+  private readonly _skippedRecords: ISkippedRecord[];
 
   /** Monotonic write counter; incremented inside the write-lock on each put. */
   private _seq: number;
@@ -306,9 +354,22 @@ export class FileTreeMemoryStore implements IMemoryStore {
     this._logger = params.logger;
     this._vectorIndex = params.vectorIndex;
     this._embed = params.embed;
+    this._skippedRecords = [];
     this._seq = 0;
     this._observationSeq = 0;
     this._writeTail = Promise.resolve();
+  }
+
+  /**
+   * Records the initial vault walk could not parse or validate and quarantined
+   * (not indexed). Non-empty only when the store was opened with
+   * {@link MemoryRecordErrorMode | `onRecordError: 'skip'`} AND at least one
+   * record failed to load. Each entry identifies the offending file so a host
+   * can repair it; the file itself is never deleted or mutated, so a later open
+   * (after the body converter is fixed) re-indexes it.
+   */
+  public get skippedRecords(): ReadonlyArray<ISkippedRecord> {
+    return this._skippedRecords;
   }
 
   /**
@@ -335,7 +396,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
           vectorIndex: params.vectorIndex,
           embed: params.embed
         });
-        return store._initialIndex().onSuccess(() => succeed(store));
+        return store._initialIndex(params.onRecordError ?? 'fail').onSuccess(() => succeed(store));
       })
     );
   }
@@ -1526,9 +1587,13 @@ export class FileTreeMemoryStore implements IMemoryStore {
   /**
    * Walk the FileTree once and rebuild the index. Also resumes the `seq`
    * counter past the highest persisted `seq` so new writes stay monotonic.
+   *
+   * In `'skip'` mode each per-record failure is captured structurally on
+   * `this._skippedRecords` (path + scope + path-tagged error) at its failure
+   * site and logged at `warn`; the walk keeps every record that loaded.
    */
-  private _initialIndex(): Result<true> {
-    return this._collectEntries(this._root, []).onSuccess((entries) =>
+  private _initialIndex(onRecordError: MemoryRecordErrorMode): Result<true> {
+    return this._collectEntries(this._root, [], onRecordError).onSuccess((entries) =>
       this._index.rebuild(entries).onSuccess(() => {
         for (const entry of entries) {
           if (entry.record.envelope.seq > this._seq) {
@@ -1543,12 +1608,13 @@ export class FileTreeMemoryStore implements IMemoryStore {
   /** Recursively collect every `.md` record under `dir` (scope = path segments). */
   private _collectEntries(
     dir: FileTree.IFileTreeDirectoryItem,
-    scopeSegments: ReadonlyArray<string>
+    scopeSegments: ReadonlyArray<string>,
+    onRecordError: MemoryRecordErrorMode
   ): Result<ReadonlyArray<IIndexedMemoryRecord>> {
     return dir.getChildren().onSuccess((children) => {
       const results: Result<ReadonlyArray<IIndexedMemoryRecord>>[] = children.map((child) => {
         if (child.type === 'directory') {
-          return this._collectEntries(child, [...scopeSegments, child.name]);
+          return this._collectEntries(child, [...scopeSegments, child.name], onRecordError);
         }
         if (!child.name.endsWith(MEMORY_FILE_EXTENSION) || scopeSegments.length === 0) {
           // Skip non-record files and any record-shaped file sitting at the root
@@ -1556,17 +1622,48 @@ export class FileTreeMemoryStore implements IMemoryStore {
           return succeed<ReadonlyArray<IIndexedMemoryRecord>>([]);
         }
         const scope: MemoryScopeKey = scopeSegments.join('/') as MemoryScopeKey;
-        return child
-          .getRawContents()
-          .onSuccess((raw) => parseMemoryFile(raw, this._registry))
-          .onSuccess((parsedRecord) => this._verifyLoaded(scope, child, parsedRecord))
-          .onSuccess((verified) =>
-            succeed<ReadonlyArray<IIndexedMemoryRecord>>([{ scope, record: verified }])
-          );
+        return this._loadRecordFile(scope, child, onRecordError);
       });
+      // `'skip'` mode: keep every record that parsed, drop the ones that failed
+      // in a single pass (each failure is captured on `this._skippedRecords` and
+      // warn-logged at its site in `_loadRecordFile`). `.orDefault([])` covers
+      // the all-invalid-subtree edge where `mapSuccess` returns Failure because
+      // no element succeeded. `'fail'` mode: `mapResults` fails the whole open on
+      // any bad record — byte-identical to the historical load path.
+      if (onRecordError === 'skip') {
+        return succeed<ReadonlyArray<IIndexedMemoryRecord>>(mapSuccess(results).orDefault([]).flat());
+      }
       return mapResults(results).onSuccess((perChild) =>
         succeed<ReadonlyArray<IIndexedMemoryRecord>>(perChild.flat())
       );
     });
+  }
+
+  /**
+   * Load and verify one record file. On failure in `'skip'` mode, records the
+   * structured {@link ISkippedRecord} identity (path + scope + path-tagged
+   * error) and logs the skip at `warn`; the failure is still returned so the
+   * caller's `mapSuccess` drops it from the loaded set. In `'fail'` mode the
+   * failure passes through untouched so the historical error is byte-identical.
+   */
+  private _loadRecordFile(
+    scope: MemoryScopeKey,
+    child: FileTree.IFileTreeFileItem,
+    onRecordError: MemoryRecordErrorMode
+  ): Result<ReadonlyArray<IIndexedMemoryRecord>> {
+    return child
+      .getRawContents()
+      .onSuccess((raw) => parseMemoryFile(raw, this._registry))
+      .onSuccess((parsedRecord) => this._verifyLoaded(scope, child, parsedRecord))
+      .onSuccess((verified) => succeed<ReadonlyArray<IIndexedMemoryRecord>>([{ scope, record: verified }]))
+      .onFailure((message) => {
+        if (onRecordError === 'skip') {
+          const path: string = `${scope}/${child.name}`;
+          const error: string = `memory record '${path}': ${message}`;
+          this._skippedRecords.push({ path, scope, error });
+          this._warnSwallowed(error);
+        }
+        return fail(message);
+      });
   }
 }

--- a/libraries/ts-agent-memory/src/test/unit/store/lenientOpen.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/lenientOpen.test.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converter, Converters, Logging, Result, fail, succeed } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
+import {
+  BodyConverterRegistry,
+  EntityId,
+  FileTreeMemoryStore,
+  IBodyConverterRegistry,
+  IIdentityCodec,
+  IIdentityCodecResult,
+  IMemoryRecord,
+  ISkippedRecord,
+  Kind,
+  MemoryScopeKey,
+  joinFrontmatter
+} from '../../../index';
+
+/**
+ * The incident: one vault holds every kind (mtm, ltm, conversation, knowledge,
+ * claim) in ONE store. A required field was added to the `claim` body; every
+ * pre-existing `claim` failed validation; and because the initial walk collapsed
+ * per-record results with `mapResults` (fail-the-whole-array on any element),
+ * every OTHER valid record became unreadable behind the failed open. These tests
+ * reproduce that shape (a poison-rejecting body converter standing in for the
+ * migrated converter) and pin the lenient (`onRecordError: 'skip'`) behavior.
+ */
+
+const noteKind: Kind = 'note' as Kind;
+const POISON: string = 'POISON';
+
+/**
+ * A permissive identity codec that treats the full `<scope>/<stem>` path as the
+ * entity id, so records can live at any nesting depth (the shipped codecs pin a
+ * fixed scope shape; this test needs arbitrary-depth scopes to prove the
+ * recursion threads skips out of nested subtrees).
+ */
+class PathIdentityCodec implements IIdentityCodec {
+  public encode(entityId: EntityId): Result<IIdentityCodecResult> {
+    const value: string = String(entityId);
+    const cut: number = value.lastIndexOf('/');
+    const scope: MemoryScopeKey = (cut >= 0 ? value.slice(0, cut) : '') as MemoryScopeKey;
+    const idStem: string = cut >= 0 ? value.slice(cut + 1) : value;
+    return succeed({ scope, idStem, isVersioned: false });
+  }
+  public decode(scope: MemoryScopeKey, encodedStem: string): Result<EntityId> {
+    return succeed(`${scope}/${encodedStem}` as EntityId);
+  }
+  public verifyRoundTrip(): Result<true> {
+    return succeed(true);
+  }
+}
+
+/** A body converter that rejects any body containing the poison marker. */
+const poisonRejectingConverter: Converter<string> = Converters.string.map((body) =>
+  body.includes(POISON) ? fail(`note body rejected: contains ${POISON}`) : succeed(body)
+);
+
+function registry(bodyConverter: Converter<string>): IBodyConverterRegistry {
+  const created = BodyConverterRegistry.create().orThrow();
+  created.register(noteKind, bodyConverter);
+  return created;
+}
+
+const codecs: ReadonlyMap<Kind, IIdentityCodec> = new Map<Kind, IIdentityCodec>([
+  [noteKind, new PathIdentityCodec()]
+]);
+
+/** Serialize a note record at `<scope>/<stem>.md` with the given body. */
+function noteFile(scope: string, stem: string, body: string): { path: string; contents: string } {
+  const envelope = {
+    id: stem,
+    entityId: `${scope}/${stem}`,
+    kind: 'note',
+    tags: [],
+    links: [],
+    created: 1,
+    updated: 1,
+    seq: 4,
+    contentHash: 'seed',
+    provenance: { source: 'agent' }
+  };
+  const frontmatter = Object.entries(envelope)
+    .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+    .join('\n');
+  return { path: `${scope}/${stem}.md`, contents: joinFrontmatter(frontmatter, body) };
+}
+
+function mutableRoot(
+  files: ReadonlyArray<{ path: string; contents: string }>
+): FileTree.IMutableFileTreeDirectoryItem {
+  const tree = FileTree.inMemory([...files], { mutable: true }).orThrow();
+  const root = tree.getDirectory('/').orThrow();
+  if (!FileTree.isMutableDirectoryItem(root)) {
+    throw new Error('expected a mutable root directory');
+  }
+  return root;
+}
+
+describe('FileTreeMemoryStore lenient open (onRecordError)', () => {
+  test('incident: one bad record does not make the whole store unopenable in skip mode', async () => {
+    const files = [
+      noteFile('mtm', 'turn-1', 'valid mtm body'),
+      noteFile('ltm', 'summary', 'valid ltm body'),
+      noteFile('knowledge', 'doc-a', 'valid knowledge body'),
+      // The migrated `claim` converter now rejects the pre-existing record.
+      noteFile('claim', 'claim-1', `${POISON} missing required field`)
+    ];
+
+    // Default (== 'fail') still fails the whole open, exactly as it did before.
+    expect(
+      FileTreeMemoryStore.create({
+        root: mutableRoot(files),
+        registry: registry(poisonRejectingConverter),
+        codecs
+      })
+    ).toFailWith(/POISON/);
+
+    // 'skip' mode opens: every valid record loads; the bad one is quarantined.
+    const store = FileTreeMemoryStore.create({
+      root: mutableRoot(files),
+      registry: registry(poisonRejectingConverter),
+      codecs,
+      onRecordError: 'skip'
+    }).orThrow();
+
+    expect(await store.list()).toSucceedAndSatisfy((listed: ReadonlyArray<IMemoryRecord<unknown>>) => {
+      expect(listed.map((r) => r.envelope.id).sort()).toEqual(['doc-a', 'summary', 'turn-1']);
+    });
+    expect(store.skippedRecords).toHaveLength(1);
+    const skip: ISkippedRecord = store.skippedRecords[0];
+    expect(skip.path).toBe('claim/claim-1.md');
+    expect(skip.scope).toBe('claim');
+    expect(skip.error).toContain('claim/claim-1.md');
+    expect(skip.error).toContain(POISON);
+  });
+
+  test('default mode is byte-identical to explicit fail mode', () => {
+    const files = [noteFile('note', 'good', 'ok'), noteFile('note', 'bad', POISON)];
+    const asDefault = FileTreeMemoryStore.create({
+      root: mutableRoot(files),
+      registry: registry(poisonRejectingConverter),
+      codecs
+    });
+    const asFail = FileTreeMemoryStore.create({
+      root: mutableRoot(files),
+      registry: registry(poisonRejectingConverter),
+      codecs,
+      onRecordError: 'fail'
+    });
+    expect(asDefault).toFail();
+    expect(asFail).toFail();
+    // Same exact failure message — the load path is untouched in fail mode.
+    expect(asDefault.isFailure() && asFail.isFailure() && asDefault.message === asFail.message).toBe(true);
+    expect(asDefault).toFailWith(/POISON/);
+  });
+
+  test('a bad record in a nested scope is skipped while valid siblings load', async () => {
+    const files = [
+      noteFile('alpha/beta', 'ok-1', 'valid'),
+      noteFile('alpha/beta', 'bad-1', POISON),
+      noteFile('alpha/beta/gamma', 'ok-2', 'valid deep')
+    ];
+    const store = FileTreeMemoryStore.create({
+      root: mutableRoot(files),
+      registry: registry(poisonRejectingConverter),
+      codecs,
+      onRecordError: 'skip'
+    }).orThrow();
+
+    expect(await store.list()).toSucceedAndSatisfy((listed: ReadonlyArray<IMemoryRecord<unknown>>) => {
+      expect(listed.map((r) => r.envelope.id).sort()).toEqual(['ok-1', 'ok-2']);
+    });
+    expect(store.skippedRecords.map((s) => s.path)).toEqual(['alpha/beta/bad-1.md']);
+    expect(store.skippedRecords[0].scope).toBe('alpha/beta');
+  });
+
+  test('multiple skips across different scopes all surface; all valid records load', async () => {
+    const files = [
+      noteFile('scope-a', 'good-a', 'a-ok'),
+      noteFile('scope-a', 'bad-a', POISON),
+      noteFile('scope-b', 'good-b', 'b-ok'),
+      noteFile('scope-b', 'bad-b', POISON)
+    ];
+    const store = FileTreeMemoryStore.create({
+      root: mutableRoot(files),
+      registry: registry(poisonRejectingConverter),
+      codecs,
+      onRecordError: 'skip'
+    }).orThrow();
+
+    expect(await store.list()).toSucceedAndSatisfy((listed: ReadonlyArray<IMemoryRecord<unknown>>) => {
+      expect(listed.map((r) => r.envelope.id).sort()).toEqual(['good-a', 'good-b']);
+    });
+    expect(store.skippedRecords.map((s) => s.path).sort()).toEqual(['scope-a/bad-a.md', 'scope-b/bad-b.md']);
+  });
+
+  test('an all-invalid subtree opens with everything skipped (mapSuccess orDefault edge)', async () => {
+    const files = [
+      noteFile('bad-scope', 'x', POISON),
+      noteFile('bad-scope', 'y', POISON),
+      noteFile('good-scope', 'z', 'fine')
+    ];
+    const store = FileTreeMemoryStore.create({
+      root: mutableRoot(files),
+      registry: registry(poisonRejectingConverter),
+      codecs,
+      onRecordError: 'skip'
+    }).orThrow();
+
+    expect(await store.list()).toSucceedAndSatisfy((listed: ReadonlyArray<IMemoryRecord<unknown>>) => {
+      expect(listed.map((r) => r.envelope.id)).toEqual(['z']);
+    });
+    expect(store.skippedRecords.map((s) => s.path).sort()).toEqual(['bad-scope/x.md', 'bad-scope/y.md']);
+  });
+
+  test('an empty vault opens with no skips in either mode', async () => {
+    const skip = FileTreeMemoryStore.create({
+      root: mutableRoot([]),
+      registry: registry(poisonRejectingConverter),
+      codecs,
+      onRecordError: 'skip'
+    }).orThrow();
+    expect(await skip.list()).toSucceedWith([]);
+    expect(skip.skippedRecords).toEqual([]);
+
+    const strict = FileTreeMemoryStore.create({
+      root: mutableRoot([]),
+      registry: registry(poisonRejectingConverter),
+      codecs
+    }).orThrow();
+    expect(strict.skippedRecords).toEqual([]);
+  });
+
+  test('each skip is logged at warn; with the default NoOpLogger skippedRecords is still populated', async () => {
+    const files = [noteFile('note', 'good', 'ok'), noteFile('note', 'bad', POISON)];
+    const logger = new Logging.InMemoryLogger('warning');
+    const withLogger = FileTreeMemoryStore.create({
+      root: mutableRoot(files),
+      registry: registry(poisonRejectingConverter),
+      codecs,
+      onRecordError: 'skip',
+      logger
+    }).orThrow();
+    expect(withLogger.skippedRecords).toHaveLength(1);
+    expect(logger.logged.some((m) => m.includes('note/bad.md') && m.includes(POISON))).toBe(true);
+
+    // No logger wired (default NoOpLogger): create still succeeds and the
+    // structured collection is still populated (observable without a logger).
+    const silent = FileTreeMemoryStore.create({
+      root: mutableRoot(files),
+      registry: registry(poisonRejectingConverter),
+      codecs,
+      onRecordError: 'skip'
+    }).orThrow();
+    expect(silent.skippedRecords.map((s) => s.path)).toEqual(['note/bad.md']);
+  });
+
+  test('re-open after the converter is fixed re-indexes the quarantined record (non-destructive)', async () => {
+    const files = [noteFile('note', 'good', 'ok'), noteFile('note', 'later', POISON)];
+    const root = mutableRoot(files);
+
+    // First open with the rejecting converter: the record is quarantined.
+    const before = FileTreeMemoryStore.create({
+      root,
+      registry: registry(poisonRejectingConverter),
+      codecs,
+      onRecordError: 'skip'
+    }).orThrow();
+    expect(before.skippedRecords).toHaveLength(1);
+    expect(await before.list()).toSucceedAndSatisfy((listed: ReadonlyArray<IMemoryRecord<unknown>>) => {
+      expect(listed.map((r) => r.envelope.id)).toEqual(['good']);
+    });
+
+    // The file was never deleted or mutated, so a fresh open with the fixed
+    // (accept-all) converter re-indexes it — quarantine is non-destructive.
+    const after = FileTreeMemoryStore.create({
+      root: mutableRoot(files),
+      registry: registry(Converters.string),
+      codecs,
+      onRecordError: 'skip'
+    }).orThrow();
+    expect(after.skippedRecords).toEqual([]);
+    expect(await after.list()).toSucceedAndSatisfy((listed: ReadonlyArray<IMemoryRecord<unknown>>) => {
+      expect(listed.map((r) => r.envelope.id).sort()).toEqual(['good', 'later']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The incident: a `FileTreeMemoryStore` vault holds every kind in one store. A required-field migration on one kind made every pre-existing record of that kind fail validation — and because the initial walk collapsed per-record results with `mapResults` (fail-the-whole-array on any element), **one bad record made the entire store unopenable**, hiding every other valid record behind the failed open.

Adds an optional **`onRecordError: 'skip' | 'fail'`** create param:

- **`'fail'` (default)** — one bad record fails the whole open. Byte-identical to the historical load path (still `mapResults`); a test pins that default and explicit-fail produce the *same failure message*.
- **`'skip'`** — a record that fails to parse/validate is quarantined (not indexed) rather than failing the open. Valid records load; each skip is `warn`-logged and surfaced structurally on the new **`FileTreeMemoryStore.skippedRecords`** getter (`path` + `scope` + path-tagged `error`); the offending file is never deleted or mutated, so a later open (after the converter is fixed) re-indexes it.

Scope is **entirely within `ts-agent-memory`** (an active surface — no compatibility burden).

## Layer-1 review (pre-push, applied before first push)

Ran an internal review on the final diff before pushing. One substantive finding, resolved:

- **Dead machinery + unjustified established-surface change (P2, fixed).** An earlier iteration threaded a `MessageAggregator` through the entire `_collectEntries` recursion into `mapSuccess(results, aggregator)` — but that aggregator was **write-only** (never read), because the actual skip capture is the structured `_skippedRecords` collection (which carries the record `path`, something the aggregator's flat strings can't). That made the aggregator dead, and it made the accompanying `mapSuccess` *behavior* change to **`ts-utils`** (a stability-obligated established surface) do nothing observable here. Resolved by dropping the aggregator threading — the walk now uses `mapSuccess(results).orDefault([]).flat()` with no aggregator — and **reverting the `ts-utils` change entirely**. The change is now scoped to `ts-agent-memory` alone, and `mapSuccess`/`mapResults` are referenced only in test comments.

No P1 findings. No `any`; all fallible ops return `Result<T>`.

## Gate (all green locally)

- `heft build --clean` — clean (API Extractor report matches)
- `eslint src` — clean
- `heft test --clean` — pass, **100% coverage** including `fileTreeMemoryStore.ts` (100/100/100/100)

Tests are scenario-first and declarative (`toSucceed*`/`toFailWith`): the incident reproduction, default==fail byte-identical, nested-scope skip, multi-scope skips, the all-invalid-subtree `orDefault` edge, empty vault (both modes), warn-logging + NoOpLogger-still-populates, and non-destructive re-open after the converter is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_