### PR TITLE
feat(crypto-utils): Argon2id secret/associatedData + hex codec (golden-vector asks A + footnote)

### DIFF
--- a/common/changes/@fgv/ts-extras-argon2/crypto-argon2-secret-ad-hex_2026-07-19-00-00.json
+++ b/common/changes/@fgv/ts-extras-argon2/crypto-argon2-secret-ad-hex_2026-07-19-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras-argon2",
+      "comment": "NodeArgon2Provider.argon2id now accepts optional IArgon2idKeyingOptions (RFC 9106 secret K + associatedData X), wired through to the argon2 (kelektiv) binding. Additive; omitting options is byte-identical to prior behavior.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-extras-argon2",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-extras/crypto-argon2-secret-ad-hex_2026-07-19-00-00.json
+++ b/common/changes/@fgv/ts-extras/crypto-argon2-secret-ad-hex_2026-07-19-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add optional IArgon2idKeyingOptions (RFC 9106 secret K + associatedData X) as an additive 4th argument to IArgon2idProvider.argon2id; add hexEncode/hexDecode lowercase-hex codec helpers to crypto-utils (exported from both Node and browser entry points). Additive and non-breaking.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-web-extras-argon2/crypto-argon2-secret-ad-hex_2026-07-19-00-00.json
+++ b/common/changes/@fgv/ts-web-extras-argon2/crypto-argon2-secret-ad-hex_2026-07-19-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-web-extras-argon2",
+      "comment": "BrowserArgon2Provider.argon2id now accepts optional IArgon2idKeyingOptions; secret K is honored (byte-identical to Node), while non-empty associatedData fails loudly (Node-only — hash-wasm has no associated-data input). Additive; omitting options is byte-identical to prior behavior.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras-argon2",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras-argon2/etc/ts-extras-argon2.api.md
+++ b/libraries/ts-extras-argon2/etc/ts-extras-argon2.api.md
@@ -11,7 +11,7 @@ export { CryptoUtils }
 
 // @public
 export class NodeArgon2Provider implements CryptoUtils.IArgon2idProvider {
-    argon2id(password: Uint8Array | string, salt: Uint8Array, params: CryptoUtils.IArgon2idParams): Promise<Result<Uint8Array>>;
+    argon2id(password: Uint8Array | string, salt: Uint8Array, params: CryptoUtils.IArgon2idParams, options?: CryptoUtils.IArgon2idKeyingOptions): Promise<Result<Uint8Array>>;
     static create(): Result<NodeArgon2Provider>;
 }
 

--- a/libraries/ts-extras-argon2/src/packlets/argon2/nodeArgon2Provider.ts
+++ b/libraries/ts-extras-argon2/src/packlets/argon2/nodeArgon2Provider.ts
@@ -45,13 +45,18 @@ export class NodeArgon2Provider implements CryptoUtils.IArgon2idProvider {
    * @param password - The password or passphrase (string or raw bytes).
    * @param salt - The salt (must be at least 8 bytes; 16+ bytes recommended).
    * @param params - Argon2id parameters. All values are validated before derivation.
+   * @param options - Optional {@link @fgv/ts-extras#CryptoUtils.IArgon2idKeyingOptions | keyed-hashing inputs}
+   * (RFC 9106 secret K and/or associated data X). Both are wired through to the
+   * underlying `argon2` binding when present and non-empty; omitting them (or
+   * passing empty arrays) leaves the output byte-identical to prior behavior.
    * @returns Success with the derived key bytes, or Failure with a descriptive message.
    * @public
    */
   public async argon2id(
     password: Uint8Array | string,
     salt: Uint8Array,
-    params: CryptoUtils.IArgon2idParams
+    params: CryptoUtils.IArgon2idParams,
+    options?: CryptoUtils.IArgon2idKeyingOptions
   ): Promise<Result<Uint8Array>> {
     const error = NodeArgon2Provider._validateParams(params);
     if (error !== undefined) {
@@ -66,7 +71,13 @@ export class NodeArgon2Provider implements CryptoUtils.IArgon2idProvider {
         timeCost: params.iterations,
         parallelism: params.parallelism,
         hashLength: params.outputBytes,
-        raw: true
+        raw: true,
+        // Only pass secret/associatedData when present and non-empty so that
+        // existing callers (and empty options) produce byte-identical output.
+        ...(options?.secret && options.secret.length > 0 ? { secret: Buffer.from(options.secret) } : {}),
+        ...(options?.associatedData && options.associatedData.length > 0
+          ? { associatedData: Buffer.from(options.associatedData) }
+          : {})
       });
       return Uint8Array.from(result);
     });

--- a/libraries/ts-extras-argon2/src/test/unit/argon2/crossRuntime.test.ts
+++ b/libraries/ts-extras-argon2/src/test/unit/argon2/crossRuntime.test.ts
@@ -109,4 +109,29 @@ describe('cross-runtime equivalence: NodeArgon2Provider vs BrowserArgon2Provider
     const browserBytes = (await browser.argon2id(password, salt, params)).orThrow();
     expect(nodeBytes).toEqual(browserBytes);
   });
+
+  // A secret (RFC 9106 keyed hashing) is supported by both backends and must
+  // stay byte-identical across them. Small params keep this fast.
+  test('secret-only keyed hashing is byte-identical across runtimes', async () => {
+    const params: CryptoUtils.IArgon2idParams = {
+      memoryKiB: 8,
+      iterations: 1,
+      parallelism: 1,
+      outputBytes: 32
+    };
+    const secret = new Uint8Array(8).fill(0x03);
+    const nodeBytes = (await node.argon2id(RFC_PASSWORD, RFC_SALT, params, { secret })).orThrow();
+    const browserBytes = (await browser.argon2id(RFC_PASSWORD, RFC_SALT, params, { secret })).orThrow();
+    expect(nodeBytes).toEqual(browserBytes);
+  });
+
+  // Associated data is Node-only: Node honors it, the WASM browser backend
+  // rejects it loudly rather than silently dropping it (which would diverge).
+  test('associatedData is Node-only: Node succeeds, browser rejects', async () => {
+    const associatedData = new Uint8Array(12).fill(0x04);
+    expect(await node.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS, { associatedData })).toSucceed();
+    expect(await browser.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS, { associatedData })).toFailWith(
+      /associatedData is not supported.*node-only/i
+    );
+  });
 });

--- a/libraries/ts-extras-argon2/src/test/unit/argon2/nodeArgon2Provider.test.ts
+++ b/libraries/ts-extras-argon2/src/test/unit/argon2/nodeArgon2Provider.test.ts
@@ -95,6 +95,63 @@ describe('NodeArgon2Provider', () => {
     });
   });
 
+  describe('keyed hashing (secret / associatedData)', () => {
+    // RFC 9106 §5.3 Argon2id known-answer test vector:
+    //   password P = 32 bytes of 0x01, salt S = 16 bytes of 0x02,
+    //   secret   K =  8 bytes of 0x03, associated data X = 12 bytes of 0x04,
+    //   t=3, m=32, p=4, tag=32.
+    //   expected tag = 0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659
+    const KAT_PARAMS: CryptoUtils.IArgon2idParams = {
+      memoryKiB: 32,
+      iterations: 3,
+      parallelism: 4,
+      outputBytes: 32
+    };
+    const KAT_PASSWORD = new Uint8Array(32).fill(0x01);
+    const KAT_SALT = new Uint8Array(16).fill(0x02);
+    const KAT_SECRET = new Uint8Array(8).fill(0x03);
+    const KAT_AD = new Uint8Array(12).fill(0x04);
+    const KAT_EXPECTED_HEX = '0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659';
+
+    test('reproduces the RFC 9106 §5.3 known-answer vector with secret + associatedData', async () => {
+      expect(
+        await provider.argon2id(KAT_PASSWORD, KAT_SALT, KAT_PARAMS, {
+          secret: KAT_SECRET,
+          associatedData: KAT_AD
+        })
+      ).toSucceedAndSatisfy((bytes) => {
+        expect(Buffer.from(bytes).toString('hex')).toBe(KAT_EXPECTED_HEX);
+      });
+    });
+
+    test('adding a secret changes the derived output', async () => {
+      const withoutSecret = (await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS)).orThrow();
+      const withSecret = (
+        await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS, { secret: KAT_SECRET })
+      ).orThrow();
+      expect(withSecret).not.toEqual(withoutSecret);
+    });
+
+    test('adding associated data changes the derived output', async () => {
+      const withoutAd = (await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS)).orThrow();
+      const withAd = (
+        await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS, { associatedData: KAT_AD })
+      ).orThrow();
+      expect(withAd).not.toEqual(withoutAd);
+    });
+
+    test('empty secret / associatedData are a no-op (byte-identical to omitting options)', async () => {
+      const baseline = (await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS)).orThrow();
+      const emptyOptions = (
+        await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS, {
+          secret: new Uint8Array(0),
+          associatedData: new Uint8Array(0)
+        })
+      ).orThrow();
+      expect(emptyOptions).toEqual(baseline);
+    });
+  });
+
   describe('parameter validation', () => {
     test('fails when memoryKiB < 8', async () => {
       expect(await provider.argon2id(RFC_PASSWORD, RFC_SALT, { ...RFC_PARAMS, memoryKiB: 7 })).toFailWith(

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -461,6 +461,8 @@ declare namespace CryptoUtils {
         base64UrlNoPadDecode,
         base64UrlNoPadEncode,
         exportPublicKeyAsMultibaseSpki,
+        hexDecode,
+        hexEncode,
         importPublicKeyFromMultibaseSpki,
         isValidMultibaseSpkiPublicKey,
         MultibaseSpkiPublicKeyRegExp,
@@ -488,6 +490,7 @@ declare namespace CryptoUtils {
         IArgon2idParams,
         ARGON2ID_OWASP_MIN,
         ARGON2ID_PASSPHRASE,
+        IArgon2idKeyingOptions,
         IArgon2idProvider,
         IEncryptedFile,
         ICryptoProvider,
@@ -756,6 +759,16 @@ declare namespace Hash {
     }
 }
 export { Hash }
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+function hexDecode(encoded: string): Result<Uint8Array>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+function hexEncode(data: Uint8Array): string;
 
 // @public
 class HpkeProvider {
@@ -1149,6 +1162,15 @@ interface IArgon2idKeyDerivationParams {
     readonly salt: string;
 }
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+interface IArgon2idKeyingOptions {
+    readonly associatedData?: Uint8Array;
+    readonly secret?: Uint8Array;
+}
+
 // @public
 interface IArgon2idParams {
     readonly iterations: number;
@@ -1159,7 +1181,9 @@ interface IArgon2idParams {
 
 // @public
 interface IArgon2idProvider {
-    argon2id(password: Uint8Array | string, salt: Uint8Array, params: IArgon2idParams): Promise<Result<Uint8Array>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    argon2id(password: Uint8Array | string, salt: Uint8Array, params: IArgon2idParams, options?: IArgon2idKeyingOptions): Promise<Result<Uint8Array>>;
 }
 
 // @public

--- a/libraries/ts-extras/src/packlets/crypto-utils/index.browser.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/index.browser.ts
@@ -73,6 +73,8 @@ export {
   base64UrlNoPadDecode,
   base64UrlNoPadEncode,
   exportPublicKeyAsMultibaseSpki,
+  hexDecode,
+  hexEncode,
   importPublicKeyFromMultibaseSpki,
   isValidMultibaseSpkiPublicKey,
   MultibaseSpkiPublicKeyRegExp,

--- a/libraries/ts-extras/src/packlets/crypto-utils/index.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/index.ts
@@ -65,6 +65,8 @@ export {
   base64UrlNoPadDecode,
   base64UrlNoPadEncode,
   exportPublicKeyAsMultibaseSpki,
+  hexDecode,
+  hexEncode,
   importPublicKeyFromMultibaseSpki,
   isValidMultibaseSpkiPublicKey,
   MultibaseSpkiPublicKeyRegExp,

--- a/libraries/ts-extras/src/packlets/crypto-utils/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/model.ts
@@ -332,6 +332,34 @@ export const ARGON2ID_PASSPHRASE: IArgon2idParams = {
 } as const;
 
 /**
+ * Optional keyed-hashing inputs for {@link CryptoUtils.IArgon2idProvider.argon2id | argon2id}
+ * (RFC 9106 §3.1). These are distinct from the cost parameters in
+ * {@link CryptoUtils.IArgon2idParams} — they change the derived output but are
+ * not tuning knobs. Both fields are optional; omitting a field (or passing an
+ * empty `Uint8Array`) is a no-op that leaves the output byte-identical to a call
+ * with no options at all.
+ * @public
+ */
+export interface IArgon2idKeyingOptions {
+  /**
+   * Optional secret key K (RFC 9106 keyed hashing, sometimes called a "pepper").
+   * When present and non-empty it is mixed into the hash so that the derived
+   * output cannot be reproduced without also knowing K. Empty or omitted means
+   * no secret. Honored by both the Node and browser backends.
+   */
+  readonly secret?: Uint8Array;
+
+  /**
+   * Optional associated data X (RFC 9106 §3.1). When present and non-empty it is
+   * mixed into the hash. **Node-only:** the WASM (`hash-wasm`) browser backend
+   * has no associated-data input, so `BrowserArgon2Provider` fails loudly rather
+   * than silently dropping it (which would produce wrong bytes). Empty or omitted
+   * means no associated data and is accepted by both backends.
+   */
+  readonly associatedData?: Uint8Array;
+}
+
+/**
  * Argon2id key derivation provider (RFC 9106).
  *
  * Implementations are in separate packages to avoid WASM bundle costs for
@@ -345,18 +373,28 @@ export interface IArgon2idProvider {
   /**
    * Derives key material from a password using Argon2id (RFC 9106 §3.1).
    *
-   * Returns the raw derived bytes as a `Uint8Array`. Both Node and browser
-   * implementations produce bit-identical output for identical inputs.
+   * Returns the raw derived bytes as a `Uint8Array`. For the same inputs that
+   * both backends support, the Node and browser implementations produce
+   * byte-identical output. The optional `associatedData` in
+   * {@link CryptoUtils.IArgon2idKeyingOptions} is the one exception: it is
+   * Node-only (the browser WASM backend has no associated-data input), so a call
+   * that supplies non-empty `associatedData` is not portable to the browser
+   * backend. Every input the browser backend *does* support (including the
+   * optional `secret`) is byte-identical across the two.
    *
    * @param password - Password or passphrase. Accepts string (UTF-8) or raw bytes.
    * @param salt - Salt bytes. Must be random and unique per credential (\>= 16 bytes recommended).
    * @param params - Argon2id parameters. Use `ARGON2ID_OWASP_MIN` as a starting point.
+   * @param options - Optional {@link CryptoUtils.IArgon2idKeyingOptions | keyed-hashing inputs}
+   * (secret K and/or associated data X). Omitting them (the default) leaves the
+   * output byte-identical to prior behavior.
    * @returns Success with derived bytes, Failure with error context.
    */
   argon2id(
     password: Uint8Array | string,
     salt: Uint8Array,
-    params: IArgon2idParams
+    params: IArgon2idParams,
+    options?: IArgon2idKeyingOptions
   ): Promise<Result<Uint8Array>>;
 }
 

--- a/libraries/ts-extras/src/packlets/crypto-utils/spkiHelpers.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/spkiHelpers.ts
@@ -97,6 +97,52 @@ export function base64UrlNoPadDecode(encoded: string): Result<Uint8Array> {
 }
 
 /**
+ * Encodes a `Uint8Array` as a lowercase hexadecimal string with no `0x` prefix.
+ *
+ * Each byte becomes exactly two lowercase hex characters (zero-padded), so an
+ * `n`-byte input yields a `2n`-character string. An empty input yields the empty
+ * string. This is the inverse of {@link CryptoUtils.hexDecode}.
+ *
+ * @param data - The binary data to encode.
+ * @returns The lowercase, unprefixed hex string.
+ * @public
+ */
+export function hexEncode(data: Uint8Array): string {
+  let hex = '';
+  for (let i = 0; i < data.length; i++) {
+    hex += data[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+/**
+ * Decodes a hexadecimal string (no `0x` prefix) back to a `Uint8Array`.
+ *
+ * Liberal in what it accepts: both lowercase and uppercase hex digits are
+ * allowed (whereas {@link CryptoUtils.hexEncode} always emits lowercase). The
+ * input must have even length and contain only hex digits (`0-9`, `a-f`, `A-F`);
+ * an empty string decodes to an empty `Uint8Array`. Odd length or any non-hex
+ * character fails with error context.
+ *
+ * @param encoded - The hex string to decode.
+ * @returns `Success` with the decoded bytes, or `Failure` with error context.
+ * @public
+ */
+export function hexDecode(encoded: string): Result<Uint8Array> {
+  if (encoded.length % 2 !== 0) {
+    return fail(`hexDecode: odd-length hex string (length ${encoded.length})`);
+  }
+  if (!/^[0-9a-fA-F]*$/.test(encoded)) {
+    return fail(`hexDecode: string contains non-hex characters`);
+  }
+  const bytes = new Uint8Array(encoded.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(encoded.slice(i * 2, i * 2 + 2), 16);
+  }
+  return succeed(bytes);
+}
+
+/**
  * The structural *shape* of a {@link CryptoUtils.MultibaseSpkiPublicKey}: the
  * multibase `'m'` prefix followed by a non-empty base64url-no-pad body
  * (`A-Z`, `a-z`, `0-9`, `-`, `_`).

--- a/libraries/ts-extras/src/test/unit/crypto/spkiHelpers.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/spkiHelpers.test.ts
@@ -364,3 +364,45 @@ describe('spkiToRawX25519', () => {
     });
   });
 });
+
+describe('hexEncode / hexDecode', () => {
+  test('encode produces lowercase, unprefixed, two-chars-per-byte output', () => {
+    expect(CryptoUtils.hexEncode(new Uint8Array([0x00, 0xff, 0x10]))).toBe('00ff10');
+    expect(CryptoUtils.hexEncode(new Uint8Array([0x0a, 0x0b, 0xde, 0xad]))).toBe('0a0bdead');
+  });
+
+  test('encode of an empty array is the empty string', () => {
+    expect(CryptoUtils.hexEncode(new Uint8Array(0))).toBe('');
+  });
+
+  test('encode zero-pads single-digit bytes', () => {
+    expect(CryptoUtils.hexEncode(new Uint8Array([0x01, 0x02, 0x0f]))).toBe('01020f');
+  });
+
+  test('decode round-trips encode for arbitrary bytes', () => {
+    const data = new Uint8Array([0, 1, 2, 3, 16, 127, 128, 253, 254, 255]);
+    expect(CryptoUtils.hexDecode(CryptoUtils.hexEncode(data))).toSucceedWith(data);
+  });
+
+  test('decode round-trips the empty string to an empty array', () => {
+    expect(CryptoUtils.hexDecode('')).toSucceedWith(new Uint8Array(0));
+  });
+
+  test('decode accepts a known lowercase vector', () => {
+    expect(CryptoUtils.hexDecode('00ff10')).toSucceedWith(new Uint8Array([0x00, 0xff, 0x10]));
+  });
+
+  test('decode accepts uppercase hex (liberal input)', () => {
+    expect(CryptoUtils.hexDecode('00FF10')).toSucceedWith(new Uint8Array([0x00, 0xff, 0x10]));
+    expect(CryptoUtils.hexDecode('DeAdBeEf')).toSucceedWith(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+  });
+
+  test('decode fails on odd-length input', () => {
+    expect(CryptoUtils.hexDecode('abc')).toFailWith(/odd-length hex string/i);
+  });
+
+  test('decode fails on non-hex characters', () => {
+    expect(CryptoUtils.hexDecode('zz')).toFailWith(/non-hex characters/i);
+    expect(CryptoUtils.hexDecode('00gg')).toFailWith(/non-hex characters/i);
+  });
+});

--- a/libraries/ts-web-extras-argon2/etc/ts-web-extras-argon2.api.md
+++ b/libraries/ts-web-extras-argon2/etc/ts-web-extras-argon2.api.md
@@ -9,7 +9,7 @@ import { Result } from '@fgv/ts-utils';
 
 // @public
 export class BrowserArgon2Provider implements CryptoUtils.IArgon2idProvider {
-    argon2id(password: Uint8Array | string, salt: Uint8Array, params: CryptoUtils.IArgon2idParams): Promise<Result<Uint8Array>>;
+    argon2id(password: Uint8Array | string, salt: Uint8Array, params: CryptoUtils.IArgon2idParams, options?: CryptoUtils.IArgon2idKeyingOptions): Promise<Result<Uint8Array>>;
     static create(): Result<BrowserArgon2Provider>;
 }
 

--- a/libraries/ts-web-extras-argon2/src/packlets/argon2/browserArgon2Provider.ts
+++ b/libraries/ts-web-extras-argon2/src/packlets/argon2/browserArgon2Provider.ts
@@ -50,20 +50,38 @@ export class BrowserArgon2Provider implements CryptoUtils.IArgon2idProvider {
    * For interoperability with server-side Node derivations, ensure both sides use the same
    * `parallelism` value (recommend `parallelism: 1` unless compatibility requires otherwise).
    *
+   * The optional secret K (RFC 9106 keyed hashing) is wired through to `hash-wasm`
+   * and produces output byte-identical to the Node backend. Associated data X, by
+   * contrast, is **not supported** by `hash-wasm` (its `argon2id` options have no
+   * associated-data field), so a call that supplies non-empty `associatedData`
+   * fails loudly rather than silently dropping it and producing wrong bytes —
+   * associated data is a Node-only feature. An empty/omitted `associatedData` is a
+   * no-op and is accepted.
+   *
    * @param password - The password or passphrase (string or raw bytes).
    * @param salt - The salt (must be at least 8 bytes; 16+ bytes recommended).
    * @param params - Argon2id parameters. All values are validated before derivation.
+   * @param options - Optional {@link @fgv/ts-extras#CryptoUtils.IArgon2idKeyingOptions | keyed-hashing inputs}.
+   * `secret` is honored; non-empty `associatedData` fails (Node-only).
    * @returns Success with the derived key bytes, or Failure with a descriptive message.
    * @public
    */
   public async argon2id(
     password: Uint8Array | string,
     salt: Uint8Array,
-    params: CryptoUtils.IArgon2idParams
+    params: CryptoUtils.IArgon2idParams,
+    options?: CryptoUtils.IArgon2idKeyingOptions
   ): Promise<Result<Uint8Array>> {
     const error = BrowserArgon2Provider._validateParams(params);
     if (error !== undefined) {
       return fail(error);
+    }
+
+    if (options?.associatedData && options.associatedData.length > 0) {
+      return fail(
+        'argon2id: associatedData is not supported by the hash-wasm (browser) backend — ' +
+          'associated data is Node-only (@fgv/ts-extras-argon2 NodeArgon2Provider)'
+      );
     }
 
     return captureAsyncResult(async () => {
@@ -74,7 +92,10 @@ export class BrowserArgon2Provider implements CryptoUtils.IArgon2idProvider {
         parallelism: params.parallelism,
         memorySize: params.memoryKiB,
         hashLength: params.outputBytes,
-        outputType: 'binary'
+        outputType: 'binary',
+        // Only pass secret when present and non-empty so empty options and prior
+        // callers produce byte-identical output.
+        ...(options?.secret && options.secret.length > 0 ? { secret: options.secret } : {})
       });
       return result;
     });

--- a/libraries/ts-web-extras-argon2/src/test/unit/argon2/browserArgon2Provider.test.ts
+++ b/libraries/ts-web-extras-argon2/src/test/unit/argon2/browserArgon2Provider.test.ts
@@ -90,6 +90,42 @@ describe('BrowserArgon2Provider', () => {
     });
   });
 
+  describe('keyed hashing (secret / associatedData)', () => {
+    const SECRET = new Uint8Array(8).fill(0x03);
+    const AD = new Uint8Array(12).fill(0x04);
+
+    test('honors a secret — output differs from the no-secret derivation', async () => {
+      const withoutSecret = (await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS)).orThrow();
+      expect(
+        await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS, { secret: SECRET })
+      ).toSucceedAndSatisfy((withSecret) => {
+        expect(withSecret).not.toEqual(withoutSecret);
+      });
+    });
+
+    test('empty secret is a no-op (byte-identical to omitting options)', async () => {
+      const baseline = (await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS)).orThrow();
+      expect(
+        await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS, { secret: new Uint8Array(0) })
+      ).toSucceedWith(baseline);
+    });
+
+    test('rejects non-empty associatedData as a Node-only feature', async () => {
+      expect(await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS, { associatedData: AD })).toFailWith(
+        /associatedData is not supported.*node-only/i
+      );
+    });
+
+    test('empty associatedData is accepted (no-op, byte-identical to omitting options)', async () => {
+      const baseline = (await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS)).orThrow();
+      expect(
+        await provider.argon2id(RFC_PASSWORD, RFC_SALT, RFC_PARAMS, {
+          associatedData: new Uint8Array(0)
+        })
+      ).toSucceedWith(baseline);
+    });
+  });
+
   describe('parameter validation', () => {
     test('fails when memoryKiB < 8', async () => {
       expect(await provider.argon2id(RFC_PASSWORD, RFC_SALT, { ...RFC_PARAMS, memoryKiB: 7 })).toFailWith(


### PR DESCRIPTION
## Summary

Two additive, non-breaking `@fgv/ts-extras` crypto-utils features from the 2026-07 golden-vector capture (docs/FUTURE.md). Both are test-provenance/ergonomics; neither changes existing behavior when the new inputs are omitted.

### Ask A — Argon2id optional `secret` (K) + `associatedData` (X)

New optional 4th arg on `IArgon2idProvider.argon2id`: `options?: IArgon2idKeyingOptions { secret?, associatedData? }` (kept off the cost-only `IArgon2idParams`).

- **Node** (`NodeArgon2Provider`) honors **both** — spread into the kelektiv `argon2.hash` options only when present and non-empty, so omitted/empty options stay byte-identical to today.
- **Browser** (`BrowserArgon2Provider`) honors `secret` (byte-identical to Node); `hash-wasm`'s `argon2id` has **no associated-data field**, so a non-empty `associatedData` **fails loudly** naming the Node-only limitation rather than silently producing wrong bytes. Empty/omitted AD is a no-op accepted by both.
- The "byte-identical across runtimes" doc claim is rescoped to "inputs both backends support (i.e. excluding the Node-only `associatedData`)."

**Headline deliverable — RFC 9106 §5.3 known-answer test reproduces exactly through the Node provider**, unmodified: `argon2id(P=32×0x01, S=16×0x02, {m=32,t=3,p=4,tag=32}, {secret:8×0x03, associatedData:12×0x04})` → `0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659`. This spec-anchors the consumer's Argon2id golden vector (previously captured-from-impl because the seam exposed neither K nor X).

### Footnote — hex codec

`hexEncode` (lowercase, unprefixed, zero-padded) / `hexDecode` (`Result`; accepts upper/lowercase, fails on odd length or non-hex) added as siblings to the base64url helpers in `spkiHelpers.ts`, exported from both `index.ts` and `index.browser.ts`. Third reached-for-missing primitive in the consumer's corpus.

## Layer-1 review (pre-PR)

Reviewed the full diff before opening. Additive interface change (optional param — existing callers and empty options are byte-identical); Node conditional-spread and browser loud-fail both correct; hex `hexDecode` validates charset + even length before parsing (no NaN path); Result pattern throughout; no `any`. No P1/P2 findings.

## Gate (agent-run, all green with 100% coverage)

| Package | build | lint | test/coverage |
|---|---|---|---|
| `ts-extras` | ✅ | ✅ | ✅ 100% |
| `ts-extras-argon2` | ✅ | ✅ | ✅ 100% (27 tests) |
| `ts-web-extras-argon2` | ✅ | ✅ | ✅ 100% (16 tests) |

Existing cross-runtime byte-identical parity suite still passes. API Extractor reports regenerated. **Rush change files included** for all three modified packages (`minor` for ts-extras, `none` for the two argon2 packages — matching each package's convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_