### PR TITLE
feat(ts-extras): KeyStore opaque byte secrets + mutable metadata (keystore-v3)

### DIFF
--- a/common/changes/@fgv/ts-extras/keystore-opaque-metadata_2026-07-19-00-00.json
+++ b/common/changes/@fgv/ts-extras/keystore-opaque-metadata_2026-07-19-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "crypto-utils/KeyStore: add the `'opaque'` symmetric secret type plus `importSecretBytes` / `getSecretBytes` for storing and reading arbitrary raw bytes verbatim (no UTF-8 round-trip), and add mutable per-entry `metadata` (JsonValue, non-secret-by-contract but carried inside the vault ciphertext) with an `updatedAt` timestamp settable via `setSecretMetadata` without touching key material. Vault format bumped to `keystore-v3` (strict superset: a v3 reader opens v1/v2 vaults; a re-saved v1/v2 vault upgrades silently). Additive/back-compatible.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -1509,6 +1509,15 @@ interface IImportKeyOptions extends IImportSecretOptions {
     readonly type?: KeyStoreSymmetricSecretType;
 }
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "KeyStore"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IImportSecretOptions"
+//
+// @public
+interface IImportSecretBytesOptions extends IImportSecretOptions {
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "KeyStore"
+    readonly metadata?: JsonValue;
+}
+
 // @public
 interface IImportSecretOptions extends IAddSecretOptions {
     readonly replace?: boolean;
@@ -1616,8 +1625,12 @@ interface IKeyStoreSymmetricEntry {
     readonly createdAt: string;
     readonly description?: string;
     readonly key: Uint8Array;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly metadata?: JsonValue;
     readonly name: string;
     readonly type: KeyStoreSymmetricSecretType;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly updatedAt?: string;
 }
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
@@ -1627,8 +1640,10 @@ interface IKeyStoreSymmetricEntryJson {
     readonly createdAt: string;
     readonly description?: string;
     readonly key: string;
+    readonly metadata?: JsonValue;
     readonly name: string;
     readonly type: KeyStoreSymmetricSecretType;
+    readonly updatedAt?: string;
 }
 
 // @public
@@ -2040,6 +2055,7 @@ declare namespace KeyStore {
         IAddSecretOptions,
         IImportSecretOptions,
         IImportKeyOptions,
+        IImportSecretBytesOptions,
         IAddSecretFromPasswordOptions,
         DEFAULT_SECRET_ITERATIONS,
         IAddSecretFromPasswordResult,
@@ -2081,11 +2097,15 @@ class KeyStore_2 implements IEncryptionProvider {
     getPublicKeyJwk(name: string): Result<JsonWebKey>;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     getSecret(name: string): Result<IKeyStoreEntry>;
+    getSecretBytes(name: string): Result<Uint8Array>;
     getSecretProvider(): Result<SecretProvider>;
     hasSecret(name: string): Result<boolean>;
     importApiKey(name: string, apiKey: string, options?: IImportSecretOptions): Promise<Result<IAddSecretResult>>;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "KeyStore"
     importSecret(name: string, key: Uint8Array, options?: IImportKeyOptions): Promise<Result<IAddSecretResult>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "KeyStore"
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "KeyStore"
+    importSecretBytes(name: string, bytes: Uint8Array, options?: IImportSecretBytesOptions): Promise<Result<IAddSecretResult>>;
     initialize(password: string): Promise<Result<KeyStore_2>>;
     get isDirty(): boolean;
     get isNew(): boolean;
@@ -2099,6 +2119,8 @@ class KeyStore_2 implements IEncryptionProvider {
     renameSecret(oldName: string, newName: string): Result<IKeyStoreEntry>;
     save(password: string): Promise<Result<IKeyStoreFile>>;
     saveWithKey(derivedKey: Uint8Array): Promise<Result<IKeyStoreFile>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    setSecretMetadata(name: string, value: JsonValue): Result<IKeyStoreSymmetricEntry>;
     get state(): KeyStoreLockState;
     unlock(password: string): Promise<Result<KeyStore_2>>;
     unlockWithKey(derivedKey: Uint8Array): Promise<Result<KeyStore_2>>;
@@ -2132,7 +2154,7 @@ const keystoreAsymmetricSecretType: Converter<KeyStoreAsymmetricSecretType>;
 const keystoreFile: Converter<IKeyStoreFile>;
 
 // @public
-type KeyStoreFormat = 'keystore-v1' | 'keystore-v2';
+type KeyStoreFormat = 'keystore-v1' | 'keystore-v2' | 'keystore-v3';
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
@@ -2164,7 +2186,7 @@ const keystoreSecretType: Converter<KeyStoreSecretType>;
 const keystoreSymmetricEntryJson: Converter<IKeyStoreSymmetricEntryJson>;
 
 // @public
-type KeyStoreSymmetricSecretType = 'encryption-key' | 'api-key';
+type KeyStoreSymmetricSecretType = 'encryption-key' | 'api-key' | 'opaque';
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
@@ -2588,9 +2610,9 @@ class ZipFileTreeAccessors<TCT extends string = string> implements FileTree.IFil
 
 // Warnings were encountered during analysis:
 //
-// src/packlets/crypto-utils/keystore/keyStore.ts:1558:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// src/packlets/crypto-utils/keystore/keyStore.ts:1595:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "KeyStore"
-// src/packlets/crypto-utils/keystore/keyStore.ts:1689:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/crypto-utils/keystore/keyStore.ts:1677:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/packlets/crypto-utils/keystore/keyStore.ts:1714:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "KeyStore"
+// src/packlets/crypto-utils/keystore/keyStore.ts:1808:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 
 // (No @packageDocumentation comment for this package)
 

--- a/libraries/ts-extras/src/packlets/crypto-utils/keystore/converters.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/keystore/converters.ts
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 import { Converter, Converters, succeed, Validation, Validator, Validators } from '@fgv/ts-utils';
+import { Converters as JsonConverters } from '@fgv/ts-json-base';
 import { base64String, encryptionAlgorithm, pbkdf2KeyDerivationParams } from '../converters';
 import {
   allKeyPairAlgorithms,
@@ -63,7 +64,7 @@ export const keystoreSecretType: Converter<KeyStoreSecretType> =
 
 /**
  * Converter for {@link CryptoUtils.KeyStore.KeyStoreSymmetricSecretType | symmetric secret type} discriminator.
- * Accepts only `'encryption-key'` and `'api-key'`.
+ * Accepts `'encryption-key'`, `'api-key'`, and `'opaque'`.
  * @public
  */
 export const keystoreSymmetricSecretType: Converter<KeyStoreSymmetricSecretType> =
@@ -138,12 +139,15 @@ export const keystoreSymmetricEntryJson: Converter<IKeyStoreSymmetricEntryJson> 
       type: keystoreSymmetricSecretType,
       key: base64String,
       description: Converters.string,
-      createdAt: Converters.string
+      metadata: JsonConverters.jsonValue,
+      createdAt: Converters.string,
+      updatedAt: Converters.string
     },
     {
       // `type` is optional at the input layer for legacy-vault compatibility;
-      // the .map() below normalizes by injecting the default.
-      optionalFields: ['type', 'description']
+      // the .map() below normalizes by injecting the default. `metadata` and
+      // `updatedAt` are keystore-v3 additions, optional so v1/v2 entries parse.
+      optionalFields: ['type', 'description', 'metadata', 'updatedAt']
     }
   ).map((entry) =>
     succeed<IKeyStoreSymmetricEntryJson>({

--- a/libraries/ts-extras/src/packlets/crypto-utils/keystore/keyStore.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/keystore/keyStore.ts
@@ -48,6 +48,7 @@ import {
   IAddSecretResult,
   IGetKeyPairOptions,
   IImportKeyOptions,
+  IImportSecretBytesOptions,
   IImportSecretOptions,
   IKeyStoreAsymmetricEntry,
   IKeyStoreCreateParams,
@@ -918,6 +919,120 @@ export class KeyStore implements IEncryptionProvider {
     return succeed(decoder.decode(entry.key));
   }
 
+  /**
+   * Imports arbitrary raw bytes into the vault with type `'opaque'`.
+   *
+   * Unlike {@link KeyStore.importSecret} (which enforces a 32-byte AES-256 key)
+   * and {@link KeyStore.importApiKey} (which UTF-8 encodes a string), this
+   * accepts a byte buffer of any length and stores it verbatim — including
+   * embedded NUL bytes. Use it for byte blobs that are neither a fixed-size key
+   * nor a UTF-8 string (e.g. a serialized credential bundle), so they are not
+   * mistyped as `'api-key'`.
+   *
+   * @param name - Unique name for the secret
+   * @param bytes - The raw bytes to store
+   * @param options - Optional description, initial metadata, whether to replace existing
+   * @returns Success with entry, Failure if locked, empty, or exists and !replace
+   * @public
+   */
+  public async importSecretBytes(
+    name: string,
+    bytes: Uint8Array,
+    options?: IImportSecretBytesOptions
+  ): Promise<Result<IAddSecretResult>> {
+    if (!this._secrets) {
+      return fail('Key store is locked');
+    }
+    if (!name || name.length === 0) {
+      return fail('Secret name cannot be empty');
+    }
+
+    const existing = this._secrets.get(name);
+    if (existing && !options?.replace) {
+      return fail(`Secret '${name}' already exists - use replace=true to overwrite`);
+    }
+
+    const entry: IKeyStoreSymmetricEntry = {
+      name,
+      type: 'opaque',
+      key: new Uint8Array(bytes), // Copy to prevent external modification
+      description: options?.description,
+      metadata: options?.metadata,
+      createdAt: getCurrentTimestamp()
+    };
+
+    const warning = existing ? await this._releaseEntryResources(existing) : undefined;
+    this._secrets.set(name, entry);
+    this._dirty = true;
+
+    return succeed({ entry, replaced: existing !== undefined, warning });
+  }
+
+  /**
+   * Retrieves the raw stored bytes for a symmetric entry, returned verbatim
+   * (never UTF-8 decoded). Intended for `'opaque'` entries but works for any
+   * symmetric type; asymmetric-keypair entries carry no raw key material and
+   * are rejected.
+   *
+   * @param name - Name of the secret
+   * @returns Success with a copy of the stored bytes, Failure if not found,
+   * locked, or the entry is asymmetric
+   * @public
+   */
+  public getSecretBytes(name: string): Result<Uint8Array> {
+    if (!this._secrets) {
+      return fail('Key store is locked');
+    }
+    const entry = this._secrets.get(name);
+    if (!entry) {
+      return fail(`Secret '${name}' not found`);
+    }
+    if (entry.type === 'asymmetric-keypair') {
+      return fail(`Secret '${name}' is an asymmetric keypair, not raw byte material (type: ${entry.type})`);
+    }
+    // Copy so callers cannot mutate the in-memory vault buffer.
+    return succeed(new Uint8Array(entry.key));
+  }
+
+  /**
+   * Replaces the mutable metadata on a symmetric entry and stamps `updatedAt`
+   * with the current timestamp. Does NOT touch the secret `key` bytes — the
+   * material reads back identically afterward.
+   *
+   * Metadata is non-secret by contract but physically lives inside the vault
+   * ciphertext (see {@link CryptoUtils.KeyStore.IKeyStoreSymmetricEntry.metadata}).
+   *
+   * @param name - Name of the secret to update
+   * @param value - New metadata value (replaces any prior metadata)
+   * @returns Success with the updated entry, Failure if not found, locked, or
+   * the entry is asymmetric
+   * @public
+   */
+  public setSecretMetadata(name: string, value: JsonValue): Result<IKeyStoreSymmetricEntry> {
+    if (!this._secrets) {
+      return fail('Key store is locked');
+    }
+    const entry = this._secrets.get(name);
+    if (!entry) {
+      return fail(`Secret '${name}' not found`);
+    }
+    if (entry.type === 'asymmetric-keypair') {
+      return fail(
+        `Secret '${name}' is an asymmetric keypair; metadata is only supported on symmetric entries (type: ${entry.type})`
+      );
+    }
+
+    const updated: IKeyStoreSymmetricEntry = {
+      ...entry,
+      metadata: value,
+      updatedAt: getCurrentTimestamp()
+    };
+    this._secrets.set(name, updated);
+    this._dirty = true;
+
+    return succeed(updated);
+  }
+
   // ============================================================================
   // Asymmetric Keypair Management
   // ============================================================================
@@ -1402,7 +1517,9 @@ export class KeyStore implements IEncryptionProvider {
           type: entry.type,
           key: this._cryptoProvider.toBase64(entry.key),
           description: entry.description,
-          createdAt: entry.createdAt
+          metadata: entry.metadata,
+          createdAt: entry.createdAt,
+          updatedAt: entry.updatedAt
         };
       }
     }
@@ -1526,7 +1643,9 @@ export class KeyStore implements IEncryptionProvider {
           type: jsonEntry.type,
           key: keyBytesResult.value,
           description: jsonEntry.description,
-          createdAt: jsonEntry.createdAt
+          metadata: jsonEntry.metadata,
+          createdAt: jsonEntry.createdAt,
+          updatedAt: jsonEntry.updatedAt
         };
         secrets.set(name, entry);
       }

--- a/libraries/ts-extras/src/packlets/crypto-utils/keystore/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/keystore/model.ts
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import { JsonValue } from '@fgv/ts-json-base';
 import {
   EncryptionAlgorithm,
   ICryptoProvider,
@@ -44,21 +45,30 @@ export { allKeyPairAlgorithms, KeyPairAlgorithm } from '../model';
  *   asymmetric-keypair entries. A strict superset of v1 — the field is
  *   optional, so a v2 reader opens a v1 vault with no special-casing, and a
  *   v1 vault opened and re-saved is silently upgraded to v2.
+ * - `'keystore-v3'`: adds the `'opaque'` symmetric secret type and the optional
+ *   `metadata` / `updatedAt` fields on symmetric entries. A strict superset of
+ *   v1/v2 — the additions are optional (and `'opaque'` is simply a new enum
+ *   value), so a v3 reader opens a v1/v2 vault with no special-casing, and a
+ *   v1/v2 vault opened and re-saved is silently upgraded to v3.
  * @public
  */
-export type KeyStoreFormat = 'keystore-v1' | 'keystore-v2';
+export type KeyStoreFormat = 'keystore-v1' | 'keystore-v2' | 'keystore-v3';
 
 /**
  * All recognized key store format versions (readable by the current library).
  * @public
  */
-export const allKeyStoreFormats: ReadonlyArray<KeyStoreFormat> = ['keystore-v1', 'keystore-v2'];
+export const allKeyStoreFormats: ReadonlyArray<KeyStoreFormat> = [
+  'keystore-v1',
+  'keystore-v2',
+  'keystore-v3'
+];
 
 /**
- * Current format version constant. New vaults are written as `'keystore-v2'`.
+ * Current format version constant. New vaults are written as `'keystore-v3'`.
  * @public
  */
-export const KEYSTORE_FORMAT: KeyStoreFormat = 'keystore-v2';
+export const KEYSTORE_FORMAT: KeyStoreFormat = 'keystore-v3';
 
 /**
  * Default PBKDF2 iterations for key store encryption.
@@ -81,9 +91,13 @@ export const MIN_SALT_LENGTH: number = 16;
  * Discriminator for symmetric secret types stored in the vault.
  * - `'encryption-key'`: A 32-byte AES-256 encryption key.
  * - `'api-key'`: An arbitrary-length API key string (UTF-8 encoded).
+ * - `'opaque'`: Arbitrary raw bytes with no encoding contract — stored and
+ *   returned verbatim (never UTF-8 decoded). Use for byte blobs that are
+ *   neither a fixed-size AES key nor a UTF-8 string (e.g. a serialized
+ *   credential bundle), so they are not mistyped as `'api-key'`.
  * @public
  */
-export type KeyStoreSymmetricSecretType = 'encryption-key' | 'api-key';
+export type KeyStoreSymmetricSecretType = 'encryption-key' | 'api-key' | 'opaque';
 
 /**
  * All valid symmetric secret types.
@@ -91,7 +105,8 @@ export type KeyStoreSymmetricSecretType = 'encryption-key' | 'api-key';
  */
 export const allKeyStoreSymmetricSecretTypes: ReadonlyArray<KeyStoreSymmetricSecretType> = [
   'encryption-key',
-  'api-key'
+  'api-key',
+  'opaque'
 ];
 
 /**
@@ -147,6 +162,7 @@ export interface IKeyStoreSymmetricEntry {
    * The secret data.
    * - For `'encryption-key'`: 32-byte AES-256 key.
    * - For `'api-key'`: UTF-8 encoded API key string (arbitrary length).
+   * - For `'opaque'`: arbitrary raw bytes, stored and returned verbatim.
    */
   readonly key: Uint8Array;
 
@@ -156,9 +172,30 @@ export interface IKeyStoreSymmetricEntry {
   readonly description?: string;
 
   /**
+   * Optional mutable, non-secret-by-contract metadata for this entry. Set via
+   * {@link CryptoUtils.KeyStore.KeyStore.setSecretMetadata} without touching the
+   * secret `key` bytes.
+   *
+   * "Non-secret by contract" means the field is intended for lifecycle metadata
+   * (rotation timestamps, labels, provenance) rather than secret material.
+   * PHYSICALLY it lives inside the vault's AES-GCM ciphertext alongside the key
+   * bytes — the vault has no plaintext index — so it is protected at rest by the
+   * master password; the "non-secret" designation is a usage contract, not a
+   * weaker custody class.
+   */
+  readonly metadata?: JsonValue;
+
+  /**
    * When this secret was added (ISO 8601).
    */
   readonly createdAt: string;
+
+  /**
+   * When this entry was last mutated (ISO 8601). Stamped on any metadata
+   * mutation (see {@link CryptoUtils.KeyStore.KeyStore.setSecretMetadata}).
+   * Absent on entries that have never been mutated since creation.
+   */
+  readonly updatedAt?: string;
 }
 
 /**
@@ -277,9 +314,23 @@ export interface IKeyStoreSymmetricEntryJson {
   readonly description?: string;
 
   /**
+   * Optional mutable, non-secret-by-contract metadata for this entry. Present
+   * only on `'keystore-v3'` vaults whose entry carried metadata; a v1/v2 vault
+   * omits the field. Physically carried inside the vault ciphertext (the vault
+   * has no plaintext index).
+   */
+  readonly metadata?: JsonValue;
+
+  /**
    * When this secret was added (ISO 8601).
    */
   readonly createdAt: string;
+
+  /**
+   * When this entry was last mutated (ISO 8601). Present only on `'keystore-v3'`
+   * vaults whose entry has been mutated since creation.
+   */
+  readonly updatedAt?: string;
 }
 
 /**
@@ -518,6 +569,19 @@ export interface IImportKeyOptions extends IImportSecretOptions {
    * @defaultValue 'encryption-key'
    */
   readonly type?: KeyStoreSymmetricSecretType;
+}
+
+/**
+ * Options for importing raw opaque bytes via {@link KeyStore.importSecretBytes}.
+ * Extends {@link IImportSecretOptions} with optional initial metadata.
+ * @public
+ */
+export interface IImportSecretBytesOptions extends IImportSecretOptions {
+  /**
+   * Optional initial mutable metadata to store with the entry. Can also be set
+   * or replaced later via {@link KeyStore.setSecretMetadata}.
+   */
+  readonly metadata?: JsonValue;
 }
 
 /**

--- a/libraries/ts-extras/src/test/unit/crypto/keystore/converters.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/keystore/converters.test.ts
@@ -31,10 +31,13 @@ describe('Key Store Converters', () => {
       expect(CryptoUtils.KeyStore.Converters.keystoreFormat.convert('keystore-v2')).toSucceedWith(
         'keystore-v2'
       );
+      expect(CryptoUtils.KeyStore.Converters.keystoreFormat.convert('keystore-v3')).toSucceedWith(
+        'keystore-v3'
+      );
     });
 
     test('rejects invalid format', () => {
-      expect(CryptoUtils.KeyStore.Converters.keystoreFormat.convert('keystore-v3')).toFail();
+      expect(CryptoUtils.KeyStore.Converters.keystoreFormat.convert('keystore-v4')).toFail();
     });
 
     test('rejects non-string', () => {

--- a/libraries/ts-extras/src/test/unit/crypto/keystore/keyStoreEscrow.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/keystore/keyStoreEscrow.test.ts
@@ -161,7 +161,7 @@ describe('KeyStore private-key escrow', () => {
       const publicJwk = added.orThrow().entry.publicKeyJwk;
       expect(added.orThrow().entry.escrowedPrivateKeyJwk).toBeDefined();
       const file = (await deviceA.save(testPassword)).orThrow();
-      expect(file.format).toBe('keystore-v2');
+      expect(file.format).toBe('keystore-v3');
 
       // Device B: fresh empty backend + the recovered vault file.
       const deviceBStorage = new InMemoryPrivateKeyStorage();
@@ -268,11 +268,11 @@ describe('KeyStore private-key escrow', () => {
       );
     });
 
-    test('re-saving a v1 vault silently upgrades the file to keystore-v2', async () => {
+    test('re-saving a v1 vault silently upgrades the file to keystore-v3', async () => {
       const v1 = await makeV1File();
       const keystore = await openDeviceKeystore(v1, new InMemoryPrivateKeyStorage());
       const resaved = (await keystore.save(testPassword)).orThrow();
-      expect(resaved.format).toBe('keystore-v2');
+      expect(resaved.format).toBe('keystore-v3');
     });
 
     test('isKeyStoreFile recognizes both v1 and v2 files', async () => {

--- a/libraries/ts-extras/src/test/unit/crypto/keystore/keyStoreOpaqueMetadata.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/keystore/keyStoreOpaqueMetadata.test.ts
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import * as CryptoUtils from '../../../../packlets/crypto-utils';
+import { InMemoryPrivateKeyStorage } from './inMemoryPrivateKeyStorage';
+
+describe('KeyStore opaque byte secrets + metadata (keystore-v3)', () => {
+  const provider = CryptoUtils.nodeCryptoProvider;
+  const testPassword = 'test-password-123';
+
+  describe('opaque byte secrets', () => {
+    let keystore: CryptoUtils.KeyStore.KeyStore;
+    // Binary payload with an embedded NUL byte and high bytes — must survive
+    // verbatim (no UTF-8 round-trip).
+    const binaryBytes = new Uint8Array([0x00, 0x01, 0xff, 0x7f, 0x00, 0x80, 0x42]);
+
+    beforeEach(async () => {
+      keystore = CryptoUtils.KeyStore.KeyStore.create({ cryptoProvider: provider }).orThrow();
+      await keystore.initialize(testPassword);
+    });
+
+    describe('importSecretBytes / getSecretBytes', () => {
+      test('round-trips raw bytes verbatim including 0x00', async () => {
+        expect(await keystore.importSecretBytes('blob', binaryBytes)).toSucceedAndSatisfy((addResult) => {
+          expect(addResult.entry.type).toBe('opaque');
+          expect(addResult.replaced).toBe(false);
+          expect(addResult.entry.createdAt).toBeDefined();
+        });
+
+        expect(keystore.getSecretBytes('blob')).toSucceedAndSatisfy((bytes) => {
+          expect(Array.from(bytes)).toEqual(Array.from(binaryBytes));
+        });
+      });
+
+      test('stores a defensive copy of the input bytes', async () => {
+        const mutable = new Uint8Array(binaryBytes);
+        await keystore.importSecretBytes('blob', mutable);
+        mutable[0] = 0x99; // external mutation after import
+
+        expect(keystore.getSecretBytes('blob')).toSucceedAndSatisfy((bytes) => {
+          expect(bytes[0]).toBe(0x00);
+        });
+      });
+
+      test('returns a copy so callers cannot mutate the vault buffer', async () => {
+        await keystore.importSecretBytes('blob', binaryBytes);
+        const first = keystore.getSecretBytes('blob').orThrow();
+        first[0] = 0x99;
+
+        expect(keystore.getSecretBytes('blob')).toSucceedAndSatisfy((bytes) => {
+          expect(bytes[0]).toBe(0x00);
+        });
+      });
+
+      test('supports description and initial metadata', async () => {
+        expect(
+          await keystore.importSecretBytes('blob', binaryBytes, {
+            description: 'credential bundle',
+            metadata: { source: 'import', version: 2 }
+          })
+        ).toSucceedAndSatisfy((addResult) => {
+          expect(addResult.entry.description).toBe('credential bundle');
+          expect(addResult.entry.metadata).toEqual({ source: 'import', version: 2 });
+        });
+      });
+
+      test('does not overwrite an existing secret without replace', async () => {
+        await keystore.importSecretBytes('blob', binaryBytes);
+        expect(await keystore.importSecretBytes('blob', new Uint8Array([1, 2, 3]))).toFailWith(
+          /already exists/i
+        );
+      });
+
+      test('replaces an existing secret with replace=true', async () => {
+        await keystore.importSecretBytes('blob', binaryBytes);
+        expect(
+          await keystore.importSecretBytes('blob', new Uint8Array([1, 2, 3]), { replace: true })
+        ).toSucceedAndSatisfy((addResult) => {
+          expect(addResult.replaced).toBe(true);
+        });
+        expect(keystore.getSecretBytes('blob')).toSucceedAndSatisfy((bytes) => {
+          expect(Array.from(bytes)).toEqual([1, 2, 3]);
+        });
+      });
+
+      test('importSecretBytes fails with empty name', async () => {
+        expect(await keystore.importSecretBytes('', binaryBytes)).toFailWith(/name cannot be empty/i);
+      });
+
+      test('importSecretBytes fails when locked', async () => {
+        keystore.lock(true);
+        expect(await keystore.importSecretBytes('blob', binaryBytes)).toFailWith(/locked/i);
+      });
+
+      test('getSecretBytes works for encryption-key and api-key entries too', async () => {
+        await keystore.addSecret('enc');
+        await keystore.importApiKey('api', 'sk-abc');
+
+        expect(keystore.getSecretBytes('enc')).toSucceedAndSatisfy((bytes) => {
+          expect(bytes.length).toBe(CryptoUtils.Constants.AES_256_KEY_SIZE);
+        });
+        expect(keystore.getSecretBytes('api')).toSucceedAndSatisfy((bytes) => {
+          expect(new TextDecoder().decode(bytes)).toBe('sk-abc');
+        });
+      });
+
+      test('getSecretBytes fails on missing name', () => {
+        expect(keystore.getSecretBytes('nope')).toFailWith(/not found/i);
+      });
+
+      test('getSecretBytes fails on an asymmetric entry', async () => {
+        const ks = CryptoUtils.KeyStore.KeyStore.create({
+          cryptoProvider: provider,
+          privateKeyStorage: new InMemoryPrivateKeyStorage()
+        }).orThrow();
+        await ks.initialize(testPassword);
+        await ks.addKeyPair('kp', { algorithm: 'ecdsa-p256' });
+
+        expect(ks.getSecretBytes('kp')).toFailWith(/asymmetric keypair/i);
+      });
+
+      test('getSecretBytes fails when locked', async () => {
+        await keystore.importSecretBytes('blob', binaryBytes);
+        await keystore.save(testPassword);
+        keystore.lock();
+        expect(keystore.getSecretBytes('blob')).toFailWith(/locked/i);
+      });
+
+      test('opaque entries surface correctly under listSecretsByType / listSecrets', async () => {
+        await keystore.importSecretBytes('blob-1', binaryBytes);
+        await keystore.importSecretBytes('blob-2', binaryBytes);
+        await keystore.importApiKey('api', 'sk-abc');
+
+        expect(keystore.listSecretsByType('opaque')).toSucceedAndSatisfy((names) => {
+          expect(names).toEqual(expect.arrayContaining(['blob-1', 'blob-2']));
+          expect(names).toHaveLength(2);
+        });
+        // opaque entries are NOT reported as api-key (the bug this type fixes)
+        expect(keystore.listSecretsByType('api-key')).toSucceedWith(['api']);
+        expect(keystore.listSecrets()).toSucceedAndSatisfy((names) => {
+          expect(names).toEqual(expect.arrayContaining(['blob-1', 'blob-2', 'api']));
+        });
+      });
+    });
+
+    describe('setSecretMetadata', () => {
+      test('sets metadata, stamps updatedAt, and leaves key bytes unchanged', async () => {
+        await keystore.importSecretBytes('blob', binaryBytes);
+        const before = keystore.getSecretBytes('blob').orThrow();
+
+        expect(keystore.setSecretMetadata('blob', { rotated: true, at: 'now' })).toSucceedAndSatisfy(
+          (entry) => {
+            expect(entry.metadata).toEqual({ rotated: true, at: 'now' });
+            expect(entry.updatedAt).toBeDefined();
+            // key bytes are the same material as before the metadata update
+            expect(Array.from(entry.key)).toEqual(Array.from(binaryBytes));
+          }
+        );
+
+        // secret still reads back identically after the metadata update
+        expect(keystore.getSecretBytes('blob')).toSucceedAndSatisfy((after) => {
+          expect(Array.from(after)).toEqual(Array.from(before));
+        });
+      });
+
+      test('replaces prior metadata', async () => {
+        await keystore.importSecretBytes('blob', binaryBytes, { metadata: { a: 1 } });
+        keystore.setSecretMetadata('blob', { b: 2 }).orThrow();
+
+        expect(keystore.getSecret('blob')).toSucceedAndSatisfy((entry) => {
+          if (entry.type !== 'asymmetric-keypair') {
+            expect(entry.metadata).toEqual({ b: 2 });
+          }
+        });
+      });
+
+      test('works on encryption-key entries', async () => {
+        await keystore.addSecret('enc');
+        expect(keystore.setSecretMetadata('enc', 'a-label')).toSucceedAndSatisfy((entry) => {
+          expect(entry.metadata).toBe('a-label');
+        });
+      });
+
+      test('fails on missing name', () => {
+        expect(keystore.setSecretMetadata('nope', {})).toFailWith(/not found/i);
+      });
+
+      test('fails on an asymmetric entry', async () => {
+        const ks = CryptoUtils.KeyStore.KeyStore.create({
+          cryptoProvider: provider,
+          privateKeyStorage: new InMemoryPrivateKeyStorage()
+        }).orThrow();
+        await ks.initialize(testPassword);
+        await ks.addKeyPair('kp', { algorithm: 'ecdsa-p256' });
+
+        expect(ks.setSecretMetadata('kp', {})).toFailWith(/asymmetric keypair/i);
+      });
+
+      test('fails when locked', () => {
+        keystore.lock(true);
+        expect(keystore.setSecretMetadata('blob', {})).toFailWith(/locked/i);
+      });
+    });
+
+    describe('persistence', () => {
+      test('opaque secrets and metadata survive a full save/open round-trip', async () => {
+        await keystore.importSecretBytes('blob', binaryBytes, { description: 'bundle' });
+        keystore.setSecretMetadata('blob', { rotated: true }).orThrow();
+        const savedFile = (await keystore.save(testPassword)).orThrow();
+
+        expect(savedFile.format).toBe('keystore-v3');
+
+        const reopened = CryptoUtils.KeyStore.KeyStore.open({
+          cryptoProvider: provider,
+          keystoreFile: savedFile
+        }).orThrow();
+        await reopened.unlock(testPassword);
+
+        expect(reopened.listSecretsByType('opaque')).toSucceedWith(['blob']);
+        expect(reopened.getSecretBytes('blob')).toSucceedAndSatisfy((bytes) => {
+          expect(Array.from(bytes)).toEqual(Array.from(binaryBytes));
+        });
+        expect(reopened.getSecret('blob')).toSucceedAndSatisfy((entry) => {
+          if (entry.type !== 'asymmetric-keypair') {
+            expect(entry.description).toBe('bundle');
+            expect(entry.metadata).toEqual({ rotated: true });
+            expect(entry.updatedAt).toBeDefined();
+          }
+        });
+      });
+
+      test('a new vault is written as keystore-v3', async () => {
+        await keystore.addSecret('s');
+        const savedFile = (await keystore.save(testPassword)).orThrow();
+        expect(savedFile.format).toBe('keystore-v3');
+        expect(CryptoUtils.KeyStore.KEYSTORE_FORMAT).toBe('keystore-v3');
+      });
+    });
+  });
+
+  describe('format upgrade to keystore-v3', () => {
+    // Builds a real encrypted keystore file for a prior format version by
+    // encrypting the vault contents directly with the crypto provider — the
+    // same wire shape KeyStore.save would have produced under that version.
+    async function buildLegacyVaultFile(
+      version: 'keystore-v1' | 'keystore-v2'
+    ): Promise<CryptoUtils.KeyStore.IKeyStoreFile> {
+      const salt = provider.generateRandomBytes(CryptoUtils.KeyStore.MIN_SALT_LENGTH).orThrow();
+      const iterations = 100000;
+      const derived = (await provider.deriveKey(testPassword, salt, iterations)).orThrow();
+      const keyBytes = provider.generateRandomBytes(CryptoUtils.Constants.AES_256_KEY_SIZE).orThrow();
+      const vault = {
+        version,
+        secrets: {
+          'legacy-key': {
+            name: 'legacy-key',
+            type: 'encryption-key',
+            key: provider.toBase64(keyBytes),
+            createdAt: new Date().toISOString()
+          }
+        }
+      };
+      const enc = (await provider.encrypt(JSON.stringify(vault), derived)).orThrow();
+      return {
+        format: version,
+        algorithm: 'AES-256-GCM',
+        iv: provider.toBase64(enc.iv),
+        authTag: provider.toBase64(enc.authTag),
+        encryptedData: provider.toBase64(enc.encryptedData),
+        keyDerivation: {
+          kdf: 'pbkdf2',
+          salt: provider.toBase64(salt),
+          iterations
+        }
+      };
+    }
+
+    test.each(['keystore-v1', 'keystore-v2'] as const)(
+      'a %s vault opens and re-saves as keystore-v3',
+      async (version) => {
+        const legacyFile = await buildLegacyVaultFile(version);
+        expect(legacyFile.format).toBe(version);
+
+        const ks = CryptoUtils.KeyStore.KeyStore.open({
+          cryptoProvider: provider,
+          keystoreFile: legacyFile
+        }).orThrow();
+        expect(await ks.unlock(testPassword)).toSucceed();
+        expect(ks.listSecrets()).toSucceedWith(['legacy-key']);
+
+        // Re-saving silently upgrades the on-disk format to v3.
+        const resaved = (await ks.save(testPassword)).orThrow();
+        expect(resaved.format).toBe('keystore-v3');
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two additive shape features on `CryptoUtils.KeyStore` (credential-store asks D1/D2 from docs/FUTURE.md), plus a `keystore-v3` format bump. No crypto change — these are shape-over-existing-primitives.

### D1 — opaque byte-secret type
Adds `'opaque'` to `KeyStoreSymmetricSecretType`, plus:
- `importSecretBytes(name, bytes, options?)` — stores raw bytes verbatim (incl. embedded NUL) with `type: 'opaque'`, defensive-copied; supports `description`/`metadata`/`replace`.
- `getSecretBytes(name)` — returns a defensive copy of the raw bytes (no UTF-8 decode); rejects missing/locked/asymmetric.

Fixes the mistyping the consumer flagged: a JSON credential bundle stored via `importApiKey` was reported as `'api-key'` by `listSecretsByType`. It's now typed `'opaque'` and kept out of the `'api-key'` bucket (dedicated test).

### D2 — mutable per-entry metadata + `updatedAt`
Adds optional `metadata?: JsonValue` and `updatedAt?: string` to the symmetric entry (both wire-forms), plus `setSecretMetadata(name, value)` which replaces metadata and stamps `updatedAt` **without touching key material** (verified: the secret reads back byte-identical after a metadata update). Metadata lives inside the AES-GCM ciphertext — the vault has no plaintext index — documented as "non-secret by contract, physically in ciphertext". Optional fields, so pre-existing entries parse unchanged.

### keystore-v3 format bump
Both `'opaque'` (an enum value old readers' converters reject) and `metadata`/`updatedAt` are forward-incompatible, so following the v1→v2 escrow precedent this is a **strict-superset** bump: a v3 reader opens v1/v2 with no special-casing; a v1/v2 vault re-saves as v3; new vaults write v3. Covered by a `test.each` over v1 and v2.

## Reconciliation note

The implementing agent's worktree isolation leaked git state into the shared checkout, leaving its final commit based on the pre-#554 release. I rebuilt this branch cleanly off the **current** release (post-#554), applied only the keystore source + tests + change file (#554 touched no keystore file — zero source overlap), and **regenerated the API report from scratch** so it correctly layers keystore + argon2/hex. Verified the api.md diff vs release contains only keystore additions.

## Layer-1 review (pre-PR)

Reviewed the method implementations directly: locked/not-found/asymmetric guards on all three methods, defensive copies in `importSecretBytes`/`getSecretBytes`, immutable metadata update that leaves key bytes untouched, `_releaseEntryResources` on replace, returns meaningful values (no `Result<void>`). Result pattern throughout, Converters for the JSON path, no `any`. No P1/P2 findings.

## Gate (all green)

`libraries/ts-extras`: `heft build --clean` ✅ (API report regenerated), `eslint src` ✅ clean, `heft test --clean` ✅ **100% coverage** (keystore `100/100/100/100`). New `keyStoreOpaqueMetadata.test.ts` (23 tests: byte round-trip incl. 0x00, defensive-copy both directions, `listSecretsByType('opaque')`, the not-reported-as-api-key fix, missing/asymmetric/locked failures, metadata set + `updatedAt` stamp + key-unchanged, full save→open persistence, v1/v2→v3 upgrade). Rush change file included (`type: minor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_