### PR TITLE
feat(crypto-utils): X25519 seed-derived keypair import (golden-vector ask B)

### DIFF
--- a/common/changes/@fgv/ts-extras/crypto-x25519-seed-import_2026-07-19-02-00.json
+++ b/common/changes/@fgv/ts-extras/crypto-x25519-seed-import_2026-07-19-02-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Extend ICryptoProvider.importKeyPairFromSeed to support 'x25519' (SeedDerivableAlgorithm now 'ed25519' | 'x25519'), deriving a deterministic X25519 key-agreement keypair (private 'deriveBits', public no-usage) from a fixed 32-byte seed. This lets a checked-in recipient keypair back a reproducible HpkeProvider seal/open round-trip vector; with a non-extractable private key it composes with openBase's supplied recipient-public-key path.",
+      "type": "minor",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-web-extras/crypto-x25519-seed-import_2026-07-19-02-30.json
+++ b/common/changes/@fgv/ts-web-extras/crypto-x25519-seed-import_2026-07-19-02-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Test-only: cover X25519 seed-derived keypair import on BrowserCryptoProvider (cross-provider parity with Node against the RFC 7748 vector) now that importKeyPairFromSeed supports 'x25519'; update the stale assertion that x25519 is unsupported.",
+      "type": "none",
+      "packageName": "@fgv/ts-web-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-web-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -551,6 +551,8 @@ const DEFAULT_SECRET_ITERATIONS: number;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "ISeedAlgorithmParams"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
 function deriveKeyPairFromSeed(algorithm: SeedDerivableAlgorithm, seed: Uint8Array, extractable: boolean): Promise<Result<CryptoKeyPair>>;
@@ -1251,6 +1253,7 @@ interface ICryptoProvider {
     generateUuid(): Result<Uuid>;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "ICryptoProvider"
     hmacSha256(key: CryptoKey, data: Uint8Array): Promise<Result<Uint8Array>>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     importKeyPairFromSeed(algorithm: SeedDerivableAlgorithm, seed: Uint8Array, extractable: boolean): Promise<Result<CryptoKeyPair>>;
@@ -2480,9 +2483,11 @@ type SecretProvider = (secretName: string) => Promise<Result<Uint8Array>>;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //
 // @public
-type SeedDerivableAlgorithm = 'ed25519';
+type SeedDerivableAlgorithm = 'ed25519' | 'x25519';
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //

--- a/libraries/ts-extras/src/packlets/crypto-utils/model.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/model.ts
@@ -147,15 +147,22 @@ export type KeyPairAlgorithm = 'ecdsa-p256' | 'rsa-oaep-2048' | 'ecdh-p256' | 'e
  * derived *deterministically* from a fixed secret seed, for use with
  * {@link CryptoUtils.ICryptoProvider.importKeyPairFromSeed | importKeyPairFromSeed}.
  *
- * Only `'ed25519'` is supported today: an Ed25519 private key *is* a 32-byte
- * seed and its public key is a deterministic function of that seed (RFC 8032),
- * so the same seed always yields the same keypair on every runtime. The type is
- * a proper subset because algorithms like RSA or the NIST curves are not
- * recoverable from a bare seed. It is intentionally left open to grow (e.g.
- * `'x25519'`) without a breaking change.
+ * Two algorithms are supported, both of whose 32-byte private scalar *is* the
+ * seed and whose public key is a deterministic function of it, so the same seed
+ * always yields the same keypair on every runtime:
+ * - `'ed25519'` — signing keypair (RFC 8032). Private usage `'sign'`, public
+ *   usage `'verify'`.
+ * - `'x25519'` — Diffie-Hellman key-agreement keypair (RFC 7748), the recipient
+ *   keypair consumed by {@link CryptoUtils.HpkeProvider}. Private usage
+ *   `'deriveBits'`, public key imported with no usages. Deriving a fixed X25519
+ *   recipient keypair from a checked-in seed is what makes a deterministic HPKE
+ *   seal/open round-trip vector possible.
+ *
+ * The type is a proper subset of {@link CryptoUtils.KeyPairAlgorithm} because
+ * algorithms like RSA or the NIST curves are not recoverable from a bare seed.
  * @public
  */
-export type SeedDerivableAlgorithm = 'ed25519';
+export type SeedDerivableAlgorithm = 'ed25519' | 'x25519';
 
 /**
  * Caller-supplied HKDF parameters that domain-separate one
@@ -635,16 +642,19 @@ export interface ICryptoProvider {
    * material (key escrow, HD-style derivation, deterministic test vectors) rather
    * than freshly sampled by {@link CryptoUtils.ICryptoProvider.generateKeyPair | generateKeyPair}.
    *
-   * For `'ed25519'` the private key *is* its 32-byte seed and the public key is a
-   * deterministic function of that seed (RFC 8032), so the returned public key is
-   * recovered even when the caller requests a non-extractable private key. The
-   * transient extractable key used internally to recover the public half is never
-   * returned or logged when `extractable` is `false`.
-   * @param algorithm - The {@link CryptoUtils.SeedDerivableAlgorithm | seed-derivable algorithm}.
-   * Only `'ed25519'` is supported today; any other value fails loudly with context.
-   * @param seed - The secret seed. For `'ed25519'` it must be exactly 32 bytes;
-   * any other length fails loudly, before any WebCrypto call. The bytes are copied,
-   * not retained or mutated.
+   * For both `'ed25519'` and `'x25519'` the private key *is* its 32-byte seed and
+   * the public key is a deterministic function of that seed (RFC 8032 / RFC 7748),
+   * so the returned public key is recovered even when the caller requests a
+   * non-extractable private key. The transient extractable key used internally to
+   * recover the public half is never returned or logged when `extractable` is
+   * `false`. The returned keys carry the algorithm's usages: `'ed25519'` →
+   * private `'sign'` / public `'verify'`; `'x25519'` → private `'deriveBits'` /
+   * public no-usage (ready to hand to {@link CryptoUtils.HpkeProvider}).
+   * @param algorithm - The {@link CryptoUtils.SeedDerivableAlgorithm | seed-derivable algorithm}
+   * (`'ed25519'` or `'x25519'`); any other value fails loudly with context.
+   * @param seed - The secret seed. It must be exactly 32 bytes for both supported
+   * algorithms; any other length fails loudly, before any WebCrypto call. The
+   * bytes are copied, not retained or mutated.
    * @param extractable - Whether the returned private key may be exported. The
    * returned public key is identical for a given seed regardless of this flag.
    * @returns Success with the derived `CryptoKeyPair`, or Failure with error context.

--- a/libraries/ts-extras/src/packlets/crypto-utils/seedDerivedKeyPair.ts
+++ b/libraries/ts-extras/src/packlets/crypto-utils/seedDerivedKeyPair.ts
@@ -22,32 +22,72 @@ import { captureAsyncResult, fail, Result } from '@fgv/ts-utils';
 import { SeedDerivableAlgorithm } from './model';
 
 /**
- * The RFC 8410 §7 DER prefix for an Ed25519 PKCS#8 `OneAsymmetricKey`
- * (a.k.a. `PrivateKeyInfo`) wrapping a bare 32-byte seed. The 16 bytes below
- * decode as:
- *
- * ```text
- *   30 2e             SEQUENCE (46 bytes)
- *     02 01 00        INTEGER version 0 (v1)
- *     30 05           SEQUENCE AlgorithmIdentifier (5 bytes)
- *       06 03 2b6570    OID 1.3.101.112 (id-Ed25519)
- *     04 22           OCTET STRING privateKey (34 bytes)
- *       04 20         OCTET STRING CurvePrivateKey (32 bytes)
- * ```
- *
- * The 32-byte seed follows immediately, for a total of 48 bytes. An Ed25519
- * private key *is* its 32-byte seed (RFC 8032 §5.1.5), and the public key is a
- * deterministic function of that seed, so wrapping the seed in this envelope and
- * importing it via WebCrypto recovers the exact keypair on every runtime.
+ * Per-algorithm parameters for the shared seed→keypair derivation. The two
+ * supported algorithms differ only in the OID embedded in the PKCS#8 envelope,
+ * the WebCrypto algorithm name, the JWK curve name, and the key usages — the
+ * envelope structure and 32-byte seed handling are identical.
  */
-const _ED25519_PKCS8_SEED_PREFIX: ReadonlyArray<number> = [
-  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20
-];
+interface ISeedAlgorithmParams {
+  /**
+   * The RFC 8410 §7 DER prefix for a PKCS#8 `OneAsymmetricKey` wrapping a bare
+   * 32-byte seed. Decodes as:
+   *
+   * ```text
+   *   30 2e             SEQUENCE (46 bytes)
+   *     02 01 00        INTEGER version 0 (v1)
+   *     30 05           SEQUENCE AlgorithmIdentifier (5 bytes)
+   *       06 03 2b65XX    OID 1.3.101.XXX
+   *     04 22           OCTET STRING privateKey (34 bytes)
+   *       04 20         OCTET STRING CurvePrivateKey (32 bytes)
+   * ```
+   *
+   * The 32-byte seed follows immediately (total 48 bytes). Ed25519 uses OID
+   * 1.3.101.112 (`...2b 65 70`); X25519 uses 1.3.101.110 (`...2b 65 6e`) — the
+   * two prefixes differ only in that final OID byte.
+   */
+  readonly pkcs8Prefix: ReadonlyArray<number>;
+  /** WebCrypto algorithm name (`importKey`'s `algorithm.name`). */
+  readonly webCryptoName: 'Ed25519' | 'X25519';
+  /** JWK curve name for the reconstructed public key. */
+  readonly jwkCrv: 'Ed25519' | 'X25519';
+  /** Usages for the imported private key. */
+  readonly privateUsages: ReadonlyArray<KeyUsage>;
+  /** Usages for the reconstructed public key (empty for X25519). */
+  readonly publicUsages: ReadonlyArray<KeyUsage>;
+}
 
 /**
- * Required length, in bytes, of an Ed25519 seed (RFC 8032 §5.1.5).
+ * An Ed25519 or X25519 private key *is* its 32-byte seed (RFC 8032 §5.1.5 /
+ * RFC 7748 §5), and the public key is a deterministic function of that seed, so
+ * wrapping the seed in the PKCS#8 envelope and importing it via WebCrypto
+ * recovers the exact keypair on every runtime.
  */
-const _ED25519_SEED_LENGTH: number = 32;
+const _SEED_ALGORITHMS: Readonly<Record<SeedDerivableAlgorithm, ISeedAlgorithmParams>> = {
+  ed25519: {
+    pkcs8Prefix: [
+      0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20
+    ],
+    webCryptoName: 'Ed25519',
+    jwkCrv: 'Ed25519',
+    privateUsages: ['sign'],
+    publicUsages: ['verify']
+  },
+  x25519: {
+    pkcs8Prefix: [
+      0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x6e, 0x04, 0x22, 0x04, 0x20
+    ],
+    webCryptoName: 'X25519',
+    jwkCrv: 'X25519',
+    privateUsages: ['deriveBits'],
+    publicUsages: []
+  }
+};
+
+/**
+ * Required length, in bytes, of an Ed25519 / X25519 seed (RFC 8032 §5.1.5 /
+ * RFC 7748 §5).
+ */
+const _SEED_LENGTH: number = 32;
 
 /**
  * Derives an asymmetric keypair *deterministically* from a fixed secret seed
@@ -57,25 +97,30 @@ const _ED25519_SEED_LENGTH: number = 32;
  * {@link CryptoUtils.ICryptoProvider.importKeyPairFromSeed | importKeyPairFromSeed}
  * for the public contract.
  *
- * For `'ed25519'`: wraps the 32-byte seed in the RFC 8410 PKCS#8 envelope, then
- * runs a transient-extractable-then-derive dance so the public key is
- * recoverable even when the caller requests a non-extractable private key:
+ * For each supported algorithm: wraps the 32-byte seed in the RFC 8410 PKCS#8
+ * envelope, then runs a transient-extractable-then-derive dance so the public
+ * key is recoverable even when the caller requests a non-extractable private key:
  *
  * 1. Import the PKCS#8 as a *transient* extractable private key.
  * 2. Export it to JWK to read the deterministic public coordinate `x`.
- * 3. Import `{ kty: 'OKP', crv: 'Ed25519', x }` as the returned public key.
+ * 3. Import `{ kty: 'OKP', crv, x }` as the returned public key.
  * 4. For the returned private key: reuse the transient key when `extractable`
  *    is `true`; otherwise re-import the same PKCS#8 as a non-extractable key.
  *    The transient extractable key is never returned when `extractable` is
  *    `false`, so seed material cannot escape through it.
+ *
+ * The two algorithms differ only in the OID/name/curve/usages (see
+ * {@link ISeedAlgorithmParams}); `'x25519'` yields the DH key-agreement keypair
+ * (private `'deriveBits'`, public no-usage) that {@link CryptoUtils.HpkeProvider}
+ * consumes as its recipient key.
  *
  * The seed bytes are copied into a freshly allocated PKCS#8 buffer, so the
  * `BufferSource` handed to WebCrypto is always backed by a plain `ArrayBuffer`
  * (side-stepping the Node-20 `SharedArrayBuffer`-view rejection) and the
  * caller's `seed` is never mutated.
  *
- * @param algorithm - The seed-derivable algorithm; only `'ed25519'` is
- * supported today. Any other value fails loudly rather than being mis-handled.
+ * @param algorithm - The seed-derivable algorithm (`'ed25519'` or `'x25519'`).
+ * Any other value fails loudly rather than being mis-handled.
  * @param seed - The 32-byte secret seed. Any other length fails loudly, before
  * any WebCrypto call.
  * @param extractable - Whether the returned private key may be exported.
@@ -87,14 +132,15 @@ export async function deriveKeyPairFromSeed(
   seed: Uint8Array,
   extractable: boolean
 ): Promise<Result<CryptoKeyPair>> {
-  if (algorithm !== 'ed25519') {
+  const params = _SEED_ALGORITHMS[algorithm];
+  if (params === undefined) {
     return fail(
-      `importKeyPairFromSeed: unsupported seed-derivable algorithm '${algorithm}' (only 'ed25519' is supported)`
+      `importKeyPairFromSeed: unsupported seed-derivable algorithm '${algorithm}' (supported: 'ed25519', 'x25519')`
     );
   }
-  if (seed.length !== _ED25519_SEED_LENGTH) {
+  if (seed.length !== _SEED_LENGTH) {
     return fail(
-      `importKeyPairFromSeed: ed25519 seed must be exactly ${_ED25519_SEED_LENGTH} bytes, got ${seed.length}`
+      `importKeyPairFromSeed: ${algorithm} seed must be exactly ${_SEED_LENGTH} bytes, got ${seed.length}`
     );
   }
 
@@ -102,10 +148,13 @@ export async function deriveKeyPairFromSeed(
   // to WebCrypto is a `Uint8Array<ArrayBuffer>` — Node 20+ rejects a shared-buffer
   // view, and TypeScript's `BufferSource` excludes the `SharedArrayBuffer` branch.
   const pkcs8: Uint8Array<ArrayBuffer> = new Uint8Array(
-    new ArrayBuffer(_ED25519_PKCS8_SEED_PREFIX.length + _ED25519_SEED_LENGTH)
+    new ArrayBuffer(params.pkcs8Prefix.length + _SEED_LENGTH)
   );
-  pkcs8.set(_ED25519_PKCS8_SEED_PREFIX, 0);
-  pkcs8.set(seed, _ED25519_PKCS8_SEED_PREFIX.length);
+  pkcs8.set(params.pkcs8Prefix, 0);
+  pkcs8.set(seed, params.pkcs8Prefix.length);
+
+  const algo = { name: params.webCryptoName };
+  const privateUsages = [...params.privateUsages];
 
   return (
     await captureAsyncResult<CryptoKeyPair>(async () => {
@@ -113,18 +162,18 @@ export async function deriveKeyPairFromSeed(
       // Transient extractable private key — only used to read the deterministic
       // public coordinate; dropped (never returned/logged) when the caller
       // asked for a non-extractable private key.
-      const transientPrivateKey = await subtle.importKey('pkcs8', pkcs8, { name: 'Ed25519' }, true, ['sign']);
+      const transientPrivateKey = await subtle.importKey('pkcs8', pkcs8, algo, true, privateUsages);
       const jwk = await subtle.exportKey('jwk', transientPrivateKey);
       const publicKey = await subtle.importKey(
         'jwk',
-        { kty: 'OKP', crv: 'Ed25519', x: jwk.x },
-        { name: 'Ed25519' },
+        { kty: 'OKP', crv: params.jwkCrv, x: jwk.x },
+        algo,
         true,
-        ['verify']
+        [...params.publicUsages]
       );
       const privateKey = extractable
         ? transientPrivateKey
-        : await subtle.importKey('pkcs8', pkcs8, { name: 'Ed25519' }, false, ['sign']);
+        : await subtle.importKey('pkcs8', pkcs8, algo, false, privateUsages);
       return { publicKey, privateKey };
     })
   ).withErrorFormat((e) => `importKeyPairFromSeed: failed to derive ${algorithm} keypair from seed: ${e}`);

--- a/libraries/ts-extras/src/test/unit/crypto/hpkeProvider.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/hpkeProvider.test.ts
@@ -21,7 +21,12 @@
 import '@fgv/ts-utils-jest';
 
 import * as crypto from 'crypto';
-import { HpkeProvider, IHpkeSealResult, spkiToRawX25519 } from '../../../packlets/crypto-utils';
+import {
+  HpkeProvider,
+  IHpkeSealResult,
+  nodeCryptoProvider,
+  spkiToRawX25519
+} from '../../../packlets/crypto-utils';
 import {
   HKDF_RFC5869_CASE1,
   RECIPIENT_PRIV_JWK,
@@ -376,6 +381,62 @@ describe('HpkeProvider', () => {
         expect(decoded.enc.length).toBe(32);
         expect(decoded.ciphertext.length).toBe(16);
       });
+    });
+  });
+
+  // The seam that makes a fully reproducible HPKE vector possible: derive the
+  // recipient keypair from a fixed, checked-in x25519 seed via importKeyPairFromSeed,
+  // so the same recipient identity can be regenerated on any runtime (a native/mobile
+  // port validates against the same vector) without checking in a raw private CryptoKey.
+  describe('deterministic recipient from a checked-in x25519 seed', () => {
+    // RFC 7748 §6.1 Alice private scalar + its derived X25519 public key.
+    const RECIPIENT_SEED_HEX: string = '77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a';
+    const RECIPIENT_PUBLIC_HEX: string = '8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a';
+
+    function hexToBytes(hex: string): Uint8Array {
+      const bytes = new Uint8Array(hex.length / 2);
+      for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+      }
+      return bytes;
+    }
+    function bytesToHex(bytes: Uint8Array): string {
+      return Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+    }
+
+    let hpke: HpkeProvider;
+    beforeAll(() => {
+      hpke = HpkeProvider.create(subtle).orThrow();
+    });
+
+    test('the recipient derived from the fixed seed matches the checked-in public key', async () => {
+      const pair = (
+        await nodeCryptoProvider.importKeyPairFromSeed('x25519', hexToBytes(RECIPIENT_SEED_HEX), false)
+      ).orThrow();
+      const rawPub = new Uint8Array(await subtle.exportKey('raw', pair.publicKey));
+      expect(bytesToHex(rawPub)).toBe(RECIPIENT_PUBLIC_HEX);
+    });
+
+    test('seal to the derived public and open with the derived (non-extractable) private round-trips', async () => {
+      // extractable=false is the secure default for a checked-in recipient. HPKE
+      // Decap then needs the recipient public key supplied explicitly (the PR #536
+      // affordance) — which seed derivation conveniently hands us, so the two
+      // features compose: a fixed seed yields a non-extractable private plus the
+      // public bytes openBase requires.
+      const pair = (
+        await nodeCryptoProvider.importKeyPairFromSeed('x25519', hexToBytes(RECIPIENT_SEED_HEX), false)
+      ).orThrow();
+      const rawPub = new Uint8Array(await subtle.exportKey('raw', pair.publicKey));
+      const info = new TextEncoder().encode('fgv-hpke-x25519-seed-vector');
+      const aad = new TextEncoder().encode('vector-aad');
+      const plaintext = new TextEncoder().encode('deterministic recipient round-trip');
+
+      const sealed = (await hpke.sealBase(pair.publicKey, info, aad, plaintext)).orThrow();
+      expect(
+        await hpke.openBase(pair.privateKey, info, aad, sealed.enc, sealed.ciphertext, rawPub)
+      ).toSucceedAndSatisfy((pt) => expect(pt).toEqual(plaintext));
     });
   });
 });

--- a/libraries/ts-extras/src/test/unit/crypto/seedDerivedKeyPair.test.ts
+++ b/libraries/ts-extras/src/test/unit/crypto/seedDerivedKeyPair.test.ts
@@ -159,9 +159,9 @@ describe('Crypto.seedDerivedKeyPair (Ed25519 from seed)', () => {
     });
 
     test('rejects an unsupported seed-derivable algorithm', async () => {
-      const badAlgorithm = 'x25519' as unknown as SeedDerivableAlgorithm;
+      const badAlgorithm = 'ed448' as unknown as SeedDerivableAlgorithm;
       expect(await provider.importKeyPairFromSeed(badAlgorithm, seed, true)).toFailWith(
-        /unsupported seed-derivable algorithm 'x25519'/i
+        /unsupported seed-derivable algorithm 'ed448'/i
       );
     });
   });
@@ -172,6 +172,68 @@ describe('Crypto.seedDerivedKeyPair (Ed25519 from seed)', () => {
       const viaHelper = (await provider.exportPublicKeySpki(helperPair.publicKey)).orThrow();
       const viaProvider = await deriveSpki(seed, true);
       expect(viaHelper).toEqual(viaProvider);
+    });
+  });
+});
+
+// RFC 7748 §6.1 X25519 Diffie-Hellman example: Alice's private scalar and the
+// public key that WebCrypto derives from it (clamping applied internally). Used
+// as the deterministic known-answer vector for x25519 seed derivation.
+const RFC7748_ALICE_PRIVATE_HEX: string = '77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a';
+const RFC7748_ALICE_PUBLIC_HEX: string = '8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a';
+
+describe('Crypto.seedDerivedKeyPair (X25519 from seed)', () => {
+  const provider = CryptoUtils.nodeCryptoProvider;
+  const seed = hexToBytes(RFC7748_ALICE_PRIVATE_HEX);
+
+  async function derivePublicRaw(fromSeed: Uint8Array, extractable: boolean): Promise<string> {
+    const pair = (await provider.importKeyPairFromSeed('x25519', fromSeed, extractable)).orThrow();
+    const raw = new Uint8Array(await crypto.webcrypto.subtle.exportKey('raw', pair.publicKey));
+    return bytesToHex(raw);
+  }
+
+  describe('RFC 7748 known-answer vector', () => {
+    test("derives Alice's public key from her private scalar", async () => {
+      expect(await derivePublicRaw(seed, true)).toBe(RFC7748_ALICE_PUBLIC_HEX);
+    });
+
+    test('the derived keypair carries X25519 deriveBits usage on the private key', async () => {
+      const pair = (await provider.importKeyPairFromSeed('x25519', seed, true)).orThrow();
+      expect(pair.privateKey.algorithm.name).toBe('X25519');
+      expect(pair.privateKey.usages).toContain('deriveBits');
+      // X25519 public keys carry no usages.
+      expect(pair.publicKey.usages).toEqual([]);
+    });
+  });
+
+  describe('determinism', () => {
+    test('the same seed yields the byte-identical public key on repeated derivation', async () => {
+      expect(await derivePublicRaw(seed, true)).toBe(await derivePublicRaw(seed, false));
+    });
+
+    test('a different seed yields a different public key', async () => {
+      const other = await derivePublicRaw(new Uint8Array(32).fill(0x07), true);
+      expect(other).not.toBe(RFC7748_ALICE_PUBLIC_HEX);
+    });
+  });
+
+  describe('extractable matrix', () => {
+    test('extractable=false returns a non-extractable private key; public stays recoverable', async () => {
+      const pair = (await provider.importKeyPairFromSeed('x25519', seed, false)).orThrow();
+      expect(pair.privateKey.extractable).toBe(false);
+      // The transient extractable key must not leak the seed through the returned private key.
+      await expect(crypto.webcrypto.subtle.exportKey('pkcs8', pair.privateKey)).rejects.toThrow();
+      // The public half is always extractable and matches the vector.
+      const raw = new Uint8Array(await crypto.webcrypto.subtle.exportKey('raw', pair.publicKey));
+      expect(bytesToHex(raw)).toBe(RFC7748_ALICE_PUBLIC_HEX);
+    });
+  });
+
+  describe('validation', () => {
+    test.each([31, 33, 0, 64])('rejects a seed of %d bytes', async (len) => {
+      expect(await provider.importKeyPairFromSeed('x25519', new Uint8Array(len), true)).toFailWith(
+        /x25519 seed must be exactly 32 bytes/i
+      );
     });
   });
 });

--- a/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.seedKeyPair.test.ts
+++ b/libraries/ts-web-extras/src/test/unit/browserCryptoProvider.seedKeyPair.test.ts
@@ -125,10 +125,38 @@ describe('BrowserCryptoProvider — importKeyPairFromSeed (Ed25519)', () => {
     });
 
     test('rejects an unsupported seed-derivable algorithm', async () => {
-      const badAlgorithm = 'x25519' as unknown as CryptoUtils.SeedDerivableAlgorithm;
+      const badAlgorithm = 'ed448' as unknown as CryptoUtils.SeedDerivableAlgorithm;
       expect(await browser.importKeyPairFromSeed(badAlgorithm, seed, true)).toFailWith(
         /unsupported seed-derivable algorithm/i
       );
+    });
+  });
+
+  describe('X25519 from seed (RFC 7748) — cross-provider parity', () => {
+    // RFC 7748 §6.1 Alice private scalar + its derived X25519 public key.
+    const x25519Seed = hexToBytes('77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a');
+    const RFC7748_ALICE_PUBLIC_HEX: string =
+      '8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a';
+
+    async function rawPublic(provider: CryptoUtils.ICryptoProvider, extractable: boolean): Promise<string> {
+      const pair = (await provider.importKeyPairFromSeed('x25519', x25519Seed, extractable)).orThrow();
+      const raw = new Uint8Array(await globalThis.crypto.subtle.exportKey('raw', pair.publicKey));
+      return bytesToHex(raw);
+    }
+
+    test("the browser provider derives Alice's public key from her private scalar", async () => {
+      expect(await rawPublic(browser, true)).toBe(RFC7748_ALICE_PUBLIC_HEX);
+    });
+
+    test('Node and browser derive the byte-identical X25519 public key from the same seed', async () => {
+      expect(await rawPublic(browser, false)).toBe(await rawPublic(node, false));
+    });
+
+    test('the derived private key carries X25519 deriveBits usage', async () => {
+      const pair = (await browser.importKeyPairFromSeed('x25519', x25519Seed, false)).orThrow();
+      expect(pair.privateKey.algorithm.name).toBe('X25519');
+      expect(pair.privateKey.usages).toContain('deriveBits');
+      expect(pair.privateKey.extractable).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Additive, non-breaking extension of `ICryptoProvider.importKeyPairFromSeed` to support `'x25519'` (golden-vector ask B from docs/FUTURE.md). `SeedDerivableAlgorithm` is now `'ed25519' | 'x25519'` — the model already anticipated this ("intentionally left open to grow (e.g. `'x25519'`) without a breaking change").

The shared `deriveKeyPairFromSeed` helper is generalized over a per-algorithm config (PKCS#8 OID prefix / WebCrypto name / JWK curve / key usages); the **Ed25519 path is byte-for-byte unchanged** (the two PKCS#8 prefixes differ only in the final OID byte — id-Ed25519 `…2b6570` vs id-X25519 `…2b656e`). For X25519 the 32-byte seed is the private scalar and the public key is derived deterministically via the same transient-extractable-then-derive dance, returned with private `'deriveBits'` / public no-usage — exactly what `HpkeProvider` consumes as its recipient key.

### Why this exists — the deterministic HPKE vector it unlocks

The consumer's HPKE context vector had no checked-in seal→open round-trip because that needs a **fixed** recipient X25519 private key to check in, and the provider exposed no X25519 private-key import. Now a fixed recipient keypair can be regenerated from a checked-in 32-byte seed (no raw private `CryptoKey` in the repo), making the round-trip reproducible across runtimes (a native/mobile port validates against the same vector).

**Composes with two shipped items** exactly as the capture predicted: it's the X25519 analogue of the seed-deterministic Ed25519 primitive (#549), and the HPKE round-trip test uses a **non-extractable** private key (the secure default) plus `openBase`'s supplied recipient-public-key path (#536) — the two features compose because seed derivation hands the caller *both* halves.

## Verification (KATs, not captured-from-impl)

- **RFC 7748 §6.1**: seed = Alice's private scalar `77076d…` → derived public `8520f0…` (verified WebCrypto reproduces the spec vector before pinning it).
- **HPKE**: derive recipient from that fixed seed → public matches the checked-in value → `sealBase`/`openBase` round-trips a plaintext (non-extractable private + supplied public).

## Real finding during implementation (surfaced, not papered over)

The first HPKE round-trip failed with "key is not extractable" — Decap must recover the recipient public from the private, which needs extractability *unless* the public is supplied. Rather than weaken the test to `extractable=true`, I kept the secure non-extractable default and passed the derived public bytes (the #536 path), which is the realistic usage this seam is for. Also updated a pre-existing seed test that asserted `'x25519'` was *rejected* (now supported) to use a genuinely unsupported algorithm.

## Layer-1 review + gate

Reviewed the generalization for Ed25519-path invariance and X25519 correctness. Scope is **ts-extras only** — both providers already delegate to the shared helper and pass the algorithm through, so `ts-web-extras` needs no source change (coverage intact). `heft build` ✅ (API report regenerated: `SeedDerivableAlgorithm` widened), `eslint` ✅ clean, `heft test` ✅ **100% coverage** (`seedDerivedKeyPair.ts` and `hpkeProvider.ts` both `100/100/100/100`; seed suite 27 tests, HPKE suite 31). Rush change file included (`type: minor`). No `any`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_