### PR TITLE
feat(testbed): sqlite-vec persistent-memory scenario (extra credit)

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2656,6 +2656,9 @@ importers:
       '@fgv/heft-dual-rig':
         specifier: workspace:*
         version: link:../../rigs/heft-dual-rig
+      '@fgv/ts-agent-memory-sqlite-vec':
+        specifier: workspace:*
+        version: link:../../libraries/ts-agent-memory-sqlite-vec
       '@fgv/ts-utils-jest':
         specifier: workspace:*
         version: link:../../libraries/ts-utils-jest
@@ -2677,6 +2680,9 @@ importers:
       '@testing-library/react':
         specifier: ^16
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/better-sqlite3':
+        specifier: ^7.6.11
+        version: 7.6.13
       '@types/heft-jest':
         specifier: 1.0.6
         version: 1.0.6
@@ -2704,6 +2710,9 @@ importers:
       babel-loader:
         specifier: ~10.1.0
         version: 10.1.1(@babel/core@7.29.7)(webpack@5.105.4)
+      better-sqlite3:
+        specifier: ^12.0.0
+        version: 12.11.1
       css-loader:
         specifier: ~7.1.2
         version: 7.1.4(webpack@5.105.4)
@@ -2749,6 +2758,9 @@ importers:
       rimraf:
         specifier: ^6.1.2
         version: 6.1.3
+      sqlite-vec:
+        specifier: ^0.1.9
+        version: 0.1.9
       style-loader:
         specifier: ~4.0.0
         version: 4.0.0(webpack@5.105.4)

--- a/samples/testbed/config/jest.config.json
+++ b/samples/testbed/config/jest.config.json
@@ -14,7 +14,8 @@
     "<rootDir>/lib/web/index.js",
     "<rootDir>/lib/generated/",
     "<rootDir>/lib/scenarios/[a-zA-Z]+ClientTools/",
-    "<rootDir>/lib/scenarios/memoryToolsGate/"
+    "<rootDir>/lib/scenarios/memoryToolsGate/",
+    "<rootDir>/lib/scenarios/sqliteVecMemoryPersistence/index.js"
   ],
   "collectCoverage": true,
   "coverageReporters": ["text", "lcov", "html"],

--- a/samples/testbed/package.json
+++ b/samples/testbed/package.json
@@ -92,6 +92,10 @@
     "typescript": "5.9.3",
     "webpack": "~5.105.4",
     "webpack-cli": "~6.0.1",
-    "webpack-dev-server": "~5.2.2"
+    "webpack-dev-server": "~5.2.2",
+    "@fgv/ts-agent-memory-sqlite-vec": "workspace:*",
+    "@types/better-sqlite3": "^7.6.11",
+    "better-sqlite3": "^12.0.0",
+    "sqlite-vec": "^0.1.9"
   }
 }

--- a/samples/testbed/src/scenarios/index.ts
+++ b/samples/testbed/src/scenarios/index.ts
@@ -18,6 +18,7 @@ import { localClassifierSafetyScenario } from './localClassifierSafety';
 import { localEmbeddingSearchScenario } from './localEmbeddingSearch';
 import { localSummarizationScenario } from './localSummarization';
 import { mcpProbeScenario } from './mcpProbe';
+import { sqliteVecMemoryPersistenceScenario } from './sqliteVecMemoryPersistence';
 import { memoryToolsGateScenario } from './memoryToolsGate';
 import {
   anthropicModelTiersScenario,
@@ -43,6 +44,7 @@ export const scenarios: readonly IScenario[] = [
   mcpProbeScenario,
   memoryToolsGateScenario,
   crossProviderEmbeddingSearchScenario,
+  sqliteVecMemoryPersistenceScenario,
   openaiModelTiersScenario,
   anthropicModelTiersScenario,
   geminiModelTiersScenario

--- a/samples/testbed/src/scenarios/sqliteVecMemoryPersistence/index.ts
+++ b/samples/testbed/src/scenarios/sqliteVecMemoryPersistence/index.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * `sqliteVecMemoryPersistence` scenario (CLI-only).
+ *
+ * Demonstrates `@fgv/ts-agent-memory-sqlite-vec`: a small corpus is embedded with a local
+ * `Xenova/all-MiniLM-L6-v2` pipeline into a **file-backed** `SqliteVecVectorIndex`, queried,
+ * then the connection is closed and the SAME file is reopened — the second query runs with no
+ * re-embedding and returns the same ranking, proving the persistence guarantee.
+ *
+ * The scenario is CLI-only: `better-sqlite3` is a Node-native module, so it is loaded (with the
+ * embedder and the index package) via `webpackIgnore` dynamic imports that never enter the
+ * browser bundle. The persistence logic itself lives in the fully-testable `persistenceDemo`
+ * module; this file is the thin live-model wrapper.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import type { IScenario, IScenarioContext, ICliScenarioImpl } from '../../shell';
+import { DemoEmbedFn, IDemoDoc, OpenIndexFn, runPersistenceDemo } from './persistenceDemo';
+
+const MODEL_ID: string = 'Xenova/all-MiniLM-L6-v2';
+
+const CORPUS: ReadonlyArray<IDemoDoc> = [
+  { id: 'cats', text: 'Domestic cats are small carnivorous mammals often kept as pets.' },
+  { id: 'dogs', text: 'Dogs are loyal domesticated animals descended from wolves.' },
+  { id: 'sqlite', text: 'SQLite is an embedded relational database stored in a single file.' },
+  { id: 'vectors', text: 'A vector embedding maps text to a point in high-dimensional space.' },
+  { id: 'coffee', text: 'Espresso is a concentrated coffee brewed by forcing hot water through grounds.' }
+];
+
+const QUERY: string = 'a lightweight on-disk database for storing embeddings';
+
+const cliImpl: ICliScenarioImpl = {
+  async run(context: IScenarioContext): Promise<Result<string>> {
+    context.logger.info(`Loading model ${MODEL_ID} for the sqlite-vec persistence demo…`);
+
+    // Load Node-only facades lazily; the `webpackIgnore` comments keep native deps
+    // (ONNX runtime, better-sqlite3) out of any browser bundle.
+    const transformers = await import(/* webpackIgnore: true */ '@fgv/ts-extras-transformers');
+    const sqliteVec = await import(/* webpackIgnore: true */ '@fgv/ts-agent-memory-sqlite-vec');
+    const betterSqlite = await import(/* webpackIgnore: true */ 'better-sqlite3');
+    const Database = betterSqlite.default;
+
+    const pipeline = await transformers.loadPipeline('feature-extraction', MODEL_ID);
+    if (pipeline.isFailure()) {
+      return fail(pipeline.message);
+    }
+
+    const embed: DemoEmbedFn = async (text: string): Promise<Result<Float32Array>> => {
+      const tensor = await transformers.embed(pipeline.value, text, {
+        pooling: 'mean',
+        normalize: true
+      });
+      if (tensor.isFailure()) {
+        return fail(tensor.message);
+      }
+      // A [1, D] pooled Tensor: row 0 of tolist() is the sentence vector.
+      const nested = tensor.value.tolist() as number[][];
+      return succeed(Float32Array.from(nested[0]));
+    };
+
+    const openIndex: OpenIndexFn = async (dbPath: string) => {
+      const db = new Database(dbPath);
+      const created = await sqliteVec.SqliteVecVectorIndex.create({ database: db });
+      if (created.isFailure()) {
+        db.close();
+        return fail(created.message);
+      }
+      return succeed({
+        index: created.value,
+        close: (): void => {
+          db.close();
+        }
+      });
+    };
+
+    const dir: string = fs.mkdtempSync(path.join(os.tmpdir(), 'svmem-'));
+    const dbPath: string = path.join(dir, 'vectors.db');
+    try {
+      const result = await runPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 3,
+        dbPath,
+        embed,
+        openIndex
+      });
+      if (result.isFailure()) {
+        return fail(result.message);
+      }
+      const r = result.value;
+      const fmt = (hits: ReadonlyArray<{ id: string; score: number }>): string =>
+        hits.map((h, i) => `  ${i + 1}. [${h.score.toFixed(4)}] ${h.id}`).join('\n');
+      return succeed(
+        `sqlite-vec persistent memory demo\n` +
+          `Embedded ${r.corpusSize} docs (dim ${r.dimension}) into a SQLite file.\n` +
+          `Query: "${QUERY}"\n` +
+          `Session 1 (freshly embedded):\n${fmt(r.session1)}\n` +
+          `Session 2 (reopened file, NO re-embedding):\n${fmt(r.session2)}\n` +
+          `Persistence: ${
+            r.persistedAcrossReopen ? 'VERIFIED — identical ranking across reopen' : 'MISMATCH'
+          }`
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+};
+
+/**
+ * `sqliteVecMemoryPersistence` scenario: local embeddings persisted in a `sqlite-vec`
+ * file-backed `IVectorIndex`, proving no re-embedding is needed on reopen. CLI-only.
+ * @public
+ */
+export const sqliteVecMemoryPersistenceScenario: IScenario = {
+  id: 'sqlite-vec-memory-persistence',
+  title: 'SQLite-vec Persistent Memory',
+  description:
+    'Embeds a small corpus with a local `Xenova/all-MiniLM-L6-v2` pipeline into a file-backed ' +
+    '`@fgv/ts-agent-memory-sqlite-vec` index, then closes and reopens the file to show the ' +
+    'vectors persist — the second query returns the same ranking with no re-embedding. CLI-only.',
+  category: 'ai',
+  tags: ['agent-memory', 'embeddings', 'sqlite-vec', 'persistence', 'local-ai'],
+  cli: cliImpl
+};
+
+// Re-export the testable core.
+export { runPersistenceDemo };
+export type {
+  DemoEmbedFn,
+  IDemoDoc,
+  IDemoHit,
+  IOpenedIndex,
+  IPersistenceDemoResult,
+  OpenIndexFn
+} from './persistenceDemo';

--- a/samples/testbed/src/scenarios/sqliteVecMemoryPersistence/persistenceDemo.ts
+++ b/samples/testbed/src/scenarios/sqliteVecMemoryPersistence/persistenceDemo.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import type { IEdgeTarget, IVectorIndex, MemoryId, MemoryScopeKey } from '@fgv/ts-agent-memory';
+
+/**
+ * Embeds a single text into a vector. Injected so the demo core is testable with a
+ * deterministic embedder (no model download) and the CLI can supply a real local
+ * `@fgv/ts-extras-transformers` pipeline.
+ * @public
+ */
+export type DemoEmbedFn = (text: string) => Promise<Result<Float32Array>>;
+
+/** A persistent vector index opened at a path, plus a close handle for its connection. */
+export interface IOpenedIndex {
+  readonly index: IVectorIndex;
+  readonly close: () => void;
+}
+
+/**
+ * Opens a persistent {@link IVectorIndex} backed by a file at `dbPath`. Injected so the
+ * demo core does not import `better-sqlite3` / `@fgv/ts-agent-memory-sqlite-vec` directly
+ * (keeping it out of the browser bundle) — the CLI supplies the real opener.
+ * @public
+ */
+export type OpenIndexFn = (dbPath: string) => Promise<Result<IOpenedIndex>>;
+
+/** One document in the demo corpus. */
+export interface IDemoDoc {
+  readonly id: string;
+  readonly text: string;
+}
+
+/** One ranked hit (record id + similarity score). */
+export interface IDemoHit {
+  readonly id: string;
+  readonly score: number;
+}
+
+/** The result of the persistence demo — session-2 results should match session-1 with no re-embedding. */
+export interface IPersistenceDemoResult {
+  readonly corpusSize: number;
+  readonly dimension: number;
+  /** Query results from the freshly-embedded index. */
+  readonly session1: ReadonlyArray<IDemoHit>;
+  /** Query results after closing and reopening the same file — produced with NO re-embedding. */
+  readonly session2: ReadonlyArray<IDemoHit>;
+  /** `true` when session-2 ordering matches session-1 (persistence verified). */
+  readonly persistedAcrossReopen: boolean;
+}
+
+/** The scope every demo record lives under. */
+const DEMO_SCOPE: string = 'knowledge';
+
+function targetFor(id: string): IEdgeTarget {
+  return { scope: DEMO_SCOPE as unknown as MemoryScopeKey, id: id as unknown as MemoryId };
+}
+
+async function queryHits(
+  index: IVectorIndex,
+  queryVector: Float32Array,
+  topK: number
+): Promise<Result<ReadonlyArray<IDemoHit>>> {
+  return (await index.query(queryVector, topK)).onSuccess((hits) =>
+    succeed(hits.map((h) => ({ id: h.target.id as unknown as string, score: h.score })))
+  );
+}
+
+/**
+ * Demonstrates the persistence guarantee of `@fgv/ts-agent-memory-sqlite-vec`: embed a
+ * corpus into a file-backed vector index, query it, then **close the connection and reopen
+ * the same file** — the second session queries with no re-embedding and returns the same
+ * ranking. The embedder and index-opener are injected so the core is fully testable offline.
+ *
+ * @param params - corpus, query, topK, the on-disk `dbPath`, and the injected `embed` / `openIndex`.
+ * @returns `Success` with both sessions' results (and whether they match), or `Failure` with context.
+ * @public
+ */
+export async function runPersistenceDemo(params: {
+  readonly corpus: ReadonlyArray<IDemoDoc>;
+  readonly query: string;
+  readonly topK: number;
+  readonly dbPath: string;
+  readonly embed: DemoEmbedFn;
+  readonly openIndex: OpenIndexFn;
+}): Promise<Result<IPersistenceDemoResult>> {
+  const { corpus, query, topK, dbPath, embed, openIndex } = params;
+
+  // Embed the query once; the same vector drives both sessions so a match proves persistence.
+  const queryEmbed = await embed(query);
+  if (queryEmbed.isFailure()) {
+    return fail(`embed query: ${queryEmbed.message}`);
+  }
+  const queryVector: Float32Array = queryEmbed.value;
+
+  // Embed the corpus.
+  const docVectors: Float32Array[] = [];
+  for (const doc of corpus) {
+    const embedded = await embed(doc.text);
+    if (embedded.isFailure()) {
+      return fail(`embed '${doc.id}': ${embedded.message}`);
+    }
+    docVectors.push(embedded.value);
+  }
+
+  // Session 1: open a fresh persistent index, add every embedding, query.
+  const opened1 = await openIndex(dbPath);
+  if (opened1.isFailure()) {
+    return fail(`open index (session 1): ${opened1.message}`);
+  }
+  let session1: ReadonlyArray<IDemoHit>;
+  try {
+    for (let i = 0; i < corpus.length; i++) {
+      const added = await opened1.value.index.add(targetFor(corpus[i].id), docVectors[i]);
+      if (added.isFailure()) {
+        return fail(`add '${corpus[i].id}': ${added.message}`);
+      }
+    }
+    const queried = await queryHits(opened1.value.index, queryVector, topK);
+    if (queried.isFailure()) {
+      return fail(`query (session 1): ${queried.message}`);
+    }
+    session1 = queried.value;
+  } finally {
+    opened1.value.close();
+  }
+
+  // Session 2: reopen the SAME file — no embedding, no add, just query. This is the guarantee.
+  const opened2 = await openIndex(dbPath);
+  if (opened2.isFailure()) {
+    return fail(`reopen index (session 2): ${opened2.message}`);
+  }
+  let session2: ReadonlyArray<IDemoHit>;
+  try {
+    const queried = await queryHits(opened2.value.index, queryVector, topK);
+    if (queried.isFailure()) {
+      return fail(`query (session 2): ${queried.message}`);
+    }
+    session2 = queried.value;
+  } finally {
+    opened2.value.close();
+  }
+
+  const order1: string = session1.map((h) => h.id).join(',');
+  const order2: string = session2.map((h) => h.id).join(',');
+  return succeed({
+    corpusSize: corpus.length,
+    dimension: queryVector.length,
+    session1,
+    session2,
+    persistedAcrossReopen: order1 === order2
+  });
+}

--- a/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
+++ b/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
@@ -13,6 +13,7 @@ Array [
   "mcp-probe",
   "memory-tools-gate",
   "cross-provider-embedding-search",
+  "sqlite-vec-memory-persistence",
   "openai-model-tiers",
   "anthropic-model-tiers",
   "google-gemini-model-tiers",

--- a/samples/testbed/src/test/unit/scenarios/sqliteVecMemoryPersistence.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/sqliteVecMemoryPersistence.test.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+
+import BetterSqlite3 from 'better-sqlite3';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import type {
+  IEdgeTarget,
+  IVectorIndex,
+  IVectorQueryHit,
+  MemoryId,
+  MemoryScopeKey
+} from '@fgv/ts-agent-memory';
+import { SqliteVecVectorIndex } from '@fgv/ts-agent-memory-sqlite-vec';
+import {
+  DemoEmbedFn,
+  IDemoDoc,
+  IOpenedIndex,
+  OpenIndexFn,
+  runPersistenceDemo
+} from '../../../scenarios/sqliteVecMemoryPersistence';
+
+const CORPUS: ReadonlyArray<IDemoDoc> = [
+  { id: 'alpha', text: 'the quick brown fox' },
+  { id: 'beta', text: 'lazy dogs sleep soundly' },
+  { id: 'gamma', text: 'databases store rows and columns' }
+];
+const QUERY: string = 'stored rows in a database';
+const DIM: number = 8;
+
+/** A deterministic embedder — distinct, stable vector per text; no model download. */
+const deterministicEmbed: DemoEmbedFn = async (text: string): Promise<Result<Float32Array>> => {
+  const v = new Float32Array(DIM);
+  for (let i = 0; i < text.length; i++) {
+    v[i % DIM] += text.charCodeAt(i) / 100;
+  }
+  return succeed(v);
+};
+
+/** A real file-backed opener over better-sqlite3 + SqliteVecVectorIndex. */
+const realOpenIndex: OpenIndexFn = async (dbPath: string): Promise<Result<IOpenedIndex>> => {
+  const db = new BetterSqlite3(dbPath);
+  const created = await SqliteVecVectorIndex.create({ database: db });
+  if (created.isFailure()) {
+    db.close();
+    return fail(created.message);
+  }
+  return succeed({
+    index: created.value,
+    close: (): void => {
+      db.close();
+    }
+  });
+};
+
+function hit(id: string, score: number): IVectorQueryHit {
+  const target: IEdgeTarget = {
+    scope: 'knowledge' as unknown as MemoryScopeKey,
+    id: id as unknown as MemoryId
+  };
+  return { target, score };
+}
+
+/** A fully-fake index for exercising failure branches. */
+function fakeIndex(overrides: Partial<IVectorIndex>): IVectorIndex {
+  return {
+    add: overrides.add ?? (async (): Promise<Result<string>> => succeed('k')),
+    remove: overrides.remove ?? (async (t: IEdgeTarget): Promise<Result<IEdgeTarget>> => succeed(t)),
+    query: overrides.query ?? (async (): Promise<Result<ReadonlyArray<IVectorQueryHit>>> => succeed([]))
+  };
+}
+
+function fakeOpener(index: IVectorIndex): OpenIndexFn {
+  return async (): Promise<Result<IOpenedIndex>> => succeed({ index, close: (): void => undefined });
+}
+
+describe('sqliteVecMemoryPersistence — runPersistenceDemo', () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'svmem-test-'));
+    dbPath = path.join(dir, 'vectors.db');
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('embeds a corpus, persists it, and reopening the file yields the identical ranking (no re-embed)', async () => {
+    expect(
+      await runPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 3,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex: realOpenIndex
+      })
+    ).toSucceedAndSatisfy((result) => {
+      expect(result.corpusSize).toBe(3);
+      expect(result.dimension).toBe(DIM);
+      expect(result.session1).toHaveLength(3);
+      // The reopened session queried the same file with no embedding — identical ranking.
+      expect(result.session2).toEqual(result.session1);
+      expect(result.persistedAcrossReopen).toBe(true);
+      // Scores are descending cosine similarity.
+      expect(result.session1[0].score).toBeGreaterThanOrEqual(result.session1[1].score);
+    });
+  });
+
+  test('fails with context when the query cannot be embedded', async () => {
+    const embed: DemoEmbedFn = async (text) =>
+      text === QUERY ? fail('boom') : succeed(new Float32Array(DIM));
+    expect(
+      await runPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 3,
+        dbPath,
+        embed,
+        openIndex: realOpenIndex
+      })
+    ).toFailWith(/embed query: boom/);
+  });
+
+  test('fails with context when a corpus document cannot be embedded', async () => {
+    const embed: DemoEmbedFn = async (text) =>
+      text === CORPUS[1].text ? fail('bad doc') : succeed(new Float32Array(DIM).fill(1));
+    expect(
+      await runPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 3,
+        dbPath,
+        embed,
+        openIndex: realOpenIndex
+      })
+    ).toFailWith(/embed 'beta': bad doc/);
+  });
+
+  test('fails when the index cannot be opened for session 1', async () => {
+    const openIndex: OpenIndexFn = async () => fail('disk error');
+    expect(
+      await runPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 3,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toFailWith(/open index \(session 1\): disk error/);
+  });
+
+  test('fails with context when an add fails', async () => {
+    const openIndex = fakeOpener(fakeIndex({ add: async () => fail('add boom') }));
+    expect(
+      await runPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 3,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toFailWith(/add 'alpha': add boom/);
+  });
+
+  test('fails when the session-1 query fails', async () => {
+    const openIndex = fakeOpener(fakeIndex({ query: async () => fail('query boom') }));
+    expect(
+      await runPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 3,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toFailWith(/query \(session 1\): query boom/);
+  });
+
+  test('fails when the index cannot be reopened for session 2', async () => {
+    let call = 0;
+    const openIndex: OpenIndexFn = async () => {
+      call += 1;
+      return call === 1
+        ? succeed({ index: fakeIndex({}), close: (): void => undefined })
+        : fail('reopen error');
+    };
+    expect(
+      await runPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 3,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toFailWith(/reopen index \(session 2\): reopen error/);
+  });
+
+  test('fails when the session-2 query fails', async () => {
+    let call = 0;
+    const openIndex: OpenIndexFn = async () => {
+      call += 1;
+      const index = call === 1 ? fakeIndex({}) : fakeIndex({ query: async () => fail('s2 query boom') });
+      return succeed({ index, close: (): void => undefined });
+    };
+    expect(
+      await runPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 3,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toFailWith(/query \(session 2\): s2 query boom/);
+  });
+
+  test('reports persistedAcrossReopen=false when the two sessions rank differently', async () => {
+    let call = 0;
+    const openIndex: OpenIndexFn = async () => {
+      call += 1;
+      const hits = call === 1 ? [hit('alpha', 0.9), hit('beta', 0.5)] : [hit('beta', 0.9), hit('alpha', 0.5)];
+      return succeed({
+        index: fakeIndex({ query: async () => succeed(hits) }),
+        close: (): void => undefined
+      });
+    };
+    expect(
+      await runPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 3,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toSucceedAndSatisfy((result) => {
+      expect(result.persistedAcrossReopen).toBe(false);
+      expect(result.session1.map((h) => h.id)).toEqual(['alpha', 'beta']);
+      expect(result.session2.map((h) => h.id)).toEqual(['beta', 'alpha']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The extra-credit testbed scenario you flagged — a live demo of the new `@fgv/ts-agent-memory-sqlite-vec` package, exercising **embeddings + persistence** end-to-end.

Flow: embed a small corpus with a local `Xenova/all-MiniLM-L6-v2` pipeline into a **file-backed** `SqliteVecVectorIndex`, query it, then **close the connection and reopen the same file** — the second query runs with **no re-embedding** and returns the same ranking, demonstrating the package's whole reason for existing.

## Design — CLI-only, fully verifiable offline

- **CLI-only** (`web?`/`cli?` are both optional on `IScenario`). `better-sqlite3` is Node-native, so it — plus the embedder and index package — load via `webpackIgnore` dynamic imports that never enter the browser bundle. No browser-bundle risk (which I couldn't validate here anyway).
- **Testable core** (`persistenceDemo.ts`): the persistence logic takes an injected embedder + index-opener, so it's covered at **100%** with a *real* `better-sqlite3` + `SqliteVecVectorIndex` and a deterministic embedder (proving real cross-reopen persistence), plus a fake for every failure branch.
- **Thin CLI wrapper** (`index.ts`): the live-model + `webpackIgnore` loading is added to `coveragePathIgnorePatterns`, matching the repo's existing precedent for non-unit-testable scenario wrappers (the `*ClientTools` / `memoryToolsGate` scenarios).

## Gate

`heft build` ✅, `eslint` ✅, `heft test` ✅ **100% coverage** (my files at 100/100/100/100; global gate still 100%). New test suite: 9 tests. Registry snapshot updated for the new id. `better-sqlite3` + `sqlite-vec` + the index package added as testbed deps (dev — the sample is `shouldPublish: false`); no change file required.

The live `Xenova/all-MiniLM-L6-v2` model isn't exercised in CI (like the other local-AI scenarios — the injected embedder keeps unit tests offline); the CLI path follows the proven `localEmbeddingSearch` webpackIgnore pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_