### PR TITLE
Add SqliteVecFragmentIndex — persistent IFragmentVectorIndex (N-Ask5 Q7)

### DIFF
--- a/common/changes/@fgv/ts-agent-memory-sqlite-vec/claude-sqlite-vec-fragment-index_2026-07-19-00-00.json
+++ b/common/changes/@fgv/ts-agent-memory-sqlite-vec/claude-sqlite-vec-fragment-index_2026-07-19-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add SqliteVecFragmentIndex — a persistent, sqlite-vec-backed IFragmentVectorIndex, the durable counterpart to InMemoryFragmentCosineIndex (fragment-granular sibling of the existing SqliteVecVectorIndex). Holds many vectors per record, each tagged with an in-record [start,end) locator, in a vec0 virtual table keyed on target_key as a PARTITION KEY with the offsets in auxiliary columns. addFragments is whole-record-replace (atomic delete-then-insert), remove drops every fragment of a target, and query(vector, topK, maxPerRecord?) applies the per-record cap during selection before the topK cut — byte-identical semantics and cosine scoring (score = 1 - cosineDistance) to the in-memory index, with the same reopen dimension recovery so a persistent fragment index answers queries with no re-embedding on open. Adds ISqliteVecFragmentIndexCreateParams (bring-your-own better-sqlite3 Database; default table name 'memory_fragments'). Consumer-owned connection lifecycle; ANN/large-N remains out of scope.",
+      "type": "minor",
+      "packageName": "@fgv/ts-agent-memory-sqlite-vec"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory-sqlite-vec",
+  "email": "noreply@anthropic.com"
+}

--- a/common/changes/@fgv/ts-agent-memory/claude-agent-memory-fragment-retrieval_2026-07-19-00-00.json
+++ b/common/changes/@fgv/ts-agent-memory/claude-agent-memory-fragment-retrieval_2026-07-19-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add fragment-granular (sub-document) semantic retrieval (N-Ask5). New vector types IFragmentLocator ([start,end) half-open, opaque offsets), IEmbeddedFragment, and the IFragmentVectorIndex seam (a sibling of IVectorIndex, not a subtype: addFragments whole-record-replace, remove, and query(vector, topK, maxPerRecord?) returning per-fragment IVectorQueryHit hits carrying the matched locator); IVectorQueryHit gains an additive optional locator populated only by the fragment index. InMemoryFragmentCosineIndex is the brute-force in-memory implementation (dimension-established-on-first-add, defensive copies, cosine scoring, maxPerRecord cap applied during selection before the topK cut, rebuild from an IMemoryRecordSource via a FragmentEmbedder). FragmentSemanticRetriever is the discovery-half retriever (returns per-fragment hits rather than records, so it is deliberately not an IMemoryRetriever; degrades loudly when no backend is wired). FileTreeMemoryStore gains additive fragmentIndex?/fragmentEmbedder? create params wiring best-effort fragment-embed-on-write plus fragment removal on delete and cap-cull eviction, symmetric with and independent of the record-vector embed-on-write path (a store may wire record vectors, fragment vectors, both, or neither; unwired is byte-identical).",
+      "type": "minor",
+      "packageName": "@fgv/ts-agent-memory"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-agent-memory-sqlite-vec/README.md
+++ b/libraries/ts-agent-memory-sqlite-vec/README.md
@@ -9,6 +9,8 @@ A **persistent, `sqlite-vec`-backed [`IVectorIndex`](https://github.com/ErikFort
 
 This is a thin **Result-integration boundary** over [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) + [`sqlite-vec`](https://github.com/asg017/sqlite-vec): it converts their throwing surface into `Result<T>` and implements the `IVectorIndex` seam. It adds no opinion beyond that — see [Not in scope](#not-in-scope).
 
+The package ships two indexes with the same durability story: `SqliteVecVectorIndex` (one vector per record — the record-granular `IVectorIndex`) and `SqliteVecFragmentIndex` (many vectors per record, each tagged with an in-record `[start, end)` locator — the fragment-granular `IFragmentVectorIndex`, the durable counterpart to `InMemoryFragmentCosineIndex`). See [Fragment-granular index](#fragment-granular-index).
+
 ## Why
 
 `InMemoryCosineIndex` is brute-force and in-memory, rebuilt from the store by re-embedding the whole vault on open. That is fine for small per-agent vaults; at v2 durability/scale, re-embedding on every open stops being cheap. This package closes that gap with **zero core `ts-agent-memory` change**: the store already writes to the vector index incrementally on `put`/`delete` and only re-embeds when the consumer explicitly calls `rebuild(store.asRecordSource())`. Back the store with a persistent index instead, and skip that rebuild — the vectors are already on disk.
@@ -52,14 +54,46 @@ db.close(); // you own the lifecycle — this index never closes your connection
 
 ## Persistence guarantee
 
-Vectors written in one process are present in the next. `SqliteVecVectorIndex.create` recovers the established dimension from the existing `vec0` table, so a reopened index answers queries immediately with **no re-embedding**. That is the entire point of the package.
+Vectors written in one process are present in the next. `SqliteVecVectorIndex.create` recovers the established dimension from the existing `vec0` table, so a reopened index answers queries immediately with **no re-embedding**. That is the entire point of the package. `SqliteVecFragmentIndex` gives the same guarantee for fragments.
+
+## Fragment-granular index
+
+`SqliteVecFragmentIndex` is the durable `IFragmentVectorIndex` — the "discovery" half of a search-then-read contract, where a hit's `(target, locator)` tells you which record **and** which span matched. It is the persistent counterpart to `InMemoryFragmentCosineIndex` and shares its exact semantics.
+
+```ts
+import Database from 'better-sqlite3';
+import { SqliteVecFragmentIndex } from '@fgv/ts-agent-memory-sqlite-vec';
+import { FileTreeMemoryStore, FragmentSemanticRetriever } from '@fgv/ts-agent-memory';
+
+const db = new Database('/path/to/vault/fragments.db');
+const fragmentIndex = (await SqliteVecFragmentIndex.create({ database: db })).orThrow();
+
+// Wire it into the store alongside (or instead of) the record-level vectorIndex.
+// The store chunks + embeds each record via the consumer-supplied fragmentEmbedder
+// and maintains the fragment index on put/delete/evict.
+const store = (
+  await FileTreeMemoryStore.create({ root, registry, fragmentIndex, fragmentEmbedder })
+).orThrow();
+
+// Query for spans, not records:
+const retriever = FragmentSemanticRetriever.create({
+  backend: { fragmentIndex, embedQuery }
+}).orThrow();
+const hits = (await retriever.retrieve({ semantic: 'refund policy', topK: 5, maxPerRecord: 2 })).orThrow();
+// each hit carries { target, locator: { start, end }, score } — read the record, slice the span.
+```
+
+- Keyed on `target_key` as a `vec0` **`PARTITION KEY`** (many rows share it), with the `[start, end)` offsets in auxiliary columns — so `addFragments` is whole-record-replace, `remove` drops every fragment of a target, and both are per-target-clean.
+- `query(vector, topK, maxPerRecord?)` applies the optional per-record cap **during selection, before the `topK` cut**, so one long document cannot crowd others out.
+- Same dimension-establishment, cosine scoring (`score = 1 − cosineDistance`), reopen-recovery, and loud-failure contract as the record index — byte-identical to `InMemoryFragmentCosineIndex`.
+
+Hold the record and fragment indexes in **distinct tables** (default `memory_vectors` vs `memory_fragments`, or supply `tableName`); they are fully independent and may share one database file.
 
 ## Not in scope
 
 Deliberately excluded — reach for the upstream libraries (or a different backend) directly if you need these:
 
-- **ANN / large-N indexing.** Query is a brute-force `vec0` KNN scan — correct and durable for the same "thousands of records" regime the in-memory index targets. An approximate-nearest-neighbor structure for very large N is a different backend behind the same `IVectorIndex` seam.
-- **Chunk / fragment-granular entries.** One vector per record, matching v1 `IVectorIndex`. Multiple vectors per record with in-record locators is a separate `ts-agent-memory` design (see its `N-Ask5`).
+- **ANN / large-N indexing.** Query is a brute-force `vec0` KNN scan — correct and durable for the same "thousands of records" regime the in-memory index targets. An approximate-nearest-neighbor structure for very large N is a different backend behind the same `IVectorIndex` / `IFragmentVectorIndex` seam. (This applies to both indexes, including `SqliteVecFragmentIndex`, whose capped query fetches the full ranked set.)
 - **Connection lifecycle.** You open and close the `better-sqlite3` `Database`; this index never does. Pooling, WAL/pragma tuning, backups, and multi-process coordination are yours.
 - **Embedding.** This is a vector *index*, not an embedder — the store's consumer-wired `MemoryEmbedder` produces the vectors (`@fgv/ts-extras/ai-assist` `callProviderEmbedding`, `@fgv/ts-extras-transformers`, etc.).
 - **A browser sibling.** `better-sqlite3` is Node-only. A WASM-SQLite browser variant, if ever needed, is a separate package.

--- a/libraries/ts-agent-memory-sqlite-vec/etc/ts-agent-memory-sqlite-vec.api.md
+++ b/libraries/ts-agent-memory-sqlite-vec/etc/ts-agent-memory-sqlite-vec.api.md
@@ -24,8 +24,6 @@ export interface ISqliteVecVectorIndexCreateParams {
     readonly tableName?: string;
 }
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-agent-memory-sqlite-vec" does not have an export "IFragmentVectorIndex"
-//
 // @public
 export class SqliteVecFragmentIndex implements IFragmentVectorIndex {
     // Warning: (ae-unresolved-inheritdoc-reference) The @inheritDoc reference could not be resolved: The package "@fgv/ts-agent-memory-sqlite-vec" does not have an export "IFragmentVectorIndex"

--- a/libraries/ts-agent-memory-sqlite-vec/etc/ts-agent-memory-sqlite-vec.api.md
+++ b/libraries/ts-agent-memory-sqlite-vec/etc/ts-agent-memory-sqlite-vec.api.md
@@ -6,14 +6,43 @@
 
 import type BetterSqlite3 from 'better-sqlite3';
 import { IEdgeTarget } from '@fgv/ts-agent-memory';
+import { IEmbeddedFragment } from '@fgv/ts-agent-memory';
+import { IFragmentVectorIndex } from '@fgv/ts-agent-memory';
 import { IVectorIndex } from '@fgv/ts-agent-memory';
 import { IVectorQueryHit } from '@fgv/ts-agent-memory';
 import { Result } from '@fgv/ts-utils';
 
 // @public
+export interface ISqliteVecFragmentIndexCreateParams {
+    readonly database: BetterSqlite3.Database;
+    readonly tableName?: string;
+}
+
+// @public
 export interface ISqliteVecVectorIndexCreateParams {
     readonly database: BetterSqlite3.Database;
     readonly tableName?: string;
+}
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-agent-memory-sqlite-vec" does not have an export "IFragmentVectorIndex"
+//
+// @public
+export class SqliteVecFragmentIndex implements IFragmentVectorIndex {
+    // Warning: (ae-unresolved-inheritdoc-reference) The @inheritDoc reference could not be resolved: The package "@fgv/ts-agent-memory-sqlite-vec" does not have an export "IFragmentVectorIndex"
+    //
+    // (undocumented)
+    addFragments(target: IEdgeTarget, fragments: ReadonlyArray<IEmbeddedFragment>): Promise<Result<number>>;
+    static create(params: ISqliteVecFragmentIndexCreateParams): Promise<Result<SqliteVecFragmentIndex>>;
+    get fragmentCount(): number;
+    // Warning: (ae-unresolved-inheritdoc-reference) The @inheritDoc reference could not be resolved: The package "@fgv/ts-agent-memory-sqlite-vec" does not have an export "IFragmentVectorIndex"
+    //
+    // (undocumented)
+    query(vector: Float32Array, topK: number, maxPerRecord?: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>>;
+    get recordCount(): number;
+    // Warning: (ae-unresolved-inheritdoc-reference) The @inheritDoc reference could not be resolved: The package "@fgv/ts-agent-memory-sqlite-vec" does not have an export "IFragmentVectorIndex"
+    //
+    // (undocumented)
+    remove(target: IEdgeTarget): Promise<Result<IEdgeTarget>>;
 }
 
 // @public

--- a/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/index.ts
+++ b/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/index.ts
@@ -5,3 +5,4 @@
 
 export * from './model';
 export * from './sqliteVecVectorIndex';
+export * from './sqliteVecFragmentIndex';

--- a/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/model.ts
+++ b/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/model.ts
@@ -29,3 +29,28 @@ export interface ISqliteVecVectorIndexCreateParams {
    */
   readonly tableName?: string;
 }
+
+/**
+ * Parameters for {@link SqliteVecFragmentIndex.create}.
+ * @public
+ */
+export interface ISqliteVecFragmentIndexCreateParams {
+  /**
+   * A `better-sqlite3` `Database` the consumer owns (bring-your-own, mirroring
+   * {@link ISqliteVecVectorIndexCreateParams.database}). The consumer opens it and
+   * owns its lifecycle — this index never closes it. `create` loads the
+   * `sqlite-vec` extension onto the connection and, if the fragment table already
+   * exists (a reopened persistent file), recovers its established dimension so no
+   * re-embedding is required on open.
+   */
+  readonly database: BetterSqlite3.Database;
+
+  /**
+   * Name of the `vec0` virtual table that holds the fragment embeddings. Must be a
+   * simple SQL identifier (`[A-Za-z_][A-Za-z0-9_]*`). Defaults to
+   * `'memory_fragments'`. Supply a distinct name (distinct from any record-level
+   * {@link SqliteVecVectorIndex} table) to hold more than one independent index in
+   * a single database file.
+   */
+  readonly tableName?: string;
+}

--- a/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/sqliteVecFragmentIndex.ts
+++ b/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/sqliteVecFragmentIndex.ts
@@ -38,8 +38,8 @@ interface IKnnRow {
 }
 
 /**
- * A persistent, `sqlite-vec`-backed {@link IFragmentVectorIndex} for
- * `@fgv/ts-agent-memory` — the fragment-granular sibling of
+ * A persistent, `sqlite-vec`-backed `IFragmentVectorIndex` (from
+ * `@fgv/ts-agent-memory`) — the fragment-granular sibling of
  * {@link SqliteVecVectorIndex}, and the **durable** counterpart to the in-memory
  * `InMemoryFragmentCosineIndex`.
  *
@@ -145,6 +145,17 @@ export class SqliteVecFragmentIndex implements IFragmentVectorIndex {
     for (const fragment of fragments) {
       if (fragment.vector.length === 0) {
         return Promise.resolve(fail(`fragment index: cannot add '${key}': empty fragment vector`));
+      }
+      // Locator offsets are persisted as SQLite integers (bound via BigInt). Reject a
+      // non-safe-integer offset up front with a clear message, rather than letting
+      // `BigInt(nonInteger)` throw cryptically inside the write transaction OR storing
+      // a value the read-side `_toOffset` guard would later reject on every query.
+      if (!Number.isSafeInteger(fragment.locator.start) || !Number.isSafeInteger(fragment.locator.end)) {
+        return Promise.resolve(
+          fail(
+            `fragment index: cannot add '${key}': locator [${fragment.locator.start}, ${fragment.locator.end}) offsets must be safe integers`
+          )
+        );
       }
       if (dimension === undefined) {
         dimension = fragment.vector.length;

--- a/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/sqliteVecFragmentIndex.ts
+++ b/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/sqliteVecFragmentIndex.ts
@@ -23,11 +23,17 @@ const DEFAULT_TABLE_NAME: string = 'memory_fragments';
 /** A simple SQL identifier — the only shape allowed for the table name (it is interpolated into DDL). */
 const IDENTIFIER_RE: RegExp = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
-/** One KNN row as returned by the fragment `vec0` MATCH query. */
+/**
+ * One KNN row as returned by the fragment `vec0` MATCH query. The offset columns are
+ * typed `number | bigint` because `better-sqlite3` returns integer columns as
+ * `bigint` when a consumer enables its safe-integer mode (`defaultSafeIntegers`);
+ * {@link SqliteVecFragmentIndex._toOffset} coerces them to a plain `number` (and
+ * fails loudly on an out-of-safe-range value) before they reach the public locator.
+ */
 interface IKnnRow {
   readonly target_key: string;
-  readonly start_off: number;
-  readonly end_off: number;
+  readonly start_off: number | bigint;
+  readonly end_off: number | bigint;
   readonly distance: number;
 }
 
@@ -82,7 +88,9 @@ export class SqliteVecFragmentIndex implements IFragmentVectorIndex {
     if (this._stmts === undefined) {
       return 0;
     }
-    return (this._stmts.recordCount.get() as { c: number }).c;
+    // `Number(...)` narrows the count in case the consumer enabled better-sqlite3
+    // safe-integer mode (which returns `count(*)` as a `bigint`).
+    return Number((this._stmts.recordCount.get() as { c: number | bigint }).c);
   }
 
   /** The total number of fragments currently held across all records. Zero before the first add. */
@@ -90,7 +98,7 @@ export class SqliteVecFragmentIndex implements IFragmentVectorIndex {
     if (this._stmts === undefined) {
       return 0;
     }
-    return (this._stmts.fragmentCount.get() as { c: number }).c;
+    return Number((this._stmts.fragmentCount.get() as { c: number | bigint }).c);
   }
 
   /**
@@ -210,7 +218,7 @@ export class SqliteVecFragmentIndex implements IFragmentVectorIndex {
         // and apply the cap + topK cut here — exactly as the in-memory index does.
         // Uncapped, KNN's own `k = topK` is already the answer.
         const fetchK: number =
-          maxPerRecord === undefined ? topK : (stmts.fragmentCount.get() as { c: number }).c;
+          maxPerRecord === undefined ? topK : Number((stmts.fragmentCount.get() as { c: number | bigint }).c);
         if (fetchK <= 0) {
           return [];
         }
@@ -233,10 +241,14 @@ export class SqliteVecFragmentIndex implements IFragmentVectorIndex {
             }
             perRecord.set(row.target_key, used + 1);
           }
+          const key: string = row.target_key;
           hits.push({
-            target: SqliteVecFragmentIndex._parseKey(row.target_key),
+            target: SqliteVecFragmentIndex._parseKey(key),
             score: 1 - row.distance,
-            locator: { start: row.start_off, end: row.end_off }
+            locator: {
+              start: SqliteVecFragmentIndex._toOffset(row.start_off, key),
+              end: SqliteVecFragmentIndex._toOffset(row.end_off, key)
+            }
           });
         }
         return hits;
@@ -313,14 +325,38 @@ export class SqliteVecFragmentIndex implements IFragmentVectorIndex {
 
   /**
    * Reverse `edgeTargetKey` — the canonical key is `scope\0id` with NUL excluded
-   * from both components, so the first NUL splits it unambiguously.
+   * from both components, so the first NUL splits it unambiguously. A key with no
+   * NUL cannot have been written by `edgeTargetKey`; rather than fabricate a wrong
+   * `(scope, id)` from corrupt / externally-edited table data, throw so the query
+   * surfaces it as a loud `Failure`.
    */
   private static _parseKey(key: string): IEdgeTarget {
     const nul: number = key.indexOf('\0');
+    if (nul < 0) {
+      throw new Error(`malformed target key '${key}': missing scope/id separator (corrupt persisted data)`);
+    }
     return {
       scope: key.slice(0, nul) as unknown as MemoryScopeKey,
       id: key.slice(nul + 1) as unknown as MemoryId
     };
+  }
+
+  /**
+   * Coerce a persisted locator offset to a plain `number`. `better-sqlite3` returns
+   * integer columns as `bigint` under safe-integer mode, so an offset can arrive as
+   * either; both narrow to `number` here. A value outside the safe-integer range
+   * (only reachable via corrupt / externally-edited data — the index only ever
+   * writes in-document offsets) throws rather than silently losing precision, so the
+   * query surfaces it as a loud `Failure`.
+   */
+  private static _toOffset(value: number | bigint, key: string): number {
+    const n: number = Number(value);
+    if (!Number.isSafeInteger(n)) {
+      throw new Error(
+        `fragment '${key}': locator offset ${String(value)} is not a safe integer (corrupt persisted data)`
+      );
+    }
+    return n;
   }
 }
 

--- a/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/sqliteVecFragmentIndex.ts
+++ b/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/sqliteVecFragmentIndex.ts
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import type BetterSqlite3 from 'better-sqlite3';
+import { load as loadSqliteVec } from 'sqlite-vec';
+import { Result, captureResult, fail, succeed } from '@fgv/ts-utils';
+import {
+  IEdgeTarget,
+  IEmbeddedFragment,
+  IFragmentVectorIndex,
+  IVectorQueryHit,
+  MemoryId,
+  MemoryScopeKey,
+  edgeTargetKey
+} from '@fgv/ts-agent-memory';
+import { ISqliteVecFragmentIndexCreateParams } from './model';
+
+/** Default name for the fragment `vec0` virtual table. */
+const DEFAULT_TABLE_NAME: string = 'memory_fragments';
+
+/** A simple SQL identifier — the only shape allowed for the table name (it is interpolated into DDL). */
+const IDENTIFIER_RE: RegExp = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** One KNN row as returned by the fragment `vec0` MATCH query. */
+interface IKnnRow {
+  readonly target_key: string;
+  readonly start_off: number;
+  readonly end_off: number;
+  readonly distance: number;
+}
+
+/**
+ * A persistent, `sqlite-vec`-backed {@link IFragmentVectorIndex} for
+ * `@fgv/ts-agent-memory` — the fragment-granular sibling of
+ * {@link SqliteVecVectorIndex}, and the **durable** counterpart to the in-memory
+ * `InMemoryFragmentCosineIndex`.
+ *
+ * @remarks
+ * Where {@link SqliteVecVectorIndex} keys one vector per record on a
+ * `target_key` primary key, this index holds **many** vectors per record — one per
+ * in-record `[start, end)` span — so it keys the `vec0` table on `target_key` as a
+ * **`PARTITION KEY`** (many rows may share it) and stores each fragment's locator
+ * offsets in two auxiliary columns (`+start_off`, `+end_off`) that ride alongside
+ * the vector and are returned on query but never filtered. A query is a brute-force
+ * `vec0` KNN scan across all partitions returning per-fragment hits, each carrying
+ * its record `target` and the matched `locator`.
+ *
+ * Semantics match `InMemoryFragmentCosineIndex` exactly: `addFragments` is
+ * whole-record-replace (a single transaction deletes every prior fragment of the
+ * target, then inserts the new set), `remove` drops every fragment of a target,
+ * and `query` applies the optional `maxPerRecord` cap **during selection, before
+ * the topK cut** — so one long document cannot crowd others out. The dimension is
+ * established by the first `addFragments` (the `vec0` column is fixed-width) and
+ * recovered from the table schema when a persistent file is reopened; similarity is
+ * cosine (`score = 1 - cosineDistance`), byte-identical to the in-memory index.
+ * Large-N ANN indexing is explicitly out of scope, same regime as the record index.
+ *
+ * The `better-sqlite3` `Database` is consumer-owned (bring-your-own): this index
+ * loads the `sqlite-vec` extension onto it and reads/writes the table, but never
+ * opens or closes the connection.
+ * @public
+ */
+export class SqliteVecFragmentIndex implements IFragmentVectorIndex {
+  private readonly _db: BetterSqlite3.Database;
+  private readonly _table: string;
+  /** The dimension of every stored fragment vector; `undefined` until the table exists. */
+  private _dimension: number | undefined;
+  /** Prepared statements; created once the table exists (established or recovered). */
+  private _stmts: IFragmentStatements | undefined;
+
+  private constructor(db: BetterSqlite3.Database, table: string, dimension: number | undefined) {
+    this._db = db;
+    this._table = table;
+    this._dimension = dimension;
+    this._stmts = dimension === undefined ? undefined : this._prepare();
+  }
+
+  /** The number of records that currently have at least one stored fragment. Zero before the first add. */
+  public get recordCount(): number {
+    if (this._stmts === undefined) {
+      return 0;
+    }
+    return (this._stmts.recordCount.get() as { c: number }).c;
+  }
+
+  /** The total number of fragments currently held across all records. Zero before the first add. */
+  public get fragmentCount(): number {
+    if (this._stmts === undefined) {
+      return 0;
+    }
+    return (this._stmts.fragmentCount.get() as { c: number }).c;
+  }
+
+  /**
+   * Family-convention factory. Loads the `sqlite-vec` extension onto the supplied
+   * `better-sqlite3` connection and, if the fragment table already exists (a
+   * reopened persistent file), recovers its established dimension so no
+   * re-embedding is needed on open.
+   *
+   * @param params - See {@link ISqliteVecFragmentIndexCreateParams}.
+   * @returns `Success` with the index, or `Failure` if the table name is not a
+   * simple identifier or the extension fails to load.
+   */
+  public static create(params: ISqliteVecFragmentIndexCreateParams): Promise<Result<SqliteVecFragmentIndex>> {
+    const table: string = params.tableName ?? DEFAULT_TABLE_NAME;
+    if (!IDENTIFIER_RE.test(table)) {
+      return Promise.resolve(
+        fail(`sqlite-vec fragment index: table name '${table}' is not a simple SQL identifier`)
+      );
+    }
+    return Promise.resolve(
+      captureResult(() => {
+        loadSqliteVec(params.database);
+        const dimension: number | undefined = SqliteVecFragmentIndex._readExistingDimension(
+          params.database,
+          table
+        );
+        return new SqliteVecFragmentIndex(params.database, table, dimension);
+      }).withErrorFormat((e) => `sqlite-vec fragment index: failed to initialize: ${e}`)
+    );
+  }
+
+  /** {@inheritDoc IFragmentVectorIndex.addFragments} */
+  public addFragments(
+    target: IEdgeTarget,
+    fragments: ReadonlyArray<IEmbeddedFragment>
+  ): Promise<Result<number>> {
+    const key: string = edgeTargetKey(target);
+    // Validate every fragment before touching the database, so a bad fragment never
+    // leaves the record half-replaced or the dimension half-established (whole-record
+    // replace is all-or-nothing). The effective dimension is the established one, or —
+    // on a still-dimensionless index — the first fragment's length; it is committed
+    // (via table creation) only once the whole batch validates.
+    let dimension: number | undefined = this._dimension;
+    for (const fragment of fragments) {
+      if (fragment.vector.length === 0) {
+        return Promise.resolve(fail(`fragment index: cannot add '${key}': empty fragment vector`));
+      }
+      if (dimension === undefined) {
+        dimension = fragment.vector.length;
+      } else if (fragment.vector.length !== dimension) {
+        return Promise.resolve(
+          fail(
+            `fragment index: cannot add '${key}': fragment dimension ${fragment.vector.length} does not match index dimension ${dimension}`
+          )
+        );
+      }
+    }
+    return Promise.resolve(
+      captureResult(() => {
+        // A same-target re-author (or an empty batch) still needs the table to exist
+        // to delete prior fragments; create it lazily on the first non-empty add.
+        if (this._stmts === undefined) {
+          if (fragments.length === 0) {
+            // Nothing stored yet and nothing to store: no table, no work.
+            return 0;
+          }
+          this._createTable(dimension as number);
+          this._dimension = dimension;
+          this._stmts = this._prepare();
+        }
+        this._stmts.replace(key, fragments);
+        return fragments.length;
+      }).withErrorFormat((e) => `fragment index: cannot add '${key}': ${e}`)
+    );
+  }
+
+  /** {@inheritDoc IFragmentVectorIndex.remove} */
+  public remove(target: IEdgeTarget): Promise<Result<IEdgeTarget>> {
+    return Promise.resolve(
+      captureResult(() => {
+        // Idempotent: removing a target with no fragments (or before any add created
+        // the table) still succeeds.
+        if (this._stmts !== undefined) {
+          this._stmts.deleteByTarget.run(edgeTargetKey(target));
+        }
+        return target;
+      }).withErrorFormat((e) => `fragment index: cannot remove '${edgeTargetKey(target)}': ${e}`)
+    );
+  }
+
+  /** {@inheritDoc IFragmentVectorIndex.query} */
+  public query(
+    vector: Float32Array,
+    topK: number,
+    maxPerRecord?: number
+  ): Promise<Result<ReadonlyArray<IVectorQueryHit>>> {
+    if (topK <= 0 || this._stmts === undefined) {
+      return Promise.resolve(succeed([]));
+    }
+    if (vector.length !== this._dimension) {
+      return Promise.resolve(
+        fail(
+          `fragment index: query dimension ${vector.length} does not match index dimension ${this._dimension}`
+        )
+      );
+    }
+    const stmts: IFragmentStatements = this._stmts;
+    return Promise.resolve(
+      captureResult<ReadonlyArray<IVectorQueryHit>>(() => {
+        // With a per-record cap the topK winners may lie past the first topK rows (a
+        // capped record's later fragments are skipped), so fetch the full ranked set
+        // and apply the cap + topK cut here — exactly as the in-memory index does.
+        // Uncapped, KNN's own `k = topK` is already the answer.
+        const fetchK: number =
+          maxPerRecord === undefined ? topK : (stmts.fragmentCount.get() as { c: number }).c;
+        if (fetchK <= 0) {
+          return [];
+        }
+        const rows: ReadonlyArray<IKnnRow> = stmts.query.all(
+          SqliteVecFragmentIndex._toBlob(vector),
+          fetchK
+        ) as ReadonlyArray<IKnnRow>;
+        // sqlite-vec returns rows ascending by distance (nearest first); score is
+        // `1 - cosineDistance`, so this order is already descending score.
+        const hits: IVectorQueryHit[] = [];
+        const perRecord: Map<string, number> = new Map<string, number>();
+        for (const row of rows) {
+          if (hits.length >= topK) {
+            break;
+          }
+          if (maxPerRecord !== undefined) {
+            const used: number = perRecord.get(row.target_key) ?? 0;
+            if (used >= maxPerRecord) {
+              continue;
+            }
+            perRecord.set(row.target_key, used + 1);
+          }
+          hits.push({
+            target: SqliteVecFragmentIndex._parseKey(row.target_key),
+            score: 1 - row.distance,
+            locator: { start: row.start_off, end: row.end_off }
+          });
+        }
+        return hits;
+      }).withErrorFormat((e) => `fragment index: query failed: ${e}`)
+    );
+  }
+
+  /** Create the fragment `vec0` virtual table with the established dimension. */
+  private _createTable(dimension: number): void {
+    this._db.exec(
+      `CREATE VIRTUAL TABLE IF NOT EXISTS "${this._table}" USING vec0(` +
+        `target_key TEXT PARTITION KEY, embedding float[${dimension}] distance_metric=cosine, ` +
+        `+start_off integer, +end_off integer)`
+    );
+  }
+
+  /** Prepare the statements the index reuses. Requires the table to exist. */
+  private _prepare(): IFragmentStatements {
+    const del: BetterSqlite3.Statement = this._db.prepare(
+      `DELETE FROM "${this._table}" WHERE target_key = ?`
+    );
+    const ins: BetterSqlite3.Statement = this._db.prepare(
+      `INSERT INTO "${this._table}"(target_key, embedding, start_off, end_off) VALUES (?, ?, ?, ?)`
+    );
+    // Whole-record replace: drop every prior fragment of the target, then insert the
+    // new set, atomically. An empty set collapses to a pure delete.
+    const replaceTxn: BetterSqlite3.Transaction<
+      (key: string, fragments: ReadonlyArray<IEmbeddedFragment>) => void
+    > = this._db.transaction((key: string, fragments: ReadonlyArray<IEmbeddedFragment>) => {
+      del.run(key);
+      for (const fragment of fragments) {
+        ins.run(
+          key,
+          SqliteVecFragmentIndex._toBlob(fragment.vector),
+          // vec0 typed columns reject a JS float; bind the offsets as integers.
+          BigInt(fragment.locator.start),
+          BigInt(fragment.locator.end)
+        );
+      }
+    });
+    return {
+      deleteByTarget: del,
+      replace: (key: string, fragments: ReadonlyArray<IEmbeddedFragment>): void => {
+        replaceTxn(key, fragments);
+      },
+      query: this._db.prepare(
+        `SELECT target_key, start_off, end_off, distance FROM "${this._table}" WHERE embedding MATCH ? AND k = ?`
+      ),
+      fragmentCount: this._db.prepare(`SELECT count(*) AS c FROM "${this._table}"`),
+      recordCount: this._db.prepare(`SELECT count(DISTINCT target_key) AS c FROM "${this._table}"`)
+    };
+  }
+
+  /**
+   * Recover the established dimension of an existing fragment `vec0` table from its
+   * stored `CREATE VIRTUAL TABLE` SQL (`float[<n>]`). Returns `undefined` when the
+   * table does not exist yet (a fresh database — dimension is set by the first add).
+   */
+  private static _readExistingDimension(db: BetterSqlite3.Database, table: string): number | undefined {
+    const row: { sql: string } | undefined = db
+      .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(table) as { sql: string } | undefined;
+    if (row === undefined) {
+      return undefined;
+    }
+    const match: RegExpMatchArray | null = row.sql.match(/float\[(\d+)\]/);
+    return match === null ? undefined : Number(match[1]);
+  }
+
+  /** Pack a `Float32Array` as the little-endian byte blob `vec0` stores. Copies, so the caller may reuse its buffer. */
+  private static _toBlob(vector: Float32Array): Uint8Array {
+    return new Uint8Array(Float32Array.from(vector).buffer);
+  }
+
+  /**
+   * Reverse `edgeTargetKey` — the canonical key is `scope\0id` with NUL excluded
+   * from both components, so the first NUL splits it unambiguously.
+   */
+  private static _parseKey(key: string): IEdgeTarget {
+    const nul: number = key.indexOf('\0');
+    return {
+      scope: key.slice(0, nul) as unknown as MemoryScopeKey,
+      id: key.slice(nul + 1) as unknown as MemoryId
+    };
+  }
+}
+
+/** The prepared statements / helpers the fragment index reuses once its table exists. */
+interface IFragmentStatements {
+  readonly deleteByTarget: BetterSqlite3.Statement;
+  readonly replace: (key: string, fragments: ReadonlyArray<IEmbeddedFragment>) => void;
+  readonly query: BetterSqlite3.Statement;
+  readonly fragmentCount: BetterSqlite3.Statement;
+  readonly recordCount: BetterSqlite3.Statement;
+}

--- a/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/sqliteVecFragmentIndex.ts
+++ b/libraries/ts-agent-memory-sqlite-vec/src/packlets/sqlite-vec-index/sqliteVecFragmentIndex.ts
@@ -157,8 +157,13 @@ export class SqliteVecFragmentIndex implements IFragmentVectorIndex {
             // Nothing stored yet and nothing to store: no table, no work.
             return 0;
           }
-          this._createTable(dimension as number);
-          this._dimension = dimension;
+          // `fragments` is non-empty here (the empty case returned above), so the
+          // validation loop proved every fragment shares `fragments[0]`'s length —
+          // which IS the dimension to establish. Read it straight from the first
+          // fragment: no cast, no invariant-dependent narrowing.
+          const established: number = fragments[0].vector.length;
+          this._createTable(established);
+          this._dimension = established;
           this._stmts = this._prepare();
         }
         this._stmts.replace(key, fragments);

--- a/libraries/ts-agent-memory-sqlite-vec/src/test/unit/sqliteVecFragmentIndex.test.ts
+++ b/libraries/ts-agent-memory-sqlite-vec/src/test/unit/sqliteVecFragmentIndex.test.ts
@@ -336,6 +336,55 @@ describe('SqliteVecFragmentIndex', () => {
     });
   });
 
+  describe('safe-integer mode and corrupt persisted data', () => {
+    const toBlob = (...v: number[]): Uint8Array => new Uint8Array(Float32Array.from(v).buffer);
+
+    async function seededWithRow(): Promise<SqliteVecFragmentIndex> {
+      // A valid add creates the table and establishes dim 2; corrupt rows are then
+      // inserted directly to model externally-edited / safe-integer-mode data.
+      const index = await makeIndex();
+      (await index.addFragments(target('knowledge', 'doc-a'), [frag(0, 5, 1, 0)])).orThrow();
+      return index;
+    }
+
+    function insertRaw(key: string, start: bigint, end: bigint, ...vec: number[]): void {
+      db.prepare(
+        'INSERT INTO memory_fragments(target_key, embedding, start_off, end_off) VALUES (?, ?, ?, ?)'
+      ).run(key, toBlob(...vec), start, end);
+    }
+
+    test('coerces bigint offsets (better-sqlite3 safe-integer mode) to number locators', async () => {
+      const index = await seededWithRow();
+      // Under safe-integer mode every integer column comes back as a bigint.
+      db.defaultSafeIntegers(true);
+      expect(await index.query(Float32Array.from([1, 0]), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          const locator = hits[0].locator;
+          expect(locator).toEqual(loc(0, 5));
+          expect(typeof locator?.start).toBe('number');
+          expect(typeof locator?.end).toBe('number');
+        }
+      );
+    });
+
+    test('fails loudly when a stored offset is outside the safe-integer range', async () => {
+      const index = await seededWithRow();
+      // Safe-integer mode returns the huge offset as a bigint (no read-time throw),
+      // so the _toOffset guard is what must fire.
+      db.defaultSafeIntegers(true);
+      insertRaw('knowledge\0doc-b', BigInt(2) ** BigInt(60), BigInt(0), 0, 1);
+      expect(await index.query(Float32Array.from([0, 1]), 5)).toFailWith(
+        /locator offset .* is not a safe integer/i
+      );
+    });
+
+    test('fails loudly when a stored key is missing the NUL separator', async () => {
+      const index = await seededWithRow();
+      insertRaw('nonulkey', BigInt(0), BigInt(5), 0, 1);
+      expect(await index.query(Float32Array.from([0, 1]), 5)).toFailWith(/missing scope\/id separator/i);
+    });
+  });
+
   describe('custom table name', () => {
     test('two fragment indexes on distinct tables in one database are independent', async () => {
       const a = (await SqliteVecFragmentIndex.create({ database: db, tableName: 'frag_a' })).orThrow();

--- a/libraries/ts-agent-memory-sqlite-vec/src/test/unit/sqliteVecFragmentIndex.test.ts
+++ b/libraries/ts-agent-memory-sqlite-vec/src/test/unit/sqliteVecFragmentIndex.test.ts
@@ -144,6 +144,19 @@ describe('SqliteVecFragmentIndex', () => {
       );
     });
 
+    test('rejects a non-safe-integer locator offset up front (never persists an unreadable locator)', async () => {
+      const index = await makeIndex();
+      // A non-integer offset: reject before the write, with a clear message.
+      expect(await index.addFragments(target('knowledge', 'doc-a'), [frag(0.5, 5, 1, 0)])).toFailWith(
+        /locator \[0\.5, 5\) offsets must be safe integers/i
+      );
+      // A too-large (non-safe) integer offset is likewise rejected.
+      expect(
+        await index.addFragments(target('knowledge', 'doc-b'), [frag(0, Number.MAX_SAFE_INTEGER + 1, 1, 0)])
+      ).toFailWith(/offsets must be safe integers/i);
+      expect(index.recordCount).toBe(0);
+    });
+
     test('a failed multi-fragment add on a fresh index does not establish a dimension (all-or-nothing)', async () => {
       const index = await makeIndex();
       // dim 2 then dim 3 in the same batch: fails, and must NOT commit dim 2.

--- a/libraries/ts-agent-memory-sqlite-vec/src/test/unit/sqliteVecFragmentIndex.test.ts
+++ b/libraries/ts-agent-memory-sqlite-vec/src/test/unit/sqliteVecFragmentIndex.test.ts
@@ -1,0 +1,393 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+
+import BetterSqlite3 from 'better-sqlite3';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  IEdgeTarget,
+  IEmbeddedFragment,
+  IFragmentLocator,
+  IVectorQueryHit,
+  MemoryId,
+  MemoryScopeKey
+} from '@fgv/ts-agent-memory';
+import { SqliteVecFragmentIndex } from '../../index';
+
+function target(scope: string, id: string): IEdgeTarget {
+  return { scope: scope as unknown as MemoryScopeKey, id: id as unknown as MemoryId };
+}
+function loc(start: number, end: number): IFragmentLocator {
+  return { start, end };
+}
+function frag(start: number, end: number, ...values: number[]): IEmbeddedFragment {
+  return { locator: loc(start, end), vector: Float32Array.from(values) };
+}
+
+describe('SqliteVecFragmentIndex', () => {
+  let db: BetterSqlite3.Database;
+
+  beforeEach(() => {
+    db = new BetterSqlite3(':memory:');
+  });
+  afterEach(() => {
+    // Some tests close `db` themselves to exercise error paths; guard double-close.
+    if (db.open) {
+      db.close();
+    }
+  });
+
+  async function makeIndex(): Promise<SqliteVecFragmentIndex> {
+    return (await SqliteVecFragmentIndex.create({ database: db })).orThrow();
+  }
+
+  describe('create', () => {
+    test('succeeds over a fresh database with an empty index', async () => {
+      expect(await SqliteVecFragmentIndex.create({ database: db })).toSucceedAndSatisfy(
+        (index: SqliteVecFragmentIndex) => {
+          expect(index.recordCount).toBe(0);
+          expect(index.fragmentCount).toBe(0);
+        }
+      );
+    });
+
+    test('rejects a table name that is not a simple identifier', async () => {
+      expect(
+        await SqliteVecFragmentIndex.create({ database: db, tableName: 'bad name; DROP TABLE x' })
+      ).toFailWith(/not a simple SQL identifier/i);
+    });
+
+    test('fails loudly when the sqlite-vec extension cannot load (closed database)', async () => {
+      const closed = new BetterSqlite3(':memory:');
+      closed.close();
+      expect(await SqliteVecFragmentIndex.create({ database: closed })).toFailWith(/failed to initialize/i);
+    });
+
+    test('recovers no dimension from a pre-existing non-vec0 table of the same name', async () => {
+      db.exec('CREATE TABLE memory_fragments (foo TEXT)');
+      expect(await SqliteVecFragmentIndex.create({ database: db })).toSucceedAndSatisfy(
+        (index: SqliteVecFragmentIndex) => {
+          expect(index.recordCount).toBe(0);
+        }
+      );
+    });
+  });
+
+  describe('addFragments', () => {
+    test('stores every fragment and reports the count; tracks record/fragment counts', async () => {
+      const index = await makeIndex();
+      expect(
+        await index.addFragments(target('knowledge', 'doc-a'), [frag(0, 5, 1, 0), frag(5, 10, 0, 1)])
+      ).toSucceedWith(2);
+      expect(index.recordCount).toBe(1);
+      expect(index.fragmentCount).toBe(2);
+    });
+
+    test('whole-record replace — a second addFragments drops the prior fragments', async () => {
+      const index = await makeIndex();
+      const t = target('knowledge', 'doc-a');
+      (await index.addFragments(t, [frag(0, 5, 1, 0), frag(5, 10, 0, 1)])).orThrow();
+      expect(await index.addFragments(t, [frag(0, 3, 1, 1)])).toSucceedWith(1);
+      expect(index.recordCount).toBe(1);
+      expect(index.fragmentCount).toBe(1);
+      expect(await index.query(Float32Array.from([1, 1]), 5)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits).toHaveLength(1);
+          expect(hits[0].locator).toEqual(loc(0, 3));
+        }
+      );
+    });
+
+    test('an empty fragments array drops an existing record', async () => {
+      const index = await makeIndex();
+      const t = target('knowledge', 'doc-a');
+      (await index.addFragments(t, [frag(0, 5, 1, 0)])).orThrow();
+      expect(await index.addFragments(t, [])).toSucceedWith(0);
+      expect(index.recordCount).toBe(0);
+      expect(index.fragmentCount).toBe(0);
+    });
+
+    test('an empty fragments array on a fresh index is a no-op (no table created)', async () => {
+      const index = await makeIndex();
+      expect(await index.addFragments(target('knowledge', 'doc-a'), [])).toSucceedWith(0);
+      expect(index.recordCount).toBe(0);
+      // A later real add still establishes the dimension cleanly.
+      expect(await index.addFragments(target('knowledge', 'doc-b'), [frag(0, 5, 1, 0)])).toSucceedWith(1);
+    });
+
+    test('same stem in different scopes are distinct entries', async () => {
+      const index = await makeIndex();
+      (await index.addFragments(target('conversations/a', 'turn-3'), [frag(0, 5, 1, 0)])).orThrow();
+      (await index.addFragments(target('conversations/b', 'turn-3'), [frag(0, 5, 0, 1)])).orThrow();
+      expect(index.recordCount).toBe(2);
+      expect(index.fragmentCount).toBe(2);
+    });
+
+    test('fails loudly on an empty fragment vector — and stores nothing', async () => {
+      const index = await makeIndex();
+      expect(
+        await index.addFragments(target('knowledge', 'doc-a'), [frag(0, 5, 1, 0), frag(5, 10)])
+      ).toFailWith(/cannot add 'knowledge\0doc-a': empty fragment vector/i);
+      expect(index.recordCount).toBe(0);
+    });
+
+    test('fails loudly on a fragment-dimension mismatch against the established dimension', async () => {
+      const index = await makeIndex();
+      (await index.addFragments(target('knowledge', 'a'), [frag(0, 5, 1, 0)])).orThrow();
+      expect(await index.addFragments(target('knowledge', 'b'), [frag(0, 5, 1, 0, 0)])).toFailWith(
+        /fragment dimension 3 does not match index dimension 2/i
+      );
+    });
+
+    test('a failed multi-fragment add on a fresh index does not establish a dimension (all-or-nothing)', async () => {
+      const index = await makeIndex();
+      // dim 2 then dim 3 in the same batch: fails, and must NOT commit dim 2.
+      expect(
+        await index.addFragments(target('knowledge', 'doc-1'), [frag(0, 5, 1, 0), frag(5, 10, 1, 0, 0)])
+      ).toFailWith(/fragment dimension 3 does not match index dimension 2/i);
+      expect(index.recordCount).toBe(0);
+      // A fresh dim-3 record now indexes cleanly (the index was never poisoned to dim 2).
+      expect(await index.addFragments(target('knowledge', 'doc-2'), [frag(0, 5, 1, 0, 0)])).toSucceedWith(1);
+    });
+
+    test('fails loudly (best-effort caller unaffected) when the underlying add throws', async () => {
+      const index = await makeIndex();
+      (await index.addFragments(target('knowledge', 'doc-a'), [frag(0, 5, 1, 0)])).orThrow();
+      db.close();
+      expect(await index.addFragments(target('knowledge', 'doc-b'), [frag(0, 5, 0, 1)])).toFailWith(
+        /cannot add 'knowledge\0doc-b'/i
+      );
+    });
+  });
+
+  describe('query', () => {
+    async function seeded(): Promise<SqliteVecFragmentIndex> {
+      const index = await makeIndex();
+      (
+        await index.addFragments(target('knowledge', 'doc-a'), [frag(0, 5, 1, 0), frag(5, 10, 0, 1)])
+      ).orThrow();
+      (await index.addFragments(target('knowledge', 'doc-b'), [frag(0, 5, 1, 1)])).orThrow();
+      return index;
+    }
+
+    test('returns fragment hits in descending score order, each carrying its locator', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 3)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits[0].target.id).toBe('doc-a');
+          expect(hits[0].locator).toEqual(loc(0, 5));
+          expect(hits[0].score).toBeCloseTo(1, 5);
+          expect(hits[1].target.id).toBe('doc-b');
+          expect(hits[1].score).toBeCloseTo(1 / Math.sqrt(2), 5);
+          expect(hits[2].target.id).toBe('doc-a');
+          expect(hits[2].locator).toEqual(loc(5, 10));
+          expect(hits[2].score).toBeCloseTo(0, 5);
+        }
+      );
+    });
+
+    test('truncates to topK', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 2)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits).toHaveLength(2);
+          expect(hits.map((h) => h.target.id)).toEqual(['doc-a', 'doc-b']);
+        }
+      );
+    });
+
+    test('maxPerRecord caps fragments per record during selection (before the topK cut)', async () => {
+      const index = await makeIndex();
+      (
+        await index.addFragments(target('knowledge', 'doc-a'), [
+          frag(0, 5, 1, 0),
+          frag(5, 10, 0.9, 0.1),
+          frag(10, 15, 0.8, 0.2)
+        ])
+      ).orThrow();
+      (await index.addFragments(target('knowledge', 'doc-b'), [frag(0, 5, 0.7, 0.3)])).orThrow();
+      // Without a cap the top-2 would be doc-a twice; maxPerRecord=1 surfaces doc-b.
+      expect(await index.query(Float32Array.from([1, 0]), 2, 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits).toHaveLength(2);
+          expect(hits.map((h) => h.target.id)).toEqual(['doc-a', 'doc-b']);
+          expect(hits[0].locator).toEqual(loc(0, 5));
+        }
+      );
+    });
+
+    test('maxPerRecord=0 yields no hits', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 5, 0)).toSucceedWith([]);
+    });
+
+    test('maxPerRecord larger than any record leaves the ranking unchanged', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 5, 10)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits).toHaveLength(3);
+          expect(hits[0].target.id).toBe('doc-a');
+        }
+      );
+    });
+
+    test('returns empty for a non-positive topK', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 0)).toSucceedWith([]);
+      expect(await index.query(Float32Array.from([1, 0]), -5)).toSucceedWith([]);
+    });
+
+    test('returns empty before any add (no established dimension)', async () => {
+      const index = await makeIndex();
+      expect(await index.query(Float32Array.from([1, 0, 0]), 5)).toSucceedWith([]);
+    });
+
+    test('returns empty when a capped query runs against an emptied (but existing) table', async () => {
+      const index = await makeIndex();
+      const t = target('knowledge', 'doc-a');
+      (await index.addFragments(t, [frag(0, 5, 1, 0)])).orThrow();
+      (await index.addFragments(t, [])).orThrow(); // table now exists but holds 0 rows
+      // fetchK derives from the (zero) fragment count under a cap → short-circuits to [].
+      expect(await index.query(Float32Array.from([1, 0]), 5, 2)).toSucceedWith([]);
+    });
+
+    test('rejects a query vector of the wrong dimension', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0, 0]), 3)).toFailWith(
+        /query dimension 3 does not match index dimension 2/i
+      );
+    });
+
+    test('a capped query stops at topK even when more ranked rows remain', async () => {
+      // maxPerRecord makes the fetch span the full ranked set (3 fragments), but
+      // topK=1 must return exactly one hit — the top row — and stop.
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 1, 5)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits).toHaveLength(1);
+          expect(hits[0].target.id).toBe('doc-a');
+          expect(hits[0].locator).toEqual(loc(0, 5));
+        }
+      );
+    });
+
+    test('fails loudly when the underlying query throws', async () => {
+      const index = await seeded();
+      db.close();
+      expect(await index.query(Float32Array.from([1, 0]), 3)).toFailWith(/query failed/i);
+    });
+  });
+
+  describe('remove', () => {
+    test('removes every fragment of a record and is reflected in subsequent queries', async () => {
+      const index = await makeIndex();
+      const a = target('knowledge', 'doc-a');
+      const b = target('knowledge', 'doc-b');
+      (await index.addFragments(a, [frag(0, 5, 1, 0), frag(5, 10, 1, 0)])).orThrow();
+      (await index.addFragments(b, [frag(0, 5, 0, 1)])).orThrow();
+      expect(await index.remove(a)).toSucceedWith(a);
+      expect(index.recordCount).toBe(1);
+      expect(index.fragmentCount).toBe(1);
+      expect(await index.query(Float32Array.from([1, 0]), 5)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits.map((h) => h.target.id)).toEqual(['doc-b']);
+        }
+      );
+    });
+
+    test('is idempotent — removing a missing target succeeds', async () => {
+      const index = await makeIndex();
+      (await index.addFragments(target('knowledge', 'doc-a'), [frag(0, 5, 1, 0)])).orThrow();
+      expect(await index.remove(target('knowledge', 'missing'))).toSucceedWith(
+        target('knowledge', 'missing')
+      );
+      expect(index.recordCount).toBe(1);
+    });
+
+    test('succeeds before any add (no table yet)', async () => {
+      const index = await makeIndex();
+      expect(await index.remove(target('knowledge', 'doc-a'))).toSucceedWith(target('knowledge', 'doc-a'));
+      expect(index.recordCount).toBe(0);
+    });
+
+    test('fails loudly when the underlying remove throws', async () => {
+      const index = await makeIndex();
+      (await index.addFragments(target('knowledge', 'doc-a'), [frag(0, 5, 1, 0)])).orThrow();
+      db.close();
+      expect(await index.remove(target('knowledge', 'doc-a'))).toFailWith(
+        /cannot remove 'knowledge\0doc-a'/i
+      );
+    });
+  });
+
+  describe('custom table name', () => {
+    test('two fragment indexes on distinct tables in one database are independent', async () => {
+      const a = (await SqliteVecFragmentIndex.create({ database: db, tableName: 'frag_a' })).orThrow();
+      const b = (await SqliteVecFragmentIndex.create({ database: db, tableName: 'frag_b' })).orThrow();
+      (await a.addFragments(target('s', 'one'), [frag(0, 5, 1, 0)])).orThrow();
+      expect(a.fragmentCount).toBe(1);
+      expect(b.fragmentCount).toBe(0);
+    });
+  });
+
+  describe('persistence across reopen (the durability guarantee)', () => {
+    let dir: string;
+    let dbPath: string;
+
+    beforeEach(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), 'svfrag-'));
+      dbPath = path.join(dir, 'fragments.db');
+    });
+    afterEach(() => {
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    test('fragments written to a file survive a close + reopen with no re-embed, dimension + locators recovered', async () => {
+      const first = new BetterSqlite3(dbPath);
+      const writeIndex = (await SqliteVecFragmentIndex.create({ database: first })).orThrow();
+      (
+        await writeIndex.addFragments(target('knowledge', 'doc-a'), [
+          frag(0, 5, 1, 0, 0),
+          frag(5, 12, 0, 1, 0)
+        ])
+      ).orThrow();
+      (
+        await writeIndex.addFragments(target('conversations/c', 'turn-1'), [frag(0, 8, 0.9, 0.1, 0)])
+      ).orThrow();
+      first.close();
+
+      // Second session: a brand-new connection + index over the same file. No adds
+      // (no re-embedding) — fragments, dimension, and locators come straight off disk.
+      const second = new BetterSqlite3(dbPath);
+      const reopened = (await SqliteVecFragmentIndex.create({ database: second })).orThrow();
+      try {
+        expect(reopened.recordCount).toBe(2);
+        expect(reopened.fragmentCount).toBe(3);
+        expect(await reopened.query(Float32Array.from([1, 0, 0]), 3)).toSucceedAndSatisfy(
+          (hits: ReadonlyArray<IVectorQueryHit>) => {
+            expect(hits[0].target).toEqual(target('knowledge', 'doc-a'));
+            expect(hits[0].locator).toEqual(loc(0, 5));
+            expect(hits[0].score).toBeCloseTo(1, 5);
+            // the cross-scope target round-trips its full (scope, id) and locator
+            expect(hits[1].target).toEqual(target('conversations/c', 'turn-1'));
+            expect(hits[1].locator).toEqual(loc(0, 8));
+          }
+        );
+        // The recovered dimension is enforced on a post-reopen add.
+        expect(await reopened.addFragments(target('knowledge', 'w'), [frag(0, 4, 1, 0)])).toFailWith(
+          /fragment dimension 2 does not match index dimension 3/i
+        );
+        // A matching-dimension add still works and persists incrementally.
+        (await reopened.addFragments(target('knowledge', 'w'), [frag(0, 4, 0, 0, 1)])).orThrow();
+        expect(reopened.recordCount).toBe(3);
+      } finally {
+        second.close();
+      }
+    });
+  });
+});

--- a/libraries/ts-agent-memory-sqlite-vec/src/test/unit/sqliteVecFragmentIndex.test.ts
+++ b/libraries/ts-agent-memory-sqlite-vec/src/test/unit/sqliteVecFragmentIndex.test.ts
@@ -163,6 +163,17 @@ describe('SqliteVecFragmentIndex', () => {
         /cannot add 'knowledge\0doc-b'/i
       );
     });
+
+    test('fails loudly (never silently corrupts) when the table name collides with a non-vec0 table', async () => {
+      // A plain table already occupies the default name. `CREATE VIRTUAL TABLE IF NOT
+      // EXISTS` no-ops against it, so preparing the vector INSERT against the missing
+      // columns must fail loudly rather than corrupt state.
+      db.exec('CREATE TABLE memory_fragments (foo TEXT)');
+      const index = (await SqliteVecFragmentIndex.create({ database: db })).orThrow();
+      expect(await index.addFragments(target('knowledge', 'doc-a'), [frag(0, 5, 1, 0)])).toFailWith(
+        /cannot add 'knowledge\0doc-a'/i
+      );
+    });
   });
 
   describe('query', () => {

--- a/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
+++ b/libraries/ts-agent-memory/etc/ts-agent-memory.api.md
@@ -125,6 +125,21 @@ export class FileTreeMemoryStore implements IMemoryStore {
 }
 
 // @public
+export const FRAGMENT_SEMANTIC_UNWIRED_MESSAGE: string;
+
+// @public
+export type FragmentEmbedder = (record: IMemoryRecord<unknown>) => Promise<Result<ReadonlyArray<IEmbeddedFragment>>>;
+
+// @public
+export class FragmentSemanticRetriever {
+    get capabilities(): IFragmentRetrieverCapabilities;
+    static create(params: {
+        readonly backend?: IFragmentSemanticBackend;
+    }): Result<FragmentSemanticRetriever>;
+    retrieve(query: IFragmentQuery): Promise<Result<ReadonlyArray<IVectorQueryHit>>>;
+}
+
+// @public
 export function guardRetrieverCapabilities(query: IMemoryQuery, capabilities: IMemoryRetrieverCapabilities): Result<true>;
 
 // @public
@@ -205,6 +220,12 @@ export interface IEdgeTarget {
 }
 
 // @public
+export interface IEmbeddedFragment {
+    readonly locator: IFragmentLocator;
+    readonly vector: Float32Array;
+}
+
+// @public
 export interface IEntityResolutionCandidate {
     readonly record: IMemoryRecord<unknown>;
     readonly score: number;
@@ -227,6 +248,8 @@ export interface IFileTreeMemoryStoreCreateParams {
     readonly codecs?: ReadonlyMap<Kind, IIdentityCodec>;
     readonly defaultCodec?: IIdentityCodec;
     readonly embed?: MemoryEmbedder;
+    readonly fragmentEmbedder?: FragmentEmbedder;
+    readonly fragmentIndex?: IFragmentVectorIndex;
     readonly logger?: Logging.ILogger;
     readonly observers?: ReadonlyArray<IMemoryObserver>;
     readonly onRecordError?: MemoryRecordErrorMode;
@@ -236,6 +259,37 @@ export interface IFileTreeMemoryStoreCreateParams {
     readonly scopeEncoding?: (scope: MemoryScopeKey) => Result<string>;
     readonly vectorIndex?: IVectorIndex;
     readonly writePolicies?: ReadonlyMap<Kind, IWritePolicy>;
+}
+
+// @public
+export interface IFragmentLocator {
+    readonly end: number;
+    readonly start: number;
+}
+
+// @public
+export interface IFragmentQuery {
+    readonly maxPerRecord?: number;
+    readonly semantic: string;
+    readonly topK?: number;
+}
+
+// @public
+export interface IFragmentRetrieverCapabilities {
+    readonly supportsFragmentRecall: boolean;
+}
+
+// @public
+export interface IFragmentSemanticBackend {
+    readonly embedQuery: QueryEmbedder;
+    readonly fragmentIndex: IFragmentVectorIndex;
+}
+
+// @public
+export interface IFragmentVectorIndex {
+    addFragments(target: IEdgeTarget, fragments: ReadonlyArray<IEmbeddedFragment>): Promise<Result<number>>;
+    query(vector: Float32Array, topK: number, maxPerRecord?: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>>;
+    remove(target: IEdgeTarget): Promise<Result<IEdgeTarget>>;
 }
 
 // @public
@@ -498,6 +552,17 @@ export class InMemoryCosineIndex implements IVectorIndex {
 }
 
 // @public
+export class InMemoryFragmentCosineIndex implements IFragmentVectorIndex {
+    addFragments(target: IEdgeTarget, fragments: ReadonlyArray<IEmbeddedFragment>): Promise<Result<number>>;
+    static create(): Result<InMemoryFragmentCosineIndex>;
+    get fragmentCount(): number;
+    query(vector: Float32Array, topK: number, maxPerRecord?: number): Promise<Result<ReadonlyArray<IVectorQueryHit>>>;
+    rebuild(source: IMemoryRecordSource, embed: FragmentEmbedder): Promise<Result<number>>;
+    get recordCount(): number;
+    remove(target: IEdgeTarget): Promise<Result<IEdgeTarget>>;
+}
+
+// @public
 export interface IProvenance {
     readonly [key: string]: unknown;
     readonly by?: string;
@@ -588,6 +653,7 @@ export interface IVectorIndex {
 
 // @public
 export interface IVectorQueryHit {
+    readonly locator?: IFragmentLocator;
     readonly score: number;
     readonly target: IEdgeTarget;
 }

--- a/libraries/ts-agent-memory/src/packlets/retrieve/fragmentSemanticRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/fragmentSemanticRetriever.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import { IFragmentVectorIndex, IVectorQueryHit } from '../vector';
+import { QueryEmbedder } from './semanticRetriever';
+
+/**
+ * The loud-degradation message a {@link FragmentSemanticRetriever} returns when a
+ * fragment query is issued but no {@link IFragmentSemanticBackend | backend} is
+ * wired — the discovery surface NEVER answers a fragment query with a silent empty.
+ * @public
+ */
+export const FRAGMENT_SEMANTIC_UNWIRED_MESSAGE: string =
+  'fragment recall: no fragment index is wired; wire a IFragmentSemanticBackend to enable sub-document search';
+
+/**
+ * The fragment backend wired into a {@link FragmentSemanticRetriever}: the fragment
+ * index to query and the embedder that turns the query text into a vector. Both are
+ * required together — a fragment index is useless without a way to embed the query.
+ * @public
+ */
+export interface IFragmentSemanticBackend {
+  /** The fragment-granular vector index to query. */
+  readonly fragmentIndex: IFragmentVectorIndex;
+  /** Turns the query text into a vector. */
+  readonly embedQuery: QueryEmbedder;
+}
+
+/**
+ * A sub-document semantic-search request: the natural-language `semantic` text to
+ * match, an optional `topK` result cap (default 10), and an optional
+ * `maxPerRecord` cap that keeps one long document from monopolizing the result.
+ * @public
+ */
+export interface IFragmentQuery {
+  /** The natural-language text to embed and match against stored fragments. */
+  readonly semantic: string;
+  /** Maximum number of fragment hits to return. Defaults to 10. */
+  readonly topK?: number;
+  /**
+   * Maximum number of fragments any single record may contribute to the result.
+   * Applied during selection (before the `topK` cut). Omit for uncapped.
+   */
+  readonly maxPerRecord?: number;
+}
+
+/**
+ * What a {@link FragmentSemanticRetriever} can do given its wiring.
+ * @public
+ */
+export interface IFragmentRetrieverCapabilities {
+  /** `true` when a fragment backend is wired and fragment recall is operational. */
+  readonly supportsFragmentRecall: boolean;
+}
+
+/**
+ * The sub-document semantic-search retriever — the "discovery" half of a
+ * search-then-read contract. It embeds a fragment query, queries the
+ * {@link IFragmentVectorIndex}, and returns the raw per-fragment
+ * {@link IVectorQueryHit | hits} (each carrying a record `target` AND the matched
+ * `locator`), NOT resolved records: the consumer re-reads each record and slices it
+ * by the locator on its own read side.
+ *
+ * @remarks
+ * Deliberately NOT an {@link IMemoryRetriever}: memory recall is record-granular and
+ * returns records; fragment discovery is span-granular and returns locators. Keeping
+ * it a distinct surface matches the consumer contract (memory stays record-granular;
+ * sub-document knowledge uses a separate fragment index) and avoids overloading the
+ * record retriever's return type with a locator that only makes sense here.
+ *
+ * When no backend is wired, `supportsFragmentRecall` is `false` and any fragment
+ * query degrades loudly ({@link FRAGMENT_SEMANTIC_UNWIRED_MESSAGE}) — it NEVER
+ * returns a silent empty. A consumer-supplied backend that rejects (throws) is
+ * normalized into a `Failure`.
+ * @public
+ */
+export class FragmentSemanticRetriever {
+  private readonly _backend: IFragmentSemanticBackend | undefined;
+
+  private constructor(backend: IFragmentSemanticBackend | undefined) {
+    this._backend = backend;
+  }
+
+  /** What this retriever can do given its wiring. */
+  public get capabilities(): IFragmentRetrieverCapabilities {
+    return { supportsFragmentRecall: this._backend !== undefined };
+  }
+
+  /** Family-convention factory. */
+  public static create(params: {
+    readonly backend?: IFragmentSemanticBackend;
+  }): Result<FragmentSemanticRetriever> {
+    return succeed(new FragmentSemanticRetriever(params.backend));
+  }
+
+  /**
+   * Embed `query.semantic`, query the fragment index, and return the per-fragment
+   * hits in descending score order. Fails loudly when no backend is wired.
+   */
+  public async retrieve(query: IFragmentQuery): Promise<Result<ReadonlyArray<IVectorQueryHit>>> {
+    if (this._backend === undefined) {
+      return fail(FRAGMENT_SEMANTIC_UNWIRED_MESSAGE);
+    }
+    const backend: IFragmentSemanticBackend = this._backend;
+    // Consumer-supplied hooks may throw; normalize both a returned `fail` and a
+    // rejection into a single `fragment recall: <label> failed` Failure so
+    // `retrieve` always honors its `Promise<Result<...>>` contract.
+    const embedded: Result<Float32Array> = await FragmentSemanticRetriever._callBackend(
+      'query embedding',
+      () => backend.embedQuery(query.semantic)
+    );
+    if (embedded.isFailure()) {
+      return fail(embedded.message);
+    }
+    return FragmentSemanticRetriever._callBackend('fragment query', () =>
+      backend.fragmentIndex.query(embedded.value, query.topK ?? 10, query.maxPerRecord)
+    );
+  }
+
+  /**
+   * Invoke a consumer-supplied backend hook, normalizing both a returned `fail`
+   * and a thrown/rejected promise into a single `fragment recall: <label> failed`
+   * `Failure`.
+   */
+  private static async _callBackend<T>(label: string, op: () => Promise<Result<T>>): Promise<Result<T>> {
+    try {
+      return (await op()).withErrorFormat((msg) => `fragment recall: ${label} failed: ${msg}`);
+    } catch (err) {
+      return fail(`fragment recall: ${label} failed: ${String(err)}`);
+    }
+  }
+}

--- a/libraries/ts-agent-memory/src/packlets/retrieve/fragmentSemanticRetriever.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/fragmentSemanticRetriever.ts
@@ -14,7 +14,7 @@ import { QueryEmbedder } from './semanticRetriever';
  * @public
  */
 export const FRAGMENT_SEMANTIC_UNWIRED_MESSAGE: string =
-  'fragment recall: no fragment index is wired; wire a IFragmentSemanticBackend to enable sub-document search';
+  'fragment recall: no fragment index is wired; wire an IFragmentSemanticBackend to enable sub-document search';
 
 /**
  * The fragment backend wired into a {@link FragmentSemanticRetriever}: the fragment

--- a/libraries/ts-agent-memory/src/packlets/retrieve/index.ts
+++ b/libraries/ts-agent-memory/src/packlets/retrieve/index.ts
@@ -9,5 +9,6 @@ export * from './linkTraversalRetriever';
 export * from './tagRetriever';
 export * from './structuredFilterRetriever';
 export * from './semanticRetriever';
+export * from './fragmentSemanticRetriever';
 export * from './temporalRetrievers';
 export * from './hybridRetriever';

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -37,7 +37,15 @@ import {
   MemoryObservationOutcome,
   MemoryObservationPhase
 } from '../observe';
-import { IMemoryRecordSource, IScopedMemoryRecord, IVectorIndex, MemoryEmbedder } from '../vector';
+import {
+  FragmentEmbedder,
+  IEmbeddedFragment,
+  IFragmentVectorIndex,
+  IMemoryRecordSource,
+  IScopedMemoryRecord,
+  IVectorIndex,
+  MemoryEmbedder
+} from '../vector';
 import { defaultMemoryScopeEncoding } from './scopeEncoding';
 
 /** The on-disk extension for a memory record file. */
@@ -230,6 +238,31 @@ export interface IFileTreeMemoryStoreCreateParams {
    */
   readonly embed?: MemoryEmbedder;
   /**
+   * Optional fragment-granular vector index for sub-document semantic search.
+   * Wired together with
+   * {@link IFileTreeMemoryStoreCreateParams.fragmentEmbedder | fragmentEmbedder}:
+   * when both are present the store chunks + embeds each written record and
+   * maintains the fragment index on `put` / `delete` / cap-cull eviction — the
+   * "discovery" half of a search-then-read contract, queried through a
+   * {@link FragmentSemanticRetriever}. Independent of the record-granular
+   * {@link IFileTreeMemoryStoreCreateParams.vectorIndex | vectorIndex} pair: a
+   * store may wire record vectors, fragment vectors, both, or neither. Absent (or
+   * `fragmentEmbedder` absent) → no fragment work happens and the store behaves
+   * byte-identically (the additive, zero-overhead-when-unwired default).
+   */
+  readonly fragmentIndex?: IFragmentVectorIndex;
+  /**
+   * Optional fragment embedder applied to each record on write, wired together
+   * with {@link IFileTreeMemoryStoreCreateParams.fragmentIndex | fragmentIndex}.
+   * The consumer owns the chunking policy (window size, overlap) and the embedding
+   * call; the store stays chunking- and embedder-agnostic. Fragment index
+   * maintenance is **best-effort**, exactly like the record-vector path: a failed
+   * (or throwing) `fragmentEmbedder` / `addFragments` / `remove` is logged at
+   * `warn` and the record operation still succeeds — the fragment index is a
+   * derived view a later `rebuild` reconciles.
+   */
+  readonly fragmentEmbedder?: FragmentEmbedder;
+  /**
    * How the initial vault walk reacts to a record that fails to parse or
    * validate. Defaults to `'fail'` — one bad record fails the whole open, the
    * historical behavior, preserved byte-for-byte. Set `'skip'` to quarantine
@@ -270,6 +303,8 @@ interface IInternalParams {
   readonly logger: Logging.ILogger;
   readonly vectorIndex?: IVectorIndex;
   readonly embed?: MemoryEmbedder;
+  readonly fragmentIndex?: IFragmentVectorIndex;
+  readonly fragmentEmbedder?: FragmentEmbedder;
 }
 
 /**
@@ -302,6 +337,8 @@ export class FileTreeMemoryStore implements IMemoryStore {
   private readonly _logger: Logging.ILogger;
   private readonly _vectorIndex: IVectorIndex | undefined;
   private readonly _embed: MemoryEmbedder | undefined;
+  private readonly _fragmentIndex: IFragmentVectorIndex | undefined;
+  private readonly _fragmentEmbedder: FragmentEmbedder | undefined;
   /**
    * Records the initial walk could not load. Populated during `create()` in
    * {@link MemoryRecordErrorMode | `'skip'` mode}; empty otherwise.
@@ -354,6 +391,8 @@ export class FileTreeMemoryStore implements IMemoryStore {
     this._logger = params.logger;
     this._vectorIndex = params.vectorIndex;
     this._embed = params.embed;
+    this._fragmentIndex = params.fragmentIndex;
+    this._fragmentEmbedder = params.fragmentEmbedder;
     this._skippedRecords = [];
     this._seq = 0;
     this._observationSeq = 0;
@@ -394,7 +433,9 @@ export class FileTreeMemoryStore implements IMemoryStore {
           observers: params.observers ?? [],
           logger: params.logger ?? new Logging.NoOpLogger(),
           vectorIndex: params.vectorIndex,
-          embed: params.embed
+          embed: params.embed,
+          fragmentIndex: params.fragmentIndex,
+          fragmentEmbedder: params.fragmentEmbedder
         });
         return store._initialIndex(params.onRecordError ?? 'fail').onSuccess(() => succeed(store));
       })
@@ -790,6 +831,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
     return this._buildRecord(record, body, existing, policy, hash)
       .onSuccess((built) => succeed(this._stampRank(built)))
       .thenOnSuccess((built) => this._embedOnWrite(built, scope))
+      .thenOnSuccess((built) => this._embedFragmentsOnWrite(built, scope))
       .onSuccess((embeddedBuilt) => this._persist(embeddedBuilt, scope, idStem))
       .thenOnSuccess(async (persisted) => {
         // Everything after the authoritative `_persist` commit is best-effort and
@@ -844,6 +886,56 @@ export class FileTreeMemoryStore implements IMemoryStore {
   }
 
   /**
+   * Best-effort fragment-embed-on-write. When a fragment index AND a fragment
+   * embedder are wired, chunks + embeds the built record and replaces its
+   * fragments in the index (`addFragments` is whole-record-replace, so a re-authored
+   * document never leaves stale fragments behind — no explicit remove needed). A
+   * failure (returned `fail` OR a thrown/rejected hook) is logged and the record is
+   * returned unchanged — the put still persists, and the fragment index is a derived
+   * view a later `rebuild` reconciles. Unlike {@link FileTreeMemoryStore._embedOnWrite}
+   * it stamps nothing on the record (fragments have no per-record `embeddingRef`
+   * analog). A pass-through no-op when unwired (byte-identical record).
+   */
+  private async _embedFragmentsOnWrite(
+    built: IMemoryRecord<string>,
+    scope: MemoryScopeKey
+  ): Promise<Result<IMemoryRecord<string>>> {
+    if (this._fragmentIndex === undefined || this._fragmentEmbedder === undefined) {
+      return succeed(built);
+    }
+    const fragmentIndex: IFragmentVectorIndex = this._fragmentIndex;
+    const fragmentEmbedder: FragmentEmbedder = this._fragmentEmbedder;
+    const target: IEdgeTarget = { scope, id: built.envelope.id };
+    const embedded: Result<ReadonlyArray<IEmbeddedFragment>> = await this._tryVectorOp(
+      () => fragmentEmbedder(built),
+      `fragment embedding '${built.envelope.id}'`
+    );
+    if (embedded.isFailure()) {
+      return succeed(built);
+    }
+    await this._tryVectorOp(
+      () => fragmentIndex.addFragments(target, embedded.value),
+      `fragment add for '${built.envelope.id}'`
+    );
+    return succeed(built);
+  }
+
+  /**
+   * Best-effort fragment removal. A no-op unless the full fragment lifecycle is
+   * wired (both an index AND an embedder), so an unwired store does no fragment
+   * work and behaves byte-identically. Failures are logged, never surfaced — a
+   * committed delete/eviction must not fail because a derived fragment index could
+   * not be pruned.
+   */
+  private async _removeFragmentsBestEffort(target: IEdgeTarget): Promise<void> {
+    if (this._fragmentIndex === undefined || this._fragmentEmbedder === undefined) {
+      return;
+    }
+    const fragmentIndex: IFragmentVectorIndex = this._fragmentIndex;
+    await this._tryVectorOp(() => fragmentIndex.remove(target), `fragment removal for '${target.id}'`);
+  }
+
+  /**
    * Evict the records named by a `cull-oldest` decision, best-effort. Runs only
    * after the authoritative `_persist`, so a failed eviction is logged (never
    * fatal) and the cap self-corrects on the next admission. Returns the ids that
@@ -880,6 +972,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
   ): Promise<void> {
     for (const id of evicted) {
       await this._removeVectorBestEffort({ scope, id });
+      await this._removeFragmentsBestEffort({ scope, id });
     }
   }
 
@@ -1021,6 +1114,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
         .onSuccess(() => this._index.patch('delete', { scope, record: existing }))
         .thenOnSuccess(async () => {
           await this._removeVectorBestEffort({ scope, id: existing.envelope.id });
+          await this._removeFragmentsBestEffort({ scope, id: existing.envelope.id });
           return succeed(existing.envelope.id);
         });
     });
@@ -1116,6 +1210,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
             this._buildVersionedRecord(record, body, current, policy, hash, versionStem, validAt, now, seq)
               .onSuccess((built) => succeed(this._stampRank(built)))
               .thenOnSuccess((built) => this._embedOnWrite(built, scope))
+              .thenOnSuccess((built) => this._embedFragmentsOnWrite(built, scope))
               .onSuccess((embeddedBuilt) => this._persist(embeddedBuilt, scope, versionStem))
               .onSuccess((persisted) =>
                 this._invalidateCurrents(scope, priorCurrents, validAt, now).onSuccess(() =>

--- a/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
+++ b/libraries/ts-agent-memory/src/packlets/store/fileTreeMemoryStore.ts
@@ -990,7 +990,7 @@ export class FileTreeMemoryStore implements IMemoryStore {
     }
     if (result.isFailure()) {
       this._warnSwallowed(
-        `memory: ${label} failed (best-effort; vector index left for rebuild): ${result.message}`
+        `memory: ${label} failed (best-effort; derived index left for rebuild): ${result.message}`
       );
     }
     return result;

--- a/libraries/ts-agent-memory/src/packlets/vector/inMemoryFragmentCosineIndex.ts
+++ b/libraries/ts-agent-memory/src/packlets/vector/inMemoryFragmentCosineIndex.ts
@@ -97,19 +97,23 @@ export class InMemoryFragmentCosineIndex implements IFragmentVectorIndex {
     fragments: ReadonlyArray<IEmbeddedFragment>
   ): Promise<Result<number>> {
     const key: string = edgeTargetKey(target);
-    // Validate every fragment before mutating, so a bad fragment never leaves the
-    // record half-replaced (whole-record-replace must be all-or-nothing).
+    // Validate every fragment before mutating any state, so a bad fragment never
+    // leaves the record half-replaced OR the index dimension half-established
+    // (whole-record-replace must be all-or-nothing). The effective dimension is the
+    // established one, or — on a still-dimensionless index — the first fragment's
+    // length; it is only committed to `this._dimension` once the whole batch passes.
     const stored: IStoredFragment[] = [];
+    let dimension: number | undefined = this._dimension;
     for (const fragment of fragments) {
       if (fragment.vector.length === 0) {
         return Promise.resolve(fail(`fragment index: cannot add '${key}': empty fragment vector`));
       }
-      if (this._dimension === undefined) {
-        this._dimension = fragment.vector.length;
-      } else if (fragment.vector.length !== this._dimension) {
+      if (dimension === undefined) {
+        dimension = fragment.vector.length;
+      } else if (fragment.vector.length !== dimension) {
         return Promise.resolve(
           fail(
-            `fragment index: cannot add '${key}': fragment dimension ${fragment.vector.length} does not match index dimension ${this._dimension}`
+            `fragment index: cannot add '${key}': fragment dimension ${fragment.vector.length} does not match index dimension ${dimension}`
           )
         );
       }
@@ -117,10 +121,12 @@ export class InMemoryFragmentCosineIndex implements IFragmentVectorIndex {
       stored.push({ locator: fragment.locator, vector: Float32Array.from(fragment.vector) });
     }
     // Whole-record replace: an empty `fragments` array drops the record entirely
-    // rather than leaving an empty shell behind.
+    // rather than leaving an empty shell behind. Commit the (possibly newly-derived)
+    // dimension only alongside a successful, non-empty store.
     if (stored.length === 0) {
       this._records.delete(key);
     } else {
+      this._dimension = dimension;
       this._records.set(key, { target, fragments: stored });
     }
     return Promise.resolve(succeed(stored.length));
@@ -167,16 +173,17 @@ export class InMemoryFragmentCosineIndex implements IFragmentVectorIndex {
 
     const hits: IVectorQueryHit[] = [];
     // Apply the per-record cap during selection (before the topK cut) so a single
-    // long document cannot monopolize the result. `undefined` means uncapped.
-    const perRecord: Map<string, number> | undefined =
-      maxPerRecord === undefined ? undefined : new Map<string, number>();
+    // long document cannot monopolize the result. `undefined` maxPerRecord means
+    // uncapped; the counter map is always allocated (tiny) so the guard narrows
+    // `maxPerRecord` directly without a non-null assertion.
+    const perRecord: Map<string, number> = new Map<string, number>();
     for (const candidate of scored) {
       if (hits.length >= topK) {
         break;
       }
-      if (perRecord !== undefined) {
+      if (maxPerRecord !== undefined) {
         const used: number = perRecord.get(candidate.key) ?? 0;
-        if (used >= maxPerRecord!) {
+        if (used >= maxPerRecord) {
           continue;
         }
         perRecord.set(candidate.key, used + 1);

--- a/libraries/ts-agent-memory/src/packlets/vector/inMemoryFragmentCosineIndex.ts
+++ b/libraries/ts-agent-memory/src/packlets/vector/inMemoryFragmentCosineIndex.ts
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import { IEdgeTarget, edgeTargetKey } from '../types';
+import {
+  FragmentEmbedder,
+  IEmbeddedFragment,
+  IFragmentLocator,
+  IFragmentVectorIndex,
+  IMemoryRecordSource,
+  IScopedMemoryRecord,
+  IVectorQueryHit
+} from './vectorIndex';
+
+/** One stored fragment: its in-record locator plus the vector for that span. */
+interface IStoredFragment {
+  readonly locator: IFragmentLocator;
+  readonly vector: Float32Array;
+}
+
+/** Every stored fragment for one record, tagged with the record's scoped address. */
+interface IStoredRecordFragments {
+  readonly target: IEdgeTarget;
+  readonly fragments: IStoredFragment[];
+}
+
+/** A candidate hit carried through selection: the fragment's key, hit, and score. */
+interface IScoredFragment {
+  readonly key: string;
+  readonly hit: IVectorQueryHit;
+}
+
+/**
+ * The brute-force, in-memory cosine {@link IFragmentVectorIndex} — the
+ * fragment-granular sibling of {@link InMemoryCosineIndex}. Stores many
+ * `Float32Array`s per record (one per in-record {@link IFragmentLocator | span})
+ * and answers a query by computing cosine similarity against every stored
+ * fragment, returning the top-k fragment hits by descending score.
+ *
+ * @remarks
+ * Same regime and same non-goals as {@link InMemoryCosineIndex}: no external
+ * dependency, no ANN structure, a linear scan over the stored fragments — the seam
+ * ({@link IFragmentVectorIndex}) stays open for a consumer to swap a persistent /
+ * ANN backend once N grows. `addFragments` is whole-record-replace, so re-authoring
+ * a document never leaves stale fragments behind. The index has a single dimension
+ * established by the first fragment added; every subsequent fragment and every
+ * `query` vector must match it or fail loudly — a mismatched dimension is an
+ * embedder-wiring bug, never a silent zero-similarity result.
+ * {@link InMemoryFragmentCosineIndex.rebuild | rebuild} clears the index (and the
+ * established dimension), so a re-embed with a different model is supported.
+ *
+ * The optional `maxPerRecord` cap on `query` is applied **during selection**, before
+ * the `topK` cut, so one long document with many strong fragments cannot crowd every
+ * other record out of the result.
+ * @public
+ */
+export class InMemoryFragmentCosineIndex implements IFragmentVectorIndex {
+  /**
+   * Stored fragments keyed by the canonical {@link edgeTargetKey} of the record's
+   * scope-qualified address, so two records that share a filename stem across
+   * scopes occupy distinct entries and never overwrite each other's fragments.
+   */
+  private readonly _records: Map<string, IStoredRecordFragments>;
+  /** The dimension of every stored fragment vector; `undefined` until the first `add`. */
+  private _dimension: number | undefined;
+
+  private constructor() {
+    this._records = new Map<string, IStoredRecordFragments>();
+    this._dimension = undefined;
+  }
+
+  /** The number of records that currently have at least one stored fragment. */
+  public get recordCount(): number {
+    return this._records.size;
+  }
+
+  /** The total number of fragments currently held across all records. */
+  public get fragmentCount(): number {
+    let total: number = 0;
+    for (const record of this._records.values()) {
+      total += record.fragments.length;
+    }
+    return total;
+  }
+
+  /** Family-convention factory. */
+  public static create(): Result<InMemoryFragmentCosineIndex> {
+    return succeed(new InMemoryFragmentCosineIndex());
+  }
+
+  /** {@inheritDoc IFragmentVectorIndex.addFragments} */
+  public addFragments(
+    target: IEdgeTarget,
+    fragments: ReadonlyArray<IEmbeddedFragment>
+  ): Promise<Result<number>> {
+    const key: string = edgeTargetKey(target);
+    // Validate every fragment before mutating, so a bad fragment never leaves the
+    // record half-replaced (whole-record-replace must be all-or-nothing).
+    const stored: IStoredFragment[] = [];
+    for (const fragment of fragments) {
+      if (fragment.vector.length === 0) {
+        return Promise.resolve(fail(`fragment index: cannot add '${key}': empty fragment vector`));
+      }
+      if (this._dimension === undefined) {
+        this._dimension = fragment.vector.length;
+      } else if (fragment.vector.length !== this._dimension) {
+        return Promise.resolve(
+          fail(
+            `fragment index: cannot add '${key}': fragment dimension ${fragment.vector.length} does not match index dimension ${this._dimension}`
+          )
+        );
+      }
+      // Defensive copy: the caller may reuse or mutate the buffer after `addFragments`.
+      stored.push({ locator: fragment.locator, vector: Float32Array.from(fragment.vector) });
+    }
+    // Whole-record replace: an empty `fragments` array drops the record entirely
+    // rather than leaving an empty shell behind.
+    if (stored.length === 0) {
+      this._records.delete(key);
+    } else {
+      this._records.set(key, { target, fragments: stored });
+    }
+    return Promise.resolve(succeed(stored.length));
+  }
+
+  /** {@inheritDoc IFragmentVectorIndex.remove} */
+  public remove(target: IEdgeTarget): Promise<Result<IEdgeTarget>> {
+    this._records.delete(edgeTargetKey(target));
+    return Promise.resolve(succeed(target));
+  }
+
+  /** {@inheritDoc IFragmentVectorIndex.query} */
+  public query(
+    vector: Float32Array,
+    topK: number,
+    maxPerRecord?: number
+  ): Promise<Result<ReadonlyArray<IVectorQueryHit>>> {
+    if (topK <= 0 || this._records.size === 0) {
+      return Promise.resolve(succeed([]));
+    }
+    if (vector.length !== this._dimension) {
+      return Promise.resolve(
+        fail(
+          `fragment index: query dimension ${vector.length} does not match index dimension ${this._dimension}`
+        )
+      );
+    }
+    const queryMagnitude: number = InMemoryFragmentCosineIndex._magnitude(vector);
+    const scored: IScoredFragment[] = [];
+    for (const record of this._records.values()) {
+      for (const fragment of record.fragments) {
+        scored.push({
+          key: edgeTargetKey(record.target),
+          hit: {
+            target: record.target,
+            score: InMemoryFragmentCosineIndex._cosine(vector, queryMagnitude, fragment.vector),
+            locator: fragment.locator
+          }
+        });
+      }
+    }
+    // Descending by score; the caller re-resolves each `(target, locator)` hit.
+    scored.sort((a, b) => b.hit.score - a.hit.score);
+
+    const hits: IVectorQueryHit[] = [];
+    // Apply the per-record cap during selection (before the topK cut) so a single
+    // long document cannot monopolize the result. `undefined` means uncapped.
+    const perRecord: Map<string, number> | undefined =
+      maxPerRecord === undefined ? undefined : new Map<string, number>();
+    for (const candidate of scored) {
+      if (hits.length >= topK) {
+        break;
+      }
+      if (perRecord !== undefined) {
+        const used: number = perRecord.get(candidate.key) ?? 0;
+        if (used >= maxPerRecord!) {
+          continue;
+        }
+        perRecord.set(candidate.key, used + 1);
+      }
+      hits.push(candidate.hit);
+    }
+    return Promise.resolve(succeed(hits));
+  }
+
+  /**
+   * Re-embed every record from `source` and rebuild the fragment index from
+   * scratch. Clears the current contents (and the established dimension) first, so
+   * a re-embed with a different model is supported. Returns the total number of
+   * fragments indexed.
+   *
+   * On any failure (list, embed, or add) the index is rolled back to empty rather
+   * than left in a partially-rebuilt state.
+   *
+   * @param source - The scope-qualified record source to re-embed.
+   * @param embed - The fragment embedder applied to each record.
+   */
+  public async rebuild(source: IMemoryRecordSource, embed: FragmentEmbedder): Promise<Result<number>> {
+    this._reset();
+    const listed: Result<ReadonlyArray<IScopedMemoryRecord>> = await source.list();
+    if (listed.isFailure()) {
+      return fail(`fragment index rebuild: failed to list records: ${listed.message}`);
+    }
+    for (const scoped of listed.value) {
+      const embedded: Result<ReadonlyArray<IEmbeddedFragment>> = await embed(scoped.record);
+      if (embedded.isFailure()) {
+        this._reset();
+        return fail(
+          `fragment index rebuild: embedding '${edgeTargetKey(scoped.target)}' failed: ${embedded.message}`
+        );
+      }
+      const added: Result<number> = await this.addFragments(scoped.target, embedded.value);
+      if (added.isFailure()) {
+        this._reset();
+        return fail(`fragment index rebuild: ${added.message}`);
+      }
+    }
+    return succeed(this.fragmentCount);
+  }
+
+  /** Empty the index and forget the established dimension. */
+  private _reset(): void {
+    this._records.clear();
+    this._dimension = undefined;
+  }
+
+  /** The Euclidean magnitude (L2 norm) of a vector. */
+  private static _magnitude(vector: Float32Array): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < vector.length; i++) {
+      sum += vector[i] * vector[i];
+    }
+    return Math.sqrt(sum);
+  }
+
+  /**
+   * Cosine similarity between the query (whose magnitude is precomputed once and
+   * reused across the scan) and a stored fragment vector. A zero-magnitude vector
+   * on either side yields `0` rather than `NaN`.
+   */
+  private static _cosine(query: Float32Array, queryMagnitude: number, stored: Float32Array): number {
+    const storedMagnitude: number = InMemoryFragmentCosineIndex._magnitude(stored);
+    if (queryMagnitude === 0 || storedMagnitude === 0) {
+      return 0;
+    }
+    let dot: number = 0;
+    for (let i: number = 0; i < query.length; i++) {
+      dot += query[i] * stored[i];
+    }
+    return dot / (queryMagnitude * storedMagnitude);
+  }
+}

--- a/libraries/ts-agent-memory/src/packlets/vector/index.ts
+++ b/libraries/ts-agent-memory/src/packlets/vector/index.ts
@@ -5,3 +5,4 @@
 
 export * from './vectorIndex';
 export * from './inMemoryCosineIndex';
+export * from './inMemoryFragmentCosineIndex';

--- a/libraries/ts-agent-memory/src/packlets/vector/vectorIndex.ts
+++ b/libraries/ts-agent-memory/src/packlets/vector/vectorIndex.ts
@@ -7,10 +7,26 @@ import { Result } from '@fgv/ts-utils';
 import { IEdgeTarget, IMemoryRecord } from '../types';
 
 /**
- * A single hit returned by {@link IVectorIndex.query}: the matched record's
- * scope-qualified {@link IEdgeTarget | address} and the backend's similarity
- * score (higher = more similar; the exact scale is backend-defined). Hits are
- * returned in descending score order.
+ * A half-open `[start, end)` span into a record's body — the in-record locator a
+ * {@link IFragmentVectorIndex} carries on each fragment hit. `start` is inclusive,
+ * `end` exclusive. The unit (character / byte / token offsets) is the consumer's
+ * choice: the index stores the two integers opaquely and never interprets them,
+ * so they line up with whatever locator the consumer's own read side uses.
+ * @public
+ */
+export interface IFragmentLocator {
+  /** Inclusive start offset into the record body. */
+  readonly start: number;
+  /** Exclusive end offset into the record body. */
+  readonly end: number;
+}
+
+/**
+ * A single hit returned by {@link IVectorIndex.query} (or
+ * {@link IFragmentVectorIndex.query}): the matched record's scope-qualified
+ * {@link IEdgeTarget | address} and the backend's similarity score (higher = more
+ * similar; the exact scale is backend-defined). Hits are returned in descending
+ * score order.
  *
  * @remarks
  * The address is a `(scope, id)` pair, NOT a bare {@link MemoryId} — per-scope
@@ -18,6 +34,10 @@ import { IEdgeTarget, IMemoryRecord } from '../types';
  * stem under different scopes, so a bare id could not disambiguate two records
  * that share a stem. The caller re-resolves the hit against the record index by
  * the same scoped address.
+ *
+ * `locator` is present only on hits from a {@link IFragmentVectorIndex} — it
+ * identifies WHICH fragment of the record matched. Record-granular
+ * {@link IVectorIndex} hits omit it.
  * @public
  */
 export interface IVectorQueryHit {
@@ -25,6 +45,8 @@ export interface IVectorQueryHit {
   readonly target: IEdgeTarget;
   /** Backend similarity score; higher is more similar. */
   readonly score: number;
+  /** The matched fragment's in-record span; present only for fragment-index hits. */
+  readonly locator?: IFragmentLocator;
 }
 
 /**
@@ -66,6 +88,65 @@ export interface IVectorIndex {
 }
 
 /**
+ * One embedded fragment of a record: its in-record {@link IFragmentLocator | span}
+ * and the vector for that span. Produced by a {@link FragmentEmbedder} and stored
+ * via {@link IFragmentVectorIndex.addFragments}.
+ * @public
+ */
+export interface IEmbeddedFragment {
+  /** The fragment's in-record span. */
+  readonly locator: IFragmentLocator;
+  /** The embedding vector for that span. */
+  readonly vector: Float32Array;
+}
+
+/**
+ * The fragment-granular sibling of {@link IVectorIndex}: instead of one vector per
+ * record it holds many vectors per record, each tagged with an in-record
+ * {@link IFragmentLocator}, and its `query` returns per-fragment hits carrying that
+ * locator. This is the seam behind sub-document semantic search — the "discovery"
+ * half of a search-then-read contract, where a hit's `(target, locator)` tells the
+ * consumer which record AND which span to read.
+ *
+ * @remarks
+ * Deliberately NOT `extends IVectorIndex`: an index keyed by `(target, locator)`
+ * has no well-defined single-vector `add(target, vector)`. It is a parallel
+ * contract with three operations — `addFragments`, `remove`, `query` — reusing
+ * {@link IVectorQueryHit} (whose `locator` is always populated here). Kept distinct
+ * from the record-granular index per the consumer contract: memory recall stays
+ * record-granular; sub-document knowledge uses a separate fragment index.
+ * @public
+ */
+export interface IFragmentVectorIndex {
+  /**
+   * Add (or replace) all fragments for the scope-qualified `target`. Whole-record
+   * semantics: every fragment previously held for `target` is dropped and replaced
+   * by `fragments`, so a re-authored document never leaves stale fragments behind.
+   * Returns the number of fragments now held for the record.
+   */
+  addFragments(target: IEdgeTarget, fragments: ReadonlyArray<IEmbeddedFragment>): Promise<Result<number>>;
+
+  /**
+   * Remove every fragment for the scope-qualified `target`. Returns the removed
+   * target. Idempotent — removing a target with no fragments still succeeds.
+   */
+  remove(target: IEdgeTarget): Promise<Result<IEdgeTarget>>;
+
+  /**
+   * Return the `topK` nearest fragments to `vector`, in descending score order,
+   * each hit carrying its record `target` and fragment `locator`. When
+   * `maxPerRecord` is supplied, no more than that many fragments of any single
+   * record appear in the result — the cap is applied during selection (before the
+   * `topK` cut) so one long document cannot crowd out others.
+   */
+  query(
+    vector: Float32Array,
+    topK: number,
+    maxPerRecord?: number
+  ): Promise<Result<ReadonlyArray<IVectorQueryHit>>>;
+}
+
+/**
  * Embeds a complete record into a vector for the store's embed-on-write hook.
  * Async and `Result`-returning, since a real embedder does a network call (cloud
  * provider) or in-process model inference. The consumer wires this — the core
@@ -73,6 +154,18 @@ export interface IVectorIndex {
  * @public
  */
 export type MemoryEmbedder = (record: IMemoryRecord<unknown>) => Promise<Result<Float32Array>>;
+
+/**
+ * The fragment-granular sibling of {@link MemoryEmbedder}: chunks a record's body
+ * and embeds each chunk, returning one {@link IEmbeddedFragment} per chunk. The
+ * chunking policy (window size, overlap) lives entirely in the consumer's embedder
+ * — the core stays chunking-agnostic, exactly as it stays embedder-agnostic for
+ * the record-granular path. Used by the store's fragment-embed-on-write hook.
+ * @public
+ */
+export type FragmentEmbedder = (
+  record: IMemoryRecord<unknown>
+) => Promise<Result<ReadonlyArray<IEmbeddedFragment>>>;
 
 /**
  * A record paired with its scope-qualified {@link IEdgeTarget | address}, as

--- a/libraries/ts-agent-memory/src/test/unit/retrieve/fragmentSemanticRetriever.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/retrieve/fragmentSemanticRetriever.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import {
+  FRAGMENT_SEMANTIC_UNWIRED_MESSAGE,
+  FragmentSemanticRetriever,
+  IEdgeTarget,
+  IEmbeddedFragment,
+  IFragmentLocator,
+  IFragmentVectorIndex,
+  IVectorQueryHit,
+  MemoryId,
+  MemoryScopeKey
+} from '../../../index';
+
+function target(scope: string, id: string): IEdgeTarget {
+  return { scope: scope as MemoryScopeKey, id: id as MemoryId };
+}
+
+function loc(start: number, end: number): IFragmentLocator {
+  return { start, end };
+}
+
+function hit(scope: string, id: string, start: number, end: number, score: number): IVectorQueryHit {
+  return { target: target(scope, id), score, locator: loc(start, end) };
+}
+
+const okEmbed = (): Promise<Result<Float32Array>> => Promise.resolve(succeed(Float32Array.from([0.1, 0.2])));
+
+/** A scripted fragment index that records the args it was queried with. */
+class FakeFragmentIndex implements IFragmentVectorIndex {
+  public lastTopK: number | undefined;
+  public lastMaxPerRecord: number | undefined;
+  private readonly _hits: ReadonlyArray<IVectorQueryHit>;
+  private readonly _fail: boolean;
+  public constructor(hits: ReadonlyArray<IVectorQueryHit>, shouldFail: boolean = false) {
+    this._hits = hits;
+    this._fail = shouldFail;
+  }
+  public addFragments(
+    __t: IEdgeTarget,
+    fragments: ReadonlyArray<IEmbeddedFragment>
+  ): Promise<Result<number>> {
+    return Promise.resolve(succeed(fragments.length));
+  }
+  public remove(t: IEdgeTarget): Promise<Result<IEdgeTarget>> {
+    return Promise.resolve(succeed(t));
+  }
+  public query(
+    __vector: Float32Array,
+    topK: number,
+    maxPerRecord?: number
+  ): Promise<Result<ReadonlyArray<IVectorQueryHit>>> {
+    this.lastTopK = topK;
+    this.lastMaxPerRecord = maxPerRecord;
+    return Promise.resolve(this._fail ? fail('fragment backend down') : succeed(this._hits));
+  }
+}
+
+describe('FragmentSemanticRetriever', () => {
+  test('reports supportsFragmentRecall=false when no backend is wired', () => {
+    const r = FragmentSemanticRetriever.create({}).orThrow();
+    expect(r.capabilities.supportsFragmentRecall).toBe(false);
+  });
+
+  test('reports supportsFragmentRecall=true when a backend is wired', () => {
+    const r = FragmentSemanticRetriever.create({
+      backend: { fragmentIndex: new FakeFragmentIndex([]), embedQuery: okEmbed }
+    }).orThrow();
+    expect(r.capabilities.supportsFragmentRecall).toBe(true);
+  });
+
+  test('degrades loudly when no backend is wired — never a silent empty', async () => {
+    const r = FragmentSemanticRetriever.create({}).orThrow();
+    expect(await r.retrieve({ semantic: 'hi' })).toFailWith(FRAGMENT_SEMANTIC_UNWIRED_MESSAGE);
+  });
+
+  test('returns the per-fragment hits (target + locator + score) in backend order', async () => {
+    const hits = [hit('knowledge', 'doc-a', 0, 5, 0.9), hit('knowledge', 'doc-a', 20, 25, 0.4)];
+    const r = FragmentSemanticRetriever.create({
+      backend: { fragmentIndex: new FakeFragmentIndex(hits), embedQuery: okEmbed }
+    }).orThrow();
+    expect(await r.retrieve({ semantic: 'q' })).toSucceedAndSatisfy(
+      (result: ReadonlyArray<IVectorQueryHit>) => {
+        expect(result).toEqual(hits);
+        expect(result[0].locator).toEqual(loc(0, 5));
+        expect(result[1].locator).toEqual(loc(20, 25));
+      }
+    );
+  });
+
+  test('forwards topK and maxPerRecord to the fragment index', async () => {
+    const fragmentIndex = new FakeFragmentIndex([hit('knowledge', 'doc-a', 0, 5, 0.9)]);
+    const r = FragmentSemanticRetriever.create({
+      backend: { fragmentIndex, embedQuery: okEmbed }
+    }).orThrow();
+    expect(await r.retrieve({ semantic: 'q', topK: 3, maxPerRecord: 1 })).toSucceed();
+    expect(fragmentIndex.lastTopK).toBe(3);
+    expect(fragmentIndex.lastMaxPerRecord).toBe(1);
+  });
+
+  test('defaults topK to 10 and leaves maxPerRecord undefined when the query omits them', async () => {
+    const fragmentIndex = new FakeFragmentIndex([hit('knowledge', 'doc-a', 0, 5, 0.9)]);
+    const r = FragmentSemanticRetriever.create({
+      backend: { fragmentIndex, embedQuery: okEmbed }
+    }).orThrow();
+    expect(await r.retrieve({ semantic: 'q' })).toSucceed();
+    expect(fragmentIndex.lastTopK).toBe(10);
+    expect(fragmentIndex.lastMaxPerRecord).toBeUndefined();
+  });
+
+  test('fails loudly when the embedder fails', async () => {
+    const r = FragmentSemanticRetriever.create({
+      backend: {
+        fragmentIndex: new FakeFragmentIndex([]),
+        embedQuery: () => Promise.resolve(fail('no embed model'))
+      }
+    }).orThrow();
+    expect(await r.retrieve({ semantic: 'q' })).toFailWith(
+      /fragment recall: query embedding failed: no embed model/i
+    );
+  });
+
+  test('fails loudly when the fragment backend fails', async () => {
+    const r = FragmentSemanticRetriever.create({
+      backend: { fragmentIndex: new FakeFragmentIndex([], true), embedQuery: okEmbed }
+    }).orThrow();
+    expect(await r.retrieve({ semantic: 'q' })).toFailWith(
+      /fragment recall: fragment query failed: fragment backend down/i
+    );
+  });
+
+  test('normalizes a rejecting embedder into a Failure (never escapes as a rejection)', async () => {
+    const r = FragmentSemanticRetriever.create({
+      backend: {
+        fragmentIndex: new FakeFragmentIndex([]),
+        embedQuery: () => Promise.reject(new Error('embedder blew up'))
+      }
+    }).orThrow();
+    expect(await r.retrieve({ semantic: 'q' })).toFailWith(
+      /fragment recall: query embedding failed: .*embedder blew up/i
+    );
+  });
+
+  test('normalizes a rejecting fragment backend into a Failure', async () => {
+    const rejectingIndex: IFragmentVectorIndex = {
+      addFragments: (__t: IEdgeTarget, f: ReadonlyArray<IEmbeddedFragment>) =>
+        Promise.resolve(succeed(f.length)),
+      remove: (t: IEdgeTarget) => Promise.resolve(succeed(t)),
+      query: () => Promise.reject(new Error('socket hangup'))
+    };
+    const r = FragmentSemanticRetriever.create({
+      backend: { fragmentIndex: rejectingIndex, embedQuery: okEmbed }
+    }).orThrow();
+    expect(await r.retrieve({ semantic: 'q' })).toFailWith(
+      /fragment recall: fragment query failed: .*socket hangup/i
+    );
+  });
+});

--- a/libraries/ts-agent-memory/src/test/unit/store/fragmentEmbedOnWrite.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/fragmentEmbedOnWrite.test.ts
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import { Converters, Logging, Result, fail, succeed } from '@fgv/ts-utils';
+import { FileTree } from '@fgv/ts-json-base';
+import {
+  BodyConverterRegistry,
+  EntityId,
+  FileTreeMemoryStore,
+  FragmentSemanticRetriever,
+  IBodyConverterRegistry,
+  IEdgeTarget,
+  IEmbeddedFragment,
+  IFragmentVectorIndex,
+  IIdentityCodec,
+  IMemoryRecord,
+  IVectorQueryHit,
+  InMemoryFragmentCosineIndex,
+  Kind,
+  KnowledgeIdentityCodec,
+  MemoryCapCullPolicy,
+  MemoryId,
+  MemoryScopeKey,
+  MtmIdentityCodec,
+  IWritePolicy,
+  envelopeConverter
+} from '../../../index';
+
+const knowledgeKind: Kind = 'knowledge' as Kind;
+const mtmKind: Kind = 'mtm' as Kind;
+
+function mutableRoot(): FileTree.IMutableFileTreeDirectoryItem {
+  const tree = FileTree.inMemory([], { mutable: true }).orThrow();
+  const root = tree.getDirectory('/').orThrow();
+  if (!FileTree.isMutableDirectoryItem(root)) {
+    throw new Error('expected a mutable root directory');
+  }
+  return root;
+}
+
+function makeRecord(
+  id: string,
+  body: string,
+  kind: string = 'knowledge',
+  entityId?: string
+): IMemoryRecord<unknown> {
+  return {
+    envelope: envelopeConverter
+      .convert({
+        id,
+        entityId: entityId ?? id,
+        kind,
+        tags: [],
+        links: [],
+        created: 0,
+        updated: 0,
+        seq: 0,
+        contentHash: '',
+        provenance: { source: 'agent' }
+      })
+      .orThrow(),
+    body
+  };
+}
+
+/** Deterministic keyword-count feature space (no network), shared with the query side. */
+const MARKERS: ReadonlyArray<string> = ['cat', 'dog', 'fish'];
+function featureVector(text: string): Float32Array {
+  const lower: string = text.toLowerCase();
+  return Float32Array.from(MARKERS.map((m) => lower.split(m).length - 1));
+}
+
+/**
+ * Fragment embedder: chunks the body into whitespace-delimited words, emitting one
+ * fragment per word with its true `[start, end)` character offsets and a feature
+ * vector for that word. Models the consumer-owned chunking policy.
+ */
+const fragmentEmbed = (r: IMemoryRecord<unknown>): Promise<Result<ReadonlyArray<IEmbeddedFragment>>> =>
+  Promise.resolve(
+    Converters.string
+      .convert(r.body)
+      .withErrorFormat((msg) => `cannot embed fragments: body is not a string: ${msg}`)
+      .onSuccess((body) => {
+        const fragments: IEmbeddedFragment[] = [];
+        const re: RegExp = /\S+/g;
+        let m: RegExpExecArray | null = re.exec(body);
+        while (m !== null) {
+          fragments.push({
+            locator: { start: m.index, end: m.index + m[0].length },
+            vector: featureVector(m[0])
+          });
+          m = re.exec(body);
+        }
+        return succeed(fragments);
+      })
+  );
+
+const queryEmbed = (text: string): Promise<Result<Float32Array>> =>
+  Promise.resolve(succeed(featureVector(text)));
+
+/** Records addFragments/remove call order and can be configured to fail either op. */
+class SpyFragmentIndex implements IFragmentVectorIndex {
+  public readonly calls: string[] = [];
+  public failAdd: boolean = false;
+  public failRemove: boolean = false;
+  private readonly _inner: InMemoryFragmentCosineIndex = InMemoryFragmentCosineIndex.create().orThrow();
+
+  public async addFragments(
+    target: IEdgeTarget,
+    fragments: ReadonlyArray<IEmbeddedFragment>
+  ): Promise<Result<number>> {
+    this.calls.push(`add:${target.id}:${fragments.length}`);
+    return this.failAdd ? fail('add boom') : this._inner.addFragments(target, fragments);
+  }
+  public async remove(target: IEdgeTarget): Promise<Result<IEdgeTarget>> {
+    this.calls.push(`remove:${target.id}`);
+    return this.failRemove ? fail('remove boom') : this._inner.remove(target);
+  }
+  public query(
+    vector: Float32Array,
+    topK: number,
+    maxPerRecord?: number
+  ): Promise<Result<ReadonlyArray<IVectorQueryHit>>> {
+    return this._inner.query(vector, topK, maxPerRecord);
+  }
+}
+
+function knowledgeStore(params: {
+  fragmentIndex?: IFragmentVectorIndex;
+  fragmentEmbedder?: (r: IMemoryRecord<unknown>) => Promise<Result<ReadonlyArray<IEmbeddedFragment>>>;
+  logger?: Logging.ILogger;
+}): FileTreeMemoryStore {
+  const registry: IBodyConverterRegistry = BodyConverterRegistry.create().orThrow();
+  registry.register(knowledgeKind, Converters.string);
+  return FileTreeMemoryStore.create({
+    root: mutableRoot(),
+    registry,
+    codecs: new Map<Kind, IIdentityCodec>([[knowledgeKind, new KnowledgeIdentityCodec()]]),
+    fragmentIndex: params.fragmentIndex,
+    fragmentEmbedder: params.fragmentEmbedder,
+    logger: params.logger
+  }).orThrow();
+}
+
+describe('FileTreeMemoryStore fragment-embed-on-write', () => {
+  describe('when wired', () => {
+    test('embeds fragments on write and indexes them (queryable by span)', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const store = knowledgeStore({ fragmentIndex: index, fragmentEmbedder: fragmentEmbed });
+      expect(await store.put(makeRecord('doc-a', 'cat dog'))).toSucceed();
+      // Two words → two fragments.
+      expect(index.recordCount).toBe(1);
+      expect(index.fragmentCount).toBe(2);
+      // A query for 'cat' surfaces the 'cat' span [0,3], not the 'dog' span.
+      expect(await index.query(featureVector('cat'), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits[0].target.id).toBe('doc-a');
+          expect(hits[0].locator).toEqual({ start: 0, end: 3 });
+        }
+      );
+    });
+
+    test('stamps nothing on the record (fragments have no per-record embeddingRef)', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const store = knowledgeStore({ fragmentIndex: index, fragmentEmbedder: fragmentEmbed });
+      expect(await store.put(makeRecord('doc-a', 'cat dog'))).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown>) => {
+          expect(record.envelope.embeddingRef).toBeUndefined();
+        }
+      );
+    });
+
+    test('re-embeds on a content change via whole-record replace', async () => {
+      const spy = new SpyFragmentIndex();
+      const store = knowledgeStore({ fragmentIndex: spy, fragmentEmbedder: fragmentEmbed });
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      (await store.put(makeRecord('doc-a', 'dog fish'))).orThrow();
+      // First write: 1 fragment; second: 2 fragments, replacing the first.
+      expect(spy.calls).toEqual(['add:doc-a:1', 'add:doc-a:2']);
+      // The 'cat' fragment is gone — the new 'dog'/'fish' spans are orthogonal to a
+      // 'cat' query (best score 0), proving the whole-record replace dropped it.
+      expect(await spy.query(featureVector('cat'), 5)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits.every((h) => h.score === 0)).toBe(true);
+        }
+      );
+      expect(await spy.query(featureVector('fish'), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits[0].score).toBeCloseTo(1);
+        }
+      );
+    });
+
+    test('does not re-embed a dedup no-op (identical content)', async () => {
+      const spy = new SpyFragmentIndex();
+      const store = knowledgeStore({ fragmentIndex: spy, fragmentEmbedder: fragmentEmbed });
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      expect(spy.calls).toEqual(['add:doc-a:1']);
+    });
+
+    test('removes the fragments on delete', async () => {
+      const spy = new SpyFragmentIndex();
+      const store = knowledgeStore({ fragmentIndex: spy, fragmentEmbedder: fragmentEmbed });
+      (await store.put(makeRecord('doc-a', 'cat dog'))).orThrow();
+      expect(await store.delete(knowledgeKind, 'doc-a' as unknown as EntityId)).toSucceedWith(
+        'doc-a' as MemoryId
+      );
+      expect(spy.calls).toEqual(['add:doc-a:2', 'remove:doc-a']);
+      expect(await spy.query(featureVector('cat'), 5)).toSucceedWith([]);
+    });
+
+    test('removes evicted fragments on cap-cull eviction', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const capCull: IWritePolicy = MemoryCapCullPolicy.create({
+        maxRecords: 2,
+        mutableFields: ['body', 'tags', 'links', 'provenance', 'embeddingRef']
+      }).orThrow();
+      const registry: IBodyConverterRegistry = BodyConverterRegistry.create().orThrow();
+      registry.register(mtmKind, Converters.string);
+      const store = FileTreeMemoryStore.create({
+        root: mutableRoot(),
+        registry,
+        codecs: new Map<Kind, IIdentityCodec>([[mtmKind, new MtmIdentityCodec()]]),
+        writePolicies: new Map<Kind, IWritePolicy>([[mtmKind, capCull]]),
+        fragmentIndex: index,
+        fragmentEmbedder: fragmentEmbed
+      }).orThrow();
+
+      (await store.put(makeRecord('turn-0', 'cat', 'mtm', 'conv-1:0'))).orThrow();
+      (await store.put(makeRecord('turn-1', 'dog', 'mtm', 'conv-1:1'))).orThrow();
+      (await store.put(makeRecord('turn-2', 'fish', 'mtm', 'conv-1:2'))).orThrow();
+      // turn-0 evicted from the store AND its fragments from the index.
+      expect(index.recordCount).toBe(2);
+      expect(await index.query(featureVector('cat'), 5)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits.map((h) => h.target.id)).not.toContain('turn-0');
+        }
+      );
+    });
+
+    test('persists the record (best-effort) and logs when fragment embedding fails', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const logger = new Logging.InMemoryLogger();
+      const failEmbed = (): Promise<Result<ReadonlyArray<IEmbeddedFragment>>> =>
+        Promise.resolve(fail('no model'));
+      const store = knowledgeStore({ fragmentIndex: index, fragmentEmbedder: failEmbed, logger });
+      expect(await store.put(makeRecord('doc-a', 'cat'))).toSucceed();
+      expect(await store.getById('knowledge' as MemoryScopeKey, 'doc-a' as MemoryId)).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown> | undefined) => {
+          expect(record?.envelope.id).toBe('doc-a');
+        }
+      );
+      expect(index.recordCount).toBe(0);
+      expect(logger.logged.some((m) => /fragment embedding 'doc-a' failed.*no model/i.test(m))).toBe(true);
+    });
+
+    test('persists the record (best-effort) and logs when the fragment add fails', async () => {
+      const spy = new SpyFragmentIndex();
+      spy.failAdd = true;
+      const logger = new Logging.InMemoryLogger();
+      const store = knowledgeStore({ fragmentIndex: spy, fragmentEmbedder: fragmentEmbed, logger });
+      expect(await store.put(makeRecord('doc-a', 'cat'))).toSucceed();
+      expect(await store.getById('knowledge' as MemoryScopeKey, 'doc-a' as MemoryId)).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown> | undefined) => {
+          expect(record?.envelope.id).toBe('doc-a');
+        }
+      );
+      expect(logger.logged.some((m) => /fragment add for 'doc-a' failed.*add boom/i.test(m))).toBe(true);
+    });
+
+    test('best-effort embed survives a throwing/rejecting fragment embedder', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const logger = new Logging.InMemoryLogger();
+      const throwingEmbed = (): Promise<Result<ReadonlyArray<IEmbeddedFragment>>> =>
+        Promise.reject(new Error('embedder kaboom'));
+      const store = knowledgeStore({ fragmentIndex: index, fragmentEmbedder: throwingEmbed, logger });
+      expect(await store.put(makeRecord('doc-a', 'cat'))).toSucceed();
+      expect(index.recordCount).toBe(0);
+      expect(logger.logged.some((m) => /fragment embedding 'doc-a' threw.*embedder kaboom/i.test(m))).toBe(
+        true
+      );
+    });
+
+    test('a committed delete succeeds (best-effort) and logs when fragment removal fails', async () => {
+      const spy = new SpyFragmentIndex();
+      const logger = new Logging.InMemoryLogger();
+      const store = knowledgeStore({ fragmentIndex: spy, fragmentEmbedder: fragmentEmbed, logger });
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      spy.failRemove = true;
+      expect(await store.delete(knowledgeKind, 'doc-a' as unknown as EntityId)).toSucceedWith(
+        'doc-a' as MemoryId
+      );
+      expect(await store.getById('knowledge' as MemoryScopeKey, 'doc-a' as MemoryId)).toSucceedWith(
+        undefined
+      );
+      expect(logger.logged.some((m) => /fragment removal for 'doc-a' failed.*remove boom/i.test(m))).toBe(
+        true
+      );
+    });
+  });
+
+  describe('when unwired', () => {
+    test('a store without a fragment index or embedder does no fragment work', async () => {
+      const store = knowledgeStore({});
+      expect(await store.put(makeRecord('doc-a', 'cat'))).toSucceedAndSatisfy(
+        (record: IMemoryRecord<unknown>) => {
+          expect(record.envelope.embeddingRef).toBeUndefined();
+        }
+      );
+    });
+
+    test('a fragment index without an embedder is fully inert (no add or remove)', async () => {
+      const spy = new SpyFragmentIndex();
+      const store = knowledgeStore({ fragmentIndex: spy });
+      (await store.put(makeRecord('doc-a', 'cat'))).orThrow();
+      (await store.delete(knowledgeKind, 'doc-a' as unknown as EntityId)).orThrow();
+      expect(spy.calls).toEqual([]);
+    });
+  });
+
+  describe('fragment discovery end-to-end', () => {
+    test('a wired store + InMemoryFragmentCosineIndex + FragmentSemanticRetriever returns per-span hits', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const store = knowledgeStore({ fragmentIndex: index, fragmentEmbedder: fragmentEmbed });
+      (await store.put(makeRecord('doc-a', 'cat cat dog'))).orThrow();
+      (await store.put(makeRecord('doc-b', 'fish fish'))).orThrow();
+
+      const retriever = FragmentSemanticRetriever.create({
+        backend: { fragmentIndex: index, embedQuery: queryEmbed }
+      }).orThrow();
+      expect(retriever.capabilities.supportsFragmentRecall).toBe(true);
+
+      // maxPerRecord=1 keeps doc-a's two 'cat' spans from crowding out the field.
+      expect(await retriever.retrieve({ semantic: 'cat', topK: 5, maxPerRecord: 1 })).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          // The top hit is a 'cat' span in doc-a; the doc-a cap is honored.
+          expect(hits[0].target.id).toBe('doc-a');
+          expect(hits[0].locator).toEqual({ start: 0, end: 3 });
+          const perRecord = hits.filter((h) => h.target.id === 'doc-a');
+          expect(perRecord).toHaveLength(1);
+        }
+      );
+    });
+  });
+});

--- a/libraries/ts-agent-memory/src/test/unit/vector/inMemoryFragmentCosineIndex.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/vector/inMemoryFragmentCosineIndex.test.ts
@@ -128,6 +128,28 @@ describe('InMemoryFragmentCosineIndex', () => {
       );
     });
 
+    test('a failed multi-fragment add on a fresh index does not establish a dimension (all-or-nothing)', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      // Batch: first fragment (dim 2) would set the dimension, second (dim 3) fails
+      // the check. The failed add must leave the index wholly dimensionless — not
+      // half-committed to dim 2 — so a later legitimate dim-3 add still succeeds.
+      expect(
+        await index.addFragments(target('knowledge', 'doc-1'), [frag(0, 5, [1, 0]), frag(5, 10, [1, 0, 0])])
+      ).toFailWith(/fragment dimension 3 does not match index dimension 2/i);
+      expect(index.recordCount).toBe(0);
+      expect(index.fragmentCount).toBe(0);
+      // The dimension was never committed: a fresh dim-3 record indexes cleanly.
+      expect(await index.addFragments(target('knowledge', 'doc-2'), [frag(0, 5, [1, 0, 0])])).toSucceedWith(
+        1
+      );
+      expect(await index.query(Float32Array.from([1, 0, 0]), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits[0].target.id).toBe('doc-2');
+          expect(hits[0].score).toBeCloseTo(1);
+        }
+      );
+    });
+
     test('stores a defensive copy — mutating the caller buffer after add does not corrupt the index', async () => {
       const index = InMemoryFragmentCosineIndex.create().orThrow();
       const buffer = Float32Array.from([1, 0]);

--- a/libraries/ts-agent-memory/src/test/unit/vector/inMemoryFragmentCosineIndex.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/vector/inMemoryFragmentCosineIndex.test.ts
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import {
+  IEdgeTarget,
+  IEmbeddedFragment,
+  IFragmentLocator,
+  IMemoryRecord,
+  IMemoryRecordSource,
+  IScopedMemoryRecord,
+  IVectorQueryHit,
+  InMemoryFragmentCosineIndex,
+  MemoryId,
+  MemoryScopeKey
+} from '../../../index';
+
+/** A scope-qualified target from a `(scope, id)` pair. */
+function target(scope: string, id: string): IEdgeTarget {
+  return { scope: scope as MemoryScopeKey, id: id as MemoryId };
+}
+
+/** A locator over an arbitrary `[start, end)` span (opaque to the index). */
+function loc(start: number, end: number): IFragmentLocator {
+  return { start, end };
+}
+
+/** An embedded fragment from a locator + a raw vector. */
+function frag(start: number, end: number, vector: number[]): IEmbeddedFragment {
+  return { locator: loc(start, end), vector: Float32Array.from(vector) };
+}
+
+/** A trivial record carrying just the id + a marker body, for rebuild tests. */
+function record(id: string, body: string = `body-${id}`): IMemoryRecord<unknown> {
+  return {
+    envelope: { id: id as MemoryId } as IMemoryRecord<unknown>['envelope'],
+    body
+  };
+}
+
+/** A scope-qualified record entry for a rebuild source. */
+function scoped(scope: string, id: string, body?: string): IScopedMemoryRecord {
+  return { target: target(scope, id), record: record(id, body) };
+}
+
+/** A scripted record source for `rebuild`. */
+class FakeSource implements IMemoryRecordSource {
+  private readonly _result: Result<ReadonlyArray<IScopedMemoryRecord>>;
+  public constructor(result: Result<ReadonlyArray<IScopedMemoryRecord>>) {
+    this._result = result;
+  }
+  public list(): Promise<Result<ReadonlyArray<IScopedMemoryRecord>>> {
+    return Promise.resolve(this._result);
+  }
+}
+
+describe('InMemoryFragmentCosineIndex', () => {
+  describe('addFragments', () => {
+    test('stores every fragment and reports the count; tracks record/fragment counts', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      expect(index.recordCount).toBe(0);
+      expect(index.fragmentCount).toBe(0);
+      const t = target('knowledge', 'doc-1');
+      expect(await index.addFragments(t, [frag(0, 5, [1, 0]), frag(5, 10, [0, 1])])).toSucceedWith(2);
+      expect(index.recordCount).toBe(1);
+      expect(index.fragmentCount).toBe(2);
+    });
+
+    test('whole-record replace — a second addFragments drops the prior fragments', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const t = target('knowledge', 'doc-1');
+      expect(await index.addFragments(t, [frag(0, 5, [1, 0]), frag(5, 10, [0, 1])])).toSucceedWith(2);
+      // Re-author with a single fragment: the old two must be gone.
+      expect(await index.addFragments(t, [frag(0, 3, [1, 1])])).toSucceedWith(1);
+      expect(index.recordCount).toBe(1);
+      expect(index.fragmentCount).toBe(1);
+      expect(await index.query(Float32Array.from([1, 1]), 5)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits).toHaveLength(1);
+          expect(hits[0].locator).toEqual(loc(0, 3));
+        }
+      );
+    });
+
+    test('an empty fragments array drops the record entirely', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const t = target('knowledge', 'doc-1');
+      expect(await index.addFragments(t, [frag(0, 5, [1, 0])])).toSucceedWith(1);
+      expect(await index.addFragments(t, [])).toSucceedWith(0);
+      expect(index.recordCount).toBe(0);
+      expect(index.fragmentCount).toBe(0);
+    });
+
+    test('same stem in different scopes are distinct entries', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const a = target('conv-a', 'turn-3');
+      const b = target('conv-b', 'turn-3');
+      expect(await index.addFragments(a, [frag(0, 5, [1, 0])])).toSucceedWith(1);
+      expect(await index.addFragments(b, [frag(0, 5, [0, 1])])).toSucceedWith(1);
+      expect(index.recordCount).toBe(2);
+      expect(await index.query(Float32Array.from([1, 1]), 5)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits).toHaveLength(2);
+          expect(hits.map((h) => h.target)).toEqual(expect.arrayContaining([a, b]));
+        }
+      );
+    });
+
+    test('fails loudly on an empty fragment vector — and does not partially store', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const t = target('knowledge', 'doc-1');
+      // First fragment is fine, second is empty: whole-record-replace must be all-or-nothing.
+      expect(await index.addFragments(t, [frag(0, 5, [1, 0]), frag(5, 10, [])])).toFailWith(
+        /empty fragment vector/i
+      );
+      expect(index.recordCount).toBe(0);
+      expect(index.fragmentCount).toBe(0);
+    });
+
+    test('fails loudly on a fragment-dimension mismatch against the established dimension', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      expect(await index.addFragments(target('knowledge', 'a'), [frag(0, 5, [1, 0])])).toSucceed();
+      expect(await index.addFragments(target('knowledge', 'b'), [frag(0, 5, [1, 0, 0])])).toFailWith(
+        /fragment dimension 3 does not match index dimension 2/i
+      );
+    });
+
+    test('stores a defensive copy — mutating the caller buffer after add does not corrupt the index', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const buffer = Float32Array.from([1, 0]);
+      (
+        await index.addFragments(target('knowledge', 'doc-1'), [{ locator: loc(0, 5), vector: buffer }])
+      ).orThrow();
+      buffer[0] = 0;
+      buffer[1] = 1;
+      expect(await index.query(Float32Array.from([1, 0]), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits[0].score).toBeCloseTo(1);
+        }
+      );
+    });
+  });
+
+  describe('query', () => {
+    async function seeded(): Promise<InMemoryFragmentCosineIndex> {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      (
+        await index.addFragments(target('knowledge', 'doc-a'), [frag(0, 5, [1, 0]), frag(5, 10, [0, 1])])
+      ).orThrow();
+      (await index.addFragments(target('knowledge', 'doc-b'), [frag(0, 5, [1, 1])])).orThrow();
+      return index;
+    }
+
+    test('returns fragment hits in descending cosine-similarity order, each carrying its locator', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 3)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          // doc-a[0,5] matches [1,0] best (score 1), then doc-b (1/sqrt2), then doc-a[5,10] (0).
+          expect(hits[0].target.id).toBe('doc-a');
+          expect(hits[0].locator).toEqual(loc(0, 5));
+          expect(hits[0].score).toBeCloseTo(1);
+          expect(hits[1].target.id).toBe('doc-b');
+          expect(hits[1].score).toBeCloseTo(1 / Math.sqrt(2));
+          expect(hits[2].target.id).toBe('doc-a');
+          expect(hits[2].locator).toEqual(loc(5, 10));
+          expect(hits[2].score).toBeCloseTo(0);
+        }
+      );
+    });
+
+    test('truncates to topK', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 2)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits).toHaveLength(2);
+          expect(hits.map((h) => h.locator)).toEqual([loc(0, 5), loc(0, 5)]);
+          expect(hits[0].target.id).toBe('doc-a');
+          expect(hits[1].target.id).toBe('doc-b');
+        }
+      );
+    });
+
+    test('maxPerRecord caps fragments per record during selection (before the topK cut)', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      // doc-a has three fragments that all beat doc-b's single fragment.
+      (
+        await index.addFragments(target('knowledge', 'doc-a'), [
+          frag(0, 5, [1, 0]),
+          frag(5, 10, [0.9, 0.1]),
+          frag(10, 15, [0.8, 0.2])
+        ])
+      ).orThrow();
+      (await index.addFragments(target('knowledge', 'doc-b'), [frag(0, 5, [0.7, 0.3])])).orThrow();
+      // Without a cap, top-2 would be doc-a twice. With maxPerRecord=1, doc-b surfaces.
+      expect(await index.query(Float32Array.from([1, 0]), 2, 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits).toHaveLength(2);
+          expect(hits.map((h) => h.target.id)).toEqual(['doc-a', 'doc-b']);
+          expect(hits[0].locator).toEqual(loc(0, 5));
+        }
+      );
+    });
+
+    test('maxPerRecord=0 yields no hits', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 5, 0)).toSucceedWith([]);
+    });
+
+    test('maxPerRecord larger than any record leaves the ranking unchanged', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 5, 10)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits).toHaveLength(3);
+          expect(hits[0].target.id).toBe('doc-a');
+        }
+      );
+    });
+
+    test('returns empty for a non-positive topK', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0]), 0)).toSucceedWith([]);
+      expect(await index.query(Float32Array.from([1, 0]), -1)).toSucceedWith([]);
+    });
+
+    test('returns empty when the index is empty (no dimension check)', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      expect(await index.query(Float32Array.from([1, 2, 3, 4]), 5)).toSucceedWith([]);
+    });
+
+    test('fails loudly on a query-dimension mismatch', async () => {
+      const index = await seeded();
+      expect(await index.query(Float32Array.from([1, 0, 0]), 3)).toFailWith(
+        /query dimension 3 does not match index dimension 2/i
+      );
+    });
+
+    test('scores a degenerate (zero-magnitude) stored fragment as 0 rather than NaN', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      (
+        await index.addFragments(target('knowledge', 'doc'), [frag(0, 5, [0, 0]), frag(5, 10, [1, 0])])
+      ).orThrow();
+      expect(await index.query(Float32Array.from([1, 0]), 2)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits.map((h) => h.locator)).toEqual([loc(5, 10), loc(0, 5)]);
+          expect(hits[1].score).toBe(0);
+        }
+      );
+    });
+
+    test('scores against a degenerate (zero-magnitude) query as 0 rather than NaN', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      (await index.addFragments(target('knowledge', 'doc'), [frag(0, 5, [1, 0])])).orThrow();
+      expect(await index.query(Float32Array.from([0, 0]), 1)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits[0].score).toBe(0);
+        }
+      );
+    });
+  });
+
+  describe('remove', () => {
+    test('removes every fragment of a record and is reflected in subsequent queries', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const a = target('knowledge', 'doc-a');
+      const b = target('knowledge', 'doc-b');
+      (await index.addFragments(a, [frag(0, 5, [1, 0]), frag(5, 10, [1, 0])])).orThrow();
+      (await index.addFragments(b, [frag(0, 5, [0, 1])])).orThrow();
+      expect(await index.remove(a)).toSucceedWith(a);
+      expect(index.recordCount).toBe(1);
+      expect(index.fragmentCount).toBe(1);
+      expect(await index.query(Float32Array.from([1, 0]), 5)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits.map((h) => h.target.id)).toEqual(['doc-b']);
+        }
+      );
+    });
+
+    test('removes only the scoped target — a same-stem record in another scope is left intact', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const a = target('conv-a', 'turn-3');
+      const b = target('conv-b', 'turn-3');
+      (await index.addFragments(a, [frag(0, 5, [1, 0])])).orThrow();
+      (await index.addFragments(b, [frag(0, 5, [0, 1])])).orThrow();
+      expect(await index.remove(a)).toSucceedWith(a);
+      expect(index.recordCount).toBe(1);
+      expect(await index.query(Float32Array.from([0, 1]), 5)).toSucceedAndSatisfy(
+        (hits: ReadonlyArray<IVectorQueryHit>) => {
+          expect(hits).toHaveLength(1);
+          expect(hits[0].target).toEqual(b);
+        }
+      );
+    });
+
+    test('is idempotent — removing an absent target still succeeds', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const t = target('knowledge', 'missing');
+      expect(await index.remove(t)).toSucceedWith(t);
+    });
+  });
+
+  describe('rebuild', () => {
+    // Deterministic: each record yields two fragments encoding the id's first char code.
+    const embed = (r: IMemoryRecord<unknown>): Promise<Result<ReadonlyArray<IEmbeddedFragment>>> => {
+      const code: number = (r.envelope.id as string).charCodeAt(0);
+      return Promise.resolve(succeed([frag(0, 5, [code, 1]), frag(5, 10, [1, code])]));
+    };
+
+    test('re-embeds every scoped record and reports the total fragment count', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const source = new FakeSource(succeed([scoped('knowledge', 'a'), scoped('knowledge', 'b')]));
+      expect(await index.rebuild(source, embed)).toSucceedWith(4);
+      expect(index.recordCount).toBe(2);
+      expect(index.fragmentCount).toBe(4);
+    });
+
+    test('keeps same-stem records under different scopes distinct across a rebuild', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const source = new FakeSource(succeed([scoped('conv-a', 'turn-3'), scoped('conv-b', 'turn-3')]));
+      expect(await index.rebuild(source, embed)).toSucceedWith(4);
+      expect(index.recordCount).toBe(2);
+    });
+
+    test('clears prior contents and re-establishes the dimension', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      (await index.addFragments(target('knowledge', 'old'), [frag(0, 5, [1, 2, 3])])).orThrow();
+      const source = new FakeSource(succeed([scoped('knowledge', 'a')]));
+      expect(await index.rebuild(source, embed)).toSucceedWith(2);
+      expect(index.recordCount).toBe(1);
+      expect(await index.query(Float32Array.from([97, 1]), 1)).toSucceed();
+    });
+
+    test('fails loudly when the source list fails and rolls back to empty', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      (await index.addFragments(target('knowledge', 'seed'), [frag(0, 5, [1, 1])])).orThrow();
+      const source = new FakeSource(fail('disk gone'));
+      expect(await index.rebuild(source, embed)).toFailWith(/failed to list records: disk gone/i);
+      expect(index.recordCount).toBe(0);
+    });
+
+    test('fails loudly and rolls back to empty when an embedding fails mid-rebuild', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      (await index.addFragments(target('knowledge', 'seed'), [frag(0, 5, [1, 1])])).orThrow();
+      let calls: number = 0;
+      const flakyEmbed = (): Promise<Result<ReadonlyArray<IEmbeddedFragment>>> => {
+        calls += 1;
+        return Promise.resolve(calls === 1 ? succeed([frag(0, 5, [1, 1])]) : fail('no model'));
+      };
+      const source = new FakeSource(succeed([scoped('conv-a', 'turn-1'), scoped('conv-b', 'turn-1')]));
+      expect(await index.rebuild(source, flakyEmbed)).toFailWith(
+        /embedding 'conv-b\0turn-1' failed: no model/i
+      );
+      expect(index.recordCount).toBe(0);
+    });
+
+    test('fails loudly and rolls back to empty when adding an embedded fragment fails', async () => {
+      const index = InMemoryFragmentCosineIndex.create().orThrow();
+      const source = new FakeSource(succeed([scoped('knowledge', 'a')]));
+      const emptyEmbed = (): Promise<Result<ReadonlyArray<IEmbeddedFragment>>> =>
+        Promise.resolve(succeed([frag(0, 5, [])]));
+      expect(await index.rebuild(source, emptyEmbed)).toFailWith(/empty fragment vector/i);
+      expect(index.recordCount).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds **`SqliteVecFragmentIndex`** to `@fgv/ts-agent-memory-sqlite-vec` — a persistent, `sqlite-vec`-backed implementation of the `IFragmentVectorIndex` seam. It is the **durable counterpart to `InMemoryFragmentCosineIndex`** and the fragment-granular sibling of the existing `SqliteVecVectorIndex` in the same package. This is the N-Ask5 **Q7** followup.

Type: **`minor`** (additive). Result-integration boundary package — consumer-owned connection lifecycle, ANN/large-N out of scope, same posture as the record index.

> **Stacked on #561.** This depends on the `IFragmentVectorIndex` interface added by #561 (fragment-granular retrieval in `@fgv/ts-agent-memory`), so it's based on that branch and will retarget to `release` automatically once #561 merges. Merge #561 first.

## What's added

- **`SqliteVecFragmentIndex`** (`src/packlets/sqlite-vec-index/sqliteVecFragmentIndex.ts`)
  - A `vec0` virtual table keyed on `target_key TEXT PARTITION KEY` (many rows per record share it), with the `[start, end)` locator offsets stored in `+start_off` / `+end_off` **auxiliary columns** (read back on query, never filtered; bound as `BigInt` because `vec0` typed columns reject JS floats).
  - `addFragments` is **whole-record-replace**: a single atomic delete-then-insert transaction, so a re-authored document never leaves stale fragments. The dimension is validated across the whole batch and committed (via table creation) only on a successful non-empty add — a mid-batch mismatch never poisons a fresh index (**all-or-nothing**, matching the in-memory index).
  - `remove` drops every fragment of a target; `query(vector, topK, maxPerRecord?)` applies the per-record cap **during selection, before the topK cut** (fetching the full ranked set when capped, `topK` otherwise).
  - Cosine scoring (`score = 1 − cosineDistance`) and reopen dimension recovery are **byte-identical to `InMemoryFragmentCosineIndex`**, so a persistent fragment index answers queries with **no re-embedding on open**.
- **`ISqliteVecFragmentIndexCreateParams`** (`model.ts`) — bring-your-own `better-sqlite3` `Database`; default table name `'memory_fragments'` (distinct from the record index's `'memory_vectors'`; both may share one file).
- README section + api-report + Rush change file.

## Testing

- `rushx build`, `rushx lint`, `rushx test` all pass; **100% coverage**, 50 tests.
- Coverage is intent-driven: per-target isolation across scopes, **reopen/durability with full locator round-trip** across two independent connections over a real file (incl. post-reopen dimension enforcement + incremental add), whole-record-replace correctness, all-or-nothing dimension establishment under a mixed-dimension batch, the full `maxPerRecord` matrix (0 / larger-than-record / crowding-prevention with score assertions / stops-at-topK-with-rows-remaining), and error paths (closed-DB for create/add/query/remove, bad table name, empty vector, dimension mismatch, **non-vec0 table-name collision fails loudly rather than corrupting**).

## Code review (layer 1)

Ran the internal `code-reviewer` on the final diff before opening:
- **P1:** none. No `any`; all fallible ops return `Result<T>`; SQL-injection surface closed (table name validated against `^[A-Za-z_][A-Za-z0-9_]*$` before any interpolation, and only the validated identifier is ever interpolated); the whole-record-replace transaction auto-rolls-back on a mid-batch throw; dimension establishment is provably all-or-nothing.
- **P2 (addressed):** replaced an invariant-based `dimension as number` cast with a direct, self-documenting read of `fragments[0].vector.length` (provably the established dimension in the non-empty branch) — no cast, no cross-file invariant read.
- **P3 (addressed):** added the non-vec0 table-name collision test (fails loudly, never corrupts). The remaining P3 (the `better-sqlite3` untyped-row `as { c: number }` shape assertions) is a pre-existing package convention shared verbatim with `SqliteVecVectorIndex` — dispositioned as out-of-scope to change unilaterally here; would warrant a shared `TECH_DEBT.md` note if the package ever tightens it.

Reviewer verdict: **Approved**, no blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_