### PR TITLE
Add sqlite-vec-fragment-persistence testbed scenario (N-Ask5)

### DIFF
--- a/samples/testbed/README.md
+++ b/samples/testbed/README.md
@@ -24,12 +24,59 @@ rushx build:web
 # launch the dev server
 rushx dev
 
-# run the CLI
+# list the available CLI scenarios (bare invocation)
 rushx cli
 
 # rebuild the generated data tree from data/
 rushx build:data
 ```
+
+## Running scenarios
+
+A scenario can expose a **web** surface (a React component in the browser app), a **CLI**
+surface (a `run` function), or both. Run them two ways:
+
+### CLI
+
+The CLI shim is `bin/testbed.js` (also wired as `rushx cli`). Build first (`rushx build`),
+then:
+
+```bash
+# list every scenario with its id and which surfaces it has
+node bin/testbed.js
+node bin/testbed.js --help          # usage banner
+
+# run a single scenario by id
+node bin/testbed.js --scenario sqlite-vec-fragment-persistence
+node bin/testbed.js --scenario sqlite-vec-memory-persistence
+```
+
+`rushx cli` runs the same shim (`rushx cli` to list; `rushx cli -- --scenario <id>` to pass
+flags through). Structured output goes to stdout; scenario diagnostics go to stderr.
+
+### Web
+
+```bash
+rushx dev            # webpack dev server — pick scenarios from the sidebar
+rushx build:web      # production bundle into dist-web/
+```
+
+Only scenarios with a web surface appear in the sidebar.
+
+### Two things to know
+
+- **Some scenarios are CLI-only.** Any scenario that uses a Node-native dependency —
+  `better-sqlite3` (the `sqlite-vec-*` scenarios) or the local ONNX runtime (the `local-*`
+  scenarios) — loads it via a `webpackIgnore` dynamic import so it never enters the browser
+  bundle. Those scenarios therefore have **no web surface** and run only under
+  `--scenario <id>`.
+- **Live-model scenarios need network.** Scenarios that embed/classify/summarize with a local
+  `@huggingface/transformers` model (`Xenova/*`) download the model from `huggingface.co` on
+  first run and cache it. In a network-restricted environment that fetch is blocked and the
+  scenario fails at model load (`Forbidden access to huggingface.co`); run them where
+  `huggingface.co` is reachable. The **unit tests** stub the model with a deterministic
+  embedder, so `rushx test` covers the real logic (including the actual file-backed
+  `sqlite-vec` round-trip) fully offline.
 
 ## Adding a scenario
 
@@ -60,10 +107,14 @@ bin/
 
 ## Scenarios
 
-| id | Title | Surfaces |
-|----|-------|---------|
-| `local-classifier-safety` | Local Classifier Safety | web, cli |
-| `local-embedding-search` | Local Embedding Search | web, cli |
+The scenario registry grows over time, so rather than duplicate it here (and let it drift),
+list the current set — with ids and which surfaces each exposes — straight from the CLI:
+
+```bash
+node bin/testbed.js        # or: rushx cli
+```
+
+The registry itself is [`src/scenarios/index.ts`](./src/scenarios/index.ts).
 
 ## Cluster context
 

--- a/samples/testbed/config/jest.config.json
+++ b/samples/testbed/config/jest.config.json
@@ -15,7 +15,8 @@
     "<rootDir>/lib/generated/",
     "<rootDir>/lib/scenarios/[a-zA-Z]+ClientTools/",
     "<rootDir>/lib/scenarios/memoryToolsGate/",
-    "<rootDir>/lib/scenarios/sqliteVecMemoryPersistence/index.js"
+    "<rootDir>/lib/scenarios/sqliteVecMemoryPersistence/index.js",
+    "<rootDir>/lib/scenarios/sqliteVecFragmentPersistence/index.js"
   ],
   "collectCoverage": true,
   "coverageReporters": ["text", "lcov", "html"],

--- a/samples/testbed/src/scenarios/index.ts
+++ b/samples/testbed/src/scenarios/index.ts
@@ -19,6 +19,7 @@ import { localEmbeddingSearchScenario } from './localEmbeddingSearch';
 import { localSummarizationScenario } from './localSummarization';
 import { mcpProbeScenario } from './mcpProbe';
 import { sqliteVecMemoryPersistenceScenario } from './sqliteVecMemoryPersistence';
+import { sqliteVecFragmentPersistenceScenario } from './sqliteVecFragmentPersistence';
 import { memoryToolsGateScenario } from './memoryToolsGate';
 import {
   anthropicModelTiersScenario,
@@ -45,6 +46,7 @@ export const scenarios: readonly IScenario[] = [
   memoryToolsGateScenario,
   crossProviderEmbeddingSearchScenario,
   sqliteVecMemoryPersistenceScenario,
+  sqliteVecFragmentPersistenceScenario,
   openaiModelTiersScenario,
   anthropicModelTiersScenario,
   geminiModelTiersScenario

--- a/samples/testbed/src/scenarios/sqliteVecFragmentPersistence/fragmentPersistenceDemo.ts
+++ b/samples/testbed/src/scenarios/sqliteVecFragmentPersistence/fragmentPersistenceDemo.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Result, fail, mapResults, succeed } from '@fgv/ts-utils';
+import type {
+  IEdgeTarget,
+  IEmbeddedFragment,
+  IFragmentVectorIndex,
+  IVectorQueryHit,
+  MemoryId,
+  MemoryScopeKey
+} from '@fgv/ts-agent-memory';
+
+/**
+ * Embeds a single text (a query, or one document fragment) into a vector. Injected so
+ * the demo core is testable with a deterministic embedder (no model download) and the
+ * CLI can supply a real local `@fgv/ts-extras-transformers` pipeline.
+ * @public
+ */
+export type DemoEmbedFn = (text: string) => Promise<Result<Float32Array>>;
+
+/** A persistent fragment index opened at a path, plus a close handle for its connection. */
+export interface IOpenedFragmentIndex {
+  readonly index: IFragmentVectorIndex;
+  readonly close: () => void;
+}
+
+/**
+ * Opens a persistent {@link IFragmentVectorIndex} backed by a file at `dbPath`. Injected
+ * so the demo core does not import `better-sqlite3` / `@fgv/ts-agent-memory-sqlite-vec`
+ * directly (keeping them out of the browser bundle) — the CLI supplies the real opener.
+ * @public
+ */
+export type OpenFragmentIndexFn = (dbPath: string) => Promise<Result<IOpenedFragmentIndex>>;
+
+/** One document in the demo corpus. */
+export interface IDemoDoc {
+  readonly id: string;
+  readonly text: string;
+}
+
+/** One ranked per-fragment hit: the record id plus the matched `[start, end)` span and score. */
+export interface IDemoFragmentHit {
+  readonly id: string;
+  readonly start: number;
+  readonly end: number;
+  readonly score: number;
+}
+
+/** The result of the fragment persistence demo — session-2 hits should match session-1 with no re-embedding. */
+export interface IFragmentPersistenceDemoResult {
+  readonly corpusSize: number;
+  /** Total fragments embedded and stored across the whole corpus. */
+  readonly fragmentCount: number;
+  readonly dimension: number;
+  /** Fragment hits from the freshly-embedded index. */
+  readonly session1: ReadonlyArray<IDemoFragmentHit>;
+  /** Fragment hits after closing and reopening the same file — produced with NO re-embedding. */
+  readonly session2: ReadonlyArray<IDemoFragmentHit>;
+  /** `true` when session-2 ordering (id + span) matches session-1 (persistence verified). */
+  readonly persistedAcrossReopen: boolean;
+}
+
+/** The scope every demo record lives under. */
+const DEMO_SCOPE: string = 'knowledge';
+
+function targetFor(id: string): IEdgeTarget {
+  return { scope: DEMO_SCOPE as unknown as MemoryScopeKey, id: id as unknown as MemoryId };
+}
+
+/** One sentence-shaped span of a document, with its `[start, end)` character offsets. */
+interface IFragmentSpan {
+  readonly text: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+/** A corpus document paired with its embedded fragments, shared across both demo sessions. */
+interface IEmbeddedDoc {
+  readonly id: string;
+  readonly fragments: ReadonlyArray<IEmbeddedFragment>;
+}
+
+/**
+ * Split a document into sentence-shaped fragments, each carrying its true `[start, end)`
+ * character offsets into the original body — the locators the consumer's own read side
+ * uses. Deterministic and dependency-free; the chunking policy is the demo's, not the
+ * index's (the index stores whatever spans it is given).
+ */
+function chunk(text: string): ReadonlyArray<IFragmentSpan> {
+  const spans: IFragmentSpan[] = [];
+  const re: RegExp = /[^.!?]+[.!?]*/g;
+  let m: RegExpExecArray | null = re.exec(text);
+  while (m !== null) {
+    const raw: string = m[0];
+    const leading: number = raw.length - raw.trimStart().length;
+    const trimmed: string = raw.trim();
+    if (trimmed.length > 0) {
+      const start: number = m.index + leading;
+      spans.push({ text: trimmed, start, end: start + trimmed.length });
+    }
+    m = re.exec(text);
+  }
+  return spans;
+}
+
+/** Convert a raw fragment hit to a demo hit, failing loudly if the index omitted the locator. */
+function toDemoHit(hit: IVectorQueryHit): Result<IDemoFragmentHit> {
+  if (hit.locator === undefined) {
+    return fail(`fragment hit for '${hit.target.id as unknown as string}' is missing its locator`);
+  }
+  return succeed({
+    id: hit.target.id as unknown as string,
+    start: hit.locator.start,
+    end: hit.locator.end,
+    score: hit.score
+  });
+}
+
+async function queryFragmentHits(
+  index: IFragmentVectorIndex,
+  queryVector: Float32Array,
+  topK: number,
+  maxPerRecord: number | undefined
+): Promise<Result<ReadonlyArray<IDemoFragmentHit>>> {
+  return (await index.query(queryVector, topK, maxPerRecord)).onSuccess((hits) =>
+    mapResults(hits.map(toDemoHit))
+  );
+}
+
+/**
+ * Demonstrates the persistence guarantee of `@fgv/ts-agent-memory-sqlite-vec`'s
+ * fragment index: each document is chunked into sentence spans, every span is embedded
+ * into a **file-backed** `SqliteVecFragmentIndex`, and a fragment query returns per-span
+ * hits. Then the connection is **closed and the same file reopened** — the second session
+ * queries with no re-embedding and returns the same per-fragment ranking (record id AND
+ * matched span). The embedder and index-opener are injected so the core is fully testable
+ * offline.
+ *
+ * @param params - corpus, query, topK, optional per-record cap, the on-disk `dbPath`, and the injected `embed` / `openIndex`.
+ * @returns `Success` with both sessions' results (and whether they match), or `Failure` with context.
+ * @public
+ */
+export async function runFragmentPersistenceDemo(params: {
+  readonly corpus: ReadonlyArray<IDemoDoc>;
+  readonly query: string;
+  readonly topK: number;
+  readonly maxPerRecord?: number;
+  readonly dbPath: string;
+  readonly embed: DemoEmbedFn;
+  readonly openIndex: OpenFragmentIndexFn;
+}): Promise<Result<IFragmentPersistenceDemoResult>> {
+  const { corpus, query, topK, maxPerRecord, dbPath, embed, openIndex } = params;
+
+  // Embed the query once; the same vector drives both sessions so a match proves persistence.
+  const queryEmbed = await embed(query);
+  if (queryEmbed.isFailure()) {
+    return fail(`embed query: ${queryEmbed.message}`);
+  }
+  const queryVector: Float32Array = queryEmbed.value;
+
+  // Chunk + embed every document's fragments up front (shared across both sessions).
+  const embeddedByDoc: IEmbeddedDoc[] = [];
+  let fragmentCount: number = 0;
+  for (const doc of corpus) {
+    const fragments: IEmbeddedFragment[] = [];
+    for (const span of chunk(doc.text)) {
+      const embedded = await embed(span.text);
+      if (embedded.isFailure()) {
+        return fail(`embed fragment of '${doc.id}': ${embedded.message}`);
+      }
+      fragments.push({ locator: { start: span.start, end: span.end }, vector: embedded.value });
+    }
+    fragmentCount += fragments.length;
+    embeddedByDoc.push({ id: doc.id, fragments });
+  }
+
+  // Session 1: open a fresh persistent fragment index, add every document's fragments, query.
+  const opened1 = await openIndex(dbPath);
+  if (opened1.isFailure()) {
+    return fail(`open index (session 1): ${opened1.message}`);
+  }
+  let session1: ReadonlyArray<IDemoFragmentHit>;
+  try {
+    for (const doc of embeddedByDoc) {
+      const added = await opened1.value.index.addFragments(targetFor(doc.id), doc.fragments);
+      if (added.isFailure()) {
+        return fail(`add fragments for '${doc.id}': ${added.message}`);
+      }
+    }
+    const queried = await queryFragmentHits(opened1.value.index, queryVector, topK, maxPerRecord);
+    if (queried.isFailure()) {
+      return fail(`query (session 1): ${queried.message}`);
+    }
+    session1 = queried.value;
+  } finally {
+    opened1.value.close();
+  }
+
+  // Session 2: reopen the SAME file — no embedding, no add, just query. This is the guarantee.
+  const opened2 = await openIndex(dbPath);
+  if (opened2.isFailure()) {
+    return fail(`reopen index (session 2): ${opened2.message}`);
+  }
+  let session2: ReadonlyArray<IDemoFragmentHit>;
+  try {
+    const queried = await queryFragmentHits(opened2.value.index, queryVector, topK, maxPerRecord);
+    if (queried.isFailure()) {
+      return fail(`query (session 2): ${queried.message}`);
+    }
+    session2 = queried.value;
+  } finally {
+    opened2.value.close();
+  }
+
+  // Compare id + span order across the two sessions — persistence means an identical ranking.
+  const order = (hits: ReadonlyArray<IDemoFragmentHit>): string =>
+    hits.map((h) => `${h.id}:${h.start}-${h.end}`).join(',');
+  return succeed({
+    corpusSize: corpus.length,
+    fragmentCount,
+    dimension: queryVector.length,
+    session1,
+    session2,
+    persistedAcrossReopen: order(session1) === order(session2)
+  });
+}

--- a/samples/testbed/src/scenarios/sqliteVecFragmentPersistence/index.ts
+++ b/samples/testbed/src/scenarios/sqliteVecFragmentPersistence/index.ts
@@ -83,6 +83,12 @@ const cliImpl: ICliScenarioImpl = {
       }
       // A [1, D] pooled Tensor: row 0 of tolist() is the sentence vector.
       const nested = tensor.value.tolist() as number[][];
+      // Defensive: a valid pooled Tensor always yields a non-empty nested array, but
+      // keep `embed` fully Result-based rather than letting an unexpected shape throw
+      // (mirrors the guard in localEmbeddingSearch/embedAdapter.ts).
+      if (nested.length === 0 || nested[0] === undefined) {
+        return fail('embedding produced an empty tensor (no row 0)');
+      }
       return succeed(Float32Array.from(nested[0]));
     };
 

--- a/samples/testbed/src/scenarios/sqliteVecFragmentPersistence/index.ts
+++ b/samples/testbed/src/scenarios/sqliteVecFragmentPersistence/index.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * `sqliteVecFragmentPersistence` scenario (CLI-only).
+ *
+ * Demonstrates the fragment-granular side of `@fgv/ts-agent-memory-sqlite-vec`: each corpus
+ * document is chunked into sentence spans, every span is embedded with a local
+ * `Xenova/all-MiniLM-L6-v2` pipeline into a **file-backed** `SqliteVecFragmentIndex`, and a
+ * fragment query returns per-span hits (record id AND the matched `[start, end)` locator).
+ * The connection is then closed and the SAME file reopened — the second query runs with no
+ * re-embedding and returns the identical per-fragment ranking, proving the persistence
+ * guarantee for the fragment index (the durable counterpart to `InMemoryFragmentCosineIndex`).
+ *
+ * CLI-only: `better-sqlite3` is a Node-native module, so it is loaded (with the embedder and
+ * the index package) via `webpackIgnore` dynamic imports that never enter the browser bundle.
+ * The persistence logic lives in the fully-testable `fragmentPersistenceDemo` module; this
+ * file is the thin live-model wrapper.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import type { IScenario, IScenarioContext, ICliScenarioImpl } from '../../shell';
+import {
+  DemoEmbedFn,
+  IDemoDoc,
+  OpenFragmentIndexFn,
+  runFragmentPersistenceDemo
+} from './fragmentPersistenceDemo';
+
+const MODEL_ID: string = 'Xenova/all-MiniLM-L6-v2';
+
+// Multi-sentence docs so each fragment is a distinct span — a fragment query can match a
+// specific sentence inside a document, not just the document as a whole.
+const CORPUS: ReadonlyArray<IDemoDoc> = [
+  {
+    id: 'cats',
+    text: 'Domestic cats are small carnivorous mammals. They are often kept as pets and sleep most of the day.'
+  },
+  {
+    id: 'databases',
+    text: 'SQLite is an embedded relational database stored in a single file. It requires no separate server process.'
+  },
+  {
+    id: 'embeddings',
+    text: 'A vector embedding maps text to a point in high-dimensional space. Nearby points represent similar meanings.'
+  },
+  {
+    id: 'coffee',
+    text: 'Espresso is a concentrated coffee brewed under pressure. It forms the base of many other drinks.'
+  }
+];
+
+const QUERY: string = 'storing vectors in an on-disk database file';
+
+const cliImpl: ICliScenarioImpl = {
+  async run(context: IScenarioContext): Promise<Result<string>> {
+    context.logger.info(`Loading model ${MODEL_ID} for the sqlite-vec fragment persistence demo…`);
+
+    // Load Node-only facades lazily; the `webpackIgnore` comments keep native deps
+    // (ONNX runtime, better-sqlite3) out of any browser bundle.
+    const transformers = await import(/* webpackIgnore: true */ '@fgv/ts-extras-transformers');
+    const sqliteVec = await import(/* webpackIgnore: true */ '@fgv/ts-agent-memory-sqlite-vec');
+    const betterSqlite = await import(/* webpackIgnore: true */ 'better-sqlite3');
+    const Database = betterSqlite.default;
+
+    const pipeline = await transformers.loadPipeline('feature-extraction', MODEL_ID);
+    if (pipeline.isFailure()) {
+      return fail(pipeline.message);
+    }
+
+    const embed: DemoEmbedFn = async (text: string): Promise<Result<Float32Array>> => {
+      const tensor = await transformers.embed(pipeline.value, text, {
+        pooling: 'mean',
+        normalize: true
+      });
+      if (tensor.isFailure()) {
+        return fail(tensor.message);
+      }
+      // A [1, D] pooled Tensor: row 0 of tolist() is the sentence vector.
+      const nested = tensor.value.tolist() as number[][];
+      return succeed(Float32Array.from(nested[0]));
+    };
+
+    const openIndex: OpenFragmentIndexFn = async (dbPath: string) => {
+      const db = new Database(dbPath);
+      const created = await sqliteVec.SqliteVecFragmentIndex.create({ database: db });
+      if (created.isFailure()) {
+        db.close();
+        return fail(created.message);
+      }
+      return succeed({
+        index: created.value,
+        close: (): void => {
+          db.close();
+        }
+      });
+    };
+
+    const dir: string = fs.mkdtempSync(path.join(os.tmpdir(), 'svfrag-'));
+    const dbPath: string = path.join(dir, 'fragments.db');
+    try {
+      const result = await runFragmentPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 4,
+        // Cap each document to one fragment so a single long doc cannot fill the result.
+        maxPerRecord: 1,
+        dbPath,
+        embed,
+        openIndex
+      });
+      if (result.isFailure()) {
+        return fail(result.message);
+      }
+      const r = result.value;
+      const docText = (id: string): string => CORPUS.find((d) => d.id === id)?.text ?? '';
+      const fmt = (hits: ReadonlyArray<{ id: string; start: number; end: number; score: number }>): string =>
+        hits
+          .map(
+            (h, i) =>
+              `  ${i + 1}. [${h.score.toFixed(4)}] ${h.id} [${h.start},${h.end}) "${docText(h.id).slice(
+                h.start,
+                h.end
+              )}"`
+          )
+          .join('\n');
+      return succeed(
+        `sqlite-vec persistent FRAGMENT memory demo\n` +
+          `Embedded ${r.fragmentCount} fragments from ${r.corpusSize} docs (dim ${r.dimension}) into a SQLite file.\n` +
+          `Query: "${QUERY}" (topK 4, maxPerRecord 1)\n` +
+          `Session 1 (freshly embedded):\n${fmt(r.session1)}\n` +
+          `Session 2 (reopened file, NO re-embedding):\n${fmt(r.session2)}\n` +
+          `Persistence: ${
+            r.persistedAcrossReopen ? 'VERIFIED — identical fragment ranking across reopen' : 'MISMATCH'
+          }`
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+};
+
+/**
+ * `sqliteVecFragmentPersistence` scenario: local per-fragment embeddings persisted in a
+ * `sqlite-vec` file-backed `IFragmentVectorIndex`, proving no re-embedding is needed on
+ * reopen and that each hit round-trips its `[start, end)` locator. CLI-only.
+ * @public
+ */
+export const sqliteVecFragmentPersistenceScenario: IScenario = {
+  id: 'sqlite-vec-fragment-persistence',
+  title: 'SQLite-vec Persistent Fragment Memory',
+  description:
+    'Chunks a small corpus into sentence spans, embeds each span with a local ' +
+    '`Xenova/all-MiniLM-L6-v2` pipeline into a file-backed `@fgv/ts-agent-memory-sqlite-vec` ' +
+    'fragment index, then closes and reopens the file to show the per-fragment vectors persist — ' +
+    'the second query returns the same ranking (record id + span) with no re-embedding. CLI-only.',
+  category: 'ai',
+  tags: ['agent-memory', 'embeddings', 'sqlite-vec', 'fragments', 'persistence', 'local-ai'],
+  cli: cliImpl
+};
+
+// Re-export the testable core.
+export { runFragmentPersistenceDemo };
+export type {
+  DemoEmbedFn,
+  IDemoDoc,
+  IDemoFragmentHit,
+  IFragmentPersistenceDemoResult,
+  IOpenedFragmentIndex,
+  OpenFragmentIndexFn
+} from './fragmentPersistenceDemo';

--- a/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
+++ b/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
@@ -14,6 +14,7 @@ Array [
   "memory-tools-gate",
   "cross-provider-embedding-search",
   "sqlite-vec-memory-persistence",
+  "sqlite-vec-fragment-persistence",
   "openai-model-tiers",
   "anthropic-model-tiers",
   "google-gemini-model-tiers",

--- a/samples/testbed/src/test/unit/scenarios/sqliteVecFragmentPersistence.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/sqliteVecFragmentPersistence.test.ts
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2026 Erik Fortune
+ * SPDX-License-Identifier: MIT
+ */
+
+import '@fgv/ts-utils-jest';
+
+import BetterSqlite3 from 'better-sqlite3';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Result, fail, succeed } from '@fgv/ts-utils';
+import type {
+  IEdgeTarget,
+  IEmbeddedFragment,
+  IFragmentVectorIndex,
+  IVectorQueryHit,
+  MemoryId,
+  MemoryScopeKey
+} from '@fgv/ts-agent-memory';
+import { SqliteVecFragmentIndex } from '@fgv/ts-agent-memory-sqlite-vec';
+import {
+  DemoEmbedFn,
+  IDemoDoc,
+  IOpenedFragmentIndex,
+  OpenFragmentIndexFn,
+  runFragmentPersistenceDemo
+} from '../../../scenarios/sqliteVecFragmentPersistence';
+
+const CORPUS: ReadonlyArray<IDemoDoc> = [
+  { id: 'alpha', text: 'the quick brown fox. it jumps over the lazy dog.' },
+  // Trailing space after the final period yields a whitespace-only span the chunker drops.
+  { id: 'beta', text: 'databases store rows and columns. ' },
+  { id: 'gamma', text: 'vectors map text to points in space.' }
+];
+const QUERY: string = 'rows stored in a database';
+const DIM: number = 8;
+
+/** A deterministic embedder — distinct, stable vector per text; no model download. */
+const deterministicEmbed: DemoEmbedFn = async (text: string): Promise<Result<Float32Array>> => {
+  const v = new Float32Array(DIM);
+  for (let i = 0; i < text.length; i++) {
+    v[i % DIM] += text.charCodeAt(i) / 100;
+  }
+  return succeed(v);
+};
+
+/** A real file-backed opener over better-sqlite3 + SqliteVecFragmentIndex. */
+const realOpenIndex: OpenFragmentIndexFn = async (dbPath: string): Promise<Result<IOpenedFragmentIndex>> => {
+  const db = new BetterSqlite3(dbPath);
+  const created = await SqliteVecFragmentIndex.create({ database: db });
+  if (created.isFailure()) {
+    db.close();
+    return fail(created.message);
+  }
+  return succeed({
+    index: created.value,
+    close: (): void => {
+      db.close();
+    }
+  });
+};
+
+function target(id: string): IEdgeTarget {
+  return { scope: 'knowledge' as unknown as MemoryScopeKey, id: id as unknown as MemoryId };
+}
+function hit(id: string, start: number, end: number, score: number): IVectorQueryHit {
+  return { target: target(id), score, locator: { start, end } };
+}
+
+/** A fully-fake fragment index for exercising failure branches. */
+function fakeIndex(overrides: Partial<IFragmentVectorIndex>): IFragmentVectorIndex {
+  return {
+    addFragments:
+      overrides.addFragments ??
+      (async (__t: IEdgeTarget, f: ReadonlyArray<IEmbeddedFragment>): Promise<Result<number>> =>
+        succeed(f.length)),
+    remove: overrides.remove ?? (async (t: IEdgeTarget): Promise<Result<IEdgeTarget>> => succeed(t)),
+    query: overrides.query ?? (async (): Promise<Result<ReadonlyArray<IVectorQueryHit>>> => succeed([]))
+  };
+}
+
+function fakeOpener(index: IFragmentVectorIndex): OpenFragmentIndexFn {
+  return async (): Promise<Result<IOpenedFragmentIndex>> => succeed({ index, close: (): void => undefined });
+}
+
+describe('sqliteVecFragmentPersistence — runFragmentPersistenceDemo', () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'svfrag-test-'));
+    dbPath = path.join(dir, 'fragments.db');
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('chunks + embeds fragments, persists them, and reopening yields the identical per-span ranking (no re-embed)', async () => {
+    expect(
+      await runFragmentPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 5,
+        maxPerRecord: 1,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex: realOpenIndex
+      })
+    ).toSucceedAndSatisfy((result) => {
+      expect(result.corpusSize).toBe(3);
+      // alpha → 2 spans, beta → 1 (trailing-space span dropped), gamma → 1 = 4 fragments.
+      expect(result.fragmentCount).toBe(4);
+      expect(result.dimension).toBe(DIM);
+      // The reopened session queried the same file with no embedding — identical ranking.
+      expect(result.session2).toEqual(result.session1);
+      expect(result.persistedAcrossReopen).toBe(true);
+      // Each hit carries a real span, and maxPerRecord=1 means no id repeats.
+      const ids = result.session1.map((h) => h.id);
+      expect(new Set(ids).size).toBe(ids.length);
+      for (const h of result.session1) {
+        expect(h.end).toBeGreaterThan(h.start);
+      }
+      // Scores are descending.
+      for (let i = 1; i < result.session1.length; i++) {
+        expect(result.session1[i - 1].score).toBeGreaterThanOrEqual(result.session1[i].score);
+      }
+    });
+  });
+
+  test('fails with context when the query cannot be embedded', async () => {
+    const embed: DemoEmbedFn = async (text) =>
+      text === QUERY ? fail('boom') : succeed(new Float32Array(DIM));
+    expect(
+      await runFragmentPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 5,
+        dbPath,
+        embed,
+        openIndex: realOpenIndex
+      })
+    ).toFailWith(/embed query: boom/);
+  });
+
+  test('fails with context when a document fragment cannot be embedded', async () => {
+    const embed: DemoEmbedFn = async (text) =>
+      text === 'the quick brown fox.' ? fail('bad fragment') : succeed(new Float32Array(DIM).fill(1));
+    expect(
+      await runFragmentPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 5,
+        dbPath,
+        embed,
+        openIndex: realOpenIndex
+      })
+    ).toFailWith(/embed fragment of 'alpha': bad fragment/);
+  });
+
+  test('fails when the index cannot be opened for session 1', async () => {
+    const openIndex: OpenFragmentIndexFn = async () => fail('disk error');
+    expect(
+      await runFragmentPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 5,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toFailWith(/open index \(session 1\): disk error/);
+  });
+
+  test('fails with context when addFragments fails', async () => {
+    const openIndex = fakeOpener(fakeIndex({ addFragments: async () => fail('add boom') }));
+    expect(
+      await runFragmentPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 5,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toFailWith(/add fragments for 'alpha': add boom/);
+  });
+
+  test('fails when the session-1 query fails', async () => {
+    const openIndex = fakeOpener(fakeIndex({ query: async () => fail('query boom') }));
+    expect(
+      await runFragmentPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 5,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toFailWith(/query \(session 1\): query boom/);
+  });
+
+  test('fails loudly when a fragment hit is missing its locator', async () => {
+    // A malformed hit with no locator must surface as a failure, not a wrong span.
+    const locatorless: IVectorQueryHit = { target: target('alpha'), score: 0.9 };
+    const openIndex = fakeOpener(fakeIndex({ query: async () => succeed([locatorless]) }));
+    expect(
+      await runFragmentPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 5,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toFailWith(/query \(session 1\): fragment hit for 'alpha' is missing its locator/);
+  });
+
+  test('fails when the index cannot be reopened for session 2', async () => {
+    let call = 0;
+    const openIndex: OpenFragmentIndexFn = async () => {
+      call += 1;
+      return call === 1
+        ? succeed({ index: fakeIndex({}), close: (): void => undefined })
+        : fail('reopen error');
+    };
+    expect(
+      await runFragmentPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 5,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toFailWith(/reopen index \(session 2\): reopen error/);
+  });
+
+  test('fails when the session-2 query fails', async () => {
+    let call = 0;
+    const openIndex: OpenFragmentIndexFn = async () => {
+      call += 1;
+      const index = call === 1 ? fakeIndex({}) : fakeIndex({ query: async () => fail('s2 query boom') });
+      return succeed({ index, close: (): void => undefined });
+    };
+    expect(
+      await runFragmentPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 5,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toFailWith(/query \(session 2\): s2 query boom/);
+  });
+
+  test('reports persistedAcrossReopen=false when the two sessions rank differently', async () => {
+    let call = 0;
+    const openIndex: OpenFragmentIndexFn = async () => {
+      call += 1;
+      const hits =
+        call === 1
+          ? [hit('alpha', 0, 20, 0.9), hit('gamma', 0, 36, 0.5)]
+          : [hit('gamma', 0, 36, 0.9), hit('alpha', 0, 20, 0.5)];
+      return succeed({
+        index: fakeIndex({ query: async () => succeed(hits) }),
+        close: (): void => undefined
+      });
+    };
+    expect(
+      await runFragmentPersistenceDemo({
+        corpus: CORPUS,
+        query: QUERY,
+        topK: 5,
+        dbPath,
+        embed: deterministicEmbed,
+        openIndex
+      })
+    ).toSucceedAndSatisfy((result) => {
+      expect(result.persistedAcrossReopen).toBe(false);
+      expect(result.session1.map((h) => h.id)).toEqual(['alpha', 'gamma']);
+      expect(result.session2.map((h) => h.id)).toEqual(['gamma', 'alpha']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a testbed scenario **`sqlite-vec-fragment-persistence`** to `samples/testbed`, giving the fragment-granular path the same live-durability demo the record path already has (`sqlite-vec-memory-persistence`). This completes the N-Ask5 tranche: the persistent fragment index (`SqliteVecFragmentIndex`, merged in #562) now has an end-to-end scenario proving its reopen-with-no-re-embed guarantee.

Package: `@fgv/testbed` (`shouldPublish: false` — no Rush change file needed).

## What it does

Chunks each corpus document into sentence spans (with true `[start, end)` character offsets), embeds every span with a local `Xenova/all-MiniLM-L6-v2` pipeline into a **file-backed** `SqliteVecFragmentIndex`, and runs a fragment query returning per-span hits (record id **and** matched locator). It then **closes the connection and reopens the same file** — the second query runs with no re-embedding and returns the identical per-fragment ranking, proving persistence. Uses `topK 4, maxPerRecord 1` so the demo also shows the per-record cap keeping one document from filling the result.

## Structure (mirrors the sibling scenario)

- **`fragmentPersistenceDemo.ts`** — the fully-testable core. Injected `DemoEmbedFn` + `OpenFragmentIndexFn` (no native deps, no model download in tests). Chunks → embeds → `addFragments` → `query` → close → reopen → `query` → compares id+span ordering across sessions. A `toDemoHit` guard fails loudly if the index ever returns a hit without a locator (`mapResults`-aggregated).
- **`index.ts`** — the CLI-only live-model wrapper. Native deps (`@fgv/ts-extras-transformers`, `@fgv/ts-agent-memory-sqlite-vec`, `better-sqlite3`) load via `webpackIgnore` dynamic imports so they never enter the browser bundle. Excluded from coverage like the sibling's wrapper (jest config).
- Registry (`scenarios/index.ts`), snapshot, and `config/jest.config.json` coverage-ignore updated.

## Testing

- `rushx build`, `rushx lint`, `rushx test` pass; **100% coverage** on the demo core, 254 tests.
- The unit test drives a **real file-backed `SqliteVecFragmentIndex` close/reopen round-trip** (not mocked) plus every failure branch (embed-query, embed-fragment, open/reopen, addFragments, both queries, and the fragment-specific missing-locator guard), and asserts chunker correctness (`fragmentCount === 4`, with the trailing-space span on one doc correctly dropped), unique-id-per-record under `maxPerRecord: 1`, positive span widths, and descending scores.
- **Live-run verification:** ran `node bin/testbed.js --scenario sqlite-vec-fragment-persistence` — the CLI wrapper dispatched, loaded all three native modules via `webpackIgnore` with no import error, and invoked `loadPipeline`; it stops only at the HuggingFace model fetch, which this sandbox's network policy blocks (the sibling scenario hits the identical wall). So the wrapper glue is verified up to the external-model boundary, and the persistence logic itself is proven by the green unit test.

## Code review (layer 1)

Ran the internal `code-reviewer` on the diff: **Approved**, no P1/P2. It independently re-derived `chunk()`'s offset math against every corpus doc (`text.slice(start, end) === trimmed` for all spans, including the empty-trimmed-span drop), confirmed the `locator?` optionality makes the `toDemoHit` guard a real check, and noted the `mapResults` aggregation as an improvement over the sibling. One P3 applied (named the inline `IEmbeddedDoc` type); the other P3 (a zero-fragment-doc test) was skipped as it exercises no distinct branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch)_