### PR TITLE
Orchestrator reflection: N-Ask5 cycle handoff + codify L39, park L38/L40

### DIFF
--- a/.ai/instructions/CODE_REVIEW_CHECKLIST.md
+++ b/.ai/instructions/CODE_REVIEW_CHECKLIST.md
@@ -172,6 +172,18 @@ Note these for improvement but don't block on them.
 - [ ] **Consistent naming with rest of codebase**
 - [ ] **Appropriate comments (not excessive, not missing)**
 
+### Documentation / TSDoc
+
+- [ ] **Only `{@link}` symbols this package itself exports.** A `{@link OtherPkgSymbol}` to a type/function exported by *another* `@fgv/*` package bakes an `ae-unresolved-link` warning verbatim into the checked-in `etc/*.api.md` — a stale-api.md / CI-diff liability, not just cosmetic. Use a plain code span (`` `IFragmentVectorIndex` ``) for cross-package symbols instead.
+  ```typescript
+  // ❌ REJECT — cross-package {@link} bakes an ae-unresolved-link warning into api.md
+  /** A persistent {@link IFragmentVectorIndex} for @fgv/ts-agent-memory. */
+
+  // ✅ PREFER — code span for a symbol another package owns
+  /** A persistent `IFragmentVectorIndex` (from `@fgv/ts-agent-memory`). */
+  ```
+  The one sanctioned cross-package reference is `{@inheritDoc OtherPkg.Symbol.method}` on a method that *implements* another package's interface — it is load-bearing for inheriting the interface's doc text and every Result-integration-boundary package relies on it (accept its `ae-unresolved-inheritdoc-reference` warning; it is sibling-consistent). Recurred across #558 and #562 before being codified.
+
 ### Testing Considerations
 
 - [ ] **New code has corresponding tests**

--- a/.ai/notes/orchestrator/handoff-agent-memory-fragment-cycle-2026-07.md
+++ b/.ai/notes/orchestrator/handoff-agent-memory-fragment-cycle-2026-07.md
@@ -1,0 +1,84 @@
+# Handoff: `@fgv/ts-agent-memory` fragment-retrieval cycle (N-Ask5) — clean close
+
+**Date:** 2026-07-20. **State:** clean — nothing in flight, all four PRs merged to `release`.
+This documents a *completed* cycle plus the horizon items that were surfaced but never
+formally requested, so a successor can pick up cold.
+
+## What shipped (all merged to `release`)
+
+The full **N-Ask5 fragment-granular semantic retrieval** feature, across four PRs:
+
+| PR | Package | Content |
+|----|---------|---------|
+| #561 | `@fgv/ts-agent-memory` | `IFragmentLocator` / `IEmbeddedFragment` / `IFragmentVectorIndex` (sibling of `IVectorIndex`, **not** `extends`), additive `IVectorQueryHit.locator?`, `FragmentEmbedder`, `InMemoryFragmentCosineIndex`, `FragmentSemanticRetriever` (per-fragment hits, **not** an `IMemoryRetriever`), store `fragmentIndex?`/`fragmentEmbedder?` best-effort embed-on-write + remove lifecycle |
+| #562 | `@fgv/ts-agent-memory-sqlite-vec` | `SqliteVecFragmentIndex` — durable `IFragmentVectorIndex` (`vec0` `PARTITION KEY` on `target_key`, `[start,end)` in aux columns; safe-integer-hardened) |
+| #563 | `@fgv/testbed` | `sqlite-vec-fragment-persistence` scenario + a "Running scenarios" README section |
+| #564 | docs | `LIBRARY_CAPABILITIES.md` + `FUTURE.md` marked SHIPPED; embed-guard backported to the record-index demo |
+
+**Two deltas from the pre-build design sketch** (recorded in the `FUTURE.md` SHIPPED block):
+`IFragmentVectorIndex` is a sibling not `extends IVectorIndex`; the persistent impl is a
+separate `SqliteVecFragmentIndex` class (PARTITION KEY), **not** a `(target_key, locator)` PK
+extension of `SqliteVecVectorIndex` (Q7's sketch). Both were deliberate simplifications found
+implementing against the real code.
+
+## Read these first (binding artifacts)
+
+- `docs/FUTURE.md` § "`@fgv/ts-agent-memory` — deferred consumer asks" — the N-Ask5 SHIPPED
+  block + the N-Ask8 RETIRED block + the one remaining conditional ask.
+- `.ai/instructions/LIBRARY_CAPABILITIES.md` — the `ts-agent-memory` / `ts-agent-memory-sqlite-vec`
+  entries now describe the shipped fragment surface (source of truth for "does this exist yet").
+- `.ai/notes/orchestrator/lessons-pending.md` L38–L40 — this cycle's lessons (see below).
+
+## Ask-queue state — CLOSED
+
+The personaility→fgv agent-memory ask queue is **closed out**: four early asks built,
+N-Ask5 shipped, N-Ask8 retired. Nothing firm is outstanding.
+
+## Horizon items (surfaced, NOT formally requested — do not build unprompted)
+
+1. **Publish.** `release` carries the whole tranche unpublished. The next `release`→`main`
+   promotion ships it; bump `.ai/BASELINE.md` at that point. Erik's call.
+2. **Unified record+fragment retrieval.** `FragmentSemanticRetriever` is deliberately *not* an
+   `IMemoryRetriever` — a consumer wiring both semantic paths queries two retrievers. A
+   `HybridRetriever`-style union (or a fragment capability on `HybridRetriever`) that merges
+   record + fragment hits is the natural next increment **once a consumer actually uses both**.
+   File as a deferred ask when that surfaces; don't pre-build.
+3. **Per-fragment incremental update (N-Ask5 Q4, deferred).** v1 is whole-record re-embed
+   (`addFragments` replace-all). Incremental per-fragment update becomes valuable only when
+   knowledge docs are large / partially re-authored. Consumer-triggered.
+4. **Fragment ANN / large-N.** Both fragment backends are brute-force (same "thousands of
+   records" regime as the record index). ANN is a different backend behind the same seam;
+   out of scope until N grows.
+5. **Browser persistent fragment index.** `sqlite-vec` is Node-only, so a browser consumer has
+   only `InMemoryFragmentCosineIndex` (ephemeral). No durable browser fragment backend exists.
+   Gap only if a browser consumer wants persistent fragments.
+6. **Conditional `resolveHandle`** (already in `FUTURE.md`) — the single remaining non-firm
+   consumer ask (input-side handle → `(kind, entityId)`), build-ready, triggers only if the
+   consumer adopts the substrate's `memory_context` / `memory_read` tool bodies.
+
+## Lessons parked (triage next codification batch)
+
+- **L38** — native-boundary packages (wrapping a lib with runtime modes like better-sqlite3
+  safe-integer mode) are a **layer-1 blind spot**; expect a *substantive* Copilot loop even
+  after a clean `code-reviewer` pass. → CODING_STANDARDS review-loop discipline.
+- **L39** — **2nd occurrence** (also bit #558): cross-package `{@link}` bakes an
+  `ae-unresolved-link` warning into the checked-in api.md. Only `{@link}` this package's own
+  exports; use code spans for other-package symbols; `{@inheritDoc OtherPkg.method}` is the one
+  tolerated cross-package ref. Ripe to graduate to a CODE_REVIEW_CHECKLIST line.
+- **L40** — release-durable docs must cite PRs / on-release artifacts, never active-branch task
+  files (N-Ask5's `FUTURE.md` had a dangling `n-ask5-firmup/` reference). → artifact-protocol.
+
+## What a fresh orchestrator should do first
+
+1. If Erik wants to publish: run the `release`→`main` promotion and bump `.ai/BASELINE.md`.
+   Otherwise nothing — this cycle is idle-clean.
+2. Do **not** re-open #561–#564 or rebuild anything above; the tranche is done.
+3. The other active board items (`messages-log-levels`, `prompt-assist-screeners` in
+   `docs/WORKSTREAMS.md`) are **separate streams, not part of this cycle** — don't assume ownership.
+
+## Things NOT to do
+
+- Don't build any horizon item (2–6) without an explicit request — they are intentionally
+  deferred with consumer triggers.
+- Don't reference active-branch task artifacts from release docs (L40).
+- Don't stack a new PR on a merged branch; branch fresh from `release`.

--- a/.ai/notes/orchestrator/handoff-agent-memory-fragment-cycle-2026-07.md
+++ b/.ai/notes/orchestrator/handoff-agent-memory-fragment-cycle-2026-07.md
@@ -56,15 +56,16 @@ N-Ask5 shipped, N-Ask8 retired. Nothing firm is outstanding.
    consumer ask (input-side handle → `(kind, entityId)`), build-ready, triggers only if the
    consumer adopts the substrate's `memory_context` / `memory_read` tool bodies.
 
-## Lessons parked (triage next codification batch)
+## Lessons (L39 codified this PR; L38 + L40 parked for next batch)
 
 - **L38** — native-boundary packages (wrapping a lib with runtime modes like better-sqlite3
   safe-integer mode) are a **layer-1 blind spot**; expect a *substantive* Copilot loop even
   after a clean `code-reviewer` pass. → CODING_STANDARDS review-loop discipline.
-- **L39** — **2nd occurrence** (also bit #558): cross-package `{@link}` bakes an
-  `ae-unresolved-link` warning into the checked-in api.md. Only `{@link}` this package's own
-  exports; use code spans for other-package symbols; `{@inheritDoc OtherPkg.method}` is the one
-  tolerated cross-package ref. Ripe to graduate to a CODE_REVIEW_CHECKLIST line.
+- **L39** — **CODIFIED 2026-07-20** (in this PR, #565) → `CODE_REVIEW_CHECKLIST.md` § Priority 3
+  "Documentation / TSDoc": cross-package `{@link}` bakes an `ae-unresolved-link` warning into the
+  checked-in api.md; only `{@link}` this package's own exports (code spans for other-package
+  symbols; `{@inheritDoc OtherPkg.method}` is the one tolerated cross-package ref). Graduated
+  immediately because it recurred (#558 → #562).
 - **L40** — release-durable docs must cite PRs / on-release artifacts, never active-branch task
   files (N-Ask5's `FUTURE.md` had a dangling `n-ask5-firmup/` reference). → artifact-protocol.
 

--- a/.ai/notes/orchestrator/lessons-pending.md
+++ b/.ai/notes/orchestrator/lessons-pending.md
@@ -16,6 +16,8 @@ Active clusters at most recent sweep point:
 
 Last sweep: 2026-05-30 — Review-loop discipline triad (L31, L32, L33) codified. See sweep history at end of file.
 
+Newest pending (2026-07-20, `@fgv/ts-agent-memory` fragment-retrieval cycle / N-Ask5): **L38** (native-boundary packages are a layer-1 blind spot — expect a substantive Copilot loop), **L39** (cross-package `{@link}` bakes an api.md warning — 2nd occurrence, ripe to codify), **L40** (release-durable docs must cite PRs/on-release artifacts, not active-branch task files). Not yet swept.
+
 ---
 
 ## Pending lessons
@@ -439,6 +441,36 @@ The cost: an extra review round whose entire finding-set was about description f
 **Codification candidate:** Add to `.ai/instructions/CODE_REVIEW_CHECKLIST.md` Priority 2 (Major / Should Fix): "PR description accurately frames the change scope (type-only vs runtime-affecting; additive vs breaking). Bundled latent-bug fixes are disclosed in a dedicated section."
 
 **Reference:** PR #391 Round 2 Copilot findings (`isLooseResourceCandidateDecl` / `isLooseResourceDecl` typo'd-id soundness; meta-finding on runtime-change framing).
+
+---
+
+### L38. Layer-2 (Copilot) earns its keep on native-boundary packages — it catches runtime-mode edge cases layer-1 reads-against-intent misses
+
+**Observed:** On #562 (`SqliteVecFragmentIndex`, a Result-integration boundary over `better-sqlite3` + `sqlite-vec`) the internal `code-reviewer` (layer 1) approved with **no P1/P2** and independently re-derived the correctness-critical logic (offset math, transaction atomicity, cap-before-topK). Copilot (layer 2) then surfaced **three real persisted-data robustness gaps** across two rounds, all invisible to a reads-against-intent pass because they are `better-sqlite3`/`sqlite-vec` *runtime-mode* specifics, not repo-pattern violations: (a) a `bigint` leak — integer columns return as `bigint` under `defaultSafeIntegers` mode, so a stored locator offset could reach the `number`-typed public locator as `bigint` or lose precision; (b) `_parseKey` silently fabricating a wrong `(scope,id)` from a NUL-less corrupt key rather than failing loudly; (c) an unvalidated write-side offset that `BigInt(nonInteger)` throws on / that persists as a value the read guard later rejects on every query. All three became fail-loudly guards.
+
+**Rule:** For **Result-integration-boundary packages wrapping a native lib with subtle runtime modes** (safe-integer mode, typed/auxiliary columns, driver-specific coercions, WASM/native shape quirks), layer 1 systematically under-covers the runtime-edge class. Do **not** treat a clean layer-1 pass as license to expect a nitpick-only Copilot loop on these packages — budget for layer 2 to be *substantive* on rounds 1–2, and don't call diminishing returns until it actually goes nitpicky. This is the inverse of the well-prepared-pure-TS PR where layer 1 catches everything and Copilot only polishes.
+
+**Codification candidate:** `.ai/instructions/CODING_STANDARDS.md` § "Review-loop discipline" — a note under Layer 2 naming native-boundary packages as a known layer-1-blind-spot class where a substantive Copilot loop is *expected*, not a signal that layer 1 was skipped. (Reference: #562 R1 bigint-leak + corrupt-key; R2 write-side offset validation.)
+
+---
+
+### L39. In TSDoc, only `{@link}` symbols this package itself exports — cross-package `{@link}` bakes an `ae-unresolved-link` warning into the committed api.md
+
+**Observed (2nd occurrence — recurred from #558).** A class-docstring `{@link IFragmentVectorIndex}` in `SqliteVecFragmentIndex` (the type is exported from `@fgv/ts-agent-memory`, not this package) baked an `ae-unresolved-link` warning into `etc/ts-agent-memory-sqlite-vec.api.md`; Copilot flagged it (#562 R2). The same class was tripped once before at #558. The sibling `SqliteVecVectorIndex` avoids cross-package `{@link}` in prose but *does* use `{@inheritDoc IVectorIndex.method}`, which bakes `ae-unresolved-inheritdoc-reference` warnings — **tolerated** because inheritDoc is load-bearing for inheriting the interface's doc text and every boundary package relies on it.
+
+**Rule:** `{@link}` **only** this package's own exported symbols. For a symbol from another `@fgv/*` package, use a plain code span (`` `IFragmentVectorIndex` ``), never `{@link}`. The one sanctioned cross-package reference is `{@inheritDoc OtherPkg.Symbol.method}` on a method that implements another package's interface (accept its warning; it's needed and sibling-consistent). Because these warnings are baked verbatim into the checked-in api.md, a stray cross-package `{@link}` is a CI-diff liability, not just cosmetic.
+
+**Codification candidate:** `.ai/instructions/CODE_REVIEW_CHECKLIST.md` Priority 3 (or a short api-extractor convention). It has now recurred across two packages/streams — strong candidate to graduate to a checklist line so it stops re-learning itself. (Reference: #562 R2 `ae-unresolved-link`; prior #558 instance.)
+
+---
+
+### L40. Durable docs must reference durable artifacts — never a transient task file on an unmerged branch
+
+**Observed:** The N-Ask5 `FUTURE.md` entry cited `.ai/tasks/active/n-ask5-firmup/open-questions.md` — a firm-up artifact that lived only on the `claude/n-ask5-open-questions` branch (relayed to a peer instance, never merged to `release`). By the time N-Ask5 shipped, that path was a dangling reference on `release`. Fixed by pointing the entry at the shipped PRs + the entry itself.
+
+**Rule:** When a release-durable doc (`FUTURE.md`, `LIBRARY_CAPABILITIES.md`, a convention) references a task artifact, that artifact must itself be on `release`, or the reference must point at a durable record — the **PR number** or the doc entry. Transient firm-up / analysis artifacts on feature branches must not be cited from release docs; cite the PR that consumed them instead.
+
+**Codification candidate:** `.ai/conventions/workflow/artifact-protocol.md` (or `doc-graduation.md`) — a one-line rule: "release-durable docs cite PRs or on-release artifacts, never active-branch task files." (Reference: N-Ask5 FUTURE.md dangling `n-ask5-firmup/open-questions.md`, fixed in #564.)
 
 ---
 

--- a/.ai/notes/orchestrator/lessons-pending.md
+++ b/.ai/notes/orchestrator/lessons-pending.md
@@ -16,7 +16,7 @@ Active clusters at most recent sweep point:
 
 Last sweep: 2026-05-30 — Review-loop discipline triad (L31, L32, L33) codified. See sweep history at end of file.
 
-Newest pending (2026-07-20, `@fgv/ts-agent-memory` fragment-retrieval cycle / N-Ask5): **L38** (native-boundary packages are a layer-1 blind spot — expect a substantive Copilot loop), **L39** (cross-package `{@link}` bakes an api.md warning — 2nd occurrence, ripe to codify), **L40** (release-durable docs must cite PRs/on-release artifacts, not active-branch task files). Not yet swept.
+Newest pending (2026-07-20, `@fgv/ts-agent-memory` fragment-retrieval cycle / N-Ask5): **L38** (native-boundary packages are a layer-1 blind spot — expect a substantive Copilot loop) and **L40** (release-durable docs must cite PRs/on-release artifacts, not active-branch task files) — not yet swept. **L39** (cross-package `{@link}`) was **codified 2026-07-20** into CODE_REVIEW_CHECKLIST.md (2nd occurrence → graduated immediately; see sweep history).
 
 ---
 
@@ -454,13 +454,9 @@ The cost: an extra review round whose entire finding-set was about description f
 
 ---
 
-### L39. In TSDoc, only `{@link}` symbols this package itself exports — cross-package `{@link}` bakes an `ae-unresolved-link` warning into the committed api.md
+### L39. (CODIFIED 2026-07-20 → CODE_REVIEW_CHECKLIST.md § Priority 3 "Documentation / TSDoc")
 
-**Observed (2nd occurrence — recurred from #558).** A class-docstring `{@link IFragmentVectorIndex}` in `SqliteVecFragmentIndex` (the type is exported from `@fgv/ts-agent-memory`, not this package) baked an `ae-unresolved-link` warning into `etc/ts-agent-memory-sqlite-vec.api.md`; Copilot flagged it (#562 R2). The same class was tripped once before at #558. The sibling `SqliteVecVectorIndex` avoids cross-package `{@link}` in prose but *does* use `{@inheritDoc IVectorIndex.method}`, which bakes `ae-unresolved-inheritdoc-reference` warnings — **tolerated** because inheritDoc is load-bearing for inheriting the interface's doc text and every boundary package relies on it.
-
-**Rule:** `{@link}` **only** this package's own exported symbols. For a symbol from another `@fgv/*` package, use a plain code span (`` `IFragmentVectorIndex` ``), never `{@link}`. The one sanctioned cross-package reference is `{@inheritDoc OtherPkg.Symbol.method}` on a method that implements another package's interface (accept its warning; it's needed and sibling-consistent). Because these warnings are baked verbatim into the checked-in api.md, a stray cross-package `{@link}` is a CI-diff liability, not just cosmetic.
-
-**Codification candidate:** `.ai/instructions/CODE_REVIEW_CHECKLIST.md` Priority 3 (or a short api-extractor convention). It has now recurred across two packages/streams — strong candidate to graduate to a checklist line so it stops re-learning itself. (Reference: #562 R2 `ae-unresolved-link`; prior #558 instance.)
+Cross-package `{@link}` bakes an `ae-unresolved-link` warning into the checked-in api.md; only `{@link}` this package's own exports (code span for other-package symbols; `{@inheritDoc OtherPkg.method}` is the one tolerated cross-package ref). Recurred #558 → #562, so graduated straight to a checklist line rather than waiting for a batch sweep. See sweep history.
 
 ---
 
@@ -514,3 +510,15 @@ L37 complements L31/L32/L33 (which govern layer-1's place in the broader review 
 ---
 
 When this file or accumulated peer notes get swept to release: append entry here with date, sweep PR link, and which items graduated to durable form (convention / skill / agent-prompt) vs aged out.
+
+---
+
+### 2026-07-20 — L39 codified (cross-package `{@link}` → api.md warning)
+
+**PR:** `claude/orchestrator-reflection-2026-07` (this cycle's reflection PR, #565).
+
+**Graduated:**
+
+- **L39. In TSDoc, only `{@link}` symbols this package itself exports.** A cross-package `{@link OtherPkgSymbol}` bakes an `ae-unresolved-link` warning verbatim into the checked-in `etc/*.api.md` (stale-api.md / CI-diff liability). Use a plain code span for other-package symbols; `{@inheritDoc OtherPkg.Symbol.method}` is the one sanctioned cross-package reference (load-bearing for doc inheritance on Result-integration-boundary packages; its `ae-unresolved-inheritdoc-reference` warning is tolerated + sibling-consistent). → codified into `.ai/instructions/CODE_REVIEW_CHECKLIST.md` § Priority 3, new "Documentation / TSDoc" subsection. Graduated immediately rather than batch-swept because it **recurred** (#558 → #562 R2) — the recurrence is the graduation trigger per the codification-triage convention. (Reference: #562 R2 `ae-unresolved-link` on `{@link IFragmentVectorIndex}`; prior #558 instance.)
+
+L38 (native-boundary layer-1 blind spot) and L40 (release-durable-doc artifact references) remain parked pending a future sweep.


### PR DESCRIPTION
## Summary

End-of-cycle reflection artifacts for the `@fgv/ts-agent-memory` fragment-retrieval (N-Ask5) cycle, now fully shipped across #561–#564. Docs-only; no package changes, no change file.

## Changes

**`.ai/instructions/CODE_REVIEW_CHECKLIST.md`** — **codifies L39** (it recurred #558 → #562, which is the graduation trigger per `lessons-codification-triage`, so it lands now rather than waiting for a batch sweep). New Priority 3 "Documentation / TSDoc" subsection: only `{@link}` this package's own exports — a cross-package `{@link}` bakes an `ae-unresolved-link` warning verbatim into the checked-in `etc/*.api.md` (stale-api.md / CI-diff liability); use a code span for other-package symbols; `{@inheritDoc OtherPkg.method}` is the one sanctioned cross-package reference.

**`.ai/notes/orchestrator/lessons-pending.md`** — parks the two single-occurrence lessons and records L39's graduation:
- **L38** (parked) — native-boundary packages (wrapping a lib with runtime modes, e.g. better-sqlite3 safe-integer mode) are a **layer-1 review blind spot**: on #562 the internal `code-reviewer` approved clean, then Copilot caught three real persisted-data robustness gaps. Expect a substantive Copilot loop on these packages.
- **L39** (codified → checklist; moved to sweep history).
- **L40** (parked) — release-durable docs must cite PRs / on-release artifacts, never active-branch task files (N-Ask5's `FUTURE.md` had a dangling `n-ask5-firmup/` reference, fixed in #564).

**`.ai/notes/orchestrator/handoff-agent-memory-fragment-cycle-2026-07.md`** — clean-close handoff: what shipped (four PRs + the two design deltas from the pre-build sketch), the closed ask queue, the six **surfaced-but-not-formally-requested** horizon items (publish; unified record+fragment retrieval; per-fragment incremental update; fragment ANN; browser persistent fragment index; conditional `resolveHandle`), the lessons state, and what a fresh orchestrator should/shouldn't do first.

## Note on placement

Per `doc-graduation.md` these orchestrator notes are swept to `release` at natural moments (this cycle's close). Branched fresh off the latest `release` rather than stacked on the merged #564 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4rVgY8NFE7zNBNLgEVCch