### PR TITLE
Lessons sweep: codify L38 + L40; re-file #493's FUTURE.md entry; branch-migration checklist

### DIFF
--- a/.ai/conventions/workflow/artifact-protocol.md
+++ b/.ai/conventions/workflow/artifact-protocol.md
@@ -140,10 +140,30 @@ to `followups.md`. The orchestrator drains the inbox into the
 consolidated `followups.md` periodically. See
 `convention.workflow.inbox-and-drain` for the full pattern.
 
+## Durable-doc references
+
+Release-durable docs (`docs/FUTURE.md`, `LIBRARY_CAPABILITIES.md`,
+conventions, completed-task `README.md`s) **cite PRs or on-release
+artifacts — never active-branch task files**. A transient firm-up or
+analysis artifact that lives only on a feature branch (e.g.
+`.ai/tasks/active/<id>/open-questions.md` on an unmerged branch) is a
+dangling reference the moment the durable doc lands on `release`
+without it. If the artifact itself won't graduate, cite the **PR that
+consumed it** (PR numbers are GitHub-durable) or restate the needed
+content in the durable doc's own entry.
+
+(Observed: N-Ask5's `FUTURE.md` entry cited
+`.ai/tasks/active/n-ask5-firmup/open-questions.md`, which lived only
+on a never-merged relay branch; fixed in #564 by pointing the entry
+at the shipped PRs.)
+
 ## Anti-patterns
 
 - **Migration as follow-up after merge.** Splits the coherent unit;
   risks losing context.
+- **Durable doc cites an active-branch task file.** The reference
+  dangles once the doc is on `release`. Cite the consuming PR or an
+  on-release artifact instead (see "Durable-doc references").
 - **`state.md` written only at exit.** Defeats the resume protocol.
 - **`result.md` written before phase completion.** Mid-flight
   result.md content masks not-yet-shipped work as shipped.

--- a/.ai/instructions/CODING_STANDARDS.md
+++ b/.ai/instructions/CODING_STANDARDS.md
@@ -667,3 +667,11 @@ Concrete patterns from observed loops:
 - **Round 5+ on a PR that has been mostly nitpicks since round 3** → stop and surface to the orchestrator with the diagnosis ("rounds 3–5 produced only doc and naming items; treating as diminishing returns at round N").
 
 The orchestrator handles edge cases: PRs that legitimately need 5+ rounds (large surface, novel patterns), PRs that should have stopped at 2 (one substantive round + one cleanup), PRs that hit the 10-round cap (those almost always indicate layer 1 was skipped or the PR is too large for the loop and should be decomposed). Implementing agents should call the stop and surface the reasoning; the orchestrator decides whether to push back or accept.
+
+### Native-boundary packages are a known layer-1 blind spot — expect a substantive layer-2 loop
+
+For **Result-integration-boundary packages wrapping a native library with subtle runtime modes** (safe-integer mode, typed/auxiliary columns, driver-specific coercions, WASM/native shape quirks — e.g. `better-sqlite3`, `sqlite-vec`), layer 1 systematically under-covers the runtime-edge class of finding. The internal reviewer reads against intent and repo patterns; it does not know that an integer column returns `bigint` under `defaultSafeIntegers`, or that a driver coerces a non-integer write into a value the read path later rejects.
+
+Observed on #562 (`SqliteVecFragmentIndex`): layer 1 approved clean with no P1/P2 and independently re-derived the correctness-critical logic, yet Copilot then surfaced three real persisted-data robustness gaps across two rounds (a `bigint` leak into a `number`-typed public field; a corrupt-key parse that silently fabricated a wrong result instead of failing loudly; an unvalidated write-side offset that either threw or persisted an unreadable value). All three were runtime-mode specifics, invisible to a reads-against-intent pass.
+
+**Rule:** on a native-boundary package, do **not** treat a clean layer-1 pass as license to expect a nitpick-only Copilot loop. Budget for layer 2 to be *substantive* on rounds 1–2, and don't call diminishing returns until the finding profile actually goes nitpicky. This is the inverse of the well-prepared pure-TS PR where layer 1 catches everything and Copilot only polishes — and a substantive Copilot round here is not evidence that layer 1 was skipped.

--- a/.ai/notes/orchestrator/branch-migration-checklist.md
+++ b/.ai/notes/orchestrator/branch-migration-checklist.md
@@ -1,0 +1,137 @@
+# Branch-migration checklist — `main` as trunk + `published` pointer
+
+**Status: PLANNED — not started.** Drafted 2026-07-20 (orchestrator session, PR #566).
+Prerequisite for publishing the accumulated `release` tranche (5.1.0). Come back here
+when Erik has cycles for the settings-page items; everything else can be driven by an
+orchestrator/agent session against this checklist.
+
+## Target model (locked with Erik, 2026-07-20)
+
+- **`main`** — the trunk. All feature PRs target it; CI push-gate runs on it; stable
+  publishes dispatch from it. (Already the GitHub default branch, so dependabot,
+  new-PR defaults, and badges become correct automatically at the drain.)
+- **`published`** — new branch, a pointer to the last published-stable state. Written
+  ONLY by the publish workflow (fast-forward after each stable/major publish). Enables
+  hotfix-from-published if ever needed. Replaces the old rolling release→main PR (#154).
+- **`prerelease`** — recreated off new `main` after the first stable publish; alpha
+  publishes dispatch from it, exactly as today (bump commits stay off trunk).
+- **`release`** — drained into `main`, then frozen; deleted after the docs sweep
+  (open question 1 below).
+
+## Facts verified at plan time (2026-07-20)
+
+- `release` = de facto trunk: 40 rush projects (main has 20), lockstep 5.1.0
+  unpublished (`version-policies.json` nextBump minor), **386 accumulated change files**
+  in `common/changes/` that the stable publish will consume.
+- `main` = 5.0.2 publish state + stray root-tooling commits (#238/#237-era, #464
+  security sweep, #550 yaml 2.9.0). #545 (rush bump) was closed by dependabot as
+  redundant after #550. `ts-utils-browser-test` (dropped by #464) is absent on BOTH
+  branches — no resurrection risk in the drain.
+- Known inconsistency: `release` root `package.json` has `@microsoft/rush ^5.172.1`
+  while `rush.json` says 5.177.2; `main` root has `^5.175.1` → 5.177.2 lockfile.
+- Workflows: `ci.yml` push-triggers on main only; PR-triggers on
+  main/release/prerelease/hotfix (`hotfix` doesn't exist). `publish.yml` is a manual
+  dispatch (release/alpha/major) running against the dispatched ref via
+  `GITHUB_REF_NAME`; impls use OIDC environments `npm-publish-alpha` /
+  `npm-publish-release`. Four `-legacy` workflows (NPM_TOKEN auth) still present.
+  `publish-release-impl.yml` runs `rush publish --publish --include-all` **without**
+  `--apply` (alpha impl has `--apply`) — see Phase 0 item 4.
+- Per-package publish tags exist (e.g. `@fgv/typedoc-compact-theme_v5.1.0-9-alpha`),
+  so commits on to-be-deleted branches stay reachable via tags.
+
+---
+
+## Phase 0 — Pre-flight verification
+
+**Erik (settings pages — blocking):**
+- [ ] `npm-publish-release` environment → Deployment branches rule: must allow `main`.
+- [ ] `npm-publish-alpha` environment → Deployment branches rule: must allow
+      `prerelease` (the recreated one — a branch-name rule survives recreation;
+      a branch-ref rule may not).
+- [ ] Branch protection on `main`: publish workflows push version-bump commits
+      directly to the dispatch branch (`contents: write`). If main has/gets a
+      required-PR rule, the workflow actor needs a bypass — confirm publish can push.
+- [ ] Confirm npm trusted publishing (OIDC) config is repo+workflow-file bound (not
+      branch bound) — expected to survive unchanged; verify on first publish.
+
+**Orchestrator/agent:**
+- [ ] Dry-run the stable publish semantics locally against a main-post-drain clone:
+      `rush publish --apply --pack` (or the impl's exact flags) to confirm the 386
+      change files + version policy produce the expected 5.1.0 versions/changelogs.
+      Reconcile the `--apply` discrepancy between release-impl and alpha-impl before
+      trusting the real dispatch.
+- [ ] Diff #464's touched paths between `main` and `release` to enumerate exactly
+      what the Phase 2 reconciliation PR must port (ajv CVE overrides, root deps).
+
+## Phase 1 — Snapshot `published`
+
+- [ ] `git branch published main && git push origin published` — BEFORE anything else
+      touches main. (Current main = 5.0.2 published state + root-tooling strays that
+      don't affect published package contents; honest enough as the pointer.)
+
+## Phase 2 — Reconcile strays onto `release` (small PR → release)
+
+- [ ] Align root `package.json`/`package-lock.json` with main's post-#550 state
+      (yaml 2.9.0, rush dep — also fixes the ^5.172.1 vs 5.177.2 inconsistency).
+- [ ] Port any #464 deltas not semantically present on release (from Phase 0 diff).
+- [ ] Goal: `git merge main` into a release-based branch is conflict-free.
+
+## Phase 3 — Workflow rework (PR → release, so it rides the drain)
+
+- [ ] `ci.yml`: PR triggers → `['main', 'prerelease', 'published']` (drop `release`;
+      drop or keep `hotfix`). Push triggers stay `['main']`. Change-verify logic needs
+      no change (keys off `base_ref` / main).
+- [ ] `publish.yml` impls: add branch guards — release + major jobs assert
+      `github.ref == 'refs/heads/main'`; alpha asserts `refs/heads/prerelease`.
+      Wrong-branch dispatch must fail loudly.
+- [ ] `publish-release-impl.yml` (+ major impl): add post-publish step
+      `git push origin HEAD:published` (fast-forward) after the publish commit lands.
+- [ ] Delete `publish-legacy.yml`, `publish-alpha-legacy.yml`,
+      `publish-major-legacy.yml` (and confirm nothing else references NPM_TOKEN).
+
+## Phase 4 — The drain (release → main)
+
+- [ ] Merge/close remaining release-targeting PRs first (#566 lessons sweep rides
+      along if merged before the drain).
+- [ ] Branch `merge/release-to-main` off release; `git merge main` (trivial after
+      Phase 2); PR → main; **merge-commit, not squash** (179 commits of real stream
+      history). CI change-verify passes because the change files are present.
+- [ ] Close #154 (release→main) and #256 (prerelease→release) — obsolete.
+- [ ] Sanity: CI green on main post-merge; `rush install && rush rebuild` clean.
+
+## Phase 5 — First publish + recreate `prerelease`
+
+**Order matters — stable publish FIRST, then recreate prerelease** (recreating first
+would restart alphas at 5.1.0-0, colliding with the already-published 5.1.0-43 line):
+- [ ] Dispatch `publish.yml` (release) from `main` → 5.1.0 ships; workflow
+      fast-forwards `published` (verify) and tags.
+- [ ] Verify version policy advanced (next alphas will be 5.2.0-N).
+- [ ] `git branch -f prerelease main && git push -f origin prerelease`.
+- [ ] Bump `.ai/BASELINE.md` to the 5.1.0 promotion commit.
+
+## Phase 6 — Docs sweep (chore PR → main)
+
+- [ ] Update "branch fresh off `release`" conventions → `main`: CLAUDE.md, `.ai/`
+      instructions/conventions, `.claude/agents/orchestrator.md`, current handoff
+      notes. (Grep for `release` in `.ai/` and `.claude/`.)
+- [ ] `LIBRARY_CAPABILITIES.md`: bulk-update the dozens of
+      `github.com/ErikFortune/fgv/tree/release/...` links → `/tree/main/...`.
+- [ ] Keep frozen `release` alive until this merges (so links don't dangle), then
+      resolve open question 1.
+
+## Open questions
+
+1. **Fate of `release` post-drain** — delete after the docs sweep, or keep frozen as
+   an archival pointer? (Erik's call; tags keep everything reachable either way.)
+2. `hotfix` in ci.yml PR triggers — drop, or formalize a hotfix-from-`published` flow?
+3. Add a `.github/dependabot.yml` (explicit config, grouping, cadence) as part of
+   Phase 3, or leave implicit security-only updates? (Post-drain, dependabot's
+   default-branch targeting is correct either way.)
+
+## Session context (for a cold pickup)
+
+Plan drafted in the 2026-07-20 orchestrator session that also closed the N-Ask5
+lessons inbox (#566) and triaged #493/#545/#550. Erik's framing: "switch to main as
+trunk on the next major or minor release — but we've accumulated an awful lot in the
+release branch," hence the drain-now shape rather than waiting. The rework is the
+prerequisite for shipping the unpublished 5.1.0 tranche.

--- a/.ai/notes/orchestrator/lessons-pending.md
+++ b/.ai/notes/orchestrator/lessons-pending.md
@@ -14,7 +14,7 @@ Active clusters at most recent sweep point:
 - 🟢 ts-prompt-assist cluster — Phase B + B-5 docs merged into integration; surface-tidy round in flight; cluster close pending consumer-port pressure-test (lessons L18–L21 below)
 - 🟡 `ai-assist-thinking-events` — sequencing after thinking-config phase B landed (now satisfied); ready to commission
 
-Last sweep: 2026-05-30 — Review-loop discipline triad (L31, L32, L33) codified. See sweep history at end of file.
+Last sweep: 2026-07-20 — L38 + L40 codified (cycle-close sweep, #566), following L39's immediate graduation the same day (#565). See sweep history at end of file.
 
 The N-Ask5 cycle's three lessons are all codified as of 2026-07-20: **L39** (cross-package `{@link}`) graduated immediately on recurrence via #565; **L38** (native-boundary layer-1 blind spot) and **L40** (release-durable docs cite PRs/on-release artifacts) graduated in the 2026-07-20 sweep (see sweep history). No pending lessons newer than L30.
 
@@ -444,24 +444,6 @@ The cost: an extra review round whose entire finding-set was about description f
 
 ---
 
-### L38. (CODIFIED 2026-07-20 → CODING_STANDARDS.md § "Review-loop discipline", new subsection "Native-boundary packages are a known layer-1 blind spot")
-
-Result-integration-boundary packages wrapping a native lib with subtle runtime modes (safe-integer mode, typed/auxiliary columns, driver coercions) are a layer-1 blind spot — expect a *substantive* Copilot loop even after a clean `code-reviewer` pass, and don't call diminishing returns until the finding profile actually goes nitpicky. (Reference: #562 — clean layer 1, then three real persisted-data robustness gaps from Copilot.) See sweep history.
-
----
-
-### L39. (CODIFIED 2026-07-20 → CODE_REVIEW_CHECKLIST.md § Priority 3 "Documentation / TSDoc")
-
-Cross-package `{@link}` bakes an `ae-unresolved-link` warning into the checked-in api.md; only `{@link}` this package's own exports (code span for other-package symbols; `{@inheritDoc OtherPkg.method}` is the one tolerated cross-package ref). Recurred #558 → #562, so graduated straight to a checklist line rather than waiting for a batch sweep. See sweep history.
-
----
-
-### L40. (CODIFIED 2026-07-20 → artifact-protocol.md, new "Durable-doc references" section + anti-pattern bullet)
-
-Release-durable docs cite PRs or on-release artifacts, never active-branch task files — a transient firm-up artifact on an unmerged branch is a dangling reference the moment the doc lands on `release`. (Reference: N-Ask5 `FUTURE.md` dangling `n-ask5-firmup/open-questions.md`, fixed in #564.) See sweep history.
-
----
-
 ## Sweep history
 
 ### 2026-05-30 — Review-loop discipline triad (L31, L32, L33) codified
@@ -519,7 +501,7 @@ L38 (native-boundary layer-1 blind spot) and L40 (release-durable-doc artifact r
 
 ### 2026-07-20 — L38 + L40 codified (cycle-close sweep)
 
-**PR:** `claude/fgv-orchestrator-v-orient-s1z0ax` (post-#565 orchestrator sweep; PR number recorded in the PR itself).
+**PR:** #566 (post-#565 orchestrator sweep).
 
 **Graduated:**
 

--- a/.ai/notes/orchestrator/lessons-pending.md
+++ b/.ai/notes/orchestrator/lessons-pending.md
@@ -16,7 +16,7 @@ Active clusters at most recent sweep point:
 
 Last sweep: 2026-05-30 — Review-loop discipline triad (L31, L32, L33) codified. See sweep history at end of file.
 
-Newest pending (2026-07-20, `@fgv/ts-agent-memory` fragment-retrieval cycle / N-Ask5): **L38** (native-boundary packages are a layer-1 blind spot — expect a substantive Copilot loop) and **L40** (release-durable docs must cite PRs/on-release artifacts, not active-branch task files) — not yet swept. **L39** (cross-package `{@link}`) was **codified 2026-07-20** into CODE_REVIEW_CHECKLIST.md (2nd occurrence → graduated immediately; see sweep history).
+The N-Ask5 cycle's three lessons are all codified as of 2026-07-20: **L39** (cross-package `{@link}`) graduated immediately on recurrence via #565; **L38** (native-boundary layer-1 blind spot) and **L40** (release-durable docs cite PRs/on-release artifacts) graduated in the 2026-07-20 sweep (see sweep history). No pending lessons newer than L30.
 
 ---
 
@@ -444,13 +444,9 @@ The cost: an extra review round whose entire finding-set was about description f
 
 ---
 
-### L38. Layer-2 (Copilot) earns its keep on native-boundary packages — it catches runtime-mode edge cases layer-1 reads-against-intent misses
+### L38. (CODIFIED 2026-07-20 → CODING_STANDARDS.md § "Review-loop discipline", new subsection "Native-boundary packages are a known layer-1 blind spot")
 
-**Observed:** On #562 (`SqliteVecFragmentIndex`, a Result-integration boundary over `better-sqlite3` + `sqlite-vec`) the internal `code-reviewer` (layer 1) approved with **no P1/P2** and independently re-derived the correctness-critical logic (offset math, transaction atomicity, cap-before-topK). Copilot (layer 2) then surfaced **three real persisted-data robustness gaps** across two rounds, all invisible to a reads-against-intent pass because they are `better-sqlite3`/`sqlite-vec` *runtime-mode* specifics, not repo-pattern violations: (a) a `bigint` leak — integer columns return as `bigint` under `defaultSafeIntegers` mode, so a stored locator offset could reach the `number`-typed public locator as `bigint` or lose precision; (b) `_parseKey` silently fabricating a wrong `(scope,id)` from a NUL-less corrupt key rather than failing loudly; (c) an unvalidated write-side offset that `BigInt(nonInteger)` throws on / that persists as a value the read guard later rejects on every query. All three became fail-loudly guards.
-
-**Rule:** For **Result-integration-boundary packages wrapping a native lib with subtle runtime modes** (safe-integer mode, typed/auxiliary columns, driver-specific coercions, WASM/native shape quirks), layer 1 systematically under-covers the runtime-edge class. Do **not** treat a clean layer-1 pass as license to expect a nitpick-only Copilot loop on these packages — budget for layer 2 to be *substantive* on rounds 1–2, and don't call diminishing returns until it actually goes nitpicky. This is the inverse of the well-prepared-pure-TS PR where layer 1 catches everything and Copilot only polishes.
-
-**Codification candidate:** `.ai/instructions/CODING_STANDARDS.md` § "Review-loop discipline" — a note under Layer 2 naming native-boundary packages as a known layer-1-blind-spot class where a substantive Copilot loop is *expected*, not a signal that layer 1 was skipped. (Reference: #562 R1 bigint-leak + corrupt-key; R2 write-side offset validation.)
+Result-integration-boundary packages wrapping a native lib with subtle runtime modes (safe-integer mode, typed/auxiliary columns, driver coercions) are a layer-1 blind spot — expect a *substantive* Copilot loop even after a clean `code-reviewer` pass, and don't call diminishing returns until the finding profile actually goes nitpicky. (Reference: #562 — clean layer 1, then three real persisted-data robustness gaps from Copilot.) See sweep history.
 
 ---
 
@@ -460,13 +456,9 @@ Cross-package `{@link}` bakes an `ae-unresolved-link` warning into the checked-i
 
 ---
 
-### L40. Durable docs must reference durable artifacts — never a transient task file on an unmerged branch
+### L40. (CODIFIED 2026-07-20 → artifact-protocol.md, new "Durable-doc references" section + anti-pattern bullet)
 
-**Observed:** The N-Ask5 `FUTURE.md` entry cited `.ai/tasks/active/n-ask5-firmup/open-questions.md` — a firm-up artifact that lived only on the `claude/n-ask5-open-questions` branch (relayed to a peer instance, never merged to `release`). By the time N-Ask5 shipped, that path was a dangling reference on `release`. Fixed by pointing the entry at the shipped PRs + the entry itself.
-
-**Rule:** When a release-durable doc (`FUTURE.md`, `LIBRARY_CAPABILITIES.md`, a convention) references a task artifact, that artifact must itself be on `release`, or the reference must point at a durable record — the **PR number** or the doc entry. Transient firm-up / analysis artifacts on feature branches must not be cited from release docs; cite the PR that consumed them instead.
-
-**Codification candidate:** `.ai/conventions/workflow/artifact-protocol.md` (or `doc-graduation.md`) — a one-line rule: "release-durable docs cite PRs or on-release artifacts, never active-branch task files." (Reference: N-Ask5 FUTURE.md dangling `n-ask5-firmup/open-questions.md`, fixed in #564.)
+Release-durable docs cite PRs or on-release artifacts, never active-branch task files — a transient firm-up artifact on an unmerged branch is a dangling reference the moment the doc lands on `release`. (Reference: N-Ask5 `FUTURE.md` dangling `n-ask5-firmup/open-questions.md`, fixed in #564.) See sweep history.
 
 ---
 
@@ -522,3 +514,16 @@ When this file or accumulated peer notes get swept to release: append entry here
 - **L39. In TSDoc, only `{@link}` symbols this package itself exports.** A cross-package `{@link OtherPkgSymbol}` bakes an `ae-unresolved-link` warning verbatim into the checked-in `etc/*.api.md` (stale-api.md / CI-diff liability). Use a plain code span for other-package symbols; `{@inheritDoc OtherPkg.Symbol.method}` is the one sanctioned cross-package reference (load-bearing for doc inheritance on Result-integration-boundary packages; its `ae-unresolved-inheritdoc-reference` warning is tolerated + sibling-consistent). → codified into `.ai/instructions/CODE_REVIEW_CHECKLIST.md` § Priority 3, new "Documentation / TSDoc" subsection. Graduated immediately rather than batch-swept because it **recurred** (#558 → #562 R2) — the recurrence is the graduation trigger per the codification-triage convention. (Reference: #562 R2 `ae-unresolved-link` on `{@link IFragmentVectorIndex}`; prior #558 instance.)
 
 L38 (native-boundary layer-1 blind spot) and L40 (release-durable-doc artifact references) remain parked pending a future sweep.
+
+---
+
+### 2026-07-20 — L38 + L40 codified (cycle-close sweep)
+
+**PR:** `claude/fgv-orchestrator-v-orient-s1z0ax` (post-#565 orchestrator sweep; PR number recorded in the PR itself).
+
+**Graduated:**
+
+- **L38. Native-boundary packages are a layer-1 blind spot — expect a substantive Copilot loop.** → codified in `.ai/instructions/CODING_STANDARDS.md` § "Review-loop discipline", new subsection "Native-boundary packages are a known layer-1 blind spot — expect a substantive layer-2 loop": on Result-integration-boundary packages wrapping a native lib with runtime modes, a clean layer-1 pass does not predict a nitpick-only Copilot loop; budget for substantive rounds 1–2 and judge diminishing returns by finding profile, not by the clean layer-1 pass. Swept one cycle after capture rather than aging in the inbox — the handoff had already named it load-bearing for the next native-boundary package. (Reference: #562 R1 bigint-leak + corrupt-key; R2 write-side offset validation.)
+- **L40. Release-durable docs cite PRs or on-release artifacts, never active-branch task files.** → codified in `.ai/conventions/workflow/artifact-protocol.md`, new "Durable-doc references" section + a matching anti-pattern bullet: transient firm-up/analysis artifacts on feature branches must not be cited from release-durable docs; cite the consuming PR or restate the content. (Reference: N-Ask5 `FUTURE.md` dangling `n-ask5-firmup/open-questions.md`, fixed in #564.)
+
+With this sweep the N-Ask5 cycle's lesson set (L38/L39/L40) is fully codified; the pending inbox has no entries newer than L30.

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -25,9 +25,9 @@ Description with the user's framing expanded with the design space.
 
 ## `ts-prompt-assist` — cache parsed store records in the resolve path
 
-`PromptLibrary.resolve` re-reads and **re-parses YAML from the store on every call**. The resolve path (`resolve/promptLibrary.ts:585`) calls `walkScopeChain(this._store, …)` unconditionally first, and `FileTreePromptStore` has no record cache — `store.get` → `_readPromptFile` → `yamlConverter.convert(text)` (`store/fileTreePromptStore.ts:160/239/254`) parses on every read. Per resolve this is **O(scope-chain depth) for the requested prompt only** — the `<id>.yaml` in each scope of *that resolve's* chain (`chainWalker.ts:44`) + the per-scope `_bindings.yaml` (`:67`) + recursively the inner-prompt files for any `kind: 'resource'` slots. It is NOT a re-parse of the whole library.
+`PromptLibrary.resolve` re-reads and **re-parses YAML from the store on every call**. The resolve path (`resolve/promptLibrary.ts:622`) calls `walkScopeChain(this._store, …)` unconditionally first, and `FileTreePromptStore` has no record cache — `store.get` → `_readPromptFile` → `yamlConverter.convert(text)` (`store/fileTreePromptStore.ts:160/239/254`) parses on every read. Per resolve this is **O(scope-chain depth) for the requested prompt only** — the `<id>.yaml` in each scope of *that resolve's* chain (`chainWalker.ts:44`) + the per-scope `_bindings.yaml` (`:67`) + recursively the inner-prompt files for any `kind: 'resource'` slots. It is NOT a re-parse of the whole library.
 
-What's already cached (the expensive work): the ts-res **materialization** (`_materialized`, keyed by descriptor-canonical, `:835/851`) and Mustache templates (`_mustacheCache`); `describe()` uses `_descriptorCache` (`:456`), but `resolve` does not. So only the YAML file read + parse of the requested prompt's chain is redundant on a repeat resolve of a hot prompt.
+What's already cached (the expensive work): the ts-res **materialization** (`_materialized`, keyed by descriptor-canonical, `:888/916`) and Mustache templates (`_mustacheCache`); `describe()` uses `_descriptorCache` (`:493`), but `resolve` does not. So only the YAML file read + parse of the requested prompt's chain is redundant on a repeat resolve of a hot prompt.
 
 **The fix:** add a parsed-store-record cache in the resolve path (or have `resolve` reuse a record/descriptor cache instead of hitting `walkScopeChain` raw). This is **invalidation-free today** because `FileTreePromptStore` is **read-only at v0.1** — records are immutable for the library's lifetime. The cache key must match the resolve lookup granularity (scope + id, plus the scope `_bindings.yaml`), not just id.
 
@@ -35,7 +35,7 @@ What's already cached (the expensive work): the ts-res **materialization** (`_ma
 
 **Dependencies**: the per-resolve YAML parse showing up as a real cost in a profiled workload. **Coupling note:** when a write API lands (`put`/`delete`/`watch` — itself a separate FUTURE item, the store is read-only at v0.1), this record cache needs invalidation wired to writes; design the cache so that hook is additive.
 
-**Reference**: 2026-06 investigation — an agent asserted "re-parses all prompt YAML files on every call"; verified the kernel (no record cache → per-resolve re-parse) but corrected the scope (requested prompt's chain files, not the whole library). Filed via PR #493; re-filed conflict-free by the 2026-07 lessons-sweep PR.
+**Reference**: 2026-06 investigation — an agent asserted "re-parses all prompt YAML files on every call"; verified the kernel (no record cache → per-resolve re-parse) but corrected the scope (requested prompt's chain files, not the whole library). Originally filed as PR #493; landed via #566 after #493 conflicted.
 
 ## OpenAI frontier via Responses routing
 

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -23,6 +23,20 @@ Description with the user's framing expanded with the design space.
 
 ---
 
+## `ts-prompt-assist` — cache parsed store records in the resolve path
+
+`PromptLibrary.resolve` re-reads and **re-parses YAML from the store on every call**. The resolve path (`resolve/promptLibrary.ts:585`) calls `walkScopeChain(this._store, …)` unconditionally first, and `FileTreePromptStore` has no record cache — `store.get` → `_readPromptFile` → `yamlConverter.convert(text)` (`store/fileTreePromptStore.ts:160/239/254`) parses on every read. Per resolve this is **O(scope-chain depth) for the requested prompt only** — the `<id>.yaml` in each scope of *that resolve's* chain (`chainWalker.ts:44`) + the per-scope `_bindings.yaml` (`:67`) + recursively the inner-prompt files for any `kind: 'resource'` slots. It is NOT a re-parse of the whole library.
+
+What's already cached (the expensive work): the ts-res **materialization** (`_materialized`, keyed by descriptor-canonical, `:835/851`) and Mustache templates (`_mustacheCache`); `describe()` uses `_descriptorCache` (`:456`), but `resolve` does not. So only the YAML file read + parse of the requested prompt's chain is redundant on a repeat resolve of a hot prompt.
+
+**The fix:** add a parsed-store-record cache in the resolve path (or have `resolve` reuse a record/descriptor cache instead of hitting `walkScopeChain` raw). This is **invalidation-free today** because `FileTreePromptStore` is **read-only at v0.1** — records are immutable for the library's lifetime. The cache key must match the resolve lookup granularity (scope + id, plus the scope `_bindings.yaml`), not just id.
+
+**Why deferred**: not a problem at current scale — the per-resolve parse is a handful of small files and the heavy ts-res setup is already cached. Surfaced as an investigation finding, not a live bottleneck.
+
+**Dependencies**: the per-resolve YAML parse showing up as a real cost in a profiled workload. **Coupling note:** when a write API lands (`put`/`delete`/`watch` — itself a separate FUTURE item, the store is read-only at v0.1), this record cache needs invalidation wired to writes; design the cache so that hook is additive.
+
+**Reference**: 2026-06 investigation — an agent asserted "re-parses all prompt YAML files on every call"; verified the kernel (no record cache → per-resolve re-parse) but corrected the scope (requested prompt's chain files, not the whole library). Filed via PR #493; re-filed conflict-free by the 2026-07 lessons-sweep PR.
+
 ## OpenAI frontier via Responses routing
 
 > **SHIPPED** — the `ai-assist-openai-frontier-responses` stream. `callProviderCompletion`

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -146,6 +146,23 @@ Deferred from the `ts-extras-mcp` slice-1 stream (2026-06-06). Each is additive 
 
 ---
 
+## Web-runnable CLI scenarios in `samples/testbed`
+
+Today only 2 of the testbed's 16 scenarios have `web` implementations (`local-classifier-safety`, `local-embedding-search`); everything else renders the shell's "This scenario has no web interface — run it from the CLI" panel. Most of those CLI-only scenarios are not intrinsically Node-bound — the provider client-tools, model-tiers, and embedding scenarios are HTTP calls that ai-assist already supports from the browser (directly, or via the proxied variants where CORS bites). A generic web runner — a shell-provided panel that executes a scenario's existing `run` logic in-browser and streams its logger + result text into the UI — would make the whole verification runbook drivable from the web app without writing a bespoke React component per scenario.
+
+Design space:
+- **Opt-in flag, not autodetection**: a scenario declares browser-compatibility (e.g. `webRunnable: true` or a shared `run` hoisted out of `cli`); genuinely Node-only scenarios (better-sqlite3 persistence, stdio MCP probe, Node-ONNX paths) stay CLI-only and keep the current panel.
+- **Secrets are the real prerequisite**: the shell's `IScenarioContext` currently stubs `keyStore: undefined` and `resolveSecret` (B-1 stub — "no web scenario calls it yet"). The web-side KeyStore story already exists as a primitive (`FileApiTreeAccessors.createFromLocalStorage`, per the local-ai-exploration recon) and is proven in `samples/ai-image-gen-sample`; wiring it into the testbed shell unblocks both this entry and the image-scenario port (see the P2 TECH_DEBT entry — shared prerequisite, do the wiring once).
+- **Output surface**: CLI scenarios return `Result<string>` reports; the runner needs only a monospace output panel + the existing StatusBar logger wiring.
+
+**Why deferred**: new shell capability, not a fix; the manual runbook is serviceable from the CLI today. Should follow (or ride with) the `ai-image-gen-sample` port so the secret wiring lands once.
+
+**Dependencies**: web-side KeyStore/secret wiring in the testbed shell (shared with the image-port TECH_DEBT entry); scenario-contract addition (`webRunnable` or equivalent) — additive.
+
+**Reference**: Erik 2026-07-26 ("I thought [we had a task] to make the CLI scenarios runnable in the UI… We should probably revive those"). This task was discussed but never persisted to the backlog — recovered from session context during the model-rotation verification runbook; filed now so it survives.
+
+---
+
 ## Live-wire-shape verification testbed scenarios per provider
 
 **Status: shipped 2026-06-05 via the `per-provider-testbed-scenarios` cluster** (parent PR #453 + sub-stream PRs #454, #457, #458). Three new scenarios (`openaiClientTools`, `geminiClientTools`, `xaiClientTools`) in `samples/testbed/` parallel the existing `anthropicClientTools` scenario; all four PASS on live API as of cluster close. Empirical loop ran four times during the cluster; each round surfaced a real wire-shape bug that 100%-coverage unit tests missed and that the live runs caught. See `.ai/tasks/completed/2026-06/per-provider-testbed-scenarios/README.md` for the full arc.

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -150,18 +150,16 @@ opportunistically when the right surface area is touched.
 
   **Reference**: `ai-assist-model-aliases` design §3 + Tier 2 manual-axis bumps (`.ai/tasks/active/ai-assist-model-aliases/state.md`).
 
-- **[P3] Port `samples/ai-image-gen-sample` scenarios into `samples/testbed`.**
-  The new general-purpose `samples/testbed` sample-browser (commissioned via `local-ai-exploration` cluster, 2026-05-22) is the canonical home for fgv-capability scenarios going forward. The existing `samples/ai-image-gen-sample` predates the testbed and has its own webpack pipeline + scenario shapes; its content (image generation against multiple providers, prompt-assist round-2 demo, etc.) should be ported into the testbed once the testbed shell is established.
+- **[P2] Port `samples/ai-image-gen-sample` scenarios into `samples/testbed`.** *(elevated P3 → P2, 2026-07-26)*
+  The general-purpose `samples/testbed` sample-browser (commissioned via `local-ai-exploration` cluster, 2026-05-22) is the canonical home for fgv-capability scenarios going forward. The existing `samples/ai-image-gen-sample` predates the testbed and has its own webpack pipeline + scenario shapes; its content (image generation against multiple providers, prompt-assist round-2 demo, etc.) should be ported into the testbed.
 
-  **Trigger**: after `local-ai-exploration` cluster ships and the testbed has at least 2-3 native scenarios proving the shell + scenario contract are stable.
+  **Trigger (fired)**: the original trigger — "testbed has at least 2-3 native scenarios proving the shell + scenario contract are stable" — is long met (16 registered scenarios as of 2026-07). The elevation trigger: the 2026-07 `ai-assist-model-rotation` verification runbook forced a two-app validation flow (image validation in `ai-image-gen-sample` on :3003, everything else in the testbed on :3004), and the split was surprising in practice — the testbed was expected to carry the image scenarios (Erik, 2026-07-26).
 
-  **Scope sketch**: port each `ai-image-gen-sample` scenario as a testbed `IScenario` web impl. Pull data from the existing sample's fixture pattern into the testbed's `data/` pipeline. Decide whether to retire `samples/ai-image-gen-sample` entirely (lean: retire — one canonical sample app, not two) or keep it as a "minimal sample skeleton" reference for consumers who want a single-purpose app shape.
+  **Scope sketch**: port each `ai-image-gen-sample` scenario as a testbed `IScenario` web impl. Pull data from the existing sample's fixture pattern into the testbed's `data/` pipeline. Decide whether to retire `samples/ai-image-gen-sample` entirely (lean: retire — one canonical sample app, not two) or keep it as a "minimal sample skeleton" reference for consumers who want a single-purpose app shape. Absorb the known docs-drift in the sample's README (prose still names pre-rotation model ids) — moot if the sample is retired. Note the web-side secret story is a shared prerequisite with the "web-runnable CLI scenarios" FUTURE entry — the image scenarios need API keys in the browser, which the testbed shell currently stubs (`keyStore: undefined`, B-1); `ai-image-gen-sample` already solves this per the chocolate-lab localStorage-KeyStore pattern, so the port should carry that wiring into the shell where both efforts can share it.
 
   **Not a P1**: existing sample works as-is; consumer-visible behavior unchanged either way.
 
-  **Not a P2**: the testbed has to land + stabilize before the port has a real target. P3 reflects "do this once the testbed earns the right to absorb."
-
-  **Reference**: `local-ai-exploration` cluster brief at `.ai/tasks/active/local-ai-exploration/brief.md`; Erik 2026-05-22 ("we should probably add tech debt to port the ai image scenarios over as well").
+  **Reference**: `local-ai-exploration` cluster brief at `.ai/tasks/completed/2026-05/local-ai-exploration/brief.md`; Erik 2026-05-22 ("we should probably add tech debt to port the ai image scenarios over as well"); Erik 2026-07-26 (revival — "we had a task to move the image scenarios to the testbed at one point… We should probably revive those").
 
 - **[P3] New pure-library packages must declare `"sideEffects": false` in `package.json`.**
   Every `libraries/` package whose `src/index.ts` exports only functions and types (no module-level side effects) carries `"sideEffects": false` so bundlers can tree-shake it. This was caught in PR review on `crypto-batch-2-webauthn`: `@fgv/ts-extras-webauthn` was missing the field; `@fgv/ts-web-extras-webauthn` had it. Fixed in-stream, but the gap reveals a scaffolding-checklist hole — the standard "new package" template doesn't enforce it.


### PR DESCRIPTION
## Summary

Post-#565 orchestrator sweep closing out the N-Ask5 cycle's lesson inbox, plus housekeeping absorption of conflicted docs PR #493, plus the branch-migration checklist drafted in the same session. Docs-only; no package changes, no change file.

## Changes

**`.ai/instructions/CODING_STANDARDS.md`** — codifies **L38**: new subsection under "Review-loop discipline" — *Native-boundary packages are a known layer-1 blind spot*. On Result-integration-boundary packages wrapping a native lib with subtle runtime modes (e.g. better-sqlite3 safe-integer mode), a clean layer-1 `code-reviewer` pass does not predict a nitpick-only Copilot loop; budget for substantive rounds 1–2 and judge diminishing returns by finding profile. (Reference: #562 — clean layer 1, then three real persisted-data robustness gaps from Copilot.)

**`.ai/conventions/workflow/artifact-protocol.md`** — codifies **L40**: new "Durable-doc references" section + matching anti-pattern bullet — release-durable docs cite PRs or on-release artifacts, never active-branch task files. (Reference: N-Ask5 `FUTURE.md` dangling `n-ask5-firmup/` reference, fixed in #564.)

**`.ai/notes/orchestrator/lessons-pending.md`** — L38/L39/L40 removed from Pending lessons (sweep history carries the full record, matching the L31–L37 precedent); status + "Last sweep" lines updated; 2026-07-20 sweep-history entry added citing this PR. With this sweep the N-Ask5 lesson set is fully codified and the pending inbox has no entries newer than L30.

**`docs/FUTURE.md`** — re-files the `ts-prompt-assist` parsed-record-cache entry from PR #493, which conflicted against current `release` (FUTURE.md was heavily edited by #564 since #493 branched in June). Content carried over from #493 with code-location citations refreshed against current HEAD (`promptLibrary.ts` 585→622, 835/851→888/916, 456→493; verified by grep). #493 closed as superseded.

**`.ai/notes/orchestrator/branch-migration-checklist.md`** (new) — self-contained plan + checklist for the branch-strategy migration agreed 2026-07-20: `main` as trunk, new `published` pointer branch, `release` drained then retired, `prerelease` recreated off new main. Six phases with checkboxes, Erik's blocking settings-page pre-flight items called out, verified facts pinned, and open questions listed — so the migration can be picked up cold in a later session. **Note:** this PR should merge before the Phase 4 drain so it rides `release`→`main`.

## Layer-1 review summary

`code-reviewer` run on the sweep diff. Findings: 1×P1 (codified stubs left under "Pending lessons" contradicted the status line — fixed by removing them, matching L31–L37 precedent), 3×P2 (stale "Last sweep" line — fixed; branch-name-instead-of-PR-number citation — fixed with #566; drifted FUTURE.md line citations — verified and refreshed), 3×P3 (format-drift advisories — dispositioned as consistent with the de facto looseness of the surrounding docs; Reference-line wording tightened). All findings resolved in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD