### PR TITLE
testbed: port image-generation + streaming-chat scenarios with web-side secrets (Phase A)

### DIFF
--- a/.ai/tasks/active/testbed-web-scenarios/brief.md
+++ b/.ai/tasks/active/testbed-web-scenarios/brief.md
@@ -1,0 +1,51 @@
+# Stream brief — `testbed-web-scenarios` (Phase A: image-scenario port + web secrets)
+
+**Commissioned:** 2026-07-26 (Erik: "Okay, 568 is merged. Let's land those two scenarios.")
+**Branch:** `testbed-web-scenarios` off `release` @ `a57045d9` (post-#568 model rotation).
+**Backlog anchors:** `docs/TECH_DEBT.md` "[P2] Port `samples/ai-image-gen-sample` scenarios into `samples/testbed`" + `docs/FUTURE.md` "Web-runnable CLI scenarios in `samples/testbed`" (Phase B — NOT this phase; see Sequencing).
+
+## Mission
+
+Port the two `samples/ai-image-gen-sample` scenarios — **image generation** and **streaming chat (with the ts-prompt-assist tone demo)** — into `samples/testbed` as `IScenario` web implementations, wiring the testbed shell's web-side secret story that both this port and the future web-runner phase depend on.
+
+## Ground truth (recon done — trust this, verify cheaply)
+
+- **Shell contract** (`samples/testbed/src/shell/index.ts`): `IScenario = IScenarioBase & { web?, cli? }`. `IScenarioBase.requiredSecrets?: ISecretSpec[]` is *already documented* as "surfaced in the secrets modal" — the modal was anticipated but never built. `IScenarioContext` carries `keyStore: KeyStore | undefined` (web passes `undefined` — B-1 stub), `resolveSecret(spec)` (KeyStore-first, env-var fallback via `shell/secretResolver.ts`), `logger`, `dataTree`.
+- **Web shell** (`samples/testbed/src/web/App.tsx`): builds the context with `keyStore: undefined` and a `resolveSecret` that can only see env vars (i.e. nothing, in a browser). Sidebar lists all scenarios; no-web scenarios get a CLI-only panel.
+- **Existing web scenarios** (`localClassifierSafety`, `localEmbeddingSearch` — both `index.tsx`): the only two with `web` impls; use them as the component/initialize pattern reference.
+- **Image sample** (`samples/ai-image-gen-sample/src/`): `App.tsx` (427 lines, two modes: `image` | `chat`), `components/SettingsPanel.tsx` (provider picker + API-key input + model picker + listModels fetch), `PromptPanel.tsx`, `ImageResults.tsx`, `ChatPanel.tsx` (streaming chat), `promptLibrary.ts` (ts-prompt-assist tone demo, typed `qualifierNameConverter`), `inMemoryKeyStore.ts` (33-line `InMemoryKeyStore implements AiAssist.IAiAssistKeyStore` — session-memory secrets, typed once per session). Uses `useAiAssist` from `@fgv/ts-app-shell` and `AiAssist.supportsImageGeneration` / `resolveModel(descriptor.defaultModel, 'image' | 'base')` (the model picker pre-fills from the rotated tiers — preserve this; it's the live rotation validator).
+
+## Design decisions (locked)
+
+1. **Web secrets = session-memory + shell-level secrets UI.** Port the `InMemoryKeyStore` pattern up into the testbed shell as a session secret source: a shell-owned secrets modal/panel (opened from the top bar) that lists the union of `requiredSecrets` across registered scenarios (grouped by scenario or deduped by id — implementer's call, dedupe leans cleaner since provider keys are shared), lets the user paste values, and holds them in React state for the session. The web `resolveSecret` consults this store first (then env fallback, which is a no-op in browsers). **Do NOT build a password-encrypted persistent KeyStore in this phase** — `keyStore` stays `undefined`; `resolveSecret` is the seam scenarios use. Persistent/encrypted storage is a possible future extension, not Phase A.
+2. **Scenarios declare their keys via `requiredSecrets`** using the SAME secret ids the CLI scenarios already use (`openai-api-key`/`OPENAI_API_KEY`, `anthropic-api-key`, `gemini-api-key`/`google-api-key`, `xai-api-key` — check `modelTiers/index.ts` for the exact existing specs and reuse them; do not invent parallel ids).
+3. **Two new scenarios**, registered in `scenarios/index.ts`:
+   - `image-generation` (category `ai`): port of the sample's image mode — provider picker (image-capable providers), model picker pre-filled from the `image` tier, prompt, generated-image results. Web-only (`web` impl, no `cli`).
+   - `streaming-chat` (category `ai` or `prompts` — leans `prompts` since the ts-prompt-assist tone demo is the differentiator): port of the chat mode incl. `promptLibrary.ts` tone resolution. Web-only.
+   The per-scenario components read keys via `context.resolveSecret` and render a clear "missing key — open Secrets" affordance when absent (do not crash; do not silently no-op).
+4. **Do NOT retire `samples/ai-image-gen-sample` in this phase.** Erik decides retirement after validating parity in the testbed. Do not modify the sample at all.
+5. **Reuse, don't fork:** if porting reveals a gap in `@fgv/ts-app-shell` (e.g. the modal primitive, `useAiAssist`), extend the library additively rather than hand-rolling in the testbed (repo rule: extend core libraries over working around them). `ts-app-shell` is on the active surface — additive changes need no signoff, but they DO need a Rush change file (`minor` for additive `@public` surface).
+
+## Explicitly NOT in scope (Phase A)
+
+- The generic web runner for CLI scenarios (`webRunnable` flag etc.) — that's Phase B, commissioned separately on top of this phase's secret wiring.
+- Persistent/encrypted browser KeyStore.
+- Retiring or modifying `ai-image-gen-sample`.
+- Any ai-assist library changes beyond what the port strictly requires (expected: none).
+
+## Acceptance criteria
+
+- [ ] `rushx build`, `rushx lint`, `rushx test` (100% coverage) green in `samples/testbed` and every other modified package
+- [ ] `rushx build:web` (production webpack) compiles clean — NO `resolve.fallback` stubs (they were deliberately removed in #568; a resolve error means a Node leak)
+- [ ] `rushx fixlint` run before final commit
+- [ ] No `any`; Result pattern throughout; converters/validators for untyped input
+- [ ] Rush change file for `@fgv/ts-app-shell` IF it is modified (samples are not publishable — no change file for testbed itself)
+- [ ] Both new scenarios render in the web shell, declare `requiredSecrets`, and degrade gracefully without keys
+- [ ] The secrets modal is reachable from the shell chrome and feeds `resolveSecret`
+- [ ] `code-reviewer` agent run on the final diff BEFORE coverage-gap closure; findings resolved/dispositioned (layer 1; see CODING_STANDARDS "Review-loop discipline")
+- [ ] Brief + state artifacts committed under `.ai/tasks/active/testbed-web-scenarios/`
+- [ ] PR opened to `release` with the layer-1 summary + a manual validation runbook (what Erik clicks, per provider, expected pre-filled models); Copilot loop driven to diminishing returns; DO NOT merge
+
+## Sequencing note
+
+Phase B (generic web runner) follows in a separate PR once this phase's secret wiring merges. Keep the secrets store/modal API shaped so a runner panel can consume it unchanged (it already will if scenarios only go through `resolveSecret`).

--- a/.ai/tasks/active/testbed-web-scenarios/state.md
+++ b/.ai/tasks/active/testbed-web-scenarios/state.md
@@ -1,0 +1,114 @@
+# State — `testbed-web-scenarios` (Phase A)
+
+## Status
+Implementation + scenario-driven tests complete. About to run layer-1 `code-reviewer`
+pass before closing remaining coverage gaps (per TESTING_GUIDELINES sequencing).
+
+## What shipped
+
+### Shell secret story (`samples/testbed/src/shell/`)
+- `secretResolver.ts`: replaced the B-1 stub with a real implementation. Resolution
+  order: unlocked KeyStore (if present and holds the secret) → session-memory secrets
+  map (new, optional `sessionSecrets` param) → env-var fallback. `keyStore` stays
+  `undefined` on both web and CLI in this phase (per brief design decision 1); the
+  KeyStore branch is honored because the param already existed, not newly added.
+- `sessionSecretsStore.ts` (new): `dedupeRequiredSecrets(scenarios)` (pure, dedupes
+  `requiredSecrets` across the registry by id) and `useSessionSecretsStore()` (React
+  hook holding a `ReadonlyMap<string,string>` in state; `setSecret` produces a new Map
+  identity on every update — this identity change is the reactivity signal scenario
+  effects key off via `context.resolveSecret`'s closure identity).
+- Both re-exported from the `shell/index.ts` barrel (matching the existing
+  barrel-only-import convention observed across the package).
+
+### Web shell mount (`samples/testbed/src/web/`)
+- `SecretsModal.tsx` (new): renders `@fgv/ts-app-shell`'s `Modal` listing one field per
+  deduped required secret (session-memory only, explicit no-persistence copy in the
+  modal body).
+- `App.tsx`: added a "Secrets" button to the top bar (opens the modal), wired
+  `useSessionSecretsStore()` into `TestbedShell`, and rewired `scenarioContext.resolveSecret`
+  to pass `sessionSecrets: secrets` with `secrets` in the `useMemo` deps (so the
+  `resolveSecret` closure identity changes whenever a secret is saved). Removed the two
+  stale `/* c8 ignore */` comments referencing the B-1 stub (now real code paths, both
+  covered by tests).
+- `cli.ts`: removed a stale `c8 ignore` comment on the `getEnvVar` callback (now a real,
+  exercised path — the CLI's `resolveSecret` call already passed `getEnvVar` before this
+  phase, but it never had an effect until the stub was replaced).
+
+### Two new scenarios
+- `scenarios/aiProviderSecrets.ts` (new, shared by both scenarios): `PROVIDER_SECRET_SPECS`
+  maps `AiAssist.AiProviderId` → the *existing* CLI secret ids (`openai-api-key`,
+  `anthropic-api-key`, `gemini-api-key`/`google-api-key`, `xai-api-key` — verified against
+  `modelTiers/index.ts` and the `*ClientTools` scenarios, no new ids invented).
+  `requiredSecretsForProviders`, `resolveProviderApiKey`, `SingleSecretKeyStore` (a
+  from-scratch re-implementation of the sample's `InMemoryKeyStore` shape — the sample
+  itself is untouched, per the brief), and `useProviderApiKey` (a hook that resolves +
+  tracks the current provider's key, re-resolving on provider change or on
+  `context.resolveSecret` identity change).
+- `scenarios/imageGeneration/` (`index.tsx`, `SettingsPanel.tsx`, `PromptPanel.tsx`,
+  `ImageResults.tsx`): web-only port of the sample's image mode. **No CLI** (a live key
+  can't be embedded in the CLI's non-interactive run, and the sample itself has no CLI
+  surface). No per-scenario API-key input — `SettingsPanel` shows a "no key configured —
+  open Secrets" affordance instead, per design decision 3.
+- `scenarios/streamingChat/` (`index.tsx`, `SettingsPanel.tsx`, `ChatPanel.tsx`,
+  `promptLibrary.ts`): web-only port of the sample's chat mode + the `ts-prompt-assist`
+  tone demo (near-verbatim port of `promptLibrary.ts`). Same no-per-scenario-key-input
+  pattern.
+- Both registered in `scenarios/index.ts`.
+
+## Surprises / deviations from the sample
+
+1. **The `ai-assist` image-generation API has moved on since the sample was written.**
+   The sample (`samples/ai-image-gen-sample`) builds via `webpack --mode production`
+   with `babel-loader` only — no `tsc` type-check step — so it silently went stale
+   against the current `IAiImageGenerationOptions` shape. Concretely: `.imagen` (the
+   field the sample uses for aspect ratio) no longer exists, `'gemini-imagen'` is no
+   longer a valid `AiImageApiFormat` (replaced by `'gemini-image-out'`), and
+   `GptImageSize` dropped the DALL-E-3-era `'1024x1792'`/`'1792x1024'` values in favor of
+   `'1024x1024' | '1536x1024' | '1024x1536' | 'auto'`. The ported `PromptPanel.tsx` uses
+   the **current** layered-options API instead of a line-for-line port: OpenAI sizing
+   stays a top-level `options.size`; Gemini Flash Image and xAI Grok Imagine aspect
+   ratio now go through `options.models: [{ provider, family, config: { aspectRatio } }]`
+   blocks. This is a necessary adaptation for testbed (which *does* type-check on
+   `rushx build`), not scope creep — I did not touch the sample itself. Flagging for
+   Erik: the sample itself would fail a real `tsc` pass today and may be worth a
+   separate follow-up (not this stream — out of scope per the brief, "do not modify the
+   sample").
+2. **Dropped the `provider` prop from the ported `PromptPanel`** — it existed in the
+   sample only to print a "dall-e-3 only accepts 1" hint, which is stale given the
+   #568 rotation (gpt-image-2, not dall-e-3). Replaced with a capability-driven
+   `maxCount` hint instead, which is correct for whatever model is actually resolved.
+3. **No secrets-modal `openSecrets()` context callback.** The design decision 3 wants a
+   "missing key — open Secrets" affordance; I implemented it as static text pointing at
+   the top-bar button rather than adding a new `IScenarioContext` field to
+   programmatically open the modal. Simpler, and the Sequencing note's bar
+   ("`resolveSecret` unchanged is enough for the Phase B runner") is satisfied either
+   way — this is a UX-only choice, easy to upgrade to a callback later if Erik wants
+   one-click affordance instead of "look at the top bar".
+4. **`SingleSecretKeyStore` + `useProviderApiKey` are shared** between the two new
+   scenarios (`scenarios/aiProviderSecrets.ts`) rather than duplicated — both scenarios
+   need identical "resolve the current provider's key, rebuild a one-entry
+   `IAiAssistKeyStore` adapter" logic.
+
+## Test coverage status (pre-code-reviewer)
+
+Full `rushx test` run: 380 passed, 0 failed.
+- `shell/`, `web/App.tsx`, `web/SecretsModal.tsx`, `scenarios/aiProviderSecrets.ts`: 100%.
+- `scenarios/imageGeneration/*`: ~98% statements, ~80% branches.
+- `scenarios/streamingChat/*`: ~96% statements, ~78% branches.
+- Aggregate: 99.31% stmts / 94.2% branches / 96.55% funcs / 99.31% lines.
+
+Remaining gaps are mostly defensive branches (unmount guards, `?? undefined` fallbacks
+already covered elsewhere) — will categorize properly in the coverage-closure pass
+*after* the code-reviewer pass, per the load-bearing TESTING_GUIDELINES ordering.
+
+## Open questions / follow-ups for the orchestrator
+
+- Whether to retire `samples/ai-image-gen-sample` is explicitly Erik's call after
+  validating parity (brief decision 4) — not touched.
+- The sample's own type drift (see surprise #1) might warrant a separate small fix
+  stream so `rushx build` (if ever added to its scripts) wouldn't immediately fail;
+  raising as a FYI, not filing it myself since it's outside this stream's declared
+  surface.
+- Phase B (generic web runner) is next, per the brief's sequencing note. The
+  `resolveSecret`/session-secrets-store shape should be consumable unchanged by a
+  runner panel since scenarios only ever go through `context.resolveSecret`.

--- a/samples/testbed/src/cli.ts
+++ b/samples/testbed/src/cli.ts
@@ -78,7 +78,6 @@ function buildCliContext(streams: ITestbedCliStreams): IScenarioContext {
       resolveSecret({
         spec,
         keyStore: undefined,
-        /* c8 ignore next 1 - getEnvVar is not called by the B-1 resolveSecret stub; real env-var lookup lands when the stub is replaced */
         getEnvVar: (name) => process.env[name]
       }),
     dataTree

--- a/samples/testbed/src/scenarios/aiProviderSecrets.ts
+++ b/samples/testbed/src/scenarios/aiProviderSecrets.ts
@@ -169,20 +169,28 @@ export function useProviderApiKey(
   context: IScenarioContext,
   provider: AiAssist.AiProviderId
 ): IProviderApiKeyState {
-  const [state, setState] = useState<IProviderApiKeyState>({ apiKey: '', status: 'loading' });
+  // Internal state is tagged with the provider it was resolved for. `provider` (the
+  // hook's argument) can change one render before the effect below has a chance to
+  // reset `state` to 'loading' for the new provider — without the tag, that one-frame
+  // window would expose the OLD provider's resolved key/status paired with the NEW
+  // provider's id (e.g. a stale OpenAI key momentarily reachable under a
+  // just-selected Gemini secretName). The read-time guard below closes that window.
+  const [state, setState] = useState<IProviderApiKeyState & { readonly forProvider: AiAssist.AiProviderId }>(
+    { apiKey: '', status: 'loading', forProvider: provider }
+  );
 
   useEffect(() => {
     let cancelled = false;
-    setState({ apiKey: '', status: 'loading' });
+    setState({ apiKey: '', status: 'loading', forProvider: provider });
     (async () => {
       const result = await resolveProviderApiKey(context, provider);
       if (cancelled) {
         return;
       }
       if (result.isSuccess()) {
-        setState({ apiKey: result.value, status: 'ready' });
+        setState({ apiKey: result.value, status: 'ready', forProvider: provider });
       } else {
-        setState({ apiKey: '', status: 'missing', error: result.message });
+        setState({ apiKey: '', status: 'missing', error: result.message, forProvider: provider });
       }
     })().catch(() => undefined);
     return () => {
@@ -193,5 +201,8 @@ export function useProviderApiKey(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [provider, context.resolveSecret]);
 
-  return state;
+  if (state.forProvider !== provider) {
+    return { apiKey: '', status: 'loading' };
+  }
+  return { apiKey: state.apiKey, status: state.status, error: state.error };
 }

--- a/samples/testbed/src/scenarios/aiProviderSecrets.ts
+++ b/samples/testbed/src/scenarios/aiProviderSecrets.ts
@@ -1,0 +1,197 @@
+/**
+ * Shared provider-to-secret-spec map for the web AI scenarios (`image-generation`,
+ * `streaming-chat`). Reuses the exact secret ids already declared by the CLI-only
+ * `modelTiers`/`*ClientTools` scenarios (`openai-api-key`, `anthropic-api-key`,
+ * `gemini-api-key`/`google-api-key`, `xai-api-key`) rather than inventing parallel ids, so
+ * the shell's secrets modal shows one field per provider regardless of which scenario is
+ * currently active.
+ *
+ * @packageDocumentation
+ */
+
+import { useEffect, useState } from 'react';
+import { fail, succeed, type Result } from '@fgv/ts-utils';
+import { AiAssist } from '@fgv/ts-extras';
+
+import type { IScenarioContext, ISecretSpec } from '../shell';
+
+/** A provider's primary secret spec, plus an optional alternate (Gemini accepts either). */
+interface IProviderSecretSpecs {
+  readonly primary: ISecretSpec;
+  readonly fallback?: ISecretSpec;
+}
+
+/**
+ * Providers wired into the two web AI scenarios, each mapped to the CLI-scenario secret
+ * ids it already uses. Providers with no entry here (self-hosted `ollama`/`openai-compat`,
+ * `copy-paste`, etc.) are treated as not requiring a secret.
+ * @public
+ */
+export const PROVIDER_SECRET_SPECS: Partial<Record<AiAssist.AiProviderId, IProviderSecretSpecs>> = {
+  openai: {
+    primary: {
+      id: 'openai-api-key',
+      envVarName: 'OPENAI_API_KEY',
+      description: 'OpenAI API key for image generation / streaming chat'
+    }
+  },
+  anthropic: {
+    primary: {
+      id: 'anthropic-api-key',
+      envVarName: 'ANTHROPIC_API_KEY',
+      description: 'Anthropic API key for streaming chat'
+    }
+  },
+  'google-gemini': {
+    primary: {
+      id: 'gemini-api-key',
+      envVarName: 'GEMINI_API_KEY',
+      description: 'Gemini API key for image generation / streaming chat'
+    },
+    fallback: {
+      id: 'google-api-key',
+      envVarName: 'GOOGLE_API_KEY',
+      description: 'Google API key for image generation / streaming chat (alternative to GEMINI_API_KEY)'
+    }
+  },
+  'xai-grok': {
+    primary: {
+      id: 'xai-api-key',
+      envVarName: 'XAI_API_KEY',
+      description: 'xAI API key for image generation / streaming chat'
+    }
+  }
+};
+
+/**
+ * Collects the `requiredSecrets` list for a given set of providers — every provider's
+ * primary spec, plus its fallback spec when one exists. Order-preserving, deduped by id
+ * (a provider is never listed twice even if referenced more than once).
+ * @public
+ */
+export function requiredSecretsForProviders(
+  providers: readonly AiAssist.AiProviderId[]
+): readonly ISecretSpec[] {
+  const byId = new Map<string, ISecretSpec>();
+  for (const provider of providers) {
+    const specs = PROVIDER_SECRET_SPECS[provider];
+    if (!specs) {
+      continue;
+    }
+    if (!byId.has(specs.primary.id)) {
+      byId.set(specs.primary.id, specs.primary);
+    }
+    if (specs.fallback && !byId.has(specs.fallback.id)) {
+      byId.set(specs.fallback.id, specs.fallback);
+    }
+  }
+  return Array.from(byId.values());
+}
+
+/**
+ * Resolves the API key for a provider via `context.resolveSecret`, trying the primary
+ * spec first and the fallback spec (if any) second. Providers with no entry in
+ * {@link PROVIDER_SECRET_SPECS} (self-hosted / no-secret providers) resolve to an empty
+ * string — `ts-extras`'s dispatcher omits the `Authorization` header entirely for those.
+ * @public
+ */
+export async function resolveProviderApiKey(
+  context: IScenarioContext,
+  provider: AiAssist.AiProviderId
+): Promise<Result<string>> {
+  const specs = PROVIDER_SECRET_SPECS[provider];
+  if (!specs) {
+    return succeed('');
+  }
+
+  const primaryResult = await context.resolveSecret(specs.primary);
+  if (primaryResult.isSuccess()) {
+    return primaryResult;
+  }
+  if (!specs.fallback) {
+    return primaryResult;
+  }
+
+  const fallbackResult = await context.resolveSecret(specs.fallback);
+  if (fallbackResult.isSuccess()) {
+    return fallbackResult;
+  }
+  return fail(`${primaryResult.message}; ${fallbackResult.message}`);
+}
+
+/**
+ * Minimal `AiAssist.IAiAssistKeyStore` backed by a single resolved secret value. Mirrors
+ * the shape of the `ai-image-gen-sample`'s `InMemoryKeyStore`, re-implemented here since
+ * the sample itself is not a dependency and is not to be modified — see the
+ * `testbed-web-scenarios` brief.
+ * @public
+ */
+export class SingleSecretKeyStore implements AiAssist.IAiAssistKeyStore {
+  public readonly isUnlocked: boolean = true;
+  private readonly _secrets: ReadonlyMap<string, string>;
+
+  public constructor(secrets: ReadonlyMap<string, string>) {
+    this._secrets = secrets;
+  }
+
+  public hasSecret(name: string): Result<boolean> {
+    return succeed(this._secrets.has(name));
+  }
+
+  public getApiKey(name: string): Result<string> {
+    const value = this._secrets.get(name);
+    if (value === undefined || value.length === 0) {
+      return fail(`secret "${name}" not set`);
+    }
+    return succeed(value);
+  }
+}
+
+/** Resolution status for {@link useProviderApiKey}. */
+export type ProviderApiKeyStatus = 'loading' | 'ready' | 'missing';
+
+/** Return value of {@link useProviderApiKey}. */
+export interface IProviderApiKeyState {
+  /** The resolved key, or `''` while loading/missing. */
+  readonly apiKey: string;
+  readonly status: ProviderApiKeyStatus;
+  /** Populated when `status === 'missing'`. */
+  readonly error?: string;
+}
+
+/**
+ * Resolves and tracks the API key for the given provider, re-resolving whenever the
+ * provider changes or the shell's secrets store updates (surfaced via a new
+ * `context.resolveSecret` closure identity — see `web/App.tsx`).
+ * @public
+ */
+export function useProviderApiKey(
+  context: IScenarioContext,
+  provider: AiAssist.AiProviderId
+): IProviderApiKeyState {
+  const [state, setState] = useState<IProviderApiKeyState>({ apiKey: '', status: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ apiKey: '', status: 'loading' });
+    (async () => {
+      const result = await resolveProviderApiKey(context, provider);
+      if (cancelled) {
+        return;
+      }
+      if (result.isSuccess()) {
+        setState({ apiKey: result.value, status: 'ready' });
+      } else {
+        setState({ apiKey: '', status: 'missing', error: result.message });
+      }
+    })().catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+    // context.resolveSecret's identity (not `context` itself) is the reactivity signal
+    // for "the session secrets store changed" — see web/App.tsx.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [provider, context.resolveSecret]);
+
+  return state;
+}

--- a/samples/testbed/src/scenarios/imageGeneration/ImageResults.tsx
+++ b/samples/testbed/src/scenarios/imageGeneration/ImageResults.tsx
@@ -1,0 +1,68 @@
+/**
+ * Generated-image gallery for the `image-generation` scenario. Ported from
+ * `samples/ai-image-gen-sample/src/components/ImageResults.tsx` with testbed styling
+ * tokens and `image-gen-*` test ids.
+ *
+ * @packageDocumentation
+ */
+
+import React from 'react';
+import { AiAssist } from '@fgv/ts-extras';
+
+export interface IImageResultsProps {
+  readonly response: AiAssist.IAiImageGenerationResponse;
+  readonly onUseAsReference?: (image: AiAssist.IAiGeneratedImage) => void;
+}
+
+export function ImageResults(props: IImageResultsProps): React.ReactElement {
+  const { response, onUseAsReference } = props;
+  const count = response.images.length;
+
+  return (
+    <section data-testid="image-gen-results" className="rounded-lg border border-border bg-surface-raised p-4">
+      <h3 className="text-sm font-semibold text-primary">
+        Generated {count} {count === 1 ? 'image' : 'images'}
+      </h3>
+
+      <div className="mt-3 grid gap-4 sm:grid-cols-2">
+        {response.images.map((image, idx) => (
+          <figure key={idx} data-testid={`image-gen-result-${idx}`} className="space-y-2">
+            <img
+              src={AiAssist.toDataUrl(image)}
+              alt={`Generated image ${idx + 1}`}
+              className="w-full rounded-md border border-border"
+            />
+            <figcaption className="text-xs text-muted">
+              <span className="font-mono">{image.mimeType}</span>
+              {image.revisedPrompt !== undefined && (
+                <p className="mt-1 italic text-secondary">
+                  <span className="not-italic font-semibold text-primary">Revised prompt:</span>{' '}
+                  {image.revisedPrompt}
+                </p>
+              )}
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <a
+                  href={AiAssist.toDataUrl(image)}
+                  download={`generated-${idx + 1}.${image.mimeType.split('/')[1] ?? 'png'}`}
+                  className="text-brand-primary hover:text-brand-secondary"
+                >
+                  Download
+                </a>
+                {onUseAsReference !== undefined && (
+                  <button
+                    type="button"
+                    data-testid={`image-gen-use-as-ref-${idx}`}
+                    onClick={() => onUseAsReference(image)}
+                    className="text-brand-primary hover:text-brand-secondary"
+                  >
+                    Use as reference
+                  </button>
+                )}
+              </div>
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/samples/testbed/src/scenarios/imageGeneration/PromptPanel.tsx
+++ b/samples/testbed/src/scenarios/imageGeneration/PromptPanel.tsx
@@ -7,7 +7,7 @@
  * @packageDocumentation
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import React from 'react';
 import { AiAssist } from '@fgv/ts-extras';
 import { captureAsyncResult, fail, mapResults, succeed } from '@fgv/ts-utils';
@@ -42,6 +42,14 @@ const DEFAULT_OPENAI_SIZES: ReadonlyArray<AiAssist.GptImageSize> = [
 
 /** Common aspect ratios offered for the Gemini Flash Image / xAI Grok Imagine formats. */
 const ASPECT_RATIOS: readonly string[] = ['1:1', '3:4', '4:3', '9:16', '16:9'];
+
+/**
+ * Fallback count cap used when `imageCapability` (or its `maxCount`) is unavailable — e.g.
+ * an unrecognized model id. Matches the previous hardcoded `max={4}` so behavior is
+ * unchanged in that case; every known capability declares its own `maxCount` and takes
+ * priority (OpenAI gpt-image allows up to 10, Gemini Flash Image allows 1, etc.).
+ */
+const DEFAULT_MAX_COUNT: number = 4;
 
 const ACCEPTED_REF_MIME_TYPE_LIST = ['image/png', 'image/jpeg', 'image/webp'] as const;
 const ACCEPTED_REF_MIME_TYPES: string = ACCEPTED_REF_MIME_TYPE_LIST.join(',');
@@ -106,6 +114,19 @@ export function PromptPanel(props: IPromptPanelProps): React.ReactElement {
 
   const imageFormat = imageCapability?.format;
   const acceptsRefs = imageCapability?.acceptsImageReferenceInput === true;
+  // The enforced cap for the `count` field: the selected model's own maxCount when known,
+  // else the conservative DEFAULT_MAX_COUNT. Providers differ widely here (OpenAI gpt-image
+  // allows up to 10, Gemini Flash Image allows only 1), so this must track the selected
+  // model rather than a single hardcoded constant.
+  const maxCount = imageCapability?.maxCount ?? DEFAULT_MAX_COUNT;
+
+  // Re-clamp an already-entered count when the selected model's cap drops below it (e.g.
+  // switching from a provider/model that allows 10 down to one that allows 1) — otherwise
+  // a stale in-range value from the previous model could exceed the new model's cap and
+  // fail server-side on submit.
+  useEffect(() => {
+    setCount((prev) => Math.min(prev, maxCount));
+  }, [maxCount]);
 
   // Aspect-ratio-driven formats configure via the layered `options.models` block for
   // their family rather than a top-level field (only OpenAI's `size` is top-level).
@@ -128,7 +149,10 @@ export function PromptPanel(props: IPromptPanelProps): React.ReactElement {
       return;
     }
     const options: AiAssist.IAiImageGenerationOptions = {
-      count,
+      // Belt-and-suspenders: state is kept clamped by the onChange handler and the
+      // re-clamp effect above, but clamp again at submit time so a stale value can never
+      // reach the provider even under an unusual same-render prop+submit race.
+      count: Math.min(count, maxCount),
       ...(supportsSize ? { size } : {}),
       ...(isGeminiFlashImage
         ? { models: [{ provider: 'google', family: 'gemini-flash-image', config: { aspectRatio } }] }
@@ -253,16 +277,15 @@ export function PromptPanel(props: IPromptPanelProps): React.ReactElement {
             <input
               type="number"
               min={1}
-              max={4}
+              max={maxCount}
               data-testid="image-gen-count-input"
               className="mt-1 block w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-primary focus:outline-none focus:ring-2 focus:ring-focus-ring"
               value={count}
-              onChange={(e) => setCount(Math.max(1, Number(e.target.value) || 1))}
+              onChange={(e) => setCount(Math.min(maxCount, Math.max(1, Number(e.target.value) || 1)))}
               disabled={isWorking}
             />
             <span className="mt-1 block text-xs text-muted">
-              {imageCapability?.maxCount !== undefined &&
-                `This model accepts up to ${imageCapability.maxCount} image(s) per request.`}
+              {`This model accepts up to ${maxCount} image(s) per request.`}
             </span>
           </label>
 

--- a/samples/testbed/src/scenarios/imageGeneration/PromptPanel.tsx
+++ b/samples/testbed/src/scenarios/imageGeneration/PromptPanel.tsx
@@ -103,6 +103,11 @@ export function PromptPanel(props: IPromptPanelProps): React.ReactElement {
   const isGrokImagine = imageFormat === 'xai-images' || imageFormat === 'xai-images-edits';
   const supportsSize = imageFormat === 'openai-images';
   const supportsAspectRatio = isGeminiFlashImage || isGrokImagine;
+  // `acceptedSizes` is typed `ReadonlyArray<string>` on IAiImageModelCapability (it's
+  // shared across every image format, not just OpenAI's), so narrowing it to the
+  // `openai-images`-only GptImageSize union is a cast, not a validation. Safe here
+  // because the values originate from this repo's own registry.ts (trusted, not user
+  // input) and this branch only renders when `supportsSize` (format === 'openai-images').
   const availableSizes: ReadonlyArray<AiAssist.GptImageSize> =
     (imageCapability?.acceptedSizes as ReadonlyArray<AiAssist.GptImageSize> | undefined) ??
     DEFAULT_OPENAI_SIZES;
@@ -196,6 +201,7 @@ export function PromptPanel(props: IPromptPanelProps): React.ReactElement {
                   // Surfaced to the user via alert; console gives the developer a stack
                   // trace during local development.
                   console.error('Failed to add reference images.', error);
+                  /* c8 ignore next 3 - defensive: every rejection this chain can produce originates from fileToAttachment's own `throw new Error(...)` calls, so the non-Error fallback is unreachable without a synthetic non-Error rejection */
                   window.alert(
                     error instanceof Error ? error.message : 'Failed to add one or more reference images.'
                   );

--- a/samples/testbed/src/scenarios/imageGeneration/PromptPanel.tsx
+++ b/samples/testbed/src/scenarios/imageGeneration/PromptPanel.tsx
@@ -1,0 +1,321 @@
+/**
+ * Prompt form for the `image-generation` scenario: prompt text, count, size/aspect-ratio
+ * (format-dependent), and reference-image upload. Ported from
+ * `samples/ai-image-gen-sample/src/components/PromptPanel.tsx` with testbed styling
+ * tokens and `image-gen-*` test ids.
+ *
+ * @packageDocumentation
+ */
+
+import { useState } from 'react';
+import React from 'react';
+import { AiAssist } from '@fgv/ts-extras';
+
+export interface IPromptPanelProps {
+  /**
+   * Image-generation capability resolved for the currently selected provider + model.
+   * `undefined` means the current model has no matching capability (e.g. an unknown
+   * model id) and the panel renders no format-specific affordances.
+   */
+  readonly imageCapability: AiAssist.IAiImageModelCapability | undefined;
+  readonly isWorking: boolean;
+  readonly canSubmit: boolean;
+  readonly referenceImages: ReadonlyArray<AiAssist.IAiImageAttachment>;
+  readonly onReferenceImagesChange: React.Dispatch<
+    React.SetStateAction<ReadonlyArray<AiAssist.IAiImageAttachment>>
+  >;
+  readonly onGenerate: (params: AiAssist.IAiImageGenerationParams) => Promise<void>;
+  readonly onAbort: () => void;
+}
+
+/** Default `gpt-image-*` size options (used when the capability doesn't list `acceptedSizes`). */
+const DEFAULT_OPENAI_SIZES: ReadonlyArray<AiAssist.GptImageSize> = [
+  '1024x1024',
+  '1536x1024',
+  '1024x1536',
+  'auto'
+];
+
+/** Common aspect ratios offered for the Gemini Flash Image / xAI Grok Imagine formats. */
+const ASPECT_RATIOS: readonly string[] = ['1:1', '3:4', '4:3', '9:16', '16:9'];
+
+const ACCEPTED_REF_MIME_TYPE_LIST = ['image/png', 'image/jpeg', 'image/webp'] as const;
+const ACCEPTED_REF_MIME_TYPES: string = ACCEPTED_REF_MIME_TYPE_LIST.join(',');
+const ACCEPTED_REF_MIME_TYPE_SET: ReadonlySet<string> = new Set(ACCEPTED_REF_MIME_TYPE_LIST);
+
+async function fileToAttachment(file: File): Promise<AiAssist.IAiImageAttachment> {
+  // Some browsers/OSes report JPEGs as `image/jpg`; normalize to the canonical
+  // `image/jpeg` before validation so they aren't rejected.
+  const fileType = file.type === 'image/jpg' ? 'image/jpeg' : file.type;
+  // `<input accept>` is only a hint, so validate explicitly (drag-drop / "All files" can bypass it).
+  if (!ACCEPTED_REF_MIME_TYPE_SET.has(fileType)) {
+    throw new Error(`unsupported file type: ${file.type || 'unknown'}`);
+  }
+  const dataUrl: string = await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error('failed to read file'));
+    reader.readAsDataURL(file);
+  });
+  // FileReader.readAsDataURL is spec-defined to produce `data:<mime>;base64,<data>`,
+  // but validate the structure explicitly so a malformed prefix fails loudly
+  // instead of producing a silently miscomputed mime/base64.
+  const PREFIX = 'data:';
+  const MARKER = ';base64,';
+  if (!dataUrl.startsWith(PREFIX)) {
+    throw new Error('failed to read file: invalid data URL format');
+  }
+  const markerIdx = dataUrl.indexOf(MARKER);
+  if (markerIdx === -1) {
+    throw new Error('failed to read file: expected base64 data URL');
+  }
+  const base64 = dataUrl.slice(markerIdx + MARKER.length);
+  if (!base64) {
+    throw new Error('failed to read file: empty base64 payload');
+  }
+  const headerMime = dataUrl.slice(PREFIX.length, markerIdx);
+  const mimeType = (headerMime === 'image/jpg' ? 'image/jpeg' : headerMime) || fileType;
+  return { mimeType, base64 };
+}
+
+export function PromptPanel(props: IPromptPanelProps): React.ReactElement {
+  const {
+    imageCapability,
+    isWorking,
+    canSubmit,
+    referenceImages,
+    onReferenceImagesChange,
+    onGenerate,
+    onAbort
+  } = props;
+
+  const [prompt, setPrompt] = useState('A friendly robot painting a watercolor landscape');
+  const [count, setCount] = useState(1);
+  const [size, setSize] = useState<AiAssist.GptImageSize>('1024x1024');
+  const [aspectRatio, setAspectRatio] = useState<string>('1:1');
+
+  const imageFormat = imageCapability?.format;
+  const acceptsRefs = imageCapability?.acceptsImageReferenceInput === true;
+
+  // Aspect-ratio-driven formats configure via the layered `options.models` block for
+  // their family rather than a top-level field (only OpenAI's `size` is top-level).
+  const isGeminiFlashImage = imageFormat === 'gemini-image-out';
+  const isGrokImagine = imageFormat === 'xai-images' || imageFormat === 'xai-images-edits';
+  const supportsSize = imageFormat === 'openai-images';
+  const supportsAspectRatio = isGeminiFlashImage || isGrokImagine;
+  const availableSizes: ReadonlyArray<AiAssist.GptImageSize> =
+    (imageCapability?.acceptedSizes as ReadonlyArray<AiAssist.GptImageSize> | undefined) ??
+    DEFAULT_OPENAI_SIZES;
+
+  const handleSubmit = (e: React.FormEvent): void => {
+    e.preventDefault();
+    if (!canSubmit || isWorking) {
+      return;
+    }
+    const options: AiAssist.IAiImageGenerationOptions = {
+      count,
+      ...(supportsSize ? { size } : {}),
+      ...(isGeminiFlashImage
+        ? { models: [{ provider: 'google', family: 'gemini-flash-image', config: { aspectRatio } }] }
+        : {}),
+      ...(isGrokImagine
+        ? { models: [{ provider: 'xai', family: 'grok-imagine', config: { aspectRatio } }] }
+        : {})
+    };
+    onGenerate({
+      prompt,
+      options,
+      ...(acceptsRefs && referenceImages.length > 0 ? { referenceImages } : {})
+    }).catch(() => undefined);
+  };
+
+  const handleAddRefs = async (files: FileList | null): Promise<void> => {
+    if (!files || files.length === 0) {
+      return;
+    }
+    const added = await Promise.all(Array.from(files).map(fileToAttachment));
+    // Functional update guards against state changing while file reads are in flight.
+    onReferenceImagesChange((prev) => [...prev, ...added]);
+  };
+
+  const handleRemoveRef = (index: number): void => {
+    onReferenceImagesChange((prev) => prev.filter((__ref, i) => i !== index));
+  };
+
+  const handleClearRefs = (): void => {
+    onReferenceImagesChange([]);
+  };
+
+  return (
+    <section data-testid="image-gen-prompt" className="rounded-lg border border-border bg-surface-raised p-4">
+      <h3 className="text-sm font-semibold text-primary">Prompt</h3>
+
+      <form className="mt-3 space-y-4" onSubmit={handleSubmit}>
+        <label className="block text-sm">
+          <span className="font-medium text-secondary">Describe the image</span>
+          <textarea
+            data-testid="image-gen-prompt-input"
+            className="mt-1 block w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-primary focus:outline-none focus:ring-2 focus:ring-focus-ring"
+            rows={3}
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            disabled={isWorking}
+          />
+        </label>
+
+        {acceptsRefs && (
+          <div className="rounded-md border border-border bg-surface p-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-secondary">
+                Reference images{' '}
+                <span className="font-normal text-muted">
+                  ({referenceImages.length} attached) — preserve a character or style across generations
+                </span>
+              </span>
+              {referenceImages.length > 0 && (
+                <button
+                  type="button"
+                  onClick={handleClearRefs}
+                  disabled={isWorking}
+                  className="text-xs font-medium text-secondary hover:text-primary disabled:opacity-50"
+                >
+                  Clear all
+                </button>
+              )}
+            </div>
+            <input
+              type="file"
+              accept={ACCEPTED_REF_MIME_TYPES}
+              multiple
+              disabled={isWorking}
+              aria-label="Add reference images"
+              data-testid="image-gen-ref-file-input"
+              className="mt-2 block w-full text-sm text-secondary"
+              onChange={(e) => {
+                handleAddRefs(e.target.files).catch((error: unknown) => {
+                  // Surfaced to the user via alert; console gives the developer a stack
+                  // trace during local development.
+                  console.error('Failed to add reference images.', error);
+                  window.alert(
+                    error instanceof Error ? error.message : 'Failed to add one or more reference images.'
+                  );
+                });
+                e.target.value = '';
+              }}
+            />
+            {referenceImages.length > 0 && (
+              <ul className="mt-3 flex flex-wrap gap-2">
+                {referenceImages.map((ref, idx) => (
+                  // base64 payload is unique per attachment and stable across
+                  // removes, so React won't reuse DOM nodes when indices shift.
+                  <li key={ref.base64} className="relative">
+                    <img
+                      src={AiAssist.toDataUrl(ref)}
+                      alt={`Reference ${idx + 1}`}
+                      className="h-16 w-16 rounded-md border border-border object-cover"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveRef(idx)}
+                      disabled={isWorking}
+                      aria-label={`Remove reference image ${idx + 1}`}
+                      className="absolute -right-1.5 -top-1.5 inline-flex h-5 w-5 items-center justify-center rounded-full border border-border bg-surface text-xs text-secondary hover:bg-hover disabled:opacity-50"
+                    >
+                      ×
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <label className="block text-sm">
+            <span className="font-medium text-secondary">Count</span>
+            <input
+              type="number"
+              min={1}
+              max={4}
+              data-testid="image-gen-count-input"
+              className="mt-1 block w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-primary focus:outline-none focus:ring-2 focus:ring-focus-ring"
+              value={count}
+              onChange={(e) => setCount(Math.max(1, Number(e.target.value) || 1))}
+              disabled={isWorking}
+            />
+            <span className="mt-1 block text-xs text-muted">
+              {imageCapability?.maxCount !== undefined &&
+                `This model accepts up to ${imageCapability.maxCount} image(s) per request.`}
+            </span>
+          </label>
+
+          {supportsSize && (
+            <label className="block text-sm">
+              <span className="font-medium text-secondary">Size</span>
+              <select
+                data-testid="image-gen-size-select"
+                className="mt-1 block w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-primary focus:outline-none focus:ring-2 focus:ring-focus-ring"
+                value={size}
+                onChange={(e) => setSize(e.target.value as AiAssist.GptImageSize)}
+                disabled={isWorking}
+              >
+                {availableSizes.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          {supportsAspectRatio && (
+            <label className="block text-sm">
+              <span className="font-medium text-secondary">Aspect ratio</span>
+              <select
+                data-testid="image-gen-aspect-select"
+                className="mt-1 block w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-primary focus:outline-none focus:ring-2 focus:ring-focus-ring"
+                value={aspectRatio}
+                onChange={(e) => setAspectRatio(e.target.value)}
+                disabled={isWorking}
+              >
+                {ASPECT_RATIOS.map((a) => (
+                  <option key={a} value={a}>
+                    {a}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            data-testid="image-gen-submit-btn"
+            disabled={!canSubmit || isWorking || prompt.trim().length === 0}
+            className="rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-secondary disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isWorking ? 'Generating…' : 'Generate'}
+          </button>
+
+          {isWorking && (
+            <button
+              type="button"
+              data-testid="image-gen-abort-btn"
+              onClick={onAbort}
+              className="rounded-md border border-border bg-surface px-4 py-2 text-sm font-medium text-secondary hover:bg-hover"
+            >
+              Cancel
+            </button>
+          )}
+
+          {!canSubmit && (
+            <span data-testid="image-gen-cannot-submit-hint" className="text-sm text-muted">
+              Configure an API key (Secrets, top bar) to enable generation.
+            </span>
+          )}
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/samples/testbed/src/scenarios/imageGeneration/PromptPanel.tsx
+++ b/samples/testbed/src/scenarios/imageGeneration/PromptPanel.tsx
@@ -10,6 +10,8 @@
 import { useState } from 'react';
 import React from 'react';
 import { AiAssist } from '@fgv/ts-extras';
+import { captureAsyncResult, fail, mapResults, succeed } from '@fgv/ts-utils';
+import type { Logging, Result } from '@fgv/ts-utils';
 
 export interface IPromptPanelProps {
   /**
@@ -26,6 +28,8 @@ export interface IPromptPanelProps {
   >;
   readonly onGenerate: (params: AiAssist.IAiImageGenerationParams) => Promise<void>;
   readonly onAbort: () => void;
+  /** Shell logger — used to record reference-image read/validation failures. */
+  readonly logger: Logging.LogReporter<unknown>;
 }
 
 /** Default `gpt-image-*` size options (used when the capability doesn't list `acceptedSizes`). */
@@ -43,39 +47,44 @@ const ACCEPTED_REF_MIME_TYPE_LIST = ['image/png', 'image/jpeg', 'image/webp'] as
 const ACCEPTED_REF_MIME_TYPES: string = ACCEPTED_REF_MIME_TYPE_LIST.join(',');
 const ACCEPTED_REF_MIME_TYPE_SET: ReadonlySet<string> = new Set(ACCEPTED_REF_MIME_TYPE_LIST);
 
-async function fileToAttachment(file: File): Promise<AiAssist.IAiImageAttachment> {
+async function fileToAttachment(file: File): Promise<Result<AiAssist.IAiImageAttachment>> {
   // Some browsers/OSes report JPEGs as `image/jpg`; normalize to the canonical
   // `image/jpeg` before validation so they aren't rejected.
   const fileType = file.type === 'image/jpg' ? 'image/jpeg' : file.type;
   // `<input accept>` is only a hint, so validate explicitly (drag-drop / "All files" can bypass it).
   if (!ACCEPTED_REF_MIME_TYPE_SET.has(fileType)) {
-    throw new Error(`unsupported file type: ${file.type || 'unknown'}`);
+    return fail(`unsupported file type: ${file.type || 'unknown'}`);
   }
-  const dataUrl: string = await new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = () => reject(reader.error ?? new Error('failed to read file'));
-    reader.readAsDataURL(file);
+  const dataUrlResult = await captureAsyncResult(
+    () =>
+      new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = () => reject(reader.error ?? new Error('failed to read file'));
+        reader.readAsDataURL(file);
+      })
+  );
+  return dataUrlResult.onSuccess((dataUrl) => {
+    // FileReader.readAsDataURL is spec-defined to produce `data:<mime>;base64,<data>`,
+    // but validate the structure explicitly so a malformed prefix fails loudly
+    // instead of producing a silently miscomputed mime/base64.
+    const PREFIX = 'data:';
+    const MARKER = ';base64,';
+    if (!dataUrl.startsWith(PREFIX)) {
+      return fail('failed to read file: invalid data URL format');
+    }
+    const markerIdx = dataUrl.indexOf(MARKER);
+    if (markerIdx === -1) {
+      return fail('failed to read file: expected base64 data URL');
+    }
+    const base64 = dataUrl.slice(markerIdx + MARKER.length);
+    if (!base64) {
+      return fail('failed to read file: empty base64 payload');
+    }
+    const headerMime = dataUrl.slice(PREFIX.length, markerIdx);
+    const mimeType = (headerMime === 'image/jpg' ? 'image/jpeg' : headerMime) || fileType;
+    return succeed({ mimeType, base64 });
   });
-  // FileReader.readAsDataURL is spec-defined to produce `data:<mime>;base64,<data>`,
-  // but validate the structure explicitly so a malformed prefix fails loudly
-  // instead of producing a silently miscomputed mime/base64.
-  const PREFIX = 'data:';
-  const MARKER = ';base64,';
-  if (!dataUrl.startsWith(PREFIX)) {
-    throw new Error('failed to read file: invalid data URL format');
-  }
-  const markerIdx = dataUrl.indexOf(MARKER);
-  if (markerIdx === -1) {
-    throw new Error('failed to read file: expected base64 data URL');
-  }
-  const base64 = dataUrl.slice(markerIdx + MARKER.length);
-  if (!base64) {
-    throw new Error('failed to read file: empty base64 payload');
-  }
-  const headerMime = dataUrl.slice(PREFIX.length, markerIdx);
-  const mimeType = (headerMime === 'image/jpg' ? 'image/jpeg' : headerMime) || fileType;
-  return { mimeType, base64 };
 }
 
 export function PromptPanel(props: IPromptPanelProps): React.ReactElement {
@@ -86,7 +95,8 @@ export function PromptPanel(props: IPromptPanelProps): React.ReactElement {
     referenceImages,
     onReferenceImagesChange,
     onGenerate,
-    onAbort
+    onAbort,
+    logger
   } = props;
 
   const [prompt, setPrompt] = useState('A friendly robot painting a watercolor landscape');
@@ -138,9 +148,15 @@ export function PromptPanel(props: IPromptPanelProps): React.ReactElement {
     if (!files || files.length === 0) {
       return;
     }
-    const added = await Promise.all(Array.from(files).map(fileToAttachment));
+    const results = await Promise.all(Array.from(files).map(fileToAttachment));
+    const combined = mapResults(results);
+    if (combined.isFailure()) {
+      logger.error(`Failed to add reference images: ${combined.message}`);
+      window.alert(combined.message);
+      return;
+    }
     // Functional update guards against state changing while file reads are in flight.
-    onReferenceImagesChange((prev) => [...prev, ...added]);
+    onReferenceImagesChange((prev) => [...prev, ...combined.value]);
   };
 
   const handleRemoveRef = (index: number): void => {
@@ -197,15 +213,10 @@ export function PromptPanel(props: IPromptPanelProps): React.ReactElement {
               data-testid="image-gen-ref-file-input"
               className="mt-2 block w-full text-sm text-secondary"
               onChange={(e) => {
-                handleAddRefs(e.target.files).catch((error: unknown) => {
-                  // Surfaced to the user via alert; console gives the developer a stack
-                  // trace during local development.
-                  console.error('Failed to add reference images.', error);
-                  /* c8 ignore next 3 - defensive: every rejection this chain can produce originates from fileToAttachment's own `throw new Error(...)` calls, so the non-Error fallback is unreachable without a synthetic non-Error rejection */
-                  window.alert(
-                    error instanceof Error ? error.message : 'Failed to add one or more reference images.'
-                  );
-                });
+                // handleAddRefs is Result-driven end to end (fileToAttachment returns
+                // Result, failures are logged + alerted inside handleAddRefs) — this
+                // catch only guards against an unexpected throw outside that chain.
+                handleAddRefs(e.target.files).catch(() => undefined);
                 e.target.value = '';
               }}
             />

--- a/samples/testbed/src/scenarios/imageGeneration/SettingsPanel.tsx
+++ b/samples/testbed/src/scenarios/imageGeneration/SettingsPanel.tsx
@@ -1,0 +1,151 @@
+/**
+ * Provider + model picker for the `image-generation` scenario. Ported from
+ * `samples/ai-image-gen-sample/src/components/SettingsPanel.tsx`, minus the per-scenario
+ * API-key `<input>` — keys now come from the shell's session secrets store via
+ * `context.resolveSecret` (see `useProviderApiKey` in `../aiProviderSecrets.ts`). In its
+ * place, a "missing key" affordance points the user at the top-bar Secrets button.
+ *
+ * @packageDocumentation
+ */
+
+import React from 'react';
+import { AiAssist } from '@fgv/ts-extras';
+
+import type { ProviderApiKeyStatus } from '../aiProviderSecrets';
+
+export interface ISettingsPanelProps {
+  readonly providers: ReadonlyArray<AiAssist.AiProviderId>;
+  readonly provider: AiAssist.AiProviderId;
+  readonly onProviderChange: (provider: AiAssist.AiProviderId) => void;
+  readonly apiKeyStatus: ProviderApiKeyStatus;
+  readonly apiKeyError: string | undefined;
+  readonly model: string;
+  readonly modelPlaceholder: string;
+  readonly onModelChange: (model: string) => void;
+  readonly availableModels: ReadonlyArray<AiAssist.IAiModelInfo>;
+  readonly isFetchingModels: boolean;
+  readonly modelListError: string | undefined;
+  readonly onFetchModels: () => void;
+}
+
+export function SettingsPanel(props: ISettingsPanelProps): React.ReactElement {
+  const {
+    providers,
+    provider,
+    onProviderChange,
+    apiKeyStatus,
+    apiKeyError,
+    model,
+    modelPlaceholder,
+    onModelChange,
+    availableModels,
+    isFetchingModels,
+    modelListError,
+    onFetchModels
+  } = props;
+  const descriptor = AiAssist.getProviderDescriptor(provider).orDefault();
+  const canFetchModels = apiKeyStatus === 'ready' && !isFetchingModels;
+
+  return (
+    <section
+      data-testid="image-gen-settings"
+      className="rounded-lg border border-border bg-surface-raised p-4"
+    >
+      <h3 className="text-sm font-semibold text-primary">Provider</h3>
+
+      <div className="mt-3 grid gap-4 md:grid-cols-2">
+        <label className="block text-sm">
+          <span className="font-medium text-secondary">Provider</span>
+          <select
+            data-testid="image-gen-provider-select"
+            className="mt-1 block w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-primary focus:outline-none focus:ring-2 focus:ring-focus-ring"
+            value={provider}
+            onChange={(e) => onProviderChange(e.target.value as AiAssist.AiProviderId)}
+          >
+            {providers.map((p) => {
+              const d = AiAssist.getProviderDescriptor(p).orDefault();
+              return (
+                <option key={p} value={p}>
+                  {d?.label ?? p}
+                </option>
+              );
+            })}
+          </select>
+        </label>
+
+        <div className="block text-sm">
+          <span className="font-medium text-secondary">API key</span>
+          {apiKeyStatus === 'ready' ? (
+            <p data-testid="image-gen-key-ready" className="mt-1 text-status-success-text">
+              ✓ Key configured for {descriptor?.label ?? provider}
+            </p>
+          ) : apiKeyStatus === 'loading' ? (
+            <p data-testid="image-gen-key-loading" className="mt-1 text-muted">
+              Checking for a configured key…
+            </p>
+          ) : (
+            <p data-testid="image-gen-key-missing" className="mt-1 text-status-warning-text">
+              No key configured for {descriptor?.label ?? provider}. Open{' '}
+              <strong className="font-semibold">Secrets</strong> (top bar) to add one.
+              {apiKeyError !== undefined && <span className="block text-xs text-muted">{apiKeyError}</span>}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="flex items-end gap-2">
+          <label className="block flex-1 text-sm">
+            <span className="font-medium text-secondary">Model</span>
+            <input
+              type="text"
+              data-testid="image-gen-model-input"
+              className="mt-1 block w-full rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm text-primary placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-focus-ring"
+              placeholder={modelPlaceholder}
+              value={model}
+              onChange={(e) => onModelChange(e.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
+          <button
+            type="button"
+            data-testid="image-gen-fetch-models-btn"
+            disabled={!canFetchModels}
+            onClick={onFetchModels}
+            className="h-[38px] shrink-0 rounded-md border border-border bg-surface px-3 text-sm font-medium text-secondary shadow-sm transition-colors hover:bg-hover disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isFetchingModels ? 'Fetching…' : 'Fetch available'}
+          </button>
+        </div>
+
+        {modelListError !== undefined ? (
+          <p data-testid="image-gen-model-list-error" className="mt-2 text-xs text-status-error-text">
+            <span className="font-semibold">List failed:</span> {modelListError}. You can still type a model
+            name manually.
+          </p>
+        ) : availableModels.length > 0 ? (
+          <ul data-testid="image-gen-model-list" className="mt-2 text-xs text-secondary">
+            {availableModels.map((m) => (
+              <li key={m.id}>{m.displayName ?? m.id}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-2 text-xs text-muted">
+            Override the model name when the registry default isn&apos;t available on your API tier, or
+            click <strong>Fetch available</strong> after a key is configured to see what your account can
+            use.
+          </p>
+        )}
+      </div>
+
+      {descriptor?.corsRestricted && (
+        <p className="mt-3 text-xs">
+          <span className="inline-flex items-center rounded-full bg-status-warning-bg px-2 py-0.5 font-medium text-status-warning-text">
+            CORS-restricted (proxy required for production)
+          </span>
+        </p>
+      )}
+    </section>
+  );
+}

--- a/samples/testbed/src/scenarios/imageGeneration/index.tsx
+++ b/samples/testbed/src/scenarios/imageGeneration/index.tsx
@@ -188,6 +188,7 @@ function ImageGenerationComponent({
         onReferenceImagesChange={setReferenceImages}
         onGenerate={handleGenerate}
         onAbort={handleAbort}
+        logger={context.logger}
       />
       {imageError !== undefined && (
         <div

--- a/samples/testbed/src/scenarios/imageGeneration/index.tsx
+++ b/samples/testbed/src/scenarios/imageGeneration/index.tsx
@@ -58,6 +58,7 @@ function ImageGenerationComponent({
 }: {
   readonly context: IScenarioContext;
 }): React.ReactElement {
+  /* c8 ignore next 3 - defensive: IMAGE_PROVIDERS always has at least one entry from the real ai-assist registry; the fallback guards only a hypothetical empty registry */
   const [provider, setProvider] = useState<AiAssist.AiProviderId>(
     IMAGE_PROVIDERS[0] ?? ('openai' as AiAssist.AiProviderId)
   );
@@ -77,11 +78,21 @@ function ImageGenerationComponent({
 
   const { apiKey, status: apiKeyStatus, error: apiKeyError } = useProviderApiKey(context, provider);
 
+  // `provider` only ever takes a value from IMAGE_PROVIDERS (initial state + the
+  // dropdown's own options), and `modelsByProvider` is seeded from IMAGE_PROVIDERS via
+  // `initialModelsByProvider()`, so `.get(provider)` is always defined in practice; same
+  // for `AiAssist.getProviderDescriptor(provider)` below, and for `currentModel` being
+  // non-empty (every image-capable provider's registry entry resolves a real `image`-tier
+  // default). The `??`/ternary fallbacks guard against those invariants breaking, not a
+  // reachable UI path.
+  /* c8 ignore next 1 */
   const currentModel = modelsByProvider.get(provider) ?? defaultModelFor(provider);
   const imageCapability = useMemo(() => {
     const descriptor = AiAssist.getProviderDescriptor(provider).orDefault();
+    /* c8 ignore next 1 */
     return descriptor ? AiAssist.resolveImageCapability(descriptor, currentModel) : undefined;
   }, [provider, currentModel]);
+  /* c8 ignore next 1 - defensive: imageCapability is only undefined via the equally-unreachable descriptor-undefined branch above */
   const modelAcceptsRefs = imageCapability?.acceptsImageReferenceInput === true;
 
   const keyStore = useMemo(
@@ -96,6 +107,7 @@ function ImageGenerationComponent({
         {
           provider,
           secretName: provider,
+          /* c8 ignore next 1 */
           ...(currentModel.length > 0 ? { model: currentModel } : {})
         }
       ],
@@ -143,6 +155,10 @@ function ImageGenerationComponent({
   };
 
   const handleAbort = (): void => {
+    // The Cancel button (the only caller) renders only while isWorking is true, which
+    // is exactly when handleGenerate has just set abortControllerRef.current — the
+    // undefined branch is defensive, not a reachable UI path.
+    /* c8 ignore next 1 */
     abortControllerRef.current?.abort();
   };
 

--- a/samples/testbed/src/scenarios/imageGeneration/index.tsx
+++ b/samples/testbed/src/scenarios/imageGeneration/index.tsx
@@ -1,0 +1,227 @@
+/**
+ * `image-generation` scenario — a web port of `samples/ai-image-gen-sample`'s image
+ * mode. Provider + model picker (pre-filled from the `image` tier via
+ * `AiAssist.resolveModel`), prompt form, and generated-image gallery, using
+ * `@fgv/ts-app-shell`'s `useAiAssist` hook exactly as the sample does.
+ *
+ * The sample's `InMemoryKeyStore` + per-scenario API-key `<input>` are replaced by the
+ * shell's session secrets store: `useProviderApiKey` (in `../aiProviderSecrets.ts`)
+ * resolves the current provider's key via `context.resolveSecret`, and the panel shows a
+ * "missing key — open Secrets" affordance rather than accepting typed input directly.
+ * `samples/ai-image-gen-sample` itself is untouched — see the `testbed-web-scenarios`
+ * brief for why it is not retired in this phase.
+ *
+ * Web-only: a live API key cannot be embedded in the CLI's non-interactive run, and the
+ * sample this ports has no CLI surface either.
+ *
+ * @packageDocumentation
+ */
+
+import React, { useMemo, useRef, useState } from 'react';
+import { AiAssist } from '@fgv/ts-extras';
+import { useAiAssist } from '@fgv/ts-app-shell';
+
+import type { IScenario, IScenarioContext, IWebScenarioImpl } from '../../shell';
+import { requiredSecretsForProviders, SingleSecretKeyStore, useProviderApiKey } from '../aiProviderSecrets';
+import { SettingsPanel } from './SettingsPanel';
+import { PromptPanel } from './PromptPanel';
+import { ImageResults } from './ImageResults';
+
+// ---------------------------------------------------------------------------
+// Provider list + defaults
+// ---------------------------------------------------------------------------
+
+/** Every registered provider that declares an image-generation capability. */
+const IMAGE_PROVIDERS: ReadonlyArray<AiAssist.AiProviderId> = AiAssist.getProviderDescriptors()
+  .filter((d) => AiAssist.supportsImageGeneration(d))
+  .map((d) => d.id);
+
+/** Resolves the `image`-tier default model id for a provider (empty string if unknown). */
+function defaultModelFor(provider: AiAssist.AiProviderId): string {
+  const descriptor = AiAssist.getProviderDescriptor(provider).orDefault();
+  if (!descriptor) {
+    return '';
+  }
+  return AiAssist.resolveModel(descriptor.defaultModel, 'image');
+}
+
+function initialModelsByProvider(): ReadonlyMap<AiAssist.AiProviderId, string> {
+  return new Map(IMAGE_PROVIDERS.map((p) => [p, defaultModelFor(p)]));
+}
+
+// ---------------------------------------------------------------------------
+// Web component
+// ---------------------------------------------------------------------------
+
+function ImageGenerationComponent({
+  context
+}: {
+  readonly context: IScenarioContext;
+}): React.ReactElement {
+  const [provider, setProvider] = useState<AiAssist.AiProviderId>(
+    IMAGE_PROVIDERS[0] ?? ('openai' as AiAssist.AiProviderId)
+  );
+  const [modelsByProvider, setModelsByProvider] =
+    useState<ReadonlyMap<AiAssist.AiProviderId, string>>(initialModelsByProvider);
+  const [availableByProvider, setAvailableByProvider] = useState<
+    ReadonlyMap<AiAssist.AiProviderId, ReadonlyArray<AiAssist.IAiModelInfo>>
+  >(new Map());
+  const [listErrorByProvider, setListErrorByProvider] = useState<
+    ReadonlyMap<AiAssist.AiProviderId, string>
+  >(new Map());
+  const [isFetchingModels, setIsFetchingModels] = useState(false);
+  const [lastResult, setLastResult] = useState<AiAssist.IAiImageGenerationResponse | undefined>(undefined);
+  const [imageError, setImageError] = useState<string | undefined>(undefined);
+  const [referenceImages, setReferenceImages] = useState<ReadonlyArray<AiAssist.IAiImageAttachment>>([]);
+  const abortControllerRef = useRef<AbortController | undefined>(undefined);
+
+  const { apiKey, status: apiKeyStatus, error: apiKeyError } = useProviderApiKey(context, provider);
+
+  const currentModel = modelsByProvider.get(provider) ?? defaultModelFor(provider);
+  const imageCapability = useMemo(() => {
+    const descriptor = AiAssist.getProviderDescriptor(provider).orDefault();
+    return descriptor ? AiAssist.resolveImageCapability(descriptor, currentModel) : undefined;
+  }, [provider, currentModel]);
+  const modelAcceptsRefs = imageCapability?.acceptsImageReferenceInput === true;
+
+  const keyStore = useMemo(
+    () =>
+      new SingleSecretKeyStore(apiKeyStatus === 'ready' ? new Map([[provider, apiKey]]) : new Map()),
+    [provider, apiKeyStatus, apiKey]
+  );
+
+  const settings = useMemo<AiAssist.IAiAssistSettings>(
+    () => ({
+      providers: [
+        {
+          provider,
+          secretName: provider,
+          ...(currentModel.length > 0 ? { model: currentModel } : {})
+        }
+      ],
+      defaultProvider: provider
+    }),
+    [provider, currentModel]
+  );
+
+  const { isWorking, generateImages, listModels } = useAiAssist({
+    settings,
+    keyStore,
+    logger: context.logger
+  });
+
+  const handleFetchModels = async (): Promise<void> => {
+    const targetProvider = provider;
+    setIsFetchingModels(true);
+    const result = await listModels(targetProvider, 'image-generation');
+    setIsFetchingModels(false);
+    if (result.isFailure()) {
+      setAvailableByProvider((prev) => new Map(prev).set(targetProvider, []));
+      setListErrorByProvider((prev) => new Map(prev).set(targetProvider, result.message));
+    } else {
+      setAvailableByProvider((prev) => new Map(prev).set(targetProvider, result.value));
+      setListErrorByProvider((prev) => {
+        const next = new Map(prev);
+        next.delete(targetProvider);
+        return next;
+      });
+    }
+  };
+
+  const handleGenerate = async (params: AiAssist.IAiImageGenerationParams): Promise<void> => {
+    setImageError(undefined);
+    setLastResult(undefined);
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    const result = await generateImages(provider, params, controller.signal);
+    abortControllerRef.current = undefined;
+    if (result.isFailure()) {
+      setImageError(result.message);
+    } else {
+      setLastResult(result.value);
+    }
+  };
+
+  const handleAbort = (): void => {
+    abortControllerRef.current?.abort();
+  };
+
+  return (
+    <div data-testid="image-gen-scenario" className="space-y-4">
+      <SettingsPanel
+        providers={IMAGE_PROVIDERS}
+        provider={provider}
+        onProviderChange={setProvider}
+        apiKeyStatus={apiKeyStatus}
+        apiKeyError={apiKeyError}
+        model={currentModel}
+        modelPlaceholder={defaultModelFor(provider)}
+        onModelChange={(next) => setModelsByProvider((prev) => new Map(prev).set(provider, next))}
+        availableModels={availableByProvider.get(provider) ?? []}
+        isFetchingModels={isFetchingModels}
+        modelListError={listErrorByProvider.get(provider)}
+        onFetchModels={() => {
+          handleFetchModels().catch(() => undefined);
+        }}
+      />
+      <PromptPanel
+        imageCapability={imageCapability}
+        isWorking={isWorking}
+        canSubmit={apiKeyStatus === 'ready'}
+        referenceImages={referenceImages}
+        onReferenceImagesChange={setReferenceImages}
+        onGenerate={handleGenerate}
+        onAbort={handleAbort}
+      />
+      {imageError !== undefined && (
+        <div
+          data-testid="image-gen-error"
+          className="rounded-md border border-status-error-border bg-status-error-bg p-4 text-sm text-status-error-text"
+        >
+          <strong className="font-semibold text-status-error-strong">Error:</strong> {imageError}
+        </div>
+      )}
+      {lastResult !== undefined && (
+        <ImageResults
+          response={lastResult}
+          onUseAsReference={
+            modelAcceptsRefs
+              ? (image) =>
+                  setReferenceImages((prev) => [
+                    ...prev,
+                    { mimeType: image.mimeType, base64: image.base64 }
+                  ])
+              : undefined
+          }
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario export
+// ---------------------------------------------------------------------------
+
+const webImpl: IWebScenarioImpl = {
+  component: ImageGenerationComponent
+};
+
+/**
+ * `image-generation` scenario: a web port of `samples/ai-image-gen-sample`'s image mode.
+ * @public
+ */
+export const imageGenerationScenario: IScenario = {
+  id: 'image-generation',
+  title: 'Image Generation',
+  description:
+    'Ported from samples/ai-image-gen-sample: pick an image-capable provider, resolve its ' +
+    'image-tier default model, and generate images via AiAssist.callProviderImageGeneration. ' +
+    'API keys come from the shell Secrets panel (top bar), not a per-scenario input.',
+  category: 'ai',
+  tags: ['ai-assist', 'image-generation', 'live-api'],
+  requiredSecrets: requiredSecretsForProviders(IMAGE_PROVIDERS),
+  web: webImpl
+};
+
+export { IMAGE_PROVIDERS, defaultModelFor };

--- a/samples/testbed/src/scenarios/index.ts
+++ b/samples/testbed/src/scenarios/index.ts
@@ -14,6 +14,7 @@ import { anthropicClientToolsScenario } from './anthropicClientTools';
 import { crossProviderEmbeddingSearchScenario } from './crossProviderEmbeddingSearch';
 import { gateDenyClientToolsScenario } from './gateDenyClientTools';
 import { geminiClientToolsScenario } from './geminiClientTools';
+import { imageGenerationScenario } from './imageGeneration';
 import { localClassifierSafetyScenario } from './localClassifierSafety';
 import { localEmbeddingSearchScenario } from './localEmbeddingSearch';
 import { localSummarizationScenario } from './localSummarization';
@@ -27,6 +28,7 @@ import {
   openaiModelTiersScenario
 } from './modelTiers';
 import { openaiClientToolsScenario } from './openaiClientTools';
+import { streamingChatScenario } from './streamingChat';
 import { xaiClientToolsScenario } from './xaiClientTools';
 
 /**
@@ -39,6 +41,8 @@ export const scenarios: readonly IScenario[] = [
   geminiClientToolsScenario,
   xaiClientToolsScenario,
   gateDenyClientToolsScenario,
+  imageGenerationScenario,
+  streamingChatScenario,
   localClassifierSafetyScenario,
   localEmbeddingSearchScenario,
   localSummarizationScenario,

--- a/samples/testbed/src/scenarios/streamingChat/ChatPanel.tsx
+++ b/samples/testbed/src/scenarios/streamingChat/ChatPanel.tsx
@@ -1,0 +1,248 @@
+/**
+ * Streaming-chat transcript + composer for the `streaming-chat` scenario. Ported from
+ * `samples/ai-image-gen-sample/src/components/ChatPanel.tsx` with testbed styling
+ * tokens, `streaming-chat-*` test ids, and a `disabledReason` that distinguishes
+ * "missing key" from "prompt library not ready" (the shell secrets store replaces the
+ * sample's per-scenario API-key input).
+ *
+ * @packageDocumentation
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import React from 'react';
+import { AiAssist } from '@fgv/ts-extras';
+
+import { chatTones, chatToneConverter } from './promptLibrary';
+import type { ChatTone } from './promptLibrary';
+
+function formatToneLabel(tone: ChatTone): string {
+  return tone.charAt(0).toUpperCase() + tone.slice(1);
+}
+
+export interface IChatTurn {
+  readonly role: 'user' | 'assistant';
+  readonly content: string;
+  readonly isStreaming?: boolean;
+}
+
+export interface IChatPanelProps {
+  readonly provider: AiAssist.AiProviderId;
+  readonly isWorking: boolean;
+  readonly canSubmit: boolean;
+  /**
+   * Reason shown when `canSubmit` is false — lets the parent differentiate "no API key"
+   * from "prompt library not ready" (or any other gating condition the parent owns).
+   */
+  readonly disabledReason: string;
+  readonly turns: ReadonlyArray<IChatTurn>;
+  readonly error: string | undefined;
+  readonly activeToolEvents: ReadonlyArray<string>;
+  readonly tone: ChatTone;
+  readonly onToneChange: (tone: ChatTone) => void;
+  readonly onSend: (
+    text: string,
+    options: { readonly tools?: ReadonlyArray<AiAssist.AiServerToolConfig> }
+  ) => Promise<void>;
+  readonly onAbort: () => void;
+  readonly onClear: () => void;
+}
+
+export function ChatPanel(props: IChatPanelProps): React.ReactElement {
+  const {
+    provider,
+    isWorking,
+    canSubmit,
+    disabledReason,
+    turns,
+    error,
+    activeToolEvents,
+    tone,
+    onToneChange,
+    onSend,
+    onAbort,
+    onClear
+  } = props;
+
+  const [input, setInput] = useState('');
+  const [useWebSearch, setUseWebSearch] = useState(false);
+  const transcriptRef = useRef<HTMLDivElement>(null);
+
+  const descriptor = AiAssist.getProviderDescriptor(provider).orDefault();
+  const supportsWebSearch = descriptor?.supportedTools.includes('web_search') ?? false;
+
+  // Auto-scroll the transcript as new content arrives.
+  useEffect(() => {
+    if (transcriptRef.current) {
+      transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
+    }
+  }, [turns, activeToolEvents]);
+
+  const submitMessage = (): void => {
+    if (!canSubmit || isWorking || input.trim().length === 0) {
+      return;
+    }
+    const tools: ReadonlyArray<AiAssist.AiServerToolConfig> | undefined =
+      useWebSearch && supportsWebSearch ? [{ type: 'web_search' }] : undefined;
+    const text = input;
+    setInput('');
+    onSend(text, { tools }).catch(() => undefined);
+  };
+
+  const handleSubmit = (e: React.FormEvent): void => {
+    e.preventDefault();
+    submitMessage();
+  };
+
+  return (
+    <section
+      data-testid="streaming-chat-panel"
+      className="rounded-lg border border-border bg-surface-raised p-4"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-primary">Streaming chat</h3>
+        {turns.length > 0 && (
+          <button
+            type="button"
+            data-testid="streaming-chat-clear-btn"
+            onClick={onClear}
+            disabled={isWorking}
+            className="text-xs text-muted hover:text-secondary disabled:opacity-40"
+          >
+            Clear conversation
+          </button>
+        )}
+      </div>
+
+      <div
+        ref={transcriptRef}
+        data-testid="streaming-chat-transcript"
+        className="mt-3 max-h-96 min-h-48 space-y-3 overflow-y-auto rounded-md border border-border bg-surface p-3 text-sm"
+      >
+        {turns.length === 0 ? (
+          <p className="text-muted">
+            Type a question below to start a conversation. Tokens stream in as the model generates them.
+          </p>
+        ) : (
+          turns.map((turn, idx) => (
+            <div key={idx} data-testid={`streaming-chat-turn-${idx}`} className="space-y-1">
+              <div className="text-xs font-semibold uppercase tracking-wide text-muted">
+                {turn.role === 'user' ? 'You' : 'Assistant'}
+              </div>
+              <div className="whitespace-pre-wrap text-primary">
+                {turn.content}
+                {turn.isStreaming && turn.content.length === 0 && <span className="text-muted">…</span>}
+                {turn.isStreaming && turn.content.length > 0 && (
+                  <span className="ml-0.5 inline-block h-3 w-1 animate-pulse bg-brand-primary align-middle" />
+                )}
+              </div>
+            </div>
+          ))
+        )}
+
+        {activeToolEvents.length > 0 && (
+          <div
+            data-testid="streaming-chat-tool-events"
+            className="rounded border border-border bg-surface-alt px-2 py-1 text-xs text-secondary"
+          >
+            {activeToolEvents.map((label, idx) => (
+              <div key={idx}>{label}</div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {error !== undefined && (
+        <div
+          data-testid="streaming-chat-error"
+          className="mt-3 rounded-md border border-status-error-border bg-status-error-bg p-3 text-sm text-status-error-text"
+        >
+          <strong className="font-semibold">Error:</strong> {error}
+        </div>
+      )}
+
+      <form className="mt-4 space-y-3" onSubmit={handleSubmit}>
+        <label className="block text-sm">
+          <span className="font-medium text-secondary">Message</span>
+          <textarea
+            data-testid="streaming-chat-input"
+            className="mt-1 block w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-primary focus:outline-none focus:ring-2 focus:ring-focus-ring"
+            rows={2}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                submitMessage();
+              }
+            }}
+            disabled={isWorking}
+            placeholder="Ask about a recipe, ingredients, or anything else…"
+          />
+        </label>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="submit"
+            data-testid="streaming-chat-send-btn"
+            disabled={!canSubmit || isWorking || input.trim().length === 0}
+            className="rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-secondary disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isWorking ? 'Streaming…' : 'Send'}
+          </button>
+
+          {isWorking && (
+            <button
+              type="button"
+              data-testid="streaming-chat-abort-btn"
+              onClick={onAbort}
+              className="rounded-md border border-border bg-surface px-4 py-2 text-sm font-medium text-secondary hover:bg-hover"
+            >
+              Cancel
+            </button>
+          )}
+
+          {supportsWebSearch && (
+            <label className="inline-flex items-center gap-2 text-sm text-secondary">
+              <input
+                type="checkbox"
+                data-testid="streaming-chat-web-search-checkbox"
+                checked={useWebSearch}
+                onChange={(e) => setUseWebSearch(e.target.checked)}
+                disabled={isWorking}
+                className="h-4 w-4 rounded border-border text-brand-primary focus:ring-focus-ring"
+              />
+              <span>Use web search</span>
+            </label>
+          )}
+
+          <label className="inline-flex items-center gap-2 text-sm text-secondary">
+            <span>Tone</span>
+            <select
+              data-testid="streaming-chat-tone-select"
+              value={tone}
+              // Narrow `e.target.value: string` back into `ChatTone` via the exported
+              // Converter; falls back to the current tone if the DOM string isn't a
+              // recognised option (defensive — the `<option>` set is rendered from the
+              // same `chatTones` array, so a mismatch is unreachable in normal flow).
+              onChange={(e) => onToneChange(chatToneConverter.convert(e.target.value).orDefault(tone))}
+              disabled={isWorking}
+              className="rounded-md border border-border bg-surface px-2 py-1 text-sm text-primary focus:outline-none focus:ring-2 focus:ring-focus-ring"
+            >
+              {chatTones.map((t) => (
+                <option key={t} value={t}>
+                  {formatToneLabel(t)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {!canSubmit && (
+            <span data-testid="streaming-chat-disabled-hint" className="text-sm text-muted">
+              {disabledReason}
+            </span>
+          )}
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/samples/testbed/src/scenarios/streamingChat/SettingsPanel.tsx
+++ b/samples/testbed/src/scenarios/streamingChat/SettingsPanel.tsx
@@ -1,0 +1,101 @@
+/**
+ * Provider + model picker for the `streaming-chat` scenario. A chat-specific sibling of
+ * `../imageGeneration/SettingsPanel.tsx` (different provider set, streaming-CORS notice
+ * instead of image-CORS) — kept as its own small component rather than a shared
+ * abstraction per the "three similar lines is better than a premature abstraction" rule.
+ *
+ * @packageDocumentation
+ */
+
+import React from 'react';
+import { AiAssist } from '@fgv/ts-extras';
+
+import type { ProviderApiKeyStatus } from '../aiProviderSecrets';
+
+export interface IChatSettingsPanelProps {
+  readonly providers: ReadonlyArray<AiAssist.AiProviderId>;
+  readonly provider: AiAssist.AiProviderId;
+  readonly onProviderChange: (provider: AiAssist.AiProviderId) => void;
+  readonly apiKeyStatus: ProviderApiKeyStatus;
+  readonly apiKeyError: string | undefined;
+  readonly model: string;
+  readonly modelPlaceholder: string;
+  readonly onModelChange: (model: string) => void;
+}
+
+export function ChatSettingsPanel(props: IChatSettingsPanelProps): React.ReactElement {
+  const { providers, provider, onProviderChange, apiKeyStatus, apiKeyError, model, modelPlaceholder, onModelChange } =
+    props;
+  const descriptor = AiAssist.getProviderDescriptor(provider).orDefault();
+
+  return (
+    <section
+      data-testid="streaming-chat-settings"
+      className="rounded-lg border border-border bg-surface-raised p-4"
+    >
+      <h3 className="text-sm font-semibold text-primary">Provider</h3>
+
+      <div className="mt-3 grid gap-4 md:grid-cols-2">
+        <label className="block text-sm">
+          <span className="font-medium text-secondary">Provider</span>
+          <select
+            data-testid="streaming-chat-provider-select"
+            className="mt-1 block w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-primary focus:outline-none focus:ring-2 focus:ring-focus-ring"
+            value={provider}
+            onChange={(e) => onProviderChange(e.target.value as AiAssist.AiProviderId)}
+          >
+            {providers.map((p) => {
+              const d = AiAssist.getProviderDescriptor(p).orDefault();
+              return (
+                <option key={p} value={p}>
+                  {d?.label ?? p}
+                </option>
+              );
+            })}
+          </select>
+        </label>
+
+        <div className="block text-sm">
+          <span className="font-medium text-secondary">API key</span>
+          {apiKeyStatus === 'ready' ? (
+            <p data-testid="streaming-chat-key-ready" className="mt-1 text-status-success-text">
+              ✓ Key configured for {descriptor?.label ?? provider}
+            </p>
+          ) : apiKeyStatus === 'loading' ? (
+            <p data-testid="streaming-chat-key-loading" className="mt-1 text-muted">
+              Checking for a configured key…
+            </p>
+          ) : (
+            <p data-testid="streaming-chat-key-missing" className="mt-1 text-status-warning-text">
+              No key configured for {descriptor?.label ?? provider}. Open{' '}
+              <strong className="font-semibold">Secrets</strong> (top bar) to add one.
+              {apiKeyError !== undefined && <span className="block text-xs text-muted">{apiKeyError}</span>}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <label className="mt-4 block text-sm">
+        <span className="font-medium text-secondary">Model</span>
+        <input
+          type="text"
+          data-testid="streaming-chat-model-input"
+          className="mt-1 block w-full rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm text-primary placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-focus-ring"
+          placeholder={modelPlaceholder}
+          value={model}
+          onChange={(e) => onModelChange(e.target.value)}
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </label>
+
+      {descriptor?.streamingCorsRestricted && (
+        <p className="mt-3 text-xs">
+          <span className="inline-flex items-center rounded-full bg-status-warning-bg px-2 py-0.5 font-medium text-status-warning-text">
+            Streaming CORS-restricted — calls will fail without a proxy
+          </span>
+        </p>
+      )}
+    </section>
+  );
+}

--- a/samples/testbed/src/scenarios/streamingChat/index.tsx
+++ b/samples/testbed/src/scenarios/streamingChat/index.tsx
@@ -1,0 +1,298 @@
+/**
+ * `streaming-chat` scenario — a web port of `samples/ai-image-gen-sample`'s chat mode,
+ * including the `ts-prompt-assist` tone demo (`promptLibrary.ts`). Provider + model
+ * picker, a streaming transcript, and a tone selector that re-resolves the system prompt
+ * via `PromptLibrary.resolve` before each send.
+ *
+ * As with `../imageGeneration`, the sample's per-scenario API-key `<input>` is replaced
+ * by the shell's session secrets store (`useProviderApiKey`); `samples/ai-image-gen-sample`
+ * itself is untouched.
+ *
+ * Web-only: a live API key cannot be embedded in the CLI's non-interactive run, and the
+ * sample this ports has no CLI surface either.
+ *
+ * @packageDocumentation
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { AiAssist } from '@fgv/ts-extras';
+import { useAiAssist } from '@fgv/ts-app-shell';
+
+import type { IScenario, IScenarioContext, IWebScenarioImpl } from '../../shell';
+import {
+  PROVIDER_SECRET_SPECS,
+  requiredSecretsForProviders,
+  SingleSecretKeyStore,
+  useProviderApiKey
+} from '../aiProviderSecrets';
+import { ChatSettingsPanel } from './SettingsPanel';
+import { ChatPanel, type IChatTurn } from './ChatPanel';
+import { createPromptLibrary, resolveChatSystemPrompt } from './promptLibrary';
+import type { ChatPromptLibrary, ChatTone } from './promptLibrary';
+
+// ---------------------------------------------------------------------------
+// Provider list + defaults
+// ---------------------------------------------------------------------------
+
+/** Providers this scenario wires a secret for AND that expose a chat `baseUrl`. */
+const CHAT_PROVIDERS: ReadonlyArray<AiAssist.AiProviderId> = AiAssist.getProviderDescriptors()
+  .filter((d) => d.baseUrl.length > 0 && PROVIDER_SECRET_SPECS[d.id] !== undefined)
+  .map((d) => d.id);
+
+/** Resolves the `base`-tier default model id for a provider (empty string if unknown). */
+function defaultModelFor(provider: AiAssist.AiProviderId): string {
+  const descriptor = AiAssist.getProviderDescriptor(provider).orDefault();
+  if (!descriptor) {
+    return '';
+  }
+  return AiAssist.resolveModel(descriptor.defaultModel, 'base');
+}
+
+function initialModelsByProvider(): ReadonlyMap<AiAssist.AiProviderId, string> {
+  return new Map(CHAT_PROVIDERS.map((p) => [p, defaultModelFor(p)]));
+}
+
+// ---------------------------------------------------------------------------
+// Web component
+// ---------------------------------------------------------------------------
+
+function StreamingChatComponent({ context }: { readonly context: IScenarioContext }): React.ReactElement {
+  const [provider, setProvider] = useState<AiAssist.AiProviderId>(
+    CHAT_PROVIDERS[0] ?? ('openai' as AiAssist.AiProviderId)
+  );
+  const [modelsByProvider, setModelsByProvider] =
+    useState<ReadonlyMap<AiAssist.AiProviderId, string>>(initialModelsByProvider);
+  const [chatTurns, setChatTurns] = useState<ReadonlyArray<IChatTurn>>([]);
+  const [chatError, setChatError] = useState<string | undefined>(undefined);
+  const [activeToolEvents, setActiveToolEvents] = useState<ReadonlyArray<string>>([]);
+  const [chatTone, setChatTone] = useState<ChatTone>('neutral');
+  const abortControllerRef = useRef<AbortController | undefined>(undefined);
+
+  const { apiKey, status: apiKeyStatus, error: apiKeyError } = useProviderApiKey(context, provider);
+
+  // Prompt library is built once on mount via the canonical useEffect-initialiser
+  // pattern from the ts-prompt-assist README.
+  const [promptLibrary, setPromptLibrary] = useState<ChatPromptLibrary | null>(null);
+  const [promptLibraryError, setPromptLibraryError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const result = await createPromptLibrary();
+      if (cancelled) return;
+      if (result.isFailure()) {
+        setPromptLibraryError(result.message);
+      } else {
+        setPromptLibrary(result.value);
+      }
+    })().catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const currentModel = modelsByProvider.get(provider) ?? defaultModelFor(provider);
+
+  const keyStore = useMemo(
+    () =>
+      new SingleSecretKeyStore(apiKeyStatus === 'ready' ? new Map([[provider, apiKey]]) : new Map()),
+    [provider, apiKeyStatus, apiKey]
+  );
+
+  const settings = useMemo<AiAssist.IAiAssistSettings>(
+    () => ({
+      providers: [
+        {
+          provider,
+          secretName: provider,
+          ...(currentModel.length > 0 ? { model: currentModel } : {})
+        }
+      ],
+      defaultProvider: provider
+    }),
+    [provider, currentModel]
+  );
+
+  const { isWorking, streamDirect } = useAiAssist({ settings, keyStore, logger: context.logger });
+
+  const canSubmit = apiKeyStatus === 'ready' && promptLibrary !== null;
+  // Order matches the user's mental model: the API-key gate is the first thing they
+  // configure, so name that one first; once it's set, surface the prompt-library state.
+  const disabledReason: string =
+    apiKeyStatus !== 'ready'
+      ? 'Configure an API key (Secrets, top bar) to enable chat.'
+      : promptLibraryError !== undefined
+        ? `Prompt library failed to load: ${promptLibraryError}`
+        : promptLibrary === null
+          ? 'Prompt library is still initializing…'
+          : '';
+
+  const handleSendChat = async (
+    text: string,
+    options: { readonly tools?: ReadonlyArray<AiAssist.AiServerToolConfig> }
+  ): Promise<void> => {
+    setChatError(undefined);
+    setActiveToolEvents([]);
+
+    const userTurn: IChatTurn = { role: 'user', content: text };
+    const assistantTurn: IChatTurn = { role: 'assistant', content: '', isStreaming: true };
+    setChatTurns((prev) => [...prev, userTurn, assistantTurn]);
+
+    if (promptLibrary === null) {
+      setChatError(promptLibraryError ?? 'Prompt library is still initializing.');
+      setChatTurns((prev) => prev.slice(0, -2));
+      return;
+    }
+    const systemPromptResult = await resolveChatSystemPrompt(promptLibrary, chatTone);
+    if (systemPromptResult.isFailure()) {
+      setChatError(systemPromptResult.message);
+      setChatTurns((prev) => prev.slice(0, -2));
+      return;
+    }
+
+    // Create the AbortController only once we're committed to the network call —
+    // early-return paths above would otherwise leave a stale controller in the ref.
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    // Prior turns go into messagesBefore so they're sent between the resolved system
+    // prompt and the new user message.
+    const messagesBefore: AiAssist.IChatMessage[] = chatTurns
+      .filter((t) => t.role === 'user' || t.role === 'assistant')
+      .map((t) => ({ role: t.role, content: t.content }));
+    const prompt = new AiAssist.AiPrompt(text, systemPromptResult.value);
+
+    let receivedAnyContent = false;
+    let inlineError: string | undefined;
+
+    const result = await streamDirect(
+      provider,
+      prompt,
+      (event) => {
+        if (event.type === 'text-delta') {
+          receivedAnyContent = true;
+          setChatTurns((prev) => {
+            const next = [...prev];
+            const last = next[next.length - 1];
+            if (last && last.role === 'assistant') {
+              next[next.length - 1] = { ...last, content: last.content + event.delta };
+            }
+            return next;
+          });
+        } else if (event.type === 'tool-event') {
+          if (event.phase === 'started') {
+            setActiveToolEvents((prev) => [...prev, 'Searching the web…']);
+          } else if (event.phase === 'completed') {
+            setActiveToolEvents((prev) => prev.slice(0, -1));
+          }
+        } else if (event.type === 'done') {
+          // Replace accumulated text with the adapter's canonical fullText so the
+          // transcript can't drift from what the model actually produced.
+          receivedAnyContent = event.fullText.length > 0;
+          setChatTurns((prev) => {
+            const next = [...prev];
+            const last = next[next.length - 1];
+            if (last && last.role === 'assistant') {
+              next[next.length - 1] = { ...last, content: event.fullText };
+            }
+            return next;
+          });
+        } else if (event.type === 'error') {
+          inlineError = event.message;
+        }
+      },
+      { tools: options.tools, messagesBefore, signal: controller.signal }
+    );
+    abortControllerRef.current = undefined;
+    setActiveToolEvents([]);
+
+    // Finalize the assistant turn: clear its streaming flag, or drop it entirely if
+    // nothing arrived (connect failed or aborted with no output).
+    setChatTurns((prev) => {
+      const next = [...prev];
+      const last = next[next.length - 1];
+      if (!last || last.role !== 'assistant') {
+        return next;
+      }
+      if (!receivedAnyContent && last.content.length === 0) {
+        next.pop();
+        return next;
+      }
+      next[next.length - 1] = { ...last, isStreaming: false };
+      return next;
+    });
+
+    if (inlineError !== undefined) {
+      setChatError(inlineError);
+    } else if (result.isFailure()) {
+      setChatError(result.message);
+    }
+  };
+
+  const handleClearChat = (): void => {
+    setChatTurns([]);
+    setChatError(undefined);
+    setActiveToolEvents([]);
+  };
+
+  const handleAbort = (): void => {
+    abortControllerRef.current?.abort();
+  };
+
+  return (
+    <div data-testid="streaming-chat-scenario" className="space-y-4">
+      <ChatSettingsPanel
+        providers={CHAT_PROVIDERS}
+        provider={provider}
+        onProviderChange={setProvider}
+        apiKeyStatus={apiKeyStatus}
+        apiKeyError={apiKeyError}
+        model={currentModel}
+        modelPlaceholder={defaultModelFor(provider)}
+        onModelChange={(next) => setModelsByProvider((prev) => new Map(prev).set(provider, next))}
+      />
+      <ChatPanel
+        provider={provider}
+        isWorking={isWorking}
+        canSubmit={canSubmit}
+        disabledReason={disabledReason}
+        turns={chatTurns}
+        error={chatError ?? promptLibraryError}
+        activeToolEvents={activeToolEvents}
+        tone={chatTone}
+        onToneChange={setChatTone}
+        onSend={handleSendChat}
+        onAbort={handleAbort}
+        onClear={handleClearChat}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario export
+// ---------------------------------------------------------------------------
+
+const webImpl: IWebScenarioImpl = {
+  component: StreamingChatComponent
+};
+
+/**
+ * `streaming-chat` scenario: a web port of `samples/ai-image-gen-sample`'s chat mode,
+ * including the `ts-prompt-assist` tone demo.
+ * @public
+ */
+export const streamingChatScenario: IScenario = {
+  id: 'streaming-chat',
+  title: 'Streaming Chat',
+  description:
+    'Ported from samples/ai-image-gen-sample: streaming chat via AiAssist.callProviderCompletionStream, ' +
+    'with a ts-prompt-assist PromptLibrary resolving the system prompt under a neutral/formal tone ' +
+    'qualifier before each send. API keys come from the shell Secrets panel (top bar).',
+  category: 'prompts',
+  tags: ['ai-assist', 'streaming', 'ts-prompt-assist', 'live-api'],
+  requiredSecrets: requiredSecretsForProviders(CHAT_PROVIDERS),
+  web: webImpl
+};
+
+export { CHAT_PROVIDERS, defaultModelFor };

--- a/samples/testbed/src/scenarios/streamingChat/index.tsx
+++ b/samples/testbed/src/scenarios/streamingChat/index.tsx
@@ -57,6 +57,7 @@ function initialModelsByProvider(): ReadonlyMap<AiAssist.AiProviderId, string> {
 // ---------------------------------------------------------------------------
 
 function StreamingChatComponent({ context }: { readonly context: IScenarioContext }): React.ReactElement {
+  /* c8 ignore next 3 - defensive: CHAT_PROVIDERS always has at least one entry from the real ai-assist registry; the fallback guards only a hypothetical empty registry */
   const [provider, setProvider] = useState<AiAssist.AiProviderId>(
     CHAT_PROVIDERS[0] ?? ('openai' as AiAssist.AiProviderId)
   );
@@ -91,6 +92,13 @@ function StreamingChatComponent({ context }: { readonly context: IScenarioContex
     };
   }, []);
 
+  // `provider` only ever takes a value from CHAT_PROVIDERS (initial state + the
+  // dropdown's own options), and `modelsByProvider` is seeded from CHAT_PROVIDERS via
+  // `initialModelsByProvider()`, so `.get(provider)` is always defined in practice, and
+  // `currentModel` is never empty (every keyed provider's registry entry resolves a
+  // real `base`-tier default). The fallbacks below guard against those invariants
+  // breaking, not a reachable UI path.
+  /* c8 ignore next 1 */
   const currentModel = modelsByProvider.get(provider) ?? defaultModelFor(provider);
 
   const keyStore = useMemo(
@@ -105,6 +113,7 @@ function StreamingChatComponent({ context }: { readonly context: IScenarioContex
         {
           provider,
           secretName: provider,
+          /* c8 ignore next 1 */
           ...(currentModel.length > 0 ? { model: currentModel } : {})
         }
       ],
@@ -138,6 +147,10 @@ function StreamingChatComponent({ context }: { readonly context: IScenarioContex
     const assistantTurn: IChatTurn = { role: 'assistant', content: '', isStreaming: true };
     setChatTurns((prev) => [...prev, userTurn, assistantTurn]);
 
+    // Defense in depth: ChatPanel's own `canSubmit` (built from `promptLibrary !== null`
+    // below) already gates the send button and the Enter-key path, so this branch has
+    // no reachable UI trigger — it guards a future caller that bypasses that gate.
+    /* c8 ignore next 5 */
     if (promptLibrary === null) {
       setChatError(promptLibraryError ?? 'Prompt library is still initializing.');
       setChatTurns((prev) => prev.slice(0, -2));
@@ -211,6 +224,11 @@ function StreamingChatComponent({ context }: { readonly context: IScenarioContex
     setChatTurns((prev) => {
       const next = [...prev];
       const last = next[next.length - 1];
+      // Defensive: the turns array always ends with the assistant placeholder pushed
+      // above just before this stream started (Clear is disabled while isWorking, so
+      // nothing else can mutate `chatTurns` mid-stream) — this guards a shape invariant
+      // that always holds today, not a reachable UI path.
+      /* c8 ignore next 3 */
       if (!last || last.role !== 'assistant') {
         return next;
       }
@@ -236,6 +254,10 @@ function StreamingChatComponent({ context }: { readonly context: IScenarioContex
   };
 
   const handleAbort = (): void => {
+    // The Cancel button (the only caller) renders only while isWorking is true, which
+    // is exactly when handleSendChat has just set abortControllerRef.current — the
+    // undefined branch is defensive, not a reachable UI path.
+    /* c8 ignore next 1 */
     abortControllerRef.current?.abort();
   };
 

--- a/samples/testbed/src/scenarios/streamingChat/promptLibrary.ts
+++ b/samples/testbed/src/scenarios/streamingChat/promptLibrary.ts
@@ -20,8 +20,10 @@ import type { Converter, Result } from '@fgv/ts-utils';
 // hits once per module, not per call site).
 // ---------------------------------------------------------------------------
 
-export const SCOPE: ScopeKey = Convert.scopeKey.convert('global').orThrow();
-export const CHAT_SYSTEM_PROMPT: PromptId = Convert.promptId.convert('chat-system-prompt').orThrow();
+export const SCOPE: ScopeKey = Convert.scopeKey.convert('global').shouldNotFail('SCOPE');
+export const CHAT_SYSTEM_PROMPT: PromptId = Convert.promptId
+  .convert('chat-system-prompt')
+  .shouldNotFail('CHAT_SYSTEM_PROMPT');
 
 // ---------------------------------------------------------------------------
 // Single source of truth for the qualifier-axis NAMES this scenario uses.

--- a/samples/testbed/src/scenarios/streamingChat/promptLibrary.ts
+++ b/samples/testbed/src/scenarios/streamingChat/promptLibrary.ts
@@ -1,0 +1,110 @@
+/**
+ * Wires `@fgv/ts-prompt-assist` into the `streaming-chat` scenario. The chat path's
+ * system prompt is authored as a `(scope, prompt-id)` record with a `tone`
+ * qualifier-conditional candidate, resolved at send time via `PromptLibrary.resolve`.
+ *
+ * Ported near-verbatim from `samples/ai-image-gen-sample/src/promptLibrary.ts` — the
+ * ts-prompt-assist tone demo is the differentiator this scenario ports, per the
+ * `testbed-web-scenarios` brief.
+ *
+ * @packageDocumentation
+ */
+
+import { Convert, PromptLibrary, PromptStoreFixture } from '@fgv/ts-prompt-assist';
+import type { IPromptResponseBase, IPromptStoreFixtureSeed, PromptId, ScopeKey } from '@fgv/ts-prompt-assist';
+import { Converters, succeed } from '@fgv/ts-utils';
+import type { Converter, Result } from '@fgv/ts-utils';
+
+// ---------------------------------------------------------------------------
+// Module-scope branded ids (centralised so the `.orThrow()` verbosity
+// hits once per module, not per call site).
+// ---------------------------------------------------------------------------
+
+export const SCOPE: ScopeKey = Convert.scopeKey.convert('global').orThrow();
+export const CHAT_SYSTEM_PROMPT: PromptId = Convert.promptId.convert('chat-system-prompt').orThrow();
+
+// ---------------------------------------------------------------------------
+// Single source of truth for the qualifier-axis NAMES this scenario uses.
+// ---------------------------------------------------------------------------
+
+const qualifierNames = ['tone'] as const;
+export type QualifierName = (typeof qualifierNames)[number];
+
+const qualifierNameConverter: Converter<QualifierName> = Converters.enumeratedValue<QualifierName>([
+  ...qualifierNames
+]);
+
+// ---------------------------------------------------------------------------
+// Authored prompt — base + a `tone: 'formal'` partial.
+// ---------------------------------------------------------------------------
+
+const seed: IPromptStoreFixtureSeed<QualifierName> = {
+  records: [
+    {
+      scope: SCOPE,
+      id: CHAT_SYSTEM_PROMPT,
+      descriptor: {
+        title: 'Chat system prompt',
+        schemaVersion: '1',
+        surface: 'chat',
+        slots: [],
+        output: { kind: 'free-text' }
+      },
+      candidates: [
+        {
+          conditions: {},
+          body: 'You are a helpful assistant. Answer the user clearly and concisely.'
+        },
+        {
+          conditions: { tone: 'formal' },
+          isPartial: true,
+          body: 'When responding, use a formal register: complete sentences, no contractions, and a measured, professional tone.'
+        }
+      ]
+    }
+  ],
+  qualifierNameConverter
+};
+
+// ---------------------------------------------------------------------------
+// Typed library handle.
+// ---------------------------------------------------------------------------
+
+export type ChatPromptLibrary = PromptLibrary<IPromptResponseBase, QualifierName>;
+
+export async function createPromptLibrary(): Promise<Result<ChatPromptLibrary>> {
+  const storeResult = await PromptStoreFixture.build(seed);
+  if (storeResult.isFailure()) {
+    return storeResult.withType<ChatPromptLibrary>();
+  }
+  return PromptLibrary.create({
+    store: storeResult.value,
+    qualifiers: qualifierNames
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Consumer-side qualifier-VALUE enum.
+// ---------------------------------------------------------------------------
+
+export const chatTones = ['neutral', 'formal'] as const;
+export type ChatTone = (typeof chatTones)[number];
+export const chatToneConverter: Converter<ChatTone> = Converters.enumeratedValue<ChatTone>([...chatTones]);
+
+/**
+ * Resolve the chat system prompt under the supplied tone. Returns the resolved body
+ * string suitable for use as the `system` field of an `AiPrompt`.
+ */
+export async function resolveChatSystemPrompt(
+  library: ChatPromptLibrary,
+  tone: ChatTone
+): Promise<Result<string>> {
+  const resolved = await library.resolve({
+    id: CHAT_SYSTEM_PROMPT,
+    chain: [SCOPE],
+    // 'neutral' sends `{}` because the base candidate has `conditions: {}` and ts-res
+    // treats a missing axis as matching the base.
+    qualifiers: tone === 'formal' ? { tone: 'formal' } : {}
+  });
+  return resolved.onSuccess((r) => succeed(r.body));
+}

--- a/samples/testbed/src/shell/index.ts
+++ b/samples/testbed/src/shell/index.ts
@@ -107,3 +107,6 @@ export interface IScenario extends IScenarioBase {
 }
 
 export { resolveSecret } from './secretResolver';
+export type { IResolveSecretParams } from './secretResolver';
+export { dedupeRequiredSecrets, useSessionSecretsStore } from './sessionSecretsStore';
+export type { ISessionSecretsStore } from './sessionSecretsStore';

--- a/samples/testbed/src/shell/secretResolver.ts
+++ b/samples/testbed/src/shell/secretResolver.ts
@@ -1,28 +1,31 @@
 /**
- * Shared secret-resolver helper. The brief specifies KeyStore-first / env-var-fallback
- * semantics with a structured failure naming both ids. At B-1 this is a stub that returns
- * `Result.fail` with the documented sentinel message — B-3 (or whichever scenario first
- * needs secrets) fleshes out the real implementation alongside the KeyStore-on-web wiring.
- *
- * The stub is in place so the scenario contract (`IScenarioContext.resolveSecret`) is
- * already callable from scenario code; scenarios needing secrets surface the
- * not-yet-implemented message and the orchestrator commissions the work.
+ * Shared secret-resolver helper. Resolution order is KeyStore-first (the persistent,
+ * password-protected store — not yet wired on either surface, but the seam is honored
+ * for forward compatibility), then the web-only in-memory session secrets store, then
+ * the env-var fallback (real on the CLI; a no-op on the web, since browsers have no
+ * `process.env`).
  *
  * @packageDocumentation
  */
 
+import { fail, succeed, type Result } from '@fgv/ts-utils';
 import { CryptoUtils } from '@fgv/ts-extras';
-import { fail, type Result } from '@fgv/ts-utils';
 import type { ISecretSpec } from './index';
 
 /**
  * Parameters consumed by {@link resolveSecret}. Bundles the spec with the (possibly-undefined)
- * KeyStore and an env-var lookup so the resolver is platform-agnostic.
+ * KeyStore, an optional session-memory secrets map (web-only), and an env-var lookup so the
+ * resolver is platform-agnostic.
  * @public
  */
 export interface IResolveSecretParams {
   readonly spec: ISecretSpec;
   readonly keyStore: CryptoUtils.KeyStore.KeyStore | undefined;
+  /**
+   * Session-memory secrets captured via the web shell's secrets modal, keyed by
+   * {@link ISecretSpec.id}. `undefined` on the CLI, which has no interactive secrets UI.
+   */
+  readonly sessionSecrets?: ReadonlyMap<string, string>;
   /**
    * Environment-variable lookup. Receives the env-var name and returns the value or
    * `undefined`. Injectable so web (no `process.env`) and CLI (Node `process.env`) wire it
@@ -32,20 +35,33 @@ export interface IResolveSecretParams {
 }
 
 /**
- * Resolve a secret per the brief's KeyStore-first / env-var-fallback semantics.
+ * Resolve a secret per the KeyStore-first / session-store-second / env-var-fallback-third
+ * semantics documented on {@link IResolveSecretParams}.
  *
- * At B-1 this is a stub: it returns a `Failure` whose message names both the KeyStore id and
- * the env-var fallback, plus the sentinel `'B-1 stub'` token that the test suite asserts on.
- * Real KeyStore + env-var integration arrives in B-3 or whichever scenario first needs
- * secret resolution; the function shape and call signature are locked here so scenarios can
- * code against the final contract.
  * @public
  */
 export async function resolveSecret(params: IResolveSecretParams): Promise<Result<string>> {
-  const { spec } = params;
+  const { spec, keyStore, sessionSecrets, getEnvVar } = params;
+
+  if (keyStore?.isUnlocked) {
+    const hasSecret = keyStore.hasSecret(spec.id);
+    if (hasSecret.isSuccess() && hasSecret.value) {
+      return keyStore.getApiKey(spec.id);
+    }
+  }
+
+  const sessionValue = sessionSecrets?.get(spec.id);
+  if (sessionValue !== undefined && sessionValue.length > 0) {
+    return succeed(sessionValue);
+  }
+
+  const envValue = getEnvVar(spec.envVarName);
+  if (envValue !== undefined && envValue.length > 0) {
+    return succeed(envValue);
+  }
+
   return fail(
-    `resolveSecret: not yet implemented (B-1 stub). ` +
-      `Secret '${spec.id}' (env fallback '${spec.envVarName}') — ${spec.description}. ` +
-      `See .ai/tasks/active/local-ai-exploration/brief.md.`
+    `Secret '${spec.id}' is not set (env fallback '${spec.envVarName}') — ${spec.description}. ` +
+      `Set it via the Secrets panel (web) or the ${spec.envVarName} environment variable (CLI).`
   );
 }

--- a/samples/testbed/src/shell/sessionSecretsStore.ts
+++ b/samples/testbed/src/shell/sessionSecretsStore.ts
@@ -1,0 +1,65 @@
+/**
+ * Web-side session secrets store — the in-memory secret source `resolveSecret` consults
+ * before falling back to env vars (which are a no-op in the browser). Values live only in
+ * React state for the current session; nothing is persisted or encrypted (that's a possible
+ * future extension, not this phase — see the `testbed-web-scenarios` brief).
+ *
+ * This module intentionally lives under `shell/` (not `web/`) because it is the "secret
+ * store" half of the contract the brief calls out; the modal *UI* that renders it is a
+ * `web/` concern (browsers have secrets UI, the CLI does not).
+ *
+ * @packageDocumentation
+ */
+
+import { useCallback, useState } from 'react';
+import type { IScenario, ISecretSpec } from './index';
+
+/**
+ * Collects the union of `requiredSecrets` across every registered scenario, deduped by
+ * {@link ISecretSpec.id} (provider keys are shared across scenarios, e.g. every scenario
+ * touching OpenAI declares the same `openai-api-key` id). First occurrence wins; ids are
+ * expected to carry the same `envVarName`/`description` everywhere they're declared.
+ * @public
+ */
+export function dedupeRequiredSecrets(scenarios: readonly IScenario[]): readonly ISecretSpec[] {
+  const byId = new Map<string, ISecretSpec>();
+  for (const scenario of scenarios) {
+    for (const spec of scenario.requiredSecrets ?? []) {
+      if (!byId.has(spec.id)) {
+        byId.set(spec.id, spec);
+      }
+    }
+  }
+  return Array.from(byId.values());
+}
+
+/**
+ * Return value of {@link useSessionSecretsStore}.
+ * @public
+ */
+export interface ISessionSecretsStore {
+  /** Current secret values, keyed by {@link ISecretSpec.id}. */
+  readonly secrets: ReadonlyMap<string, string>;
+  /** Set (or clear, via an empty string) the value for a given secret id. */
+  readonly setSecret: (id: string, value: string) => void;
+}
+
+/**
+ * React hook holding the session-memory secrets map. A new `Map` identity is produced on
+ * every update so consumers that key a `useMemo`/effect dependency on `secrets` (or on a
+ * `resolveSecret` closure built from it) re-run when a value changes.
+ * @public
+ */
+export function useSessionSecretsStore(): ISessionSecretsStore {
+  const [secrets, setSecrets] = useState<ReadonlyMap<string, string>>(new Map());
+
+  const setSecret = useCallback((id: string, value: string): void => {
+    setSecrets((prev) => {
+      const next = new Map(prev);
+      next.set(id, value);
+      return next;
+    });
+  }, []);
+
+  return { secrets, setSecret };
+}

--- a/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
+++ b/samples/testbed/src/test/unit/__snapshots__/scenarios.test.ts.snap
@@ -7,6 +7,8 @@ Array [
   "gemini-client-tools",
   "xai-client-tools",
   "gate-deny-client-tools",
+  "image-generation",
+  "streaming-chat",
   "local-classifier-safety",
   "local-embedding-search",
   "local-summarization",

--- a/samples/testbed/src/test/unit/scenarios/aiProviderSecrets.test.ts
+++ b/samples/testbed/src/test/unit/scenarios/aiProviderSecrets.test.ts
@@ -1,0 +1,177 @@
+import '@fgv/ts-utils-jest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { fail, succeed, type Result } from '@fgv/ts-utils';
+import type { AiAssist } from '@fgv/ts-extras';
+
+import {
+  PROVIDER_SECRET_SPECS,
+  requiredSecretsForProviders,
+  resolveProviderApiKey,
+  SingleSecretKeyStore,
+  useProviderApiKey
+} from '../../../scenarios/aiProviderSecrets';
+import type { IScenarioContext, ISecretSpec } from '../../../shell';
+
+// Minimal context stub — only `resolveSecret` and `logger` are exercised by this module.
+function makeContext(resolveSecret: IScenarioContext['resolveSecret']): IScenarioContext {
+  return {
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), detail: jest.fn() } as unknown as IScenarioContext['logger'],
+    keyStore: undefined,
+    resolveSecret,
+    dataTree: {} as unknown as IScenarioContext['dataTree']
+  };
+}
+
+describe('requiredSecretsForProviders', () => {
+  test('returns an empty array for a provider with no entry (self-hosted)', () => {
+    expect(requiredSecretsForProviders(['ollama'])).toEqual([]);
+  });
+
+  test('returns the primary spec for a single-secret provider', () => {
+    const specs = requiredSecretsForProviders(['openai']);
+    expect(specs.map((s) => s.id)).toEqual(['openai-api-key']);
+  });
+
+  test('returns primary + fallback for gemini', () => {
+    const specs = requiredSecretsForProviders(['google-gemini']);
+    expect(specs.map((s) => s.id)).toEqual(['gemini-api-key', 'google-api-key']);
+  });
+
+  test('dedupes across multiple providers', () => {
+    const specs = requiredSecretsForProviders(['openai', 'openai', 'xai-grok']);
+    expect(specs.map((s) => s.id)).toEqual(['openai-api-key', 'xai-api-key']);
+  });
+
+  test('every entry in PROVIDER_SECRET_SPECS is reachable', () => {
+    const providers = Object.keys(PROVIDER_SECRET_SPECS) as ReadonlyArray<keyof typeof PROVIDER_SECRET_SPECS>;
+    expect(requiredSecretsForProviders(providers).length).toBeGreaterThan(0);
+  });
+});
+
+describe('resolveProviderApiKey', () => {
+  test('resolves to an empty string for a provider with no secret spec', async () => {
+    const context = makeContext(async () => fail('should not be called'));
+    const result = await resolveProviderApiKey(context, 'ollama');
+    expect(result).toSucceedWith('');
+  });
+
+  test('resolves via the primary spec when it succeeds', async () => {
+    const context = makeContext(async (spec: ISecretSpec) =>
+      spec.id === 'openai-api-key' ? succeed('sk-primary') : fail('unexpected spec')
+    );
+    const result = await resolveProviderApiKey(context, 'openai');
+    expect(result).toSucceedWith('sk-primary');
+  });
+
+  test('falls back to the fallback spec when the primary fails (gemini)', async () => {
+    const context = makeContext(async (spec: ISecretSpec) =>
+      spec.id === 'google-api-key' ? succeed('sk-fallback') : fail('primary missing')
+    );
+    const result = await resolveProviderApiKey(context, 'google-gemini');
+    expect(result).toSucceedWith('sk-fallback');
+  });
+
+  test('fails with both messages when neither primary nor fallback resolve (gemini)', async () => {
+    const context = makeContext(async () => fail('not set'));
+    const result = await resolveProviderApiKey(context, 'google-gemini');
+    expect(result).toFailWith(/not set[\s\S]*not set/);
+  });
+
+  test('fails with the primary message when a provider has no fallback (openai)', async () => {
+    const context = makeContext(async () => fail('primary missing'));
+    const result = await resolveProviderApiKey(context, 'openai');
+    expect(result).toFailWith(/primary missing/);
+  });
+});
+
+describe('SingleSecretKeyStore', () => {
+  test('isUnlocked is always true', () => {
+    expect(new SingleSecretKeyStore(new Map()).isUnlocked).toBe(true);
+  });
+
+  test('hasSecret reflects the backing map', () => {
+    const store = new SingleSecretKeyStore(new Map([['openai', 'sk-test']]));
+    expect(store.hasSecret('openai')).toSucceedWith(true);
+    expect(store.hasSecret('anthropic')).toSucceedWith(false);
+  });
+
+  test('getApiKey succeeds with the stored value', () => {
+    const store = new SingleSecretKeyStore(new Map([['openai', 'sk-test']]));
+    expect(store.getApiKey('openai')).toSucceedWith('sk-test');
+  });
+
+  test('getApiKey fails when the secret is absent', () => {
+    const store = new SingleSecretKeyStore(new Map());
+    expect(store.getApiKey('openai')).toFailWith(/not set/);
+  });
+
+  test('getApiKey fails when the secret is an empty string', () => {
+    const store = new SingleSecretKeyStore(new Map([['openai', '']]));
+    expect(store.getApiKey('openai')).toFailWith(/not set/);
+  });
+});
+
+describe('useProviderApiKey', () => {
+  test('starts loading, then transitions to ready on a successful resolve', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    const { result } = renderHook(() => useProviderApiKey(context, 'openai'));
+
+    expect(result.current.status).toBe('loading');
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.apiKey).toBe('sk-test');
+    expect(result.current.error).toBeUndefined();
+  });
+
+  test('transitions to missing with the failure message when resolution fails', async () => {
+    const context = makeContext(async () => fail('no key configured'));
+    const { result } = renderHook(() => useProviderApiKey(context, 'openai'));
+
+    await waitFor(() => expect(result.current.status).toBe('missing'));
+    expect(result.current.apiKey).toBe('');
+    expect(result.current.error).toMatch(/no key configured/);
+  });
+
+  test('re-resolves when the provider changes', async () => {
+    const resolveSecret = jest.fn(async (spec: ISecretSpec): Promise<Result<string>> =>
+      succeed(`sk-${spec.id}`)
+    );
+    const context = makeContext(resolveSecret);
+    const { result, rerender } = renderHook(
+      ({ provider }: { provider: AiAssist.AiProviderId }) => useProviderApiKey(context, provider),
+      { initialProps: { provider: 'openai' } }
+    );
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.apiKey).toBe('sk-openai-api-key');
+
+    rerender({ provider: 'anthropic' });
+    await waitFor(() => expect(result.current.apiKey).toBe('sk-anthropic-api-key'));
+  });
+
+  test('re-resolves when the resolveSecret closure identity changes (session store updated)', async () => {
+    let currentValue = 'sk-first';
+    const context1 = makeContext(async () => succeed(currentValue));
+    const { result, rerender } = renderHook(({ context }) => useProviderApiKey(context, 'openai'), {
+      initialProps: { context: context1 }
+    });
+    await waitFor(() => expect(result.current.apiKey).toBe('sk-first'));
+
+    currentValue = 'sk-second';
+    const context2 = makeContext(async () => succeed(currentValue));
+    rerender({ context: context2 });
+    await waitFor(() => expect(result.current.apiKey).toBe('sk-second'));
+  });
+
+  test('ignores a resolve that completes after the component unmounts', async () => {
+    let resolveFn: (result: Result<string>) => void = () => undefined;
+    const pending = new Promise<Result<string>>((resolve) => {
+      resolveFn = resolve;
+    });
+    const context = makeContext(async () => pending);
+    const { unmount } = renderHook(() => useProviderApiKey(context, 'openai'));
+
+    unmount();
+    resolveFn(succeed('sk-late'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Test passes if no "can't update unmounted component" warning fires.
+  });
+});

--- a/samples/testbed/src/test/unit/scenarios/imageGeneration.test.tsx
+++ b/samples/testbed/src/test/unit/scenarios/imageGeneration.test.tsx
@@ -365,6 +365,49 @@ describe('imageGeneration PromptPanel', () => {
   test('shows the maxCount hint when the capability declares one', () => {
     render(<PromptPanel {...baseProps()} />);
     expect(screen.getByText(/up to 10 image\(s\)/)).not.toBeNull();
+    expect((screen.getByTestId('image-gen-count-input') as HTMLInputElement).max).toBe('10');
+  });
+
+  test('falls back to the default max count when imageCapability has no maxCount', () => {
+    render(
+      <PromptPanel
+        {...baseProps({
+          imageCapability: { modelPrefix: '', format: 'xai-images', acceptsImageReferenceInput: false }
+        })}
+      />
+    );
+    expect(screen.getByText(/up to 4 image\(s\)/)).not.toBeNull();
+    expect((screen.getByTestId('image-gen-count-input') as HTMLInputElement).max).toBe('4');
+  });
+
+  test('the count input clamps to the selected model maxCount on change', () => {
+    render(<PromptPanel {...baseProps()} />);
+    const input = screen.getByTestId('image-gen-count-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '99' } });
+    expect(input.value).toBe('10');
+  });
+
+  test('submitting sends a count clamped to the selected model maxCount', () => {
+    const onGenerate = jest.fn(async () => undefined);
+    render(<PromptPanel {...baseProps({ onGenerate })} />);
+    fireEvent.change(screen.getByTestId('image-gen-prompt-input'), { target: { value: 'a cat' } });
+    fireEvent.change(screen.getByTestId('image-gen-count-input'), { target: { value: '99' } });
+    fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+    expect(onGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ options: expect.objectContaining({ count: 10 }) })
+    );
+  });
+
+  test('switching to a model with a lower maxCount re-clamps an already-entered count', async () => {
+    const { rerender } = render(<PromptPanel {...baseProps()} />);
+    const input = screen.getByTestId('image-gen-count-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '8' } });
+    expect(input.value).toBe('8');
+
+    // GEMINI_CAPABILITY declares maxCount: 1 — lower than the 8 just entered under the
+    // OpenAI capability, so the re-clamp effect should bring the value back into range.
+    rerender(<PromptPanel {...baseProps({ imageCapability: GEMINI_CAPABILITY })} />);
+    await waitFor(() => expect(input.value).toBe('1'));
   });
 
   test('does not show reference-image affordances when acceptsImageReferenceInput is false', () => {

--- a/samples/testbed/src/test/unit/scenarios/imageGeneration.test.tsx
+++ b/samples/testbed/src/test/unit/scenarios/imageGeneration.test.tsx
@@ -233,6 +233,12 @@ describe('imageGeneration PromptPanel', () => {
       onReferenceImagesChange: jest.fn(),
       onGenerate: jest.fn(async () => undefined),
       onAbort: jest.fn(),
+      logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        detail: jest.fn()
+      } as unknown as React.ComponentProps<typeof PromptPanel>['logger'],
       ...overrides
     };
   }
@@ -418,14 +424,16 @@ describe('imageGeneration PromptPanel', () => {
     expect(result[0]?.mimeType).toBe('image/png');
   });
 
-  test('rejects an unsupported reference-image file type with an alert', async () => {
+  test('rejects an unsupported reference-image file type with an alert and logs it', async () => {
     const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined);
-    render(<PromptPanel {...baseProps()} />);
+    const props = baseProps();
+    render(<PromptPanel {...props} />);
     const file = new File(['fake-bytes'], 'ref.gif', { type: 'image/gif' });
     fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [file] } });
 
     await waitFor(() => expect(alertSpy).toHaveBeenCalled());
     expect(alertSpy.mock.calls[0]?.[0]).toMatch(/unsupported file type/);
+    expect(props.logger.error).toHaveBeenCalledWith(expect.stringMatching(/unsupported file type/));
     alertSpy.mockRestore();
   });
 

--- a/samples/testbed/src/test/unit/scenarios/imageGeneration.test.tsx
+++ b/samples/testbed/src/test/unit/scenarios/imageGeneration.test.tsx
@@ -1,0 +1,513 @@
+/**
+ * Unit tests for the `image-generation` scenario: `SettingsPanel`, `PromptPanel`,
+ * `ImageResults`, and the orchestrating `index.tsx` component. Network calls
+ * (`AiAssist.callProviderImageGeneration` / `callProviderListModels`) are stubbed via
+ * `jest.spyOn` — the same pattern `useAiAssist.test.ts` uses in `@fgv/ts-app-shell`.
+ *
+ * @packageDocumentation
+ */
+
+import '@fgv/ts-utils-jest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react';
+import { fail, succeed } from '@fgv/ts-utils';
+import { AiAssist } from '@fgv/ts-extras';
+
+import { SettingsPanel } from '../../../scenarios/imageGeneration/SettingsPanel';
+import { PromptPanel } from '../../../scenarios/imageGeneration/PromptPanel';
+import { ImageResults } from '../../../scenarios/imageGeneration/ImageResults';
+import { defaultModelFor, IMAGE_PROVIDERS, imageGenerationScenario } from '../../../scenarios/imageGeneration';
+import type { IScenarioContext } from '../../../shell';
+
+// ---------------------------------------------------------------------------
+// Scenario metadata
+// ---------------------------------------------------------------------------
+
+describe('imageGenerationScenario metadata', () => {
+  test('declares the id, category, and a web impl with no cli impl', () => {
+    expect(imageGenerationScenario.id).toBe('image-generation');
+    expect(imageGenerationScenario.category).toBe('ai');
+    expect(imageGenerationScenario.web).toBeDefined();
+    expect(imageGenerationScenario.cli).toBeUndefined();
+  });
+
+  test('IMAGE_PROVIDERS is non-empty and only contains image-capable providers', () => {
+    expect(IMAGE_PROVIDERS.length).toBeGreaterThan(0);
+    for (const provider of IMAGE_PROVIDERS) {
+      const descriptor = AiAssist.getProviderDescriptor(provider).orThrow();
+      expect(AiAssist.supportsImageGeneration(descriptor)).toBe(true);
+    }
+  });
+
+  test('requiredSecrets is derived from IMAGE_PROVIDERS (reuses existing CLI secret ids)', () => {
+    const ids = (imageGenerationScenario.requiredSecrets ?? []).map((s) => s.id);
+    expect(ids).toContain('openai-api-key');
+    expect(ids).toContain('gemini-api-key');
+    expect(ids).toContain('google-api-key');
+    // Anthropic does not support image generation — must not be declared here.
+    expect(ids).not.toContain('anthropic-api-key');
+  });
+
+  test('defaultModelFor returns the empty string for an unknown provider id', () => {
+    expect(defaultModelFor('does-not-exist' as AiAssist.AiProviderId)).toBe('');
+  });
+
+  test('defaultModelFor resolves the image tier for a known provider', () => {
+    expect(defaultModelFor('openai').length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SettingsPanel
+// ---------------------------------------------------------------------------
+
+describe('imageGeneration SettingsPanel', () => {
+  afterEach(cleanup);
+
+  function baseProps(): React.ComponentProps<typeof SettingsPanel> {
+    return {
+      providers: ['openai', 'google-gemini'],
+      provider: 'openai',
+      onProviderChange: jest.fn(),
+      apiKeyStatus: 'loading',
+      apiKeyError: undefined,
+      model: '',
+      modelPlaceholder: 'gpt-image-2',
+      onModelChange: jest.fn(),
+      availableModels: [],
+      isFetchingModels: false,
+      modelListError: undefined,
+      onFetchModels: jest.fn()
+    };
+  }
+
+  test('shows the loading key affordance', () => {
+    render(<SettingsPanel {...baseProps()} apiKeyStatus="loading" />);
+    expect(screen.getByTestId('image-gen-key-loading')).not.toBeNull();
+  });
+
+  test('shows the ready key affordance', () => {
+    render(<SettingsPanel {...baseProps()} apiKeyStatus="ready" />);
+    expect(screen.getByTestId('image-gen-key-ready')).not.toBeNull();
+  });
+
+  test('shows the missing key affordance with the error message', () => {
+    render(<SettingsPanel {...baseProps()} apiKeyStatus="missing" apiKeyError="not set" />);
+    const el = screen.getByTestId('image-gen-key-missing');
+    expect(el.textContent).toContain('not set');
+  });
+
+  test('the fetch-models button is disabled unless a key is ready', () => {
+    render(<SettingsPanel {...baseProps()} apiKeyStatus="missing" />);
+    expect((screen.getByTestId('image-gen-fetch-models-btn') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('the fetch-models button is enabled with a ready key and not already fetching', () => {
+    render(<SettingsPanel {...baseProps()} apiKeyStatus="ready" />);
+    expect((screen.getByTestId('image-gen-fetch-models-btn') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  test('the fetch-models button shows "Fetching…" and is disabled while fetching', () => {
+    render(<SettingsPanel {...baseProps()} apiKeyStatus="ready" isFetchingModels={true} />);
+    const btn = screen.getByTestId('image-gen-fetch-models-btn');
+    expect(btn.textContent).toBe('Fetching…');
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('changing the provider select calls onProviderChange', () => {
+    const onProviderChange = jest.fn();
+    render(<SettingsPanel {...baseProps()} onProviderChange={onProviderChange} />);
+    fireEvent.change(screen.getByTestId('image-gen-provider-select'), { target: { value: 'google-gemini' } });
+    expect(onProviderChange).toHaveBeenCalledWith('google-gemini');
+  });
+
+  test('changing the model input calls onModelChange', () => {
+    const onModelChange = jest.fn();
+    render(<SettingsPanel {...baseProps()} onModelChange={onModelChange} />);
+    fireEvent.change(screen.getByTestId('image-gen-model-input'), { target: { value: 'gpt-image-3' } });
+    expect(onModelChange).toHaveBeenCalledWith('gpt-image-3');
+  });
+
+  test('clicking fetch models calls onFetchModels', () => {
+    const onFetchModels = jest.fn();
+    render(<SettingsPanel {...baseProps()} apiKeyStatus="ready" onFetchModels={onFetchModels} />);
+    fireEvent.click(screen.getByTestId('image-gen-fetch-models-btn'));
+    expect(onFetchModels).toHaveBeenCalled();
+  });
+
+  test('renders the fetched model list', () => {
+    render(
+      <SettingsPanel
+        {...baseProps()}
+        availableModels={[{ id: 'gpt-image-2', displayName: 'GPT Image 2', capabilities: new Set() }]}
+      />
+    );
+    const list = screen.getByTestId('image-gen-model-list');
+    expect(within(list).getByText('GPT Image 2')).not.toBeNull();
+  });
+
+  test('renders the model-list error and still allows manual entry', () => {
+    render(<SettingsPanel {...baseProps()} modelListError="network error" />);
+    expect(screen.getByTestId('image-gen-model-list-error').textContent).toContain('network error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PromptPanel
+// ---------------------------------------------------------------------------
+
+describe('imageGeneration PromptPanel', () => {
+  afterEach(cleanup);
+
+  const OPENAI_CAPABILITY: AiAssist.IAiImageModelCapability = {
+    modelPrefix: 'gpt-image-',
+    format: 'openai-images',
+    acceptsImageReferenceInput: true,
+    acceptedSizes: ['1024x1024', '1536x1024'],
+    maxCount: 10
+  };
+
+  const GEMINI_CAPABILITY: AiAssist.IAiImageModelCapability = {
+    modelPrefix: '',
+    format: 'gemini-image-out',
+    acceptsImageReferenceInput: true,
+    maxCount: 1
+  };
+
+  function baseProps(
+    overrides: Partial<React.ComponentProps<typeof PromptPanel>> = {}
+  ): React.ComponentProps<typeof PromptPanel> {
+    return {
+      imageCapability: OPENAI_CAPABILITY,
+      isWorking: false,
+      canSubmit: true,
+      referenceImages: [],
+      onReferenceImagesChange: jest.fn(),
+      onGenerate: jest.fn(async () => undefined),
+      onAbort: jest.fn(),
+      ...overrides
+    };
+  }
+
+  test('shows the size selector for the openai-images format', () => {
+    render(<PromptPanel {...baseProps()} />);
+    expect(screen.getByTestId('image-gen-size-select')).not.toBeNull();
+    expect(screen.queryByTestId('image-gen-aspect-select')).toBeNull();
+  });
+
+  test('shows the aspect-ratio selector for the gemini-image-out format', () => {
+    render(<PromptPanel {...baseProps({ imageCapability: GEMINI_CAPABILITY })} />);
+    expect(screen.queryByTestId('image-gen-size-select')).toBeNull();
+    expect(screen.getByTestId('image-gen-aspect-select')).not.toBeNull();
+  });
+
+  test('shows neither selector when imageCapability is undefined', () => {
+    render(<PromptPanel {...baseProps({ imageCapability: undefined })} />);
+    expect(screen.queryByTestId('image-gen-size-select')).toBeNull();
+    expect(screen.queryByTestId('image-gen-aspect-select')).toBeNull();
+  });
+
+  test('submit is disabled when canSubmit is false, with a hint shown', () => {
+    render(<PromptPanel {...baseProps({ canSubmit: false })} />);
+    expect((screen.getByTestId('image-gen-submit-btn') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByTestId('image-gen-cannot-submit-hint')).not.toBeNull();
+  });
+
+  test('submit is disabled when the prompt is empty', () => {
+    render(<PromptPanel {...baseProps()} />);
+    fireEvent.change(screen.getByTestId('image-gen-prompt-input'), { target: { value: '   ' } });
+    expect((screen.getByTestId('image-gen-submit-btn') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('submitting calls onGenerate with the OpenAI size option', () => {
+    const onGenerate = jest.fn(async () => undefined);
+    render(<PromptPanel {...baseProps({ onGenerate })} />);
+    fireEvent.change(screen.getByTestId('image-gen-prompt-input'), { target: { value: 'a cat' } });
+    fireEvent.change(screen.getByTestId('image-gen-size-select'), { target: { value: '1536x1024' } });
+    fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+    expect(onGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: 'a cat', options: expect.objectContaining({ size: '1536x1024' }) })
+    );
+  });
+
+  test('submitting with the gemini format sends a models block with the aspect ratio', () => {
+    const onGenerate = jest.fn(async () => undefined);
+    render(<PromptPanel {...baseProps({ imageCapability: GEMINI_CAPABILITY, onGenerate })} />);
+    fireEvent.change(screen.getByTestId('image-gen-prompt-input'), { target: { value: 'a dog' } });
+    fireEvent.change(screen.getByTestId('image-gen-aspect-select'), { target: { value: '16:9' } });
+    fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+    expect(onGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          models: [{ provider: 'google', family: 'gemini-flash-image', config: { aspectRatio: '16:9' } }]
+        })
+      })
+    );
+  });
+
+  test('clicking submit while canSubmit is false does not call onGenerate', () => {
+    const onGenerate = jest.fn(async () => undefined);
+    render(<PromptPanel {...baseProps({ canSubmit: false, onGenerate })} />);
+    fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+    expect(onGenerate).not.toHaveBeenCalled();
+  });
+
+  test('shows the abort button while working, and clicking it calls onAbort', () => {
+    const onAbort = jest.fn();
+    render(<PromptPanel {...baseProps({ isWorking: true, onAbort })} />);
+    fireEvent.click(screen.getByTestId('image-gen-abort-btn'));
+    expect(onAbort).toHaveBeenCalled();
+  });
+
+  test('the count input clamps to a minimum of 1', () => {
+    render(<PromptPanel {...baseProps()} />);
+    const input = screen.getByTestId('image-gen-count-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '0' } });
+    expect(input.value).toBe('1');
+  });
+
+  test('shows the maxCount hint when the capability declares one', () => {
+    render(<PromptPanel {...baseProps()} />);
+    expect(screen.getByText(/up to 10 image\(s\)/)).not.toBeNull();
+  });
+
+  test('does not show reference-image affordances when acceptsImageReferenceInput is false', () => {
+    render(
+      <PromptPanel
+        {...baseProps({
+          imageCapability: { modelPrefix: '', format: 'xai-images', acceptsImageReferenceInput: false }
+        })}
+      />
+    );
+    expect(screen.queryByTestId('image-gen-ref-file-input')).toBeNull();
+  });
+
+  test('shows reference images and supports removing one', () => {
+    const onReferenceImagesChange = jest.fn();
+    render(
+      <PromptPanel
+        {...baseProps({
+          referenceImages: [{ mimeType: 'image/png', base64: 'AAA' }],
+          onReferenceImagesChange
+        })}
+      />
+    );
+    fireEvent.click(screen.getByLabelText('Remove reference image 1'));
+    const updater = onReferenceImagesChange.mock.calls[0][0] as (
+      prev: ReadonlyArray<AiAssist.IAiImageAttachment>
+    ) => ReadonlyArray<AiAssist.IAiImageAttachment>;
+    expect(updater([{ mimeType: 'image/png', base64: 'AAA' }])).toEqual([]);
+  });
+
+  test('clear-all removes every reference image', () => {
+    const onReferenceImagesChange = jest.fn();
+    render(
+      <PromptPanel
+        {...baseProps({
+          referenceImages: [{ mimeType: 'image/png', base64: 'AAA' }],
+          onReferenceImagesChange
+        })}
+      />
+    );
+    fireEvent.click(screen.getByText('Clear all'));
+    expect(onReferenceImagesChange).toHaveBeenCalledWith([]);
+  });
+
+  test('adding a valid reference image file calls onReferenceImagesChange with an attachment', async () => {
+    const onReferenceImagesChange = jest.fn();
+    render(<PromptPanel {...baseProps({ onReferenceImagesChange })} />);
+    const file = new File(['fake-bytes'], 'ref.png', { type: 'image/png' });
+    fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [file] } });
+
+    await waitFor(() => expect(onReferenceImagesChange).toHaveBeenCalled());
+    const updater = onReferenceImagesChange.mock.calls[0][0] as (
+      prev: ReadonlyArray<AiAssist.IAiImageAttachment>
+    ) => ReadonlyArray<AiAssist.IAiImageAttachment>;
+    const result = updater([]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.mimeType).toBe('image/png');
+  });
+
+  test('rejects an unsupported reference-image file type with an alert', async () => {
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+    render(<PromptPanel {...baseProps()} />);
+    const file = new File(['fake-bytes'], 'ref.gif', { type: 'image/gif' });
+    fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [file] } });
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    expect(alertSpy.mock.calls[0]?.[0]).toMatch(/unsupported file type/);
+    alertSpy.mockRestore();
+  });
+
+  test('changing the file input with no files is a no-op', () => {
+    const onReferenceImagesChange = jest.fn();
+    render(<PromptPanel {...baseProps({ onReferenceImagesChange })} />);
+    fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [] } });
+    expect(onReferenceImagesChange).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ImageResults
+// ---------------------------------------------------------------------------
+
+describe('imageGeneration ImageResults', () => {
+  afterEach(cleanup);
+
+  const RESPONSE: AiAssist.IAiImageGenerationResponse = {
+    images: [
+      { mimeType: 'image/png', base64: 'AAA', revisedPrompt: 'a revised prompt' },
+      { mimeType: 'image/jpeg', base64: 'BBB' }
+    ]
+  };
+
+  test('renders one figure per generated image with the count in the heading', () => {
+    render(<ImageResults response={RESPONSE} />);
+    expect(screen.getByTestId('image-gen-result-0')).not.toBeNull();
+    expect(screen.getByTestId('image-gen-result-1')).not.toBeNull();
+    expect(screen.getByText('Generated 2 images')).not.toBeNull();
+  });
+
+  test('renders the revised prompt when present', () => {
+    render(<ImageResults response={RESPONSE} />);
+    expect(screen.getByText(/a revised prompt/)).not.toBeNull();
+  });
+
+  test('omits the "use as reference" affordance when onUseAsReference is not supplied', () => {
+    render(<ImageResults response={RESPONSE} />);
+    expect(screen.queryByTestId('image-gen-use-as-ref-0')).toBeNull();
+  });
+
+  test('clicking "use as reference" invokes the callback with the image', () => {
+    const onUseAsReference = jest.fn();
+    render(<ImageResults response={RESPONSE} onUseAsReference={onUseAsReference} />);
+    fireEvent.click(screen.getByTestId('image-gen-use-as-ref-0'));
+    expect(onUseAsReference).toHaveBeenCalledWith(RESPONSE.images[0]);
+  });
+
+  test('singular heading for a single-image response', () => {
+    render(<ImageResults response={{ images: [{ mimeType: 'image/png', base64: 'AAA' }] }} />);
+    expect(screen.getByText('Generated 1 image')).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// index.tsx (integration, mocked AiAssist dispatch)
+// ---------------------------------------------------------------------------
+
+describe('imageGeneration integration', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    cleanup();
+  });
+
+  function makeContext(resolveSecret: IScenarioContext['resolveSecret']): IScenarioContext {
+    return {
+      logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        detail: jest.fn()
+      } as unknown as IScenarioContext['logger'],
+      keyStore: undefined,
+      resolveSecret,
+      dataTree: {} as unknown as IScenarioContext['dataTree']
+    };
+  }
+
+  test('shows the missing-key affordance when no secret resolves', async () => {
+    const context = makeContext(async () => fail('secret not configured'));
+    const Component = imageGenerationScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.getByTestId('image-gen-key-missing')).not.toBeNull());
+    expect((screen.getByTestId('image-gen-submit-btn') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('enables generation and renders results once a key resolves and generation succeeds', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    const generateSpy = jest.spyOn(AiAssist, 'callProviderImageGeneration').mockResolvedValue(
+      succeed({ images: [{ mimeType: 'image/png', base64: 'AAA' }] })
+    );
+    const Component = imageGenerationScenario.web!.component;
+    render(<Component context={context} />);
+
+    await waitFor(() => expect(screen.getByTestId('image-gen-key-ready')).not.toBeNull());
+    fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('image-gen-results')).not.toBeNull());
+    expect(generateSpy).toHaveBeenCalled();
+  });
+
+  test('shows an inline error when generation fails', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    jest.spyOn(AiAssist, 'callProviderImageGeneration').mockResolvedValue(fail('provider rejected the request'));
+    const Component = imageGenerationScenario.web!.component;
+    render(<Component context={context} />);
+
+    await waitFor(() => expect(screen.getByTestId('image-gen-key-ready')).not.toBeNull());
+    fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('image-gen-error')).not.toBeNull());
+    expect(screen.getByTestId('image-gen-error').textContent).toContain('provider rejected the request');
+  });
+
+  test('fetching models populates the model list on success', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    jest.spyOn(AiAssist, 'callProviderListModels').mockResolvedValue(
+      succeed([{ id: 'gpt-image-3', displayName: 'GPT Image 3', capabilities: new Set() }])
+    );
+    const Component = imageGenerationScenario.web!.component;
+    render(<Component context={context} />);
+
+    await waitFor(() => expect(screen.getByTestId('image-gen-key-ready')).not.toBeNull());
+    fireEvent.click(screen.getByTestId('image-gen-fetch-models-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('image-gen-model-list')).not.toBeNull());
+    expect(within(screen.getByTestId('image-gen-model-list')).getByText('GPT Image 3')).not.toBeNull();
+  });
+
+  test('fetching models surfaces a list error on failure', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    jest.spyOn(AiAssist, 'callProviderListModels').mockResolvedValue(fail('rate limited'));
+    const Component = imageGenerationScenario.web!.component;
+    render(<Component context={context} />);
+
+    await waitFor(() => expect(screen.getByTestId('image-gen-key-ready')).not.toBeNull());
+    fireEvent.click(screen.getByTestId('image-gen-fetch-models-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('image-gen-model-list-error')).not.toBeNull());
+  });
+
+  test('switching provider resets the settings panel to the new provider', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    const Component = imageGenerationScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.getByTestId('image-gen-key-ready')).not.toBeNull());
+
+    const otherProvider = IMAGE_PROVIDERS.find((p) => p !== IMAGE_PROVIDERS[0]);
+    if (otherProvider) {
+      fireEvent.change(screen.getByTestId('image-gen-provider-select'), { target: { value: otherProvider } });
+      const select = screen.getByTestId('image-gen-provider-select') as HTMLSelectElement;
+      expect(select.value).toBe(otherProvider);
+    }
+  });
+
+  test('using a generated image as a reference adds it to referenceImages when the model accepts refs', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    jest
+      .spyOn(AiAssist, 'callProviderImageGeneration')
+      .mockResolvedValue(succeed({ images: [{ mimeType: 'image/png', base64: 'AAA' }] }));
+    const Component = imageGenerationScenario.web!.component;
+    render(<Component context={context} />);
+
+    await waitFor(() => expect(screen.getByTestId('image-gen-key-ready')).not.toBeNull());
+    fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+    await waitFor(() => expect(screen.getByTestId('image-gen-results')).not.toBeNull());
+
+    const useAsRefBtn = screen.queryByTestId('image-gen-use-as-ref-0');
+    if (useAsRefBtn) {
+      fireEvent.click(useAsRefBtn);
+      await waitFor(() => expect(screen.getByLabelText('Remove reference image 1')).not.toBeNull());
+    }
+  });
+});

--- a/samples/testbed/src/test/unit/scenarios/imageGeneration.test.tsx
+++ b/samples/testbed/src/test/unit/scenarios/imageGeneration.test.tsx
@@ -10,7 +10,7 @@
 import '@fgv/ts-utils-jest';
 import React from 'react';
 import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react';
-import { fail, succeed } from '@fgv/ts-utils';
+import { fail, succeed, type Result } from '@fgv/ts-utils';
 import { AiAssist } from '@fgv/ts-extras';
 
 import { SettingsPanel } from '../../../scenarios/imageGeneration/SettingsPanel';
@@ -150,6 +150,47 @@ describe('imageGeneration SettingsPanel', () => {
     render(<SettingsPanel {...baseProps()} modelListError="network error" />);
     expect(screen.getByTestId('image-gen-model-list-error').textContent).toContain('network error');
   });
+
+  test('shows the CORS-restricted badge for a provider whose descriptor declares it', () => {
+    // xai-grok is the only image-capable provider with corsRestricted: true in the
+    // registry — see libraries/ts-extras/src/packlets/ai-assist/registry.ts.
+    render(<SettingsPanel {...baseProps()} provider="xai-grok" />);
+    expect(screen.getByText('CORS-restricted (proxy required for production)')).not.toBeNull();
+  });
+
+  test('falls back to the raw id/name when a provider or model has no registry descriptor/displayName (ready)', () => {
+    const unknownProvider = 'not-a-real-provider' as AiAssist.AiProviderId;
+    render(
+      <SettingsPanel
+        {...baseProps()}
+        providers={[unknownProvider]}
+        provider={unknownProvider}
+        apiKeyStatus="ready"
+        availableModels={[{ id: 'raw-model-id', capabilities: new Set() }]}
+      />
+    );
+    // Provider <option> label falls back to the raw id.
+    expect(screen.getByText(unknownProvider)).not.toBeNull();
+    // The "ready" key line falls back to the raw provider id too.
+    expect(screen.getByTestId('image-gen-key-ready').textContent).toContain(unknownProvider);
+    // A model with no displayName falls back to its id.
+    expect(screen.getByText('raw-model-id')).not.toBeNull();
+    // No descriptor means no CORS-restricted badge, regardless of the provider.
+    expect(screen.queryByText('CORS-restricted (proxy required for production)')).toBeNull();
+  });
+
+  test('falls back to the raw provider id in the "missing key" affordance too', () => {
+    const unknownProvider = 'not-a-real-provider' as AiAssist.AiProviderId;
+    render(
+      <SettingsPanel
+        {...baseProps()}
+        providers={[unknownProvider]}
+        provider={unknownProvider}
+        apiKeyStatus="missing"
+      />
+    );
+    expect(screen.getByTestId('image-gen-key-missing').textContent).toContain(unknownProvider);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -172,6 +213,13 @@ describe('imageGeneration PromptPanel', () => {
     format: 'gemini-image-out',
     acceptsImageReferenceInput: true,
     maxCount: 1
+  };
+
+  const XAI_CAPABILITY: AiAssist.IAiImageModelCapability = {
+    modelPrefix: 'grok-imagine-',
+    format: 'xai-images-edits',
+    acceptsImageReferenceInput: true,
+    maxCount: 10
   };
 
   function baseProps(
@@ -245,10 +293,52 @@ describe('imageGeneration PromptPanel', () => {
     );
   });
 
+  test('submitting with the xAI Grok Imagine format sends a models block with the aspect ratio', () => {
+    const onGenerate = jest.fn(async () => undefined);
+    render(<PromptPanel {...baseProps({ imageCapability: XAI_CAPABILITY, onGenerate })} />);
+    fireEvent.change(screen.getByTestId('image-gen-prompt-input'), { target: { value: 'a fox' } });
+    fireEvent.change(screen.getByTestId('image-gen-aspect-select'), { target: { value: '9:16' } });
+    fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+    expect(onGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          models: [{ provider: 'xai', family: 'grok-imagine', config: { aspectRatio: '9:16' } }]
+        })
+      })
+    );
+  });
+
+  test('submitting with attached reference images includes them when the format accepts refs', () => {
+    const onGenerate = jest.fn(async () => undefined);
+    const referenceImages = [{ mimeType: 'image/png', base64: 'AAA' }];
+    render(<PromptPanel {...baseProps({ referenceImages, onGenerate })} />);
+    fireEvent.change(screen.getByTestId('image-gen-prompt-input'), { target: { value: 'a cat' } });
+    fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+    expect(onGenerate).toHaveBeenCalledWith(expect.objectContaining({ referenceImages }));
+  });
+
   test('clicking submit while canSubmit is false does not call onGenerate', () => {
     const onGenerate = jest.fn(async () => undefined);
     render(<PromptPanel {...baseProps({ canSubmit: false, onGenerate })} />);
     fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+    expect(onGenerate).not.toHaveBeenCalled();
+  });
+
+  test('submitting the form directly (bypassing the disabled button) still honors the canSubmit guard', () => {
+    // The submit button is disabled while `canSubmit` is false, so a real click never
+    // reaches `handleSubmit` — dispatch the form's `submit` event directly to exercise
+    // the guard clause itself (e.g. an Enter keypress in a focused field would take
+    // this path even with the submit button disabled).
+    const onGenerate = jest.fn(async () => undefined);
+    const { container } = render(<PromptPanel {...baseProps({ canSubmit: false, onGenerate })} />);
+    fireEvent.submit(container.querySelector('form')!);
+    expect(onGenerate).not.toHaveBeenCalled();
+  });
+
+  test('submitting the form directly while isWorking honors the guard', () => {
+    const onGenerate = jest.fn(async () => undefined);
+    const { container } = render(<PromptPanel {...baseProps({ isWorking: true, onGenerate })} />);
+    fireEvent.submit(container.querySelector('form')!);
     expect(onGenerate).not.toHaveBeenCalled();
   });
 
@@ -339,11 +429,141 @@ describe('imageGeneration PromptPanel', () => {
     alertSpy.mockRestore();
   });
 
+  /**
+   * Spies on `FileReader.prototype.readAsDataURL` (rather than saving/restoring the
+   * whole global class) so a single test can force `reader.result` to a value that
+   * violates the `data:<mime>;base64,<data>` shape the FileReader spec guarantees for
+   * a real `readAsDataURL` call — exercising `fileToAttachment`'s defensive parse
+   * checks, which no real browser would otherwise trigger.
+   */
+  function mockFileReaderResult(dataUrl: string): jest.SpyInstance {
+    return jest.spyOn(FileReader.prototype, 'readAsDataURL').mockImplementation(function (
+      this: FileReader
+    ): void {
+      queueMicrotask(() => {
+        Object.defineProperty(this, 'result', { value: dataUrl, configurable: true });
+        (this.onload as unknown as (ev: unknown) => void)?.(new Event('load'));
+      });
+    });
+  }
+
+  /** Same idea as {@link mockFileReaderResult}, but drives the `onerror` path instead. */
+  function mockFileReaderError(error?: DOMException): jest.SpyInstance {
+    return jest.spyOn(FileReader.prototype, 'readAsDataURL').mockImplementation(function (
+      this: FileReader
+    ): void {
+      queueMicrotask(() => {
+        if (error) {
+          Object.defineProperty(this, 'error', { value: error, configurable: true });
+        }
+        (this.onerror as unknown as (ev: unknown) => void)?.(new Event('error'));
+      });
+    });
+  }
+
+  test('rejects when FileReader itself reports an error (reader.error is null)', async () => {
+    const readerSpy = mockFileReaderError();
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+    render(<PromptPanel {...baseProps()} />);
+    const file = new File(['x'], 'ref.png', { type: 'image/png' });
+    fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [file] } });
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    expect(alertSpy.mock.calls[0]?.[0]).toMatch(/failed to read file/);
+    readerSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  test('rejects with the FileReader-reported DOMException when reader.error is set', async () => {
+    const readerSpy = mockFileReaderError(new DOMException('disk read failed', 'NotReadableError'));
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+    render(<PromptPanel {...baseProps()} />);
+    const file = new File(['x'], 'ref.png', { type: 'image/png' });
+    fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [file] } });
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    expect(alertSpy.mock.calls[0]?.[0]).toMatch(/disk read failed/);
+    readerSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  test('rejects a FileReader result missing the "data:" prefix', async () => {
+    const readerSpy = mockFileReaderResult('not-a-data-url-at-all');
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+    render(<PromptPanel {...baseProps()} />);
+    const file = new File(['x'], 'ref.png', { type: 'image/png' });
+    fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [file] } });
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    expect(alertSpy.mock.calls[0]?.[0]).toMatch(/invalid data URL format/);
+    readerSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  test('rejects a FileReader result missing the ";base64," marker', async () => {
+    const readerSpy = mockFileReaderResult('data:image/png,not-base64-encoded');
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+    render(<PromptPanel {...baseProps()} />);
+    const file = new File(['x'], 'ref.png', { type: 'image/png' });
+    fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [file] } });
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    expect(alertSpy.mock.calls[0]?.[0]).toMatch(/expected base64 data URL/);
+    readerSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  test('rejects a FileReader result with an empty base64 payload', async () => {
+    const readerSpy = mockFileReaderResult('data:image/png;base64,');
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+    render(<PromptPanel {...baseProps()} />);
+    const file = new File(['x'], 'ref.png', { type: 'image/png' });
+    fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [file] } });
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    expect(alertSpy.mock.calls[0]?.[0]).toMatch(/empty base64 payload/);
+    readerSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
   test('changing the file input with no files is a no-op', () => {
     const onReferenceImagesChange = jest.fn();
     render(<PromptPanel {...baseProps({ onReferenceImagesChange })} />);
     fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [] } });
     expect(onReferenceImagesChange).not.toHaveBeenCalled();
+  });
+
+  test('normalizes an "image/jpg" file to "image/jpeg" (both the accept check and the mimeType)', async () => {
+    const onReferenceImagesChange = jest.fn();
+    render(<PromptPanel {...baseProps({ onReferenceImagesChange })} />);
+    const file = new File(['x'], 'ref.jpg', { type: 'image/jpg' });
+    fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [file] } });
+
+    await waitFor(() => expect(onReferenceImagesChange).toHaveBeenCalled());
+    const updater = onReferenceImagesChange.mock.calls[0][0] as (
+      prev: ReadonlyArray<AiAssist.IAiImageAttachment>
+    ) => ReadonlyArray<AiAssist.IAiImageAttachment>;
+    expect(updater([])[0]?.mimeType).toBe('image/jpeg');
+  });
+
+  test('rejects a file with an empty type using the "unknown" fallback in the error message', async () => {
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+    render(<PromptPanel {...baseProps()} />);
+    const file = new File(['x'], 'ref', { type: '' });
+    fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [file] } });
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    expect(alertSpy.mock.calls[0]?.[0]).toMatch(/unsupported file type: unknown/);
+    alertSpy.mockRestore();
+  });
+
+  test('falls back to the file\'s own type when the data URL header mime is empty', async () => {
+    const readerSpy = mockFileReaderResult('data:;base64,QUFB');
+    const onReferenceImagesChange = jest.fn();
+    render(<PromptPanel {...baseProps({ onReferenceImagesChange })} />);
+    const file = new File(['x'], 'ref.png', { type: 'image/png' });
+    fireEvent.change(screen.getByTestId('image-gen-ref-file-input'), { target: { files: [file] } });
+
+    await waitFor(() => expect(onReferenceImagesChange).toHaveBeenCalled());
+    const updater = onReferenceImagesChange.mock.calls[0][0] as (
+      prev: ReadonlyArray<AiAssist.IAiImageAttachment>
+    ) => ReadonlyArray<AiAssist.IAiImageAttachment>;
+    expect(updater([])[0]?.mimeType).toBe('image/png');
+    readerSpy.mockRestore();
   });
 });
 
@@ -388,6 +608,12 @@ describe('imageGeneration ImageResults', () => {
   test('singular heading for a single-image response', () => {
     render(<ImageResults response={{ images: [{ mimeType: 'image/png', base64: 'AAA' }] }} />);
     expect(screen.getByText('Generated 1 image')).not.toBeNull();
+  });
+
+  test('falls back to a "png" download extension when the mimeType has no subtype', () => {
+    render(<ImageResults response={{ images: [{ mimeType: 'not-a-mime-type', base64: 'AAA' }] }} />);
+    const link = screen.getByText('Download') as HTMLAnchorElement;
+    expect(link.getAttribute('download')).toBe('generated-1.png');
   });
 });
 
@@ -435,7 +661,17 @@ describe('imageGeneration integration', () => {
     fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
 
     await waitFor(() => expect(screen.getByTestId('image-gen-results')).not.toBeNull());
-    expect(generateSpy).toHaveBeenCalled();
+    // Verify the request actually reaching the dispatcher, not just that some Result
+    // came back — the resolved key, provider, prompt, and model must all flow through
+    // the useAiAssist -> AiAssist.callProviderImageGeneration plumbing correctly.
+    expect(generateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'sk-test',
+        descriptor: expect.objectContaining({ id: IMAGE_PROVIDERS[0] }),
+        params: expect.objectContaining({ prompt: expect.any(String) }),
+        modelOverride: expect.any(String)
+      })
+    );
   });
 
   test('shows an inline error when generation fails', async () => {
@@ -509,5 +745,54 @@ describe('imageGeneration integration', () => {
       fireEvent.click(useAsRefBtn);
       await waitFor(() => expect(screen.getByLabelText('Remove reference image 1')).not.toBeNull());
     }
+  });
+
+  test('omits "use as reference" when the resolved model does not accept reference input', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    jest
+      .spyOn(AiAssist, 'callProviderImageGeneration')
+      .mockResolvedValue(succeed({ images: [{ mimeType: 'image/png', base64: 'AAA' }] }));
+    const Component = imageGenerationScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.getByTestId('image-gen-key-ready')).not.toBeNull());
+
+    // Switch to openai, then override the model to one that matches the registry's
+    // catch-all openai-images rule (acceptsImageReferenceInput unset) rather than the
+    // gpt-image- prefix rule (acceptsImageReferenceInput: true).
+    fireEvent.change(screen.getByTestId('image-gen-provider-select'), { target: { value: 'openai' } });
+    // The key re-resolves (briefly 'loading') for the newly-selected provider — wait
+    // for 'ready' again before submitting.
+    await waitFor(() => expect(screen.getByTestId('image-gen-key-ready')).not.toBeNull());
+    fireEvent.change(screen.getByTestId('image-gen-model-input'), { target: { value: 'dall-e-2' } });
+
+    fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+    await waitFor(() => expect(screen.getByTestId('image-gen-results')).not.toBeNull());
+    expect(screen.queryByTestId('image-gen-use-as-ref-0')).toBeNull();
+  });
+
+  test('clicking Cancel while a generation is in flight aborts the request signal', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    let capturedSignal: AbortSignal | undefined;
+    let resolveGenerate: (result: Result<AiAssist.IAiImageGenerationResponse>) => void = () => undefined;
+    const pending = new Promise<Result<AiAssist.IAiImageGenerationResponse>>((resolve) => {
+      resolveGenerate = resolve;
+    });
+    jest
+      .spyOn(AiAssist, 'callProviderImageGeneration')
+      .mockImplementation(async (params: AiAssist.IProviderImageGenerationParams) => {
+        capturedSignal = params.signal;
+        return pending;
+      });
+    const Component = imageGenerationScenario.web!.component;
+    render(<Component context={context} />);
+
+    await waitFor(() => expect(screen.getByTestId('image-gen-key-ready')).not.toBeNull());
+    fireEvent.click(screen.getByTestId('image-gen-submit-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('image-gen-abort-btn')).not.toBeNull());
+    fireEvent.click(screen.getByTestId('image-gen-abort-btn'));
+    expect(capturedSignal?.aborted).toBe(true);
+
+    resolveGenerate(succeed({ images: [] }));
   });
 });

--- a/samples/testbed/src/test/unit/scenarios/streamingChat.test.tsx
+++ b/samples/testbed/src/test/unit/scenarios/streamingChat.test.tsx
@@ -10,15 +10,18 @@
 import '@fgv/ts-utils-jest';
 import React from 'react';
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
-import { fail, succeed } from '@fgv/ts-utils';
+import { fail, succeed, type Result } from '@fgv/ts-utils';
 import { AiAssist } from '@fgv/ts-extras';
+import { PromptStoreFixture } from '@fgv/ts-prompt-assist';
 
+import * as streamingChatPromptLibraryModule from '../../../scenarios/streamingChat/promptLibrary';
 import {
   chatToneConverter,
   chatTones,
   createPromptLibrary,
   resolveChatSystemPrompt
 } from '../../../scenarios/streamingChat/promptLibrary';
+import type { ChatPromptLibrary } from '../../../scenarios/streamingChat/promptLibrary';
 import { ChatSettingsPanel } from '../../../scenarios/streamingChat/SettingsPanel';
 import { ChatPanel } from '../../../scenarios/streamingChat/ChatPanel';
 import type { IChatTurn } from '../../../scenarios/streamingChat/ChatPanel';
@@ -34,9 +37,19 @@ import type { IScenarioContext } from '../../../shell';
 // ---------------------------------------------------------------------------
 
 describe('streamingChat promptLibrary', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('createPromptLibrary builds a library successfully', async () => {
     const result = await createPromptLibrary();
     expect(result).toSucceed();
+  });
+
+  test('createPromptLibrary propagates a PromptStoreFixture.build failure', async () => {
+    jest.spyOn(PromptStoreFixture, 'build').mockResolvedValue(fail('fixture build exploded'));
+    const result = await createPromptLibrary();
+    expect(result).toFailWith(/fixture build exploded/);
   });
 
   test('resolveChatSystemPrompt resolves the neutral (base) body by default', async () => {
@@ -161,6 +174,41 @@ describe('streamingChat ChatSettingsPanel', () => {
     });
     expect(onModelChange).toHaveBeenCalledWith('claude-sonnet-5');
   });
+
+  test('shows the streaming-CORS-restricted badge for a provider whose descriptor declares it', () => {
+    // xai-grok is the only chat-capable provider with streamingCorsRestricted: true in
+    // the registry — see libraries/ts-extras/src/packlets/ai-assist/registry.ts.
+    render(<ChatSettingsPanel {...baseProps()} provider="xai-grok" />);
+    expect(screen.getByText('Streaming CORS-restricted — calls will fail without a proxy')).not.toBeNull();
+  });
+
+  test('falls back to the raw provider id when there is no registry descriptor (ready)', () => {
+    const unknownProvider = 'not-a-real-provider' as AiAssist.AiProviderId;
+    render(
+      <ChatSettingsPanel
+        {...baseProps()}
+        providers={[unknownProvider]}
+        provider={unknownProvider}
+        apiKeyStatus="ready"
+      />
+    );
+    expect(screen.getByText(unknownProvider)).not.toBeNull();
+    expect(screen.getByTestId('streaming-chat-key-ready').textContent).toContain(unknownProvider);
+    expect(screen.queryByText('Streaming CORS-restricted — calls will fail without a proxy')).toBeNull();
+  });
+
+  test('falls back to the raw provider id in the "missing key" affordance too', () => {
+    const unknownProvider = 'not-a-real-provider' as AiAssist.AiProviderId;
+    render(
+      <ChatSettingsPanel
+        {...baseProps()}
+        providers={[unknownProvider]}
+        provider={unknownProvider}
+        apiKeyStatus="missing"
+      />
+    );
+    expect(screen.getByTestId('streaming-chat-key-missing').textContent).toContain(unknownProvider);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -209,6 +257,12 @@ describe('streamingChat ChatPanel', () => {
     const turns: IChatTurn[] = [{ role: 'assistant', content: '', isStreaming: true }];
     render(<ChatPanel {...baseProps({ turns })} />);
     expect(screen.getByText('…')).not.toBeNull();
+  });
+
+  test('shows a streaming cursor once partial content has arrived', () => {
+    const turns: IChatTurn[] = [{ role: 'assistant', content: 'partial', isStreaming: true }];
+    const { container } = render(<ChatPanel {...baseProps({ turns })} />);
+    expect(container.querySelector('.animate-pulse')).not.toBeNull();
   });
 
   test('shows active tool events', () => {
@@ -275,6 +329,23 @@ describe('streamingChat ChatPanel', () => {
     expect(screen.getByTestId('streaming-chat-disabled-hint').textContent).toBe('no key');
   });
 
+  test('submitting the form directly (bypassing the disabled button) still honors the canSubmit guard', () => {
+    // The send button is disabled while `canSubmit` is false, so a real click never
+    // reaches `submitMessage` — dispatch the form's `submit` event directly (e.g. an
+    // Enter keypress takes this path even with the button disabled).
+    const onSend = jest.fn(async () => undefined);
+    const { container } = render(<ChatPanel {...baseProps({ canSubmit: false, onSend })} />);
+    fireEvent.submit(container.querySelector('form')!);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  test('submitting the form directly while isWorking honors the guard', () => {
+    const onSend = jest.fn(async () => undefined);
+    const { container } = render(<ChatPanel {...baseProps({ isWorking: true, onSend })} />);
+    fireEvent.submit(container.querySelector('form')!);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
   test('shows the abort button while working, and clicking it calls onAbort', () => {
     const onAbort = jest.fn();
     render(<ChatPanel {...baseProps({ isWorking: true, onAbort })} />);
@@ -304,6 +375,11 @@ describe('streamingChat ChatPanel', () => {
     } else {
       expect(screen.queryByTestId('streaming-chat-web-search-checkbox')).toBeNull();
     }
+  });
+
+  test('hides the web-search checkbox for a provider with no registry descriptor', () => {
+    render(<ChatPanel {...baseProps({ provider: 'not-a-real-provider' as AiAssist.AiProviderId })} />);
+    expect(screen.queryByTestId('streaming-chat-web-search-checkbox')).toBeNull();
   });
 });
 
@@ -339,13 +415,60 @@ describe('streamingChat integration', () => {
     expect(screen.getByTestId('streaming-chat-disabled-hint').textContent).toMatch(/API key/);
   });
 
-  test('shows the prompt-library-initializing reason once the key resolves but before the library loads', async () => {
+  test('shows the prompt-library-error disabled reason when createPromptLibrary fails', async () => {
+    jest
+      .spyOn(streamingChatPromptLibraryModule, 'createPromptLibrary')
+      .mockResolvedValue(fail('vault unreachable'));
     const context = makeContext(async () => succeed('sk-test'));
     const Component = streamingChatScenario.web!.component;
     render(<Component context={context} />);
     await waitFor(() => expect(screen.getByTestId('streaming-chat-key-ready')).not.toBeNull());
+    await waitFor(() =>
+      expect(screen.getByTestId('streaming-chat-disabled-hint').textContent).toMatch(
+        /Prompt library failed to load: vault unreachable/
+      )
+    );
+  });
+
+  test('shows the prompt-library-initializing reason once the key resolves but before the library loads', async () => {
+    // Build the real library BEFORE mocking createPromptLibrary — the mock replaces
+    // the same module-object property this real call goes through.
+    const realResult = await createPromptLibrary();
+    let resolveLibrary: (result: Result<ChatPromptLibrary>) => void = () => undefined;
+    const pending = new Promise<Result<ChatPromptLibrary>>((resolve) => {
+      resolveLibrary = resolve;
+    });
+    jest.spyOn(streamingChatPromptLibraryModule, 'createPromptLibrary').mockReturnValue(pending);
+
+    const context = makeContext(async () => succeed('sk-test'));
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.getByTestId('streaming-chat-key-ready')).not.toBeNull());
+    expect(screen.getByTestId('streaming-chat-disabled-hint').textContent).toBe(
+      'Prompt library is still initializing…'
+    );
+
+    resolveLibrary(realResult);
     // Eventually the prompt library resolves and the composer becomes enabled.
     await waitFor(() => expect(screen.queryByTestId('streaming-chat-disabled-hint')).toBeNull());
+  });
+
+  test('the createPromptLibrary effect ignores a resolution that arrives after unmount', async () => {
+    const realResult = await createPromptLibrary();
+    let resolveLibrary: (result: Result<ChatPromptLibrary>) => void = () => undefined;
+    const pending = new Promise<Result<ChatPromptLibrary>>((resolve) => {
+      resolveLibrary = resolve;
+    });
+    jest.spyOn(streamingChatPromptLibraryModule, 'createPromptLibrary').mockReturnValue(pending);
+
+    const context = makeContext(async () => succeed('sk-test'));
+    const Component = streamingChatScenario.web!.component;
+    const { unmount } = render(<Component context={context} />);
+    unmount();
+
+    resolveLibrary(realResult);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Test passes if no "can't update unmounted component" warning fires.
   });
 
   test('sends a message and streams text deltas into the transcript', async () => {
@@ -441,5 +564,98 @@ describe('streamingChat integration', () => {
     fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
 
     await waitFor(() => expect(lastSystem).toMatch(/formal register/));
+  });
+
+  test('overriding the model input updates the resolved model for the current provider', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.queryByTestId('streaming-chat-disabled-hint')).toBeNull());
+
+    const modelInput = screen.getByTestId('streaming-chat-model-input') as HTMLInputElement;
+    fireEvent.change(modelInput, { target: { value: 'custom-model-override' } });
+    expect(modelInput.value).toBe('custom-model-override');
+  });
+
+  test('shows an inline error and rolls back the placeholder turns when resolveChatSystemPrompt fails', async () => {
+    jest
+      .spyOn(streamingChatPromptLibraryModule, 'resolveChatSystemPrompt')
+      .mockResolvedValue(fail('tone resolution exploded'));
+    const context = makeContext(async () => succeed('sk-test'));
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.queryByTestId('streaming-chat-disabled-hint')).toBeNull());
+
+    fireEvent.change(screen.getByTestId('streaming-chat-input'), { target: { value: 'hi there' } });
+    fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('streaming-chat-error')).not.toBeNull());
+    expect(screen.getByTestId('streaming-chat-error').textContent).toContain('tone resolution exploded');
+    // The optimistic user+assistant placeholder turns are rolled back on failure.
+    expect(screen.queryByTestId('streaming-chat-turn-0')).toBeNull();
+  });
+
+  test('shows tool-use events while a server-side tool call is in progress', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    async function* events(): AsyncGenerator<AiAssist.IAiStreamEvent> {
+      yield { type: 'tool-event', phase: 'started', toolType: 'web_search' };
+      yield { type: 'text-delta', delta: 'partial' };
+      yield { type: 'tool-event', phase: 'completed', toolType: 'web_search' };
+      yield { type: 'done', fullText: 'partial', truncated: false };
+    }
+    jest.spyOn(AiAssist, 'callProviderCompletionStream').mockResolvedValue(succeed(events()));
+
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.queryByTestId('streaming-chat-disabled-hint')).toBeNull());
+
+    fireEvent.change(screen.getByTestId('streaming-chat-input'), { target: { value: 'search please' } });
+    fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+
+    await waitFor(() => expect(screen.getByText('partial')).not.toBeNull());
+    // Tool events clear once the stream completes.
+    expect(screen.queryByTestId('streaming-chat-tool-events')).toBeNull();
+  });
+
+  test('clicking Cancel while streaming aborts the request signal', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    let capturedSignal: AbortSignal | undefined;
+    let resolveNext: (result: IteratorResult<AiAssist.IAiStreamEvent>) => void = () => undefined;
+    const pendingNext = new Promise<IteratorResult<AiAssist.IAiStreamEvent>>((resolve) => {
+      resolveNext = resolve;
+    });
+    const events: AsyncIterable<AiAssist.IAiStreamEvent> = {
+      [Symbol.asyncIterator]() {
+        let askedOnce = false;
+        return {
+          next: async (): Promise<IteratorResult<AiAssist.IAiStreamEvent>> => {
+            if (!askedOnce) {
+              askedOnce = true;
+              return pendingNext;
+            }
+            return { done: true, value: undefined };
+          }
+        };
+      }
+    };
+    jest
+      .spyOn(AiAssist, 'callProviderCompletionStream')
+      .mockImplementation(async (params: AiAssist.IProviderCompletionStreamParams) => {
+        capturedSignal = params.signal;
+        return succeed(events);
+      });
+
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.queryByTestId('streaming-chat-disabled-hint')).toBeNull());
+
+    fireEvent.change(screen.getByTestId('streaming-chat-input'), { target: { value: 'hi there' } });
+    fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('streaming-chat-abort-btn')).not.toBeNull());
+    fireEvent.click(screen.getByTestId('streaming-chat-abort-btn'));
+    expect(capturedSignal?.aborted).toBe(true);
+
+    resolveNext({ done: true, value: undefined });
   });
 });

--- a/samples/testbed/src/test/unit/scenarios/streamingChat.test.tsx
+++ b/samples/testbed/src/test/unit/scenarios/streamingChat.test.tsx
@@ -1,0 +1,445 @@
+/**
+ * Unit tests for the `streaming-chat` scenario: `promptLibrary`, `ChatSettingsPanel`,
+ * `ChatPanel`, and the orchestrating `index.tsx` component. Network calls
+ * (`AiAssist.callProviderCompletionStream`) are stubbed via `jest.spyOn` — the same
+ * pattern `useAiAssist.test.ts` uses in `@fgv/ts-app-shell`.
+ *
+ * @packageDocumentation
+ */
+
+import '@fgv/ts-utils-jest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { fail, succeed } from '@fgv/ts-utils';
+import { AiAssist } from '@fgv/ts-extras';
+
+import {
+  chatToneConverter,
+  chatTones,
+  createPromptLibrary,
+  resolveChatSystemPrompt
+} from '../../../scenarios/streamingChat/promptLibrary';
+import { ChatSettingsPanel } from '../../../scenarios/streamingChat/SettingsPanel';
+import { ChatPanel } from '../../../scenarios/streamingChat/ChatPanel';
+import type { IChatTurn } from '../../../scenarios/streamingChat/ChatPanel';
+import {
+  CHAT_PROVIDERS,
+  defaultModelFor,
+  streamingChatScenario
+} from '../../../scenarios/streamingChat';
+import type { IScenarioContext } from '../../../shell';
+
+// ---------------------------------------------------------------------------
+// promptLibrary
+// ---------------------------------------------------------------------------
+
+describe('streamingChat promptLibrary', () => {
+  test('createPromptLibrary builds a library successfully', async () => {
+    const result = await createPromptLibrary();
+    expect(result).toSucceed();
+  });
+
+  test('resolveChatSystemPrompt resolves the neutral (base) body by default', async () => {
+    const library = (await createPromptLibrary()).orThrow();
+    const result = await resolveChatSystemPrompt(library, 'neutral');
+    expect(result).toSucceedWith('You are a helpful assistant. Answer the user clearly and concisely.');
+  });
+
+  test('resolveChatSystemPrompt resolves the formal partial when tone is formal', async () => {
+    const library = (await createPromptLibrary()).orThrow();
+    const result = await resolveChatSystemPrompt(library, 'formal');
+    expect(result).toSucceedAndSatisfy((body) => {
+      expect(body).toMatch(/formal register/);
+      expect(body).toMatch(/helpful assistant/);
+    });
+  });
+
+  test('chatToneConverter narrows a valid tone string', () => {
+    expect(chatToneConverter.convert('formal')).toSucceedWith('formal');
+  });
+
+  test('chatToneConverter fails on an unrecognized string', () => {
+    expect(chatToneConverter.convert('sarcastic')).toFail();
+  });
+
+  test('chatTones lists neutral and formal', () => {
+    expect(chatTones).toEqual(['neutral', 'formal']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario metadata
+// ---------------------------------------------------------------------------
+
+describe('streamingChatScenario metadata', () => {
+  test('declares the id, category, and a web impl with no cli impl', () => {
+    expect(streamingChatScenario.id).toBe('streaming-chat');
+    expect(streamingChatScenario.category).toBe('prompts');
+    expect(streamingChatScenario.web).toBeDefined();
+    expect(streamingChatScenario.cli).toBeUndefined();
+  });
+
+  test('CHAT_PROVIDERS is non-empty and includes every keyed provider', () => {
+    expect(CHAT_PROVIDERS.length).toBeGreaterThan(0);
+    expect(CHAT_PROVIDERS).toContain('openai');
+    expect(CHAT_PROVIDERS).toContain('anthropic');
+    expect(CHAT_PROVIDERS).toContain('google-gemini');
+    expect(CHAT_PROVIDERS).toContain('xai-grok');
+  });
+
+  test('requiredSecrets covers all four keyed providers', () => {
+    const ids = (streamingChatScenario.requiredSecrets ?? []).map((s) => s.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'openai-api-key',
+        'anthropic-api-key',
+        'gemini-api-key',
+        'google-api-key',
+        'xai-api-key'
+      ])
+    );
+  });
+
+  test('defaultModelFor returns the empty string for an unknown provider id', () => {
+    expect(defaultModelFor('does-not-exist' as AiAssist.AiProviderId)).toBe('');
+  });
+
+  test('defaultModelFor resolves the base tier for a known provider', () => {
+    expect(defaultModelFor('openai').length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChatSettingsPanel
+// ---------------------------------------------------------------------------
+
+describe('streamingChat ChatSettingsPanel', () => {
+  afterEach(cleanup);
+
+  function baseProps(): React.ComponentProps<typeof ChatSettingsPanel> {
+    return {
+      providers: ['openai', 'anthropic'],
+      provider: 'openai',
+      onProviderChange: jest.fn(),
+      apiKeyStatus: 'loading',
+      apiKeyError: undefined,
+      model: '',
+      modelPlaceholder: 'gpt-5.6-luna',
+      onModelChange: jest.fn()
+    };
+  }
+
+  test('shows the loading key affordance', () => {
+    render(<ChatSettingsPanel {...baseProps()} apiKeyStatus="loading" />);
+    expect(screen.getByTestId('streaming-chat-key-loading')).not.toBeNull();
+  });
+
+  test('shows the ready key affordance', () => {
+    render(<ChatSettingsPanel {...baseProps()} apiKeyStatus="ready" />);
+    expect(screen.getByTestId('streaming-chat-key-ready')).not.toBeNull();
+  });
+
+  test('shows the missing key affordance with the error message', () => {
+    render(<ChatSettingsPanel {...baseProps()} apiKeyStatus="missing" apiKeyError="not set" />);
+    expect(screen.getByTestId('streaming-chat-key-missing').textContent).toContain('not set');
+  });
+
+  test('changing the provider select calls onProviderChange', () => {
+    const onProviderChange = jest.fn();
+    render(<ChatSettingsPanel {...baseProps()} onProviderChange={onProviderChange} />);
+    fireEvent.change(screen.getByTestId('streaming-chat-provider-select'), {
+      target: { value: 'anthropic' }
+    });
+    expect(onProviderChange).toHaveBeenCalledWith('anthropic');
+  });
+
+  test('changing the model input calls onModelChange', () => {
+    const onModelChange = jest.fn();
+    render(<ChatSettingsPanel {...baseProps()} onModelChange={onModelChange} />);
+    fireEvent.change(screen.getByTestId('streaming-chat-model-input'), {
+      target: { value: 'claude-sonnet-5' }
+    });
+    expect(onModelChange).toHaveBeenCalledWith('claude-sonnet-5');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChatPanel
+// ---------------------------------------------------------------------------
+
+describe('streamingChat ChatPanel', () => {
+  afterEach(cleanup);
+
+  function baseProps(
+    overrides: Partial<React.ComponentProps<typeof ChatPanel>> = {}
+  ): React.ComponentProps<typeof ChatPanel> {
+    return {
+      provider: 'openai',
+      isWorking: false,
+      canSubmit: true,
+      disabledReason: '',
+      turns: [],
+      error: undefined,
+      activeToolEvents: [],
+      tone: 'neutral',
+      onToneChange: jest.fn(),
+      onSend: jest.fn(async () => undefined),
+      onAbort: jest.fn(),
+      onClear: jest.fn(),
+      ...overrides
+    };
+  }
+
+  test('shows the empty-transcript placeholder when there are no turns', () => {
+    render(<ChatPanel {...baseProps()} />);
+    expect(screen.getByText(/Type a question below/)).not.toBeNull();
+  });
+
+  test('renders each turn with its role label', () => {
+    const turns: IChatTurn[] = [
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello there' }
+    ];
+    render(<ChatPanel {...baseProps({ turns })} />);
+    expect(screen.getByTestId('streaming-chat-turn-0').textContent).toContain('You');
+    expect(screen.getByTestId('streaming-chat-turn-1').textContent).toContain('Assistant');
+  });
+
+  test('shows a streaming ellipsis while the assistant turn has no content yet', () => {
+    const turns: IChatTurn[] = [{ role: 'assistant', content: '', isStreaming: true }];
+    render(<ChatPanel {...baseProps({ turns })} />);
+    expect(screen.getByText('…')).not.toBeNull();
+  });
+
+  test('shows active tool events', () => {
+    render(<ChatPanel {...baseProps({ activeToolEvents: ['Searching the web…'] })} />);
+    expect(screen.getByTestId('streaming-chat-tool-events').textContent).toContain('Searching the web…');
+  });
+
+  test('shows the error banner when error is set', () => {
+    render(<ChatPanel {...baseProps({ error: 'boom' })} />);
+    expect(screen.getByTestId('streaming-chat-error').textContent).toContain('boom');
+  });
+
+  test('the clear button only appears once there are turns, and calls onClear', () => {
+    const onClear = jest.fn();
+    const { rerender } = render(<ChatPanel {...baseProps({ onClear })} />);
+    expect(screen.queryByTestId('streaming-chat-clear-btn')).toBeNull();
+
+    rerender(<ChatPanel {...baseProps({ turns: [{ role: 'user', content: 'hi' }], onClear })} />);
+    fireEvent.click(screen.getByTestId('streaming-chat-clear-btn'));
+    expect(onClear).toHaveBeenCalled();
+  });
+
+  test('submitting via the send button calls onSend with the typed text and clears the input', () => {
+    const onSend = jest.fn(async () => undefined);
+    render(<ChatPanel {...baseProps({ onSend })} />);
+    const input = screen.getByTestId('streaming-chat-input') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'hello there' } });
+    fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+    expect(onSend).toHaveBeenCalledWith('hello there', { tools: undefined });
+    expect(input.value).toBe('');
+  });
+
+  test('pressing Enter (without shift) submits the message', () => {
+    const onSend = jest.fn(async () => undefined);
+    render(<ChatPanel {...baseProps({ onSend })} />);
+    const input = screen.getByTestId('streaming-chat-input');
+    fireEvent.change(input, { target: { value: 'hi' } });
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false });
+    expect(onSend).toHaveBeenCalledWith('hi', { tools: undefined });
+  });
+
+  test('pressing Shift+Enter does not submit', () => {
+    const onSend = jest.fn(async () => undefined);
+    render(<ChatPanel {...baseProps({ onSend })} />);
+    const input = screen.getByTestId('streaming-chat-input');
+    fireEvent.change(input, { target: { value: 'hi' } });
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  test('does not submit an empty message', () => {
+    const onSend = jest.fn(async () => undefined);
+    render(<ChatPanel {...baseProps({ onSend })} />);
+    fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  test('does not submit while canSubmit is false, and shows the disabled hint', () => {
+    const onSend = jest.fn(async () => undefined);
+    render(<ChatPanel {...baseProps({ canSubmit: false, disabledReason: 'no key', onSend })} />);
+    fireEvent.change(screen.getByTestId('streaming-chat-input'), { target: { value: 'hi' } });
+    fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+    expect(onSend).not.toHaveBeenCalled();
+    expect(screen.getByTestId('streaming-chat-disabled-hint').textContent).toBe('no key');
+  });
+
+  test('shows the abort button while working, and clicking it calls onAbort', () => {
+    const onAbort = jest.fn();
+    render(<ChatPanel {...baseProps({ isWorking: true, onAbort })} />);
+    fireEvent.click(screen.getByTestId('streaming-chat-abort-btn'));
+    expect(onAbort).toHaveBeenCalled();
+  });
+
+  test('changing the tone select calls onToneChange with the converted tone', () => {
+    const onToneChange = jest.fn();
+    render(<ChatPanel {...baseProps({ onToneChange })} />);
+    fireEvent.change(screen.getByTestId('streaming-chat-tone-select'), { target: { value: 'formal' } });
+    expect(onToneChange).toHaveBeenCalledWith('formal');
+  });
+
+  test('shows the web-search checkbox only for a provider that supports the tool, and sends it when checked', () => {
+    const onSend = jest.fn(async () => undefined);
+    // openai supports web_search per the registry; verify presence and wiring.
+    const descriptor = AiAssist.getProviderDescriptor('openai').orThrow();
+    const supportsWebSearch = descriptor.supportedTools.includes('web_search');
+    render(<ChatPanel {...baseProps({ provider: 'openai', onSend })} />);
+    if (supportsWebSearch) {
+      const checkbox = screen.getByTestId('streaming-chat-web-search-checkbox');
+      fireEvent.click(checkbox);
+      fireEvent.change(screen.getByTestId('streaming-chat-input'), { target: { value: 'search this' } });
+      fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+      expect(onSend).toHaveBeenCalledWith('search this', { tools: [{ type: 'web_search' }] });
+    } else {
+      expect(screen.queryByTestId('streaming-chat-web-search-checkbox')).toBeNull();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// index.tsx (integration, mocked AiAssist dispatch)
+// ---------------------------------------------------------------------------
+
+describe('streamingChat integration', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    cleanup();
+  });
+
+  function makeContext(resolveSecret: IScenarioContext['resolveSecret']): IScenarioContext {
+    return {
+      logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        detail: jest.fn()
+      } as unknown as IScenarioContext['logger'],
+      keyStore: undefined,
+      resolveSecret,
+      dataTree: {} as unknown as IScenarioContext['dataTree']
+    };
+  }
+
+  test('shows the missing-key disabled reason before the prompt library is ready', async () => {
+    const context = makeContext(async () => fail('secret not configured'));
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.getByTestId('streaming-chat-key-missing')).not.toBeNull());
+    expect(screen.getByTestId('streaming-chat-disabled-hint').textContent).toMatch(/API key/);
+  });
+
+  test('shows the prompt-library-initializing reason once the key resolves but before the library loads', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.getByTestId('streaming-chat-key-ready')).not.toBeNull());
+    // Eventually the prompt library resolves and the composer becomes enabled.
+    await waitFor(() => expect(screen.queryByTestId('streaming-chat-disabled-hint')).toBeNull());
+  });
+
+  test('sends a message and streams text deltas into the transcript', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    async function* events(): AsyncGenerator<AiAssist.IAiStreamEvent> {
+      yield { type: 'text-delta', delta: 'Hello' };
+      yield { type: 'text-delta', delta: ' world' };
+      yield { type: 'done', fullText: 'Hello world', truncated: false };
+    }
+    jest.spyOn(AiAssist, 'callProviderCompletionStream').mockResolvedValue(succeed(events()));
+
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.queryByTestId('streaming-chat-disabled-hint')).toBeNull());
+
+    fireEvent.change(screen.getByTestId('streaming-chat-input'), { target: { value: 'hi there' } });
+    fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+
+    await waitFor(() => expect(screen.getByText('Hello world')).not.toBeNull());
+  });
+
+  test('shows an inline error when the stream ends in an error event', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    async function* events(): AsyncGenerator<AiAssist.IAiStreamEvent> {
+      yield { type: 'error', message: 'connection reset' };
+    }
+    jest.spyOn(AiAssist, 'callProviderCompletionStream').mockResolvedValue(succeed(events()));
+
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.queryByTestId('streaming-chat-disabled-hint')).toBeNull());
+
+    fireEvent.change(screen.getByTestId('streaming-chat-input'), { target: { value: 'hi there' } });
+    fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('streaming-chat-error')).not.toBeNull());
+    expect(screen.getByTestId('streaming-chat-error').textContent).toContain('connection reset');
+  });
+
+  test('shows an inline error when the stream fails to open', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    jest.spyOn(AiAssist, 'callProviderCompletionStream').mockResolvedValue(fail('could not connect'));
+
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.queryByTestId('streaming-chat-disabled-hint')).toBeNull());
+
+    fireEvent.change(screen.getByTestId('streaming-chat-input'), { target: { value: 'hi there' } });
+    fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('streaming-chat-error')).not.toBeNull());
+    expect(screen.getByTestId('streaming-chat-error').textContent).toContain('could not connect');
+  });
+
+  test('clearing the conversation empties the transcript', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    async function* events(): AsyncGenerator<AiAssist.IAiStreamEvent> {
+      yield { type: 'done', fullText: 'hi back', truncated: false };
+    }
+    jest.spyOn(AiAssist, 'callProviderCompletionStream').mockResolvedValue(succeed(events()));
+
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.queryByTestId('streaming-chat-disabled-hint')).toBeNull());
+
+    fireEvent.change(screen.getByTestId('streaming-chat-input'), { target: { value: 'hi there' } });
+    fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+    await waitFor(() => expect(screen.getByText('hi back')).not.toBeNull());
+
+    fireEvent.click(screen.getByTestId('streaming-chat-clear-btn'));
+    expect(screen.queryByTestId('streaming-chat-turn-0')).toBeNull();
+  });
+
+  test('switching the tone re-resolves the system prompt on the next send', async () => {
+    const context = makeContext(async () => succeed('sk-test'));
+    let lastSystem: string | undefined;
+    jest
+      .spyOn(AiAssist, 'callProviderCompletionStream')
+      .mockImplementation(async (params: AiAssist.IProviderCompletionStreamParams) => {
+        lastSystem = params.system;
+        async function* events(): AsyncGenerator<AiAssist.IAiStreamEvent> {
+          yield { type: 'done', fullText: 'ok', truncated: false };
+        }
+        return succeed(events());
+      });
+
+    const Component = streamingChatScenario.web!.component;
+    render(<Component context={context} />);
+    await waitFor(() => expect(screen.queryByTestId('streaming-chat-disabled-hint')).toBeNull());
+
+    fireEvent.change(screen.getByTestId('streaming-chat-tone-select'), { target: { value: 'formal' } });
+    fireEvent.change(screen.getByTestId('streaming-chat-input'), { target: { value: 'hi there' } });
+    fireEvent.click(screen.getByTestId('streaming-chat-send-btn'));
+
+    await waitFor(() => expect(lastSystem).toMatch(/formal register/));
+  });
+});

--- a/samples/testbed/src/test/unit/shell/secretResolver.test.ts
+++ b/samples/testbed/src/test/unit/shell/secretResolver.test.ts
@@ -1,30 +1,114 @@
 import '@fgv/ts-utils-jest';
+import { CryptoUtils } from '@fgv/ts-extras';
 import { resolveSecret } from '../../../shell/secretResolver';
+import type { ISecretSpec } from '../../../shell';
 
-describe('resolveSecret (B-1 stub)', () => {
-  test('returns the documented B-1 stub failure naming the KeyStore id and env-var fallback', async () => {
-    const result = await resolveSecret({
-      spec: {
-        id: 'openai-api-key',
-        envVarName: 'OPENAI_API_KEY',
-        description: 'OpenAI completions'
-      },
-      keyStore: undefined,
-      getEnvVar: () => undefined
-    });
-    expect(result).toFailWith(/B-1 stub/i);
+const SPEC: ISecretSpec = {
+  id: 'openai-api-key',
+  envVarName: 'OPENAI_API_KEY',
+  description: 'OpenAI completions'
+};
+
+describe('resolveSecret', () => {
+  test('fails with a message naming the id, env fallback, and description when nothing resolves', async () => {
+    const result = await resolveSecret({ spec: SPEC, keyStore: undefined, getEnvVar: () => undefined });
     expect(result).toFailWith(/openai-api-key/);
     expect(result).toFailWith(/OPENAI_API_KEY/);
     expect(result).toFailWith(/OpenAI completions/);
   });
 
-  test('the stub does not depend on the keyStore or env-var lookup yet', async () => {
+  test('resolves from the session secrets store when present', async () => {
     const result = await resolveSecret({
-      spec: { id: 'x', envVarName: 'X', description: 'irrelevant' },
+      spec: SPEC,
       keyStore: undefined,
-      getEnvVar: (name) => (name === 'X' ? 'env-value' : undefined)
+      sessionSecrets: new Map([['openai-api-key', 'sk-session']]),
+      getEnvVar: () => undefined
     });
-    // B-1 stub always fails; B-3 will wire real resolution.
+    expect(result).toSucceedWith('sk-session');
+  });
+
+  test('ignores an empty-string session secret and falls through to env', async () => {
+    const result = await resolveSecret({
+      spec: SPEC,
+      keyStore: undefined,
+      sessionSecrets: new Map([['openai-api-key', '']]),
+      getEnvVar: (name) => (name === 'OPENAI_API_KEY' ? 'sk-env' : undefined)
+    });
+    expect(result).toSucceedWith('sk-env');
+  });
+
+  test('falls back to the env var when no session secret is set', async () => {
+    const result = await resolveSecret({
+      spec: SPEC,
+      keyStore: undefined,
+      getEnvVar: (name) => (name === 'OPENAI_API_KEY' ? 'sk-env' : undefined)
+    });
+    expect(result).toSucceedWith('sk-env');
+  });
+
+  test('ignores an empty-string env var and fails with the documented message', async () => {
+    const result = await resolveSecret({
+      spec: SPEC,
+      keyStore: undefined,
+      getEnvVar: () => ''
+    });
     expect(result.isFailure()).toBe(true);
+  });
+
+  test('session secrets take priority over the env-var fallback', async () => {
+    const result = await resolveSecret({
+      spec: SPEC,
+      keyStore: undefined,
+      sessionSecrets: new Map([['openai-api-key', 'sk-session']]),
+      getEnvVar: () => 'sk-env'
+    });
+    expect(result).toSucceedWith('sk-session');
+  });
+
+  async function unlockedKeyStore(): Promise<CryptoUtils.KeyStore.KeyStore> {
+    const keyStore = CryptoUtils.KeyStore.KeyStore.create({
+      cryptoProvider: CryptoUtils.nodeCryptoProvider
+    }).orThrow();
+    (await keyStore.initialize('correct horse battery staple')).orThrow();
+    return keyStore;
+  }
+
+  test('an unlocked KeyStore holding the secret takes priority over session and env', async () => {
+    const keyStore = await unlockedKeyStore();
+    (await keyStore.importApiKey('openai-api-key', 'sk-keystore')).orThrow();
+
+    const result = await resolveSecret({
+      spec: SPEC,
+      keyStore,
+      sessionSecrets: new Map([['openai-api-key', 'sk-session']]),
+      getEnvVar: () => 'sk-env'
+    });
+    expect(result).toSucceedWith('sk-keystore');
+  });
+
+  test('a locked KeyStore is skipped in favor of the session secret', async () => {
+    const keyStore = await unlockedKeyStore();
+    (await keyStore.importApiKey('openai-api-key', 'sk-keystore')).orThrow();
+    keyStore.lock(true);
+
+    const result = await resolveSecret({
+      spec: SPEC,
+      keyStore,
+      sessionSecrets: new Map([['openai-api-key', 'sk-session']]),
+      getEnvVar: () => undefined
+    });
+    expect(result).toSucceedWith('sk-session');
+  });
+
+  test('an unlocked KeyStore missing the secret falls through to the session secret', async () => {
+    const keyStore = await unlockedKeyStore();
+
+    const result = await resolveSecret({
+      spec: SPEC,
+      keyStore,
+      sessionSecrets: new Map([['openai-api-key', 'sk-session']]),
+      getEnvVar: () => undefined
+    });
+    expect(result).toSucceedWith('sk-session');
   });
 });

--- a/samples/testbed/src/test/unit/shell/sessionSecretsStore.test.ts
+++ b/samples/testbed/src/test/unit/shell/sessionSecretsStore.test.ts
@@ -1,0 +1,73 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { dedupeRequiredSecrets, useSessionSecretsStore } from '../../../shell/sessionSecretsStore';
+import type { IScenario } from '../../../shell';
+
+function makeScenario(id: string, requiredSecrets?: IScenario['requiredSecrets']): IScenario {
+  return {
+    id,
+    title: id,
+    description: 'desc',
+    category: 'general',
+    tags: [],
+    requiredSecrets
+  };
+}
+
+describe('dedupeRequiredSecrets', () => {
+  test('returns an empty array when no scenario declares requiredSecrets', () => {
+    expect(dedupeRequiredSecrets([makeScenario('a'), makeScenario('b')])).toEqual([]);
+  });
+
+  test('collects requiredSecrets across scenarios', () => {
+    const specs = dedupeRequiredSecrets([
+      makeScenario('a', [{ id: 'openai-api-key', envVarName: 'OPENAI_API_KEY', description: 'openai' }]),
+      makeScenario('b', [{ id: 'anthropic-api-key', envVarName: 'ANTHROPIC_API_KEY', description: 'anthropic' }])
+    ]);
+    expect(specs.map((s) => s.id)).toEqual(['openai-api-key', 'anthropic-api-key']);
+  });
+
+  test('dedupes by id, keeping the first occurrence', () => {
+    const specs = dedupeRequiredSecrets([
+      makeScenario('a', [{ id: 'openai-api-key', envVarName: 'OPENAI_API_KEY', description: 'first' }]),
+      makeScenario('b', [{ id: 'openai-api-key', envVarName: 'OPENAI_API_KEY', description: 'second' }])
+    ]);
+    expect(specs).toHaveLength(1);
+    expect(specs[0]?.description).toBe('first');
+  });
+});
+
+describe('useSessionSecretsStore', () => {
+  test('starts with an empty secrets map', () => {
+    const { result } = renderHook(() => useSessionSecretsStore());
+    expect(result.current.secrets.size).toBe(0);
+  });
+
+  test('setSecret stores a value retrievable from the map', () => {
+    const { result } = renderHook(() => useSessionSecretsStore());
+    act(() => {
+      result.current.setSecret('openai-api-key', 'sk-test');
+    });
+    expect(result.current.secrets.get('openai-api-key')).toBe('sk-test');
+  });
+
+  test('setSecret produces a new Map identity on every update', () => {
+    const { result } = renderHook(() => useSessionSecretsStore());
+    const before = result.current.secrets;
+    act(() => {
+      result.current.setSecret('openai-api-key', 'sk-test');
+    });
+    expect(result.current.secrets).not.toBe(before);
+  });
+
+  test('setSecret can overwrite an existing value', () => {
+    const { result } = renderHook(() => useSessionSecretsStore());
+    act(() => {
+      result.current.setSecret('openai-api-key', 'sk-first');
+    });
+    act(() => {
+      result.current.setSecret('openai-api-key', 'sk-second');
+    });
+    expect(result.current.secrets.get('openai-api-key')).toBe('sk-second');
+  });
+});

--- a/samples/testbed/src/test/unit/web/App.test.tsx
+++ b/samples/testbed/src/test/unit/web/App.test.tsx
@@ -440,3 +440,88 @@ describe('ScenarioHost — initialize lifecycle', () => {
     expect(screen.queryByTestId('testbed-scenario-error')).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Secrets modal wiring
+// ---------------------------------------------------------------------------
+
+describe('TestbedShell secrets wiring', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '#');
+  });
+  afterEach(cleanup);
+
+  const SECRET_SPEC = { id: 'openai-api-key', envVarName: 'OPENAI_API_KEY', description: 'OpenAI key' };
+
+  /** A scenario whose component surfaces the live `context.resolveSecret` result for the spec. */
+  function ResolveSecretProbeComponent({
+    context
+  }: {
+    context: IScenarioContext;
+  }): React.ReactElement {
+    const [resolved, setResolved] = React.useState<string>('pending');
+    React.useEffect(() => {
+      context
+        .resolveSecret(SECRET_SPEC)
+        .then((result) => setResolved(result.isSuccess() ? result.value : `failed: ${result.message}`))
+        .catch(() => undefined);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [context.resolveSecret]);
+    return <div data-testid="resolve-secret-readout">{resolved}</div>;
+  }
+
+  function makeResolveSecretScenario(): IScenario {
+    return {
+      id: 'resolve-secret-probe',
+      title: 'Resolve Secret Probe',
+      description: 'desc',
+      category: 'ai',
+      tags: ['test'],
+      requiredSecrets: [SECRET_SPEC],
+      web: { component: ResolveSecretProbeComponent }
+    };
+  }
+
+  test('the secrets button is present in the top bar and opens the modal', async () => {
+    renderInProviders(<TestbedShell scenarios={[makeResolveSecretScenario()]} />);
+    expect(screen.queryByTestId('testbed-secrets-modal')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('testbed-secrets-btn'));
+    expect(screen.getByTestId('testbed-secrets-modal')).not.toBeNull();
+    expect(screen.getByTestId('testbed-secret-field-openai-api-key')).not.toBeNull();
+    await waitFor(() => expect(screen.getByTestId('resolve-secret-readout').textContent).toMatch(/^failed:/));
+  });
+
+  test('closing the modal hides it again', async () => {
+    renderInProviders(<TestbedShell scenarios={[makeResolveSecretScenario()]} />);
+    fireEvent.click(screen.getByTestId('testbed-secrets-btn'));
+    expect(screen.getByTestId('testbed-secrets-modal')).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(screen.queryByTestId('testbed-secrets-modal')).toBeNull();
+    await waitFor(() => expect(screen.getByTestId('resolve-secret-readout').textContent).toMatch(/^failed:/));
+  });
+
+  test('a scenario missing its secret sees resolveSecret fail with a message naming the id', async () => {
+    renderInProviders(<TestbedShell scenarios={[makeResolveSecretScenario()]} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('resolve-secret-readout').textContent).toMatch(/failed:.*openai-api-key/)
+    );
+  });
+
+  test('typing a value into the Secrets modal makes it visible to a scenario via resolveSecret', async () => {
+    renderInProviders(<TestbedShell scenarios={[makeResolveSecretScenario()]} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('resolve-secret-readout').textContent).toMatch(/^failed:/)
+    );
+
+    fireEvent.click(screen.getByTestId('testbed-secrets-btn'));
+    fireEvent.change(screen.getByTestId('testbed-secret-input-openai-api-key'), {
+      target: { value: 'sk-test-value' }
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('resolve-secret-readout').textContent).toBe('sk-test-value')
+    );
+  });
+});

--- a/samples/testbed/src/test/unit/web/SecretsModal.test.tsx
+++ b/samples/testbed/src/test/unit/web/SecretsModal.test.tsx
@@ -1,0 +1,120 @@
+import '@fgv/ts-utils-jest';
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ResponsiveProvider } from '@fgv/ts-app-shell';
+
+import { SecretsModal } from '../../../web/SecretsModal';
+import type { IScenario } from '../../../shell';
+
+function renderInProviders(node: React.ReactElement): ReturnType<typeof render> {
+  return render(<ResponsiveProvider>{node}</ResponsiveProvider>);
+}
+
+const SCENARIO_WITH_SECRETS: IScenario = {
+  id: 'needs-secrets',
+  title: 'Needs Secrets',
+  description: 'desc',
+  category: 'ai',
+  tags: [],
+  requiredSecrets: [
+    { id: 'openai-api-key', envVarName: 'OPENAI_API_KEY', description: 'OpenAI key' },
+    { id: 'anthropic-api-key', envVarName: 'ANTHROPIC_API_KEY', description: 'Anthropic key' }
+  ]
+};
+
+const SCENARIO_NO_SECRETS: IScenario = {
+  id: 'no-secrets',
+  title: 'No Secrets',
+  description: 'desc',
+  category: 'general',
+  tags: []
+};
+
+describe('SecretsModal', () => {
+  afterEach(cleanup);
+
+  test('renders nothing (Modal returns null) when isOpen is false', () => {
+    renderInProviders(
+      <SecretsModal
+        isOpen={false}
+        onClose={() => undefined}
+        scenarios={[SCENARIO_WITH_SECRETS]}
+        secrets={new Map()}
+        onSetSecret={() => undefined}
+      />
+    );
+    expect(screen.queryByTestId('testbed-secrets-modal')).toBeNull();
+  });
+
+  test('shows the empty state when no scenario declares a required secret', () => {
+    renderInProviders(
+      <SecretsModal
+        isOpen={true}
+        onClose={() => undefined}
+        scenarios={[SCENARIO_NO_SECRETS]}
+        secrets={new Map()}
+        onSetSecret={() => undefined}
+      />
+    );
+    expect(screen.getByTestId('testbed-secrets-empty')).not.toBeNull();
+  });
+
+  test('renders one field per deduped required secret', () => {
+    renderInProviders(
+      <SecretsModal
+        isOpen={true}
+        onClose={() => undefined}
+        scenarios={[SCENARIO_WITH_SECRETS]}
+        secrets={new Map()}
+        onSetSecret={() => undefined}
+      />
+    );
+    expect(screen.getByTestId('testbed-secret-field-openai-api-key')).not.toBeNull();
+    expect(screen.getByTestId('testbed-secret-field-anthropic-api-key')).not.toBeNull();
+  });
+
+  test('reflects the current secret value in the input', () => {
+    renderInProviders(
+      <SecretsModal
+        isOpen={true}
+        onClose={() => undefined}
+        scenarios={[SCENARIO_WITH_SECRETS]}
+        secrets={new Map([['openai-api-key', 'sk-test']])}
+        onSetSecret={() => undefined}
+      />
+    );
+    const input = screen.getByTestId('testbed-secret-input-openai-api-key') as HTMLInputElement;
+    expect(input.value).toBe('sk-test');
+  });
+
+  test('typing into a field calls onSetSecret with the id and new value', () => {
+    const onSetSecret = jest.fn();
+    renderInProviders(
+      <SecretsModal
+        isOpen={true}
+        onClose={() => undefined}
+        scenarios={[SCENARIO_WITH_SECRETS]}
+        secrets={new Map()}
+        onSetSecret={onSetSecret}
+      />
+    );
+    const input = screen.getByTestId('testbed-secret-input-openai-api-key');
+    fireEvent.change(input, { target: { value: 'sk-new' } });
+    expect(onSetSecret).toHaveBeenCalledWith('openai-api-key', 'sk-new');
+  });
+
+  test('clicking the modal close button calls onClose', () => {
+    const onClose = jest.fn();
+    renderInProviders(
+      <SecretsModal
+        isOpen={true}
+        onClose={onClose}
+        scenarios={[SCENARIO_WITH_SECRETS]}
+        secrets={new Map()}
+        onSetSecret={() => undefined}
+      />
+    );
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/samples/testbed/src/web/App.tsx
+++ b/samples/testbed/src/web/App.tsx
@@ -32,8 +32,9 @@ import { FileTree } from '@fgv/ts-json-base';
 
 import { dataFiles } from '../generated/dataFileTree';
 import { scenarios as defaultScenarios } from '../scenarios';
-import { resolveSecret } from '../shell';
+import { resolveSecret, useSessionSecretsStore } from '../shell';
 import type { IScenario, IScenarioContext } from '../shell';
+import { SecretsModal } from './SecretsModal';
 
 // ---------------------------------------------------------------------------
 // Module-level singletons (stable across the session)
@@ -227,21 +228,30 @@ export function TestbedShell(props: ITestbedShellProps = {}): React.ReactElement
   const allScenarios = props.scenarios ?? defaultScenarios;
   const { messages, clearMessages } = useMessages();
   const [activeScenarioId, setActiveScenarioId] = useState<string>(allScenarios[0]?.id ?? '');
+  const [isSecretsModalOpen, setIsSecretsModalOpen] = useState(false);
 
   // Build a logger wired to the MessagesContext so scenario logs appear in the StatusBar.
   const logger = useLogReporter();
 
+  // Session-memory secrets store: values live only in this tab's React state (Phase A —
+  // see the testbed-web-scenarios brief). `secrets` is included in the `resolveSecret`
+  // useMemo below so its identity changes whenever a value is saved via the modal,
+  // letting scenario effects that depend on `context.resolveSecret` re-resolve.
+  const { secrets, setSecret } = useSessionSecretsStore();
+
   // Build a stable IScenarioContext. The logger reference is stable across re-renders
-  // because useLogReporter memoizes on addMessage. keyStore is undefined (B-1 stub).
+  // because useLogReporter memoizes on addMessage. keyStore stays undefined — the
+  // persistent, encrypted KeyStore is out of scope for this phase; resolveSecret (backed
+  // by the session secrets store, then env-var fallback) is the seam scenarios use.
   const scenarioContext = useMemo<IScenarioContext>(
     () => ({
       logger,
       keyStore: undefined,
-      /* c8 ignore next 2 - resolveSecret is a B-1 stub; no web scenario calls it yet */
-      resolveSecret: (spec) => resolveSecret({ spec, keyStore: undefined, getEnvVar: () => undefined }),
+      resolveSecret: (spec) =>
+        resolveSecret({ spec, keyStore: undefined, sessionSecrets: secrets, getEnvVar: () => undefined }),
       dataTree: DATA_TREE
     }),
-    [logger]
+    [logger, secrets]
   );
 
   const urlSyncConfig = useMemo(() => makeUrlSyncConfig(allScenarios), [allScenarios]);
@@ -267,6 +277,14 @@ export function TestbedShell(props: ITestbedShellProps = {}): React.ReactElement
         data-testid="testbed-top-bar"
       >
         <h1 className="text-base font-semibold tracking-tight text-white">fgv testbed</h1>
+        <button
+          type="button"
+          data-testid="testbed-secrets-btn"
+          onClick={() => setIsSecretsModalOpen(true)}
+          className="rounded p-1.5 text-sm text-white/90 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-focus-ring transition-colors"
+        >
+          Secrets
+        </button>
         <ThemeToggle />
       </header>
       <div className="testbed-body">
@@ -325,6 +343,13 @@ export function TestbedShell(props: ITestbedShellProps = {}): React.ReactElement
       >
         <StatusBar messages={messages} onClear={clearMessages} />
       </footer>
+      <SecretsModal
+        isOpen={isSecretsModalOpen}
+        onClose={() => setIsSecretsModalOpen(false)}
+        scenarios={allScenarios}
+        secrets={secrets}
+        onSetSecret={setSecret}
+      />
     </div>
   );
 }

--- a/samples/testbed/src/web/SecretsModal.tsx
+++ b/samples/testbed/src/web/SecretsModal.tsx
@@ -1,0 +1,96 @@
+/**
+ * Shell-owned secrets modal — lists the union of `requiredSecrets` across every
+ * registered scenario (deduped by id via `dedupeRequiredSecrets`) and lets the user paste
+ * values that live in session-memory React state for the current browser tab only.
+ *
+ * @packageDocumentation
+ */
+
+import React from 'react';
+import { Modal } from '@fgv/ts-app-shell';
+
+import { dedupeRequiredSecrets } from '../shell';
+import type { IScenario, ISecretSpec } from '../shell';
+
+/**
+ * Props for {@link SecretsModal}.
+ * @public
+ */
+export interface ISecretsModalProps {
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  /** Full scenario registry — the modal derives its field list from this. */
+  readonly scenarios: readonly IScenario[];
+  /** Current session-memory secret values, keyed by {@link ISecretSpec.id}. */
+  readonly secrets: ReadonlyMap<string, string>;
+  readonly onSetSecret: (id: string, value: string) => void;
+}
+
+/** Renders a single secret field: label, description, env-var fallback note, and input. */
+function SecretField({
+  spec,
+  value,
+  onChange
+}: {
+  readonly spec: ISecretSpec;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+}): React.ReactElement {
+  const inputId = `testbed-secret-input-${spec.id}`;
+  return (
+    <div className="space-y-1" data-testid={`testbed-secret-field-${spec.id}`}>
+      <label htmlFor={inputId} className="block text-sm font-medium text-primary">
+        {spec.id}
+      </label>
+      <input
+        id={inputId}
+        data-testid={`testbed-secret-input-${spec.id}`}
+        type="password"
+        autoComplete="off"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={`Falls back to ${spec.envVarName} (CLI only — not read in the browser)`}
+        className="block w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-primary placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-focus-ring"
+      />
+      <p className="text-xs text-secondary">{spec.description}</p>
+    </div>
+  );
+}
+
+/**
+ * Secrets modal. Values are held only in the session-memory store passed in via
+ * `secrets`/`onSetSecret` — nothing is persisted or encrypted (see the
+ * `testbed-web-scenarios` brief for why that's out of scope for this phase).
+ * @public
+ */
+export function SecretsModal(props: ISecretsModalProps): React.ReactElement {
+  const { isOpen, onClose, scenarios, secrets, onSetSecret } = props;
+  const specs = dedupeRequiredSecrets(scenarios);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Secrets">
+      <div data-testid="testbed-secrets-modal" className="space-y-4">
+        <p className="text-sm text-secondary">
+          API keys entered here live in memory for this browser session only — they are never persisted
+          or sent anywhere except directly to the provider you select in a scenario.
+        </p>
+        {specs.length === 0 ? (
+          <p data-testid="testbed-secrets-empty" className="text-sm text-muted">
+            No registered scenario declares a required secret yet.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {specs.map((spec) => (
+              <SecretField
+                key={spec.id}
+                spec={spec}
+                value={secrets.get(spec.id) ?? ''}
+                onChange={(value) => onSetSecret(spec.id, value)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary

Phase A of the `testbed-web-scenarios` stream. Ports two scenarios from `samples/ai-image-gen-sample` into `samples/testbed` as web-only `IScenario` implementations, and builds the testbed shell's web-side secret story so those scenarios (and any future live-API scenario) can get an API key without a per-scenario input field.

- **`image-generation` scenario** (`samples/testbed/src/scenarios/imageGeneration/`): provider + model picker (pre-filled from the `image` tier via `AiAssist.resolveModel`), prompt form (with reference-image upload for models that accept it), and generated-image gallery. Uses `@fgv/ts-app-shell`'s `useAiAssist` hook. Adapted from the sample's stale `.imagen` field to the current layered-options image-generation API (`options.models: [{ provider, family, config }]`).
- **`streaming-chat` scenario** (`samples/testbed/src/scenarios/streamingChat/`): provider + model picker, streaming chat transcript + composer, and a `@fgv/ts-prompt-assist`-driven tone demo (ported near-verbatim from the sample's `promptLibrary.ts`).
- **Web-side secrets**: a new session-memory secrets store (`samples/testbed/src/shell/sessionSecretsStore.ts`) plus a shell-owned `SecretsModal` (`samples/testbed/src/web/SecretsModal.tsx`) opened from a new "Secrets" button in the top bar. `samples/testbed/src/shell/secretResolver.ts`'s `resolveSecret` was rewritten from an always-fails stub to a real implementation with resolution order: KeyStore (if unlocked) → session-memory secrets → env-var fallback.
- Both new scenarios reuse the **existing** CLI secret ids from `modelTiers/index.ts` (openai-api-key, anthropic-api-key, gemini-api-key, google-api-key, xai-api-key) via a shared `samples/testbed/src/scenarios/aiProviderSecrets.ts` helper — no new secret ids were invented.
- `samples/ai-image-gen-sample` itself is untouched, per the brief.
- `keyStore` stays `undefined` on both web and CLI in this phase (persistent/encrypted KeyStore is out of scope).

## Layer-1 review summary

The `code-reviewer` agent was invoked per `.ai/instructions/TESTING_GUIDELINES.md`'s "Coverage Gap Resolution" sequencing (scenario tests → code-reviewer → coverage closure). The synchronous agent call did not block in this session (returned an async agent id instead of blocking output), so per the orchestrator's explicit fallback instruction, the review was performed manually against `.ai/instructions/CODE_REVIEW_CHECKLIST.md`, and the findings were later independently corroborated when the originally-launched background code-reviewer agent completed.

Findings (both passes converged on the same two P2s; no P1s):
- **P2 — provider-switch race in `useProviderApiKey`** (`aiProviderSecrets.ts`): switching providers rapidly could let a stale in-flight `resolveSecret()` resolution from the *previous* provider overwrite state after the switch, showing the wrong provider's key/status. **Fixed**: state now carries a `forProvider` tag and reads are guarded against it, so a stale resolution for a provider that's no longer selected is ignored.
- **P2 — integration test not strong enough on the image-generation request body**: an early version of the integration test checked the response but didn't assert enough about what was actually sent in the generate-images call. **Fixed**: strengthened the assertion.

Both were resolved before the final commit. No P1 (blocking) findings.

## Manual validation

Not run against live provider APIs in this session (no API keys were available in the sandbox). A manual validation runbook is recorded for whoever runs it against real keys:
1. Open the Secrets panel (top bar "Secrets" button), paste in provider API keys.
2. Open the Image Generation scenario: switch providers, switch models, try the size/aspect-ratio selectors, try reference-image upload for a model that accepts it, generate an image.
3. Open the Streaming Chat scenario: switch providers/models, send a message, watch it stream, switch "tone" and confirm the prompt-assist-resolved system prompt changes, try web-search tool use if the provider supports it.

## Gates

- [x] `rushx build` passes (samples/testbed)
- [x] `rushx lint` passes (samples/testbed)
- [x] `rushx test` passes — 412 tests, 100% statements/branches/functions/lines (samples/testbed)
- [x] `rushx fixlint` run before final commit (no changes needed — already clean)
- [x] `rushx build:web` passes (production webpack; only pre-existing bundle-size warnings, no resolve errors / no Node-only leaks into the browser bundle)
- [x] No `any` types; all fallible operations return `Result<T>`
- [x] `code-reviewer` review performed (manual substitution per orchestrator's fallback instruction, since two synchronous Agent-tool invocations returned async instead of blocking); findings resolved (see above)
- [ ] Copilot review loop — to be requested once this PR is open

## Test plan

- [x] `rushx build` / `rushx lint` / `rushx test` / `rushx build:web` all green in `samples/testbed`
- [ ] Manual live-API validation runbook above (needs real provider keys — not run in this session)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD)_