### PR TITLE
test(ts-extras): fix Buffer-pool corruption in ZipFileTreeAccessors fromFile tests

### DIFF
--- a/common/changes/@fgv/ts-extras/fix-zip-fromfile-buffer-pool_2026-07-26-23-30.json
+++ b/common/changes/@fgv/ts-extras/fix-zip-fromfile-buffer-pool_2026-07-26-23-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@fgv/ts-extras"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/src/test/unit/zipFileTreeAccessors.test.ts
+++ b/libraries/ts-extras/src/test/unit/zipFileTreeAccessors.test.ts
@@ -371,7 +371,7 @@ describe('ZipFileTreeAccessors', () => {
   describe('fromFile method', () => {
     it('should create ZipFileTreeAccessors from File object', async () => {
       const zipBuffer = createTestZip();
-      const file = new File([zipBuffer.buffer.slice(0) as ArrayBuffer], 'test.zip', {
+      const file = new File([Uint8Array.from(zipBuffer)], 'test.zip', {
         type: 'application/zip'
       });
 
@@ -1219,7 +1219,7 @@ describe('ZipFileTreeAccessors', () => {
 
     it('should handle file factory method with contentType', async () => {
       const zipBuffer = createTestZip();
-      const file = new File([zipBuffer.buffer.slice(0) as ArrayBuffer], 'test.zip', {
+      const file = new File([Uint8Array.from(zipBuffer)], 'test.zip', {
         type: 'application/zip'
       });
 


### PR DESCRIPTION
## Summary

Fixes the environment-dependent failure Erik hit during the publish run:

```
● ZipFileTreeAccessors › fromFile method › should create ZipFileTreeAccessors from File object
  Failure with "Failed to load ZIP archive: unknown compression type 8236"
```

## Root cause

The two `fromFile` tests (lines 374 and 1222 of `zipFileTreeAccessors.test.ts`) built their `File` from `zipBuffer.buffer.slice(0)` — the **underlying ArrayBuffer**, not the typed-array view. `Buffer.from(zipSync(...))` allocates small buffers as views into Node's shared **8KB Buffer pool** at a (usually nonzero) `byteOffset`, so the `File` received the entire pool: the zip at an interior offset, preceded by unrelated pool bytes. The zip parser then reads local-header fields at shifted offsets and fails with `unknown compression type <garbage>`.

Whether the test passed depended purely on Buffer-pool allocation state at run time — green in some environments (this fix's CI/sandbox runs, where the offset happened to be 0), deterministically red in others (Erik's machine). Demonstrated mechanically:

```
$ node -e "…warm pool… Buffer.from(zipSync({...}))"
zip byteOffset in pool: 112 | zip length: 119 | underlying pool size: 8192
first 2 bytes of real zip: PK | first 2 bytes of what the test passed to File: /<garbage>
```

## Fix

Construct the `File` from `Uint8Array.from(zipBuffer)` — an exact copy of the view's bytes — at both sites. Test-only change; no library code touched (a `none` change file is included for `@fgv/ts-extras`).

## Verification

- Full `zipFileTreeAccessors` suite: 65/65 pass locally post-fix.
- Byte-equality check under a deliberately warmed (nonzero-offset) pool: `File` payload === zip view bytes.
- The originally-failing environment is Erik's machine — his rerun of `rush test` is the definitive verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD)_