### PR TITLE
fix(ai-assist): guard capability resolvers against unresolved model aliases

### DIFF
--- a/.ai/tasks/active/ai-assist-alias-capability-guard/brief.md
+++ b/.ai/tasks/active/ai-assist-alias-capability-guard/brief.md
@@ -1,0 +1,119 @@
+# Stream brief — `ai-assist-alias-capability-guard`
+
+Recorded verbatim from the orchestrator kickoff (2026-07-31).
+
+## Branch
+
+`ai-assist-alias-capability-guard`, branched from `origin/release`.
+
+> Brief stated base `b689c99ca`; at fetch time `origin/release` was `fbb08cd55`
+> (one commit ahead — a rush-shim lockfile repair, #575). Branched from
+> `origin/release` per the instruction; noted in `state.md`.
+
+## Context (verified by the orchestrator)
+
+PersonAIlity (a consumer) reported that `AiAssist.resolveImageCapability` matches raw
+model-id prefixes with no alias resolution and no `MODEL_ALIAS_SIGIL` guard. The
+orchestrator confirmed it by execution and found it is WORSE than reported, and that a
+sibling function has the same flaw.
+
+The exported capability resolvers live in
+`libraries/ts-extras/src/packlets/ai-assist/registry.ts`:
+
+- `resolveImageCapability(descriptor, modelId)` — filters `descriptor.imageGeneration` by
+  `modelId.startsWith(cap.modelPrefix)`, longest prefix wins.
+- `resolveEmbeddingCapability(descriptor, modelId)` — identical shape over
+  `descriptor.embedding`.
+
+Because every provider declares a catch-all rule with `modelPrefix: ''`, an unresolved fgv
+alias (a string starting with `MODEL_ALIAS_SIGIL`, i.e. `'@'`) matches the catch-all and
+returns a **confidently wrong capability** rather than failing or returning undefined.
+Reproduced on `release`:
+
+| Provider | Alias passed in | Capability returned | Correct capability (from concrete id) |
+|---|---|---|---|
+| `openai` | `@openai:image` | `{modelPrefix:'', outputParamStyle:'response-format'}` | `{modelPrefix:'gpt-image-', acceptsImageReferenceInput:true, outputParamStyle:'output-format'}` |
+| `xai-grok` | `@xai-grok:imagine` | `{format:'xai-images', acceptsImageReferenceInput:false}` | `{format:'xai-images-edits', acceptsImageReferenceInput:true}` |
+| `openai` (embedding) | `@openai:embedding` | `{modelPrefix:''}` | `{modelPrefix:'text-embedding-3', supportsDimensions:true, maxBatchSize:2048}` |
+| `google-gemini` | `@google-gemini:flash-image` | (no mismatch — single catch-all rule) | same |
+
+Note the xAI row flips the **wire format** and `acceptsImageReferenceInput`; the embedding
+row silently drops `supportsDimensions` and the `maxBatchSize` guard. A consumer branching
+on these builds a wrong request.
+
+**The library's own paths are already safe** — `apiClient.ts` resolves the alias via
+`resolveProviderModel` (~line 1336) BEFORE calling `resolveImageCapability` (~line 1341).
+Do not "fix" that; verify it and leave it. The hazard is exclusively for consumers calling
+the exported helpers directly, which is what they are exported for.
+
+**In-repo instance to fix:** `samples/testbed/src/scenarios/imageGeneration/index.tsx`.
+`defaultModelFor()` (~line 45) returns `AiAssist.resolveModel(descriptor.defaultModel, 'image')`,
+which yields the ALIAS form (e.g. `'@openai:image'`), and that value is fed to
+`AiAssist.resolveImageCapability` (~line 89). Result: wrong capability for the OpenAI and
+xAI defaults, which suppresses the "use as reference" affordance and offers wrong
+size/quality options.
+
+## Scope
+
+**1. Guard both capability resolvers (the core fix).** Decide between two designs and
+justify the choice:
+
+- (a) **Fail loudly** on a sigil-prefixed id — returning `undefined` is NOT acceptable
+  because `undefined` already means "no rule matched". Consider changing the return to
+  `Result<T>`, but that is a BREAKING signature change on an established export.
+- (b) **Resolve the alias first** inside the helper (it already receives the `descriptor`,
+  which carries `aliases`), so passing either form works.
+
+The orchestrator's lean is toward a design where an unresolved alias cannot silently
+produce a wrong answer. The chosen design must make the wrong-capability outcome
+impossible, and must not change behavior for concrete (non-alias) ids.
+
+**2. Fix the testbed call site** so the scenario resolves the correct capability for
+OpenAI and xAI defaults. Consider whether `defaultModelFor` should return the concrete id
+(via `resolveProviderModel`) rather than the alias — the value is also displayed in the UI
+and used as the `model` in settings. Add/extend tests that would have caught the
+wrong-capability outcome.
+
+**3. TSDoc for the adjacent ask (A).** Add a `@remarks` block to `resolveProviderModel` and
+a note on `ModelSpecKey` (both in `libraries/ts-extras/src/packlets/ai-assist/model.ts`)
+recording that `tools` and `thinking` are deliberately NOT model selectors. Doc-only — do
+not add a `'tools'` key.
+
+## Files this stream may modify
+
+- `libraries/ts-extras/src/packlets/ai-assist/registry.ts`
+- `libraries/ts-extras/src/packlets/ai-assist/model.ts` — **TSDoc only**
+- `libraries/ts-extras/src/test/unit/ai-assist/**`
+- `libraries/ts-extras/etc/ts-extras.api.md` (regenerated)
+- `common/changes/@fgv/ts-extras/*.json`
+- `samples/testbed/src/scenarios/imageGeneration/**` and its tests under `samples/testbed/src/test/`
+- `.ai/tasks/active/ai-assist-alias-capability-guard/**`
+
+## Files this stream must NOT touch
+
+- `libraries/ts-extras/src/packlets/ai-assist/jsonResponse.ts` + tests — `ai-assist-fenced-json-diagnostics`
+- `libraries/ts-agent-memory/**` — `agent-memory-provenance-contract-doc`
+- `docs/WORKSTREAMS.md` — orchestrator-owned
+- `libraries/ts-extras/src/packlets/ai-assist/apiClient.ts` — verify only
+
+Both sibling streams also regenerate `etc/ts-extras.api.md`; that conflict is expected and
+the orchestrator resolves it at integration by rebuilding.
+
+## Acceptance criteria
+
+- [ ] `rushx build` passes in every modified package
+- [ ] `rushx lint` passes in every modified package
+- [ ] `rushx test` passes with 100% coverage in every modified package
+- [ ] `rushx fixlint` run before the final commit
+- [ ] No `any`; all fallible operations return `Result<T>`
+- [ ] Scenario-driven tests BEFORE chasing measured coverage; `code-reviewer` on the diff
+      BEFORE the coverage-closure pass
+- [ ] `code-reviewer` agent run on the final diff; findings resolved or dispositioned
+- [ ] Rush change file added
+- [ ] `etc/ts-extras.api.md` regenerated and committed
+- [ ] A test exists that fails against the pre-fix behavior
+
+## Deliverable
+
+Commit, push, open a PR targeting `release`. Do NOT merge. Report the PR number, the
+design choice, and any surprising finding.

--- a/.ai/tasks/active/ai-assist-alias-capability-guard/result.md
+++ b/.ai/tasks/active/ai-assist-alias-capability-guard/result.md
@@ -1,0 +1,135 @@
+# Result — `ai-assist-alias-capability-guard`
+
+## What shipped
+
+### 1. The core fix — both capability resolvers are alias-guarded
+
+`libraries/ts-extras/src/packlets/ai-assist/registry.ts`. `resolveImageCapability` and
+`resolveEmbeddingCapability` now resolve the incoming model id through `resolveModelAlias`
+**before** any prefix matching, via a new shared `@internal` generic helper
+`resolveCapabilityForModel<TCapability extends { readonly modelPrefix: string }>`.
+
+Behavior matrix:
+
+| Input | Before | After |
+|---|---|---|
+| Concrete provider id | correct capability | **unchanged** |
+| Registered fgv alias | catch-all → **confidently wrong capability** | correct capability (identical to the concrete id's) |
+| Unregistered / cyclic alias | catch-all → wrong capability | `undefined` |
+
+**Public signatures are unchanged.** `etc/ts-extras.api.md` regenerates **byte-identical to
+`release`** — the strongest available evidence that the change is non-breaking.
+
+### 2. Testbed call site
+
+`samples/testbed/src/scenarios/imageGeneration/index.tsx`. `defaultModelFor` switched from
+the bare `AiAssist.resolveModel(descriptor.defaultModel, 'image')` spec walk (yields the
+alias, e.g. `'@openai:image'`) to `AiAssist.resolveProviderModel(descriptor, undefined,
+'image')` (yields the concrete id). Also replaced an imperative `if (!descriptor)` guard with
+a Result chain.
+
+### 3. TSDoc — the adjacent ask (A)
+
+`model.ts`, doc-only. A `@remarks` block on `ModelSpecKey` and an added paragraph on
+`resolveProviderModel` record that `tools` and `thinking` are deliberately **not** model
+selectors — they are orthogonal request params riding on top of whatever model the tier
+selected, removed from `ModelSpecKey` when the quality-tier axis landed. Both explicitly tell
+a tool-path caller to pass a tier and **not** to hand-roll a `resolveModel` +
+`resolveModelAlias` walk. No `'tools'` key was added.
+
+## Design choice and why
+
+**Chose (b) — resolve the alias inside the helper.** Rejected (a) (`Result<T>` return type).
+
+The decisive reason is a hard constraint, not a preference: (a) forces edits to
+`apiClient.ts`, which the brief explicitly forbids ("verify only, do not change"), and to
+`embeddingClient.ts`, which is not on the stream's modifiable file list at all. There is no
+way to land (a) inside the declared surface. Independent of that, (b) is the smaller
+consumer-facing change and makes *both* input forms correct rather than turning one into an
+error.
+
+**On the brief's objection to `undefined`.** The objection was that `undefined` collides with
+"no rule matched". That objection targets the *wrong-capability* outcome, which design (b)
+eliminates outright: a sigil-prefixed string now either resolves to a concrete id (→ the
+correct capability) or yields `undefined`. It can never reach the catch-all. And an
+unresolvable alias names no model, so "no capability applies" is truthful rather than lossy —
+it fails in the safe direction, and both callers already surface `undefined` as a loud
+`Result.fail`. Worth noting: pre-fix, `undefined` was effectively **unreachable** for any
+provider declaring a catch-all — that unreachability *was* the bug. Post-fix it becomes a
+reachable, meaningful signal.
+
+## Gates
+
+| Gate | `@fgv/ts-extras` | `@fgv/testbed` |
+|---|---|---|
+| `rushx build` | pass (no api-extractor warning) | pass |
+| `rushx lint` | pass | pass |
+| `rushx test` | pass, 100%; `registry.ts` 100/100/100/100 | pass, 100%; `scenarios/imageGeneration` 100% |
+| `rushx fixlint` | run before final commit | run before final commit |
+| `rush change --verify` | pass | n/a |
+
+No coverage-closure pass was required — the scenario-driven tests reached 100% unaided, so
+**no `c8 ignore` directives were added**. `code-reviewer` was still run before declaring
+coverage done, per the load-bearing ordering in TESTING_GUIDELINES.
+
+## Test that fails against pre-fix behavior
+
+Verified empirically by temporarily reverting the guard and re-running: **7 of the new tests
+fail**, while **all 62 pre-existing registry tests still pass** — demonstrating the catch and
+the no-regression-for-concrete-ids property in the same run. The failing set covers all three
+reported mismatches (openai image, xai wire-format flip, openai embedding
+dimensions/batch-guard), the registry-wide invariant sweep, and all three unresolvable-alias
+cases.
+
+The invariant sweep (`holds for every registered alias on every built-in provider`) asserts
+that for every alias on every descriptor, the alias form and its concrete target select the
+identical capability object for **both** modalities. It generalizes past the three hand-picked
+repro cases and will catch a future provider that adds a specific-prefix rule alongside a new
+alias.
+
+## Layer-1 review summary
+
+`code-reviewer` run on the final diff: **Approved — zero findings at P1, P2, and P3.**
+
+It independently verified the gates, confirmed the file-scope list was honored, and ran its
+own sweep for other alias-leak sites, clearing two candidates I had also considered:
+`applyCapabilityConfig` (`apiClient.ts:1527`, `idPattern`-based) is fed only concrete ids
+returned by a live list-models API, and `mergeThinkingConfig`'s `resolvedModel` is fed from
+`resolveProviderModel` at both call sites. Its conclusion matched mine: the two functions
+fixed here were the only vulnerable lookup sites in the packlet.
+
+It specifically endorsed the shared-helper factoring (the duplicated-flaw history is the
+argument *for* consolidating), the `.orDefault()` + early-return shape over a fuller Result
+chain (the failure detail is deliberately discarded because no caller distinguishes
+unknown-alias from cyclic-alias), and confirmed TSDoc claims match the implementation.
+
+## Deliberately left undone — for the orchestrator
+
+1. **The open P3 TECH_DEBT entry is still open.** `docs/TECH_DEBT.md:164` asks for exactly
+   design (a) — `resolveImageCapability` returning `Result<IAiImageModelCapability>` — with
+   trigger "next substantive change to the provider registry or capability resolution path".
+   This stream *is* that trigger, but the file-surface constraint (`apiClient.ts` forbidden)
+   defers it. The entry was not edited, since `docs/` is outside this stream's surface. A
+   follow-on stream that owns `apiClient.ts` + `embeddingClient.ts` could land it; note that
+   the guard shipped here removes the *dangerous* half of the problem, leaving only the
+   non-idiomatic-return half the entry describes.
+
+2. **Two sibling exported predicates share the same alias-leak class — NOT fixed.**
+   `isResponsesOnlyModel` and `isAdaptiveThinkingModel` (both `@public`, both in `model.ts`)
+   also prefix-match a caller-supplied model id against descriptor prefix lists with no sigil
+   handling. Concretely: `isAdaptiveThinkingModel(anthropicDescriptor, '@anthropic:sonnet')`
+   returns `false`, whereas the concrete `'claude-sonnet-5'` returns `true` — a direct
+   consumer passing the alias gets the legacy thinking wire shape.
+
+   Not fixed because `model.ts` is **TSDoc-only** in this stream's brief, and per
+   CODING_STANDARDS § "When to ask first" an extension outside the declared surface warrants
+   a brief amendment rather than unilateral scope growth.
+
+   Mitigating factors that make this lower-priority than the capability bug: both are called
+   internally only with already-resolved concrete ids (`apiClient.ts:821,855`,
+   `streamingClient.ts:173,211`); both already document "concrete (already-resolved) model
+   id" as a precondition; and the failure mode is a loud provider-side HTTP 400 rather than a
+   silently wrong request body. Recommend a small follow-on stream that owns `model.ts` and
+   applies the same guard to both.
+
+3. **`docs/WORKSTREAMS.md` not updated** — orchestrator-owned per the brief.

--- a/.ai/tasks/active/ai-assist-alias-capability-guard/state.md
+++ b/.ai/tasks/active/ai-assist-alias-capability-guard/state.md
@@ -1,0 +1,141 @@
+# State — `ai-assist-alias-capability-guard`
+
+Running log of decisions, surprises, and reinterpretations.
+
+## Branch base
+
+Brief named `release @ b689c99ca`. At fetch time `origin/release` was **`fbb08cd55`** — one
+commit ahead (`deps: repair root rush shim lockfile; bump @microsoft/rush to 5.178.0`, #575).
+Branched from `origin/release` per the instruction's command rather than pinning the stale
+SHA; the extra commit is a lockfile/tooling repair with no bearing on this change.
+
+## Verification of the reported defect
+
+Confirmed the orchestrator's table by construction rather than by re-running a probe: the
+implementation is a pure `modelId.startsWith(cap.modelPrefix)` longest-prefix filter with no
+sigil handling, and every provider declares a `modelPrefix: ''` catch-all. Registry values
+that make the reported rows concrete:
+
+| Provider | Alias | Alias target | Specific rule that was being skipped |
+|---|---|---|---|
+| `openai` | `@openai:image` | `gpt-image-2` | `modelPrefix: 'gpt-image-'`, `acceptsImageReferenceInput: true`, `outputParamStyle: 'output-format'` |
+| `xai-grok` | `@xai-grok:imagine` | `grok-imagine-image-quality` | `modelPrefix: 'grok-imagine-'`, `format: 'xai-images-edits'`, `acceptsImageReferenceInput: true` |
+| `openai` (embedding) | `@openai:embedding` | `text-embedding-3-small` | `modelPrefix: 'text-embedding-3'`, `supportsDimensions: true`, `maxBatchSize: 2048` |
+| `google-gemini` | `@google-gemini:flash-image` | `gemini-3.1-flash-image` | single catch-all only → no mismatch, as reported |
+
+Empirically confirmed at the end of implementation by temporarily reverting the guard:
+**7 of the new tests fail against pre-fix behavior** while all **62 pre-existing registry
+tests still pass** — which simultaneously demonstrates the catch and the no-regression
+property for concrete ids.
+
+**Library-internal paths verified safe and left untouched**, as instructed:
+- `apiClient.ts:1336` `resolveProviderModel(descriptor, modelOverride, 'image')` → `:1341`
+  `resolveImageCapability(descriptor, model)`. Alias already resolved. Not modified.
+- `embeddingClient.ts:394` `resolveProviderModel(..., 'embedding')` → `:400`
+  `resolveEmbeddingCapability(descriptor, model)`. Same shape. Not modified.
+
+## Design decision — chose (b), resolve the alias inside the helper
+
+Rejected (a) (`Result<T>` return). Two reasons, the first decisive:
+
+1. **File-surface constraint makes (a) impossible within this stream.** Changing the return
+   type forces edits to `apiClient.ts` — which the brief explicitly forbids ("verify only,
+   do not change") — and to `embeddingClient.ts`, which is not on the stream's modifiable
+   list at all. There is no way to land (a) without violating the declared surface.
+2. Even setting that aside, (a) is a breaking signature change; (b) is the smaller
+   consumer-facing change and makes *both* input forms correct rather than making one of
+   them an error.
+
+Note there is an **open P3 TECH_DEBT entry** (`docs/TECH_DEBT.md:164`) asking for exactly
+(a) — `resolveImageCapability` returning `Result<IAiImageModelCapability>` instead of
+`| undefined` — with trigger "next substantive change to the provider registry or capability
+resolution path". This stream is that trigger, but the file-surface constraint defers it.
+**Left open deliberately; flagged in `result.md` for the orchestrator.** The entry was not
+edited (`docs/` is outside this stream's surface).
+
+### Why `undefined` for an unresolvable alias is defensible
+
+The brief's objection to `undefined` was that it collides with "no rule matched". That
+objection is aimed at the *wrong-capability* outcome, and design (b) eliminates that outcome
+entirely: any sigil-prefixed string either resolves to a concrete id (→ the correct
+capability) or yields `undefined`. It can never reach the catch-all. And semantically an
+unresolvable alias names no model, so "no capability applies" is the truthful answer, not a
+lossy one — it fails in the safe direction. Both callers already surface `undefined` as a
+loud `Result.fail` ("provider X does not support image generation for model Y").
+
+Worth recording: pre-fix, `undefined` was effectively **unreachable** for any provider
+declaring a catch-all — that unreachability *was* the bug. Post-fix `undefined` becomes a
+reachable, meaningful signal.
+
+## Implementation notes
+
+- Extracted a shared generic `resolveCapabilityForModel<TCapability extends { readonly
+  modelPrefix: string }>` rather than patching both copies. The flaw existed **identically in
+  both** functions, which is the argument against leaving them as parallel copies — the
+  duplication is what let the defect double. `@internal`, so no API surface added.
+- Alias resolution uses `resolveModelAlias(descriptor, modelId).orDefault()` — the
+  Result-idiomatic safe-fallback extraction, not `.orThrow()`.
+- `registry.ts` already imported types from `./model`; added a value import of
+  `resolveModelAlias`. Checked `model.ts` for a back-edge: it imports only from `@fgv/ts-utils`
+  and `@fgv/ts-json-base`, so **no import cycle**.
+
+## Surprises
+
+1. **`etc/ts-extras.api.md` regenerates byte-identical to `release`.** The fix is entirely
+   behavioral; both public signatures are unchanged. Acceptance criteria asked for a
+   regenerated api.md — it was regenerated and there is nothing to commit. This is also the
+   cleanest possible evidence that the change is non-breaking. It additionally means the
+   expected merge conflict with the two sibling streams on this file does not materialize
+   from this side.
+
+2. **TSDoc `{@link}` does not resolve for functions / consts / type aliases in this package —
+   in either form.** New `{@link resolveModelAlias}` / `{@link MODEL_ALIAS_SIGIL}` /
+   `{@link ModelSpecKey}` references baked `ae-unresolved-link` warnings into `api.md`
+   ("does not have an export X" — the symbols are exported under the `AiAssist` namespace).
+   Qualifying them as `{@link AiAssist.resolveModelAlias}` swapped the warning for a
+   different one ("This type of declaration is not supported yet by the resolver") — the
+   namespace-qualified form works for interfaces (there is existing precedent in `model.ts`)
+   but **not** for function / const / type-alias declaration kinds.
+
+   Resolved by using **plain code spans** for all new references, per the CODE_REVIEW_CHECKLIST
+   rule that an `ae-unresolved-link` in the checked-in `api.md` is a stale-api.md / CI-diff
+   liability. Net warning delta: **zero**. Pre-existing bare `{@link}` references elsewhere in
+   `model.ts` already carry these warnings; left alone (out of scope, and touching them would
+   inflate the diff).
+
+3. **The testbed's capability lookup is fixed by the library guard alone.** With design (b),
+   feeding the alias form to `resolveImageCapability` already returns the right answer, so the
+   scenario change is not strictly required for correctness. It was still made — see below.
+
+## Testbed decision — `defaultModelFor` returns the concrete id
+
+The brief flagged this as a judgment call ("what the user should SEE vs what capability
+lookup needs"). Switched `AiAssist.resolveModel(descriptor.defaultModel, 'image')` →
+`AiAssist.resolveProviderModel(descriptor, undefined, 'image')`, because the value has a
+**third** consumer the brief's framing surfaces: `SettingsPanel` renders it as
+`<input value={model}>`, directly beside a fetched dropdown of concrete ids
+(`gpt-image-1`, `dall-e-3`). Showing `@openai:image` in an editable model-id field whose
+sibling list shows real ids is incoherent, and any user edit replaces it with a concrete id
+anyway.
+
+Wire-path safety is unaffected: the library resolves either form correctly, and
+`resolveProviderModel` is the documented call-time chokepoint doing exactly this job.
+Secondary benefit — the scenario is now correct **independently** of the library guard
+(defense in depth), so a regression in either layer alone is still caught.
+
+The rewrite also replaced an imperative `if (!descriptor) return ''` with a Result chain
+(`getProviderDescriptor(...).onSuccess(...).orDefault('')`), removing a branch. Unknown-provider
+behavior is preserved (`''`), pinned by the pre-existing test.
+
+## Gates
+
+| Gate | ts-extras | testbed |
+|---|---|---|
+| `rushx build` | pass | pass |
+| `rushx lint` | pass | pass |
+| `rushx test` | pass, 100% (`registry.ts` 100/100/100/100) | pass, 100% (`scenarios/imageGeneration` 100%) |
+| `rush change --verify` | pass | n/a |
+
+No coverage-closure pass was needed — the scenario-driven tests reached 100% on their own, so
+no `c8 ignore` directives were added. `code-reviewer` was still run before declaring coverage
+done, per the load-bearing ordering in TESTING_GUIDELINES.

--- a/common/changes/@fgv/ts-extras/ai-assist-alias-capability-guard_2026-07-31-00-00.json
+++ b/common/changes/@fgv/ts-extras/ai-assist-alias-capability-guard_2026-07-31-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Fix: AiAssist.resolveImageCapability and resolveEmbeddingCapability now resolve an fgv model alias (@provider:role) before prefix-matching, so the alias form and the concrete id it names select the same capability. Previously an alias fell through to the modelPrefix:'' catch-all every provider declares and returned a confidently wrong capability (on xai-grok it flipped the wire format from xai-images-edits to xai-images and acceptsImageReferenceInput from true to false; on openai embeddings it dropped supportsDimensions and the maxBatchSize guard). An unresolvable alias (unregistered or cyclic) now yields undefined rather than the catch-all. Behavior for concrete provider model ids is unchanged and the public signatures are unchanged. Also documents on ModelSpecKey and resolveProviderModel that tools and thinking are deliberately not model selectors.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -507,9 +507,15 @@ export interface IAiClientToolTurnResult {
  * check — but that is a statement about the tier axis, not a claim that every
  * provider supports thinking: several descriptors declare
  * `thinkingMode: 'unsupported'` (e.g. `copy-paste`, `groq`, `mistral`, `ollama`,
- * `openai-compat`). Thinking support is a per-provider/per-model property; consult
- * `IAiProviderDescriptor.thinkingMode`. What the tier axis guarantees is only that
- * choosing a tier never *changes* whether thinking is available.
+ * `openai-compat`).
+ *
+ * Thinking availability is declared **per provider**, on the descriptor's
+ * `thinkingMode`; the descriptor does not encode per-model thinking availability at
+ * all, so a provider that declares support may still have individual models its own
+ * API rejects thinking on. (`adaptiveThinkingModelPrefixes` is per-model but selects
+ * a wire *shape*, not availability.) What the tier axis guarantees is therefore
+ * narrow and exact: a tier selects a model within one provider and never changes the
+ * provider, so it never changes `thinkingMode`.
  *
  * Do not add a `'tools'` or `'thinking'` key here, and do not hand-roll a
  * `resolveModel` + `resolveModelAlias` walk to emulate one — call

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -491,6 +491,24 @@ export interface IAiClientToolTurnResult {
 
 /**
  * Known context keys for model specification maps.
+ *
+ * @remarks
+ * Two axes live here and nothing else: the **quality tier** (`base` / `advanced`
+ * / `frontier`) selects the *completion* model, and `image` / `embedding` select
+ * the non-completion modalities.
+ *
+ * There is deliberately **no `tools` or `thinking` key**. Both existed before the
+ * quality-tier axis landed and were removed with it: server-side tools and
+ * reasoning effort are orthogonal *request* params that ride on top of whatever
+ * model the tier already selected — they never select a model. A tool-using or
+ * thinking-enabled call passes a tier like any other call (omit → `base`, or
+ * `'advanced'` / `'frontier'`) and sets the tools / thinking request params
+ * independently. Every base model is thinking-capable, so thinking composes with
+ * any tier with no capability check.
+ *
+ * Do not add a `'tools'` or `'thinking'` key here, and do not hand-roll a
+ * `resolveModel` + `resolveModelAlias` walk to emulate one — call
+ * `resolveProviderModel` with the tier you want.
  * @public
  */
 export type ModelSpecKey = 'base' | 'advanced' | 'frontier' | 'image' | 'embedding';
@@ -699,6 +717,20 @@ export function resolveModelAlias(descriptor: IAiProviderDescriptor, model: stri
  * call plus the duplicated empty-result check at each call-time chokepoint. The
  * `ModelSpec` branch is selected first; the resulting string — which may itself
  * be an fgv alias — is then resolved to a concrete id.
+ *
+ * **This is the whole model-selection surface — do not hand-roll the walk.**
+ * Callers should pass the `ModelSpecKey` they want and use the concrete id
+ * this returns; a manual `resolveModel` + `resolveModelAlias` sequence is
+ * both redundant and easy to get wrong (it is how alias-form ids leak into
+ * capability lookups such as `resolveImageCapability`).
+ *
+ * **`context` carries the quality tier and the modality — never tools or
+ * thinking.** `ModelSpecKey` has no `tools` / `thinking` key: server-side
+ * tools and reasoning effort are orthogonal request params that ride on top of
+ * whatever model the tier selected, and never select a model. A tool-path caller
+ * passes a tier like any other caller — omit `context` for `base`, or pass
+ * `'advanced'` / `'frontier'` — and sets the tools / thinking request params
+ * separately.
  *
  * @param descriptor - The provider descriptor (supplies `defaultModel` and `aliases`).
  * @param modelOverride - An optional caller-supplied `ModelSpec` that takes precedence

--- a/libraries/ts-extras/src/packlets/ai-assist/model.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/model.ts
@@ -503,8 +503,13 @@ export interface IAiClientToolTurnResult {
  * model the tier already selected — they never select a model. A tool-using or
  * thinking-enabled call passes a tier like any other call (omit → `base`, or
  * `'advanced'` / `'frontier'`) and sets the tools / thinking request params
- * independently. Every base model is thinking-capable, so thinking composes with
- * any tier with no capability check.
+ * independently. Thinking composes with any tier without a tier-level capability
+ * check — but that is a statement about the tier axis, not a claim that every
+ * provider supports thinking: several descriptors declare
+ * `thinkingMode: 'unsupported'` (e.g. `copy-paste`, `groq`, `mistral`, `ollama`,
+ * `openai-compat`). Thinking support is a per-provider/per-model property; consult
+ * `IAiProviderDescriptor.thinkingMode`. What the tier axis guarantees is only that
+ * choosing a tier never *changes* whether thinking is available.
  *
  * Do not add a `'tools'` or `'thinking'` key here, and do not hand-roll a
  * `resolveModel` + `resolveModelAlias` walk to emulate one — call

--- a/libraries/ts-extras/src/packlets/ai-assist/registry.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/registry.ts
@@ -30,7 +30,8 @@ import {
   type IAiEmbeddingModelCapability,
   type IAiImageModelCapability,
   type IAiModelCapabilityConfig,
-  type IAiProviderDescriptor
+  type IAiProviderDescriptor,
+  resolveModelAlias
 } from './model';
 
 // ============================================================================
@@ -365,6 +366,42 @@ export function supportsImageGeneration(descriptor: IAiProviderDescriptor): bool
 }
 
 /**
+ * Shared longest-prefix capability match, alias-guarded.
+ *
+ * @remarks
+ * `modelId` is resolved through `resolveModelAlias` **before** any prefix
+ * matching, so an fgv alias (`@<provider>:<role>`) and the concrete id it names
+ * select the same capability. Without this step an alias would fall through to
+ * the `modelPrefix: ''` catch-all every provider declares and yield a
+ * confidently wrong capability rather than no capability.
+ *
+ * An unresolvable alias (sigil-prefixed but unregistered, or cyclic) names no
+ * model, so no capability applies and the match is skipped entirely — it must
+ * never be prefix-matched verbatim. Callers already treat `undefined` as "this
+ * provider has no capability for this model" and fail with that message.
+ *
+ * A concrete (non-sigil) id passes through `resolveModelAlias` verbatim, so
+ * behavior for every raw provider id is unchanged.
+ * @internal
+ */
+function resolveCapabilityForModel<TCapability extends { readonly modelPrefix: string }>(
+  descriptor: IAiProviderDescriptor,
+  modelId: string,
+  capabilities: ReadonlyArray<TCapability> | undefined
+): TCapability | undefined {
+  const concreteModelId = resolveModelAlias(descriptor, modelId).orDefault();
+  if (concreteModelId === undefined) {
+    return undefined;
+  }
+  return (capabilities ?? [])
+    .filter((cap) => concreteModelId.startsWith(cap.modelPrefix))
+    .reduce<TCapability | undefined>(
+      (best, cap) => (best && best.modelPrefix.length >= cap.modelPrefix.length ? best : cap),
+      undefined
+    );
+}
+
+/**
  * Resolve the image-generation capability that applies to a given model id
  * for a provider. Returns the entry from
  * {@link IAiProviderDescriptor.imageGeneration} whose `modelPrefix` is the
@@ -372,22 +409,27 @@ export function supportsImageGeneration(descriptor: IAiProviderDescriptor): bool
  * order does not matter for correctness — only for tie-breaking among rules
  * with identical-length prefixes (an unusual case).
  *
+ * @remarks
+ * `modelId` may be either a concrete provider model id or an fgv model alias
+ * (`@<provider>:<role>`, see `MODEL_ALIAS_SIGIL`) — it is resolved via
+ * `resolveModelAlias` against `descriptor.aliases` before prefix matching,
+ * so both forms select the same capability. A raw provider id passes through
+ * unchanged. An alias that is not registered on `descriptor` (or is cyclic)
+ * names no model and yields `undefined` rather than falling through to the
+ * `modelPrefix: ''` catch-all.
+ *
  * @param descriptor - The provider descriptor
- * @param modelId - The resolved image model id
- * @returns The matching capability, or `undefined` when no rule matches or
- *   the provider declares no image-generation capabilities.
+ * @param modelId - The image model id — concrete or an fgv alias
+ * @returns The matching capability, or `undefined` when no rule matches, the
+ *   provider declares no image-generation capabilities, or `modelId` is an
+ *   unresolvable alias.
  * @public
  */
 export function resolveImageCapability(
   descriptor: IAiProviderDescriptor,
   modelId: string
 ): IAiImageModelCapability | undefined {
-  return (descriptor.imageGeneration ?? [])
-    .filter((cap) => modelId.startsWith(cap.modelPrefix))
-    .reduce<IAiImageModelCapability | undefined>(
-      (best, cap) => (best && best.modelPrefix.length >= cap.modelPrefix.length ? best : cap),
-      undefined
-    );
+  return resolveCapabilityForModel(descriptor, modelId, descriptor.imageGeneration);
 }
 
 /**
@@ -408,22 +450,27 @@ export function supportsEmbedding(descriptor: IAiProviderDescriptor): boolean {
  * `modelPrefix` is the longest prefix of `modelId`. Ties are broken by
  * first-encountered.
  *
+ * @remarks
+ * `modelId` may be either a concrete provider model id or an fgv model alias
+ * (`@<provider>:<role>`, see `MODEL_ALIAS_SIGIL`) — it is resolved via
+ * `resolveModelAlias` against `descriptor.aliases` before prefix matching,
+ * so both forms select the same capability. A raw provider id passes through
+ * unchanged. An alias that is not registered on `descriptor` (or is cyclic)
+ * names no model and yields `undefined` rather than falling through to the
+ * `modelPrefix: ''` catch-all.
+ *
  * @param descriptor - The provider descriptor
- * @param modelId - The resolved embedding model id
- * @returns The matching capability, or `undefined` when no rule matches or the
- *   provider declares no embedding capabilities.
+ * @param modelId - The embedding model id — concrete or an fgv alias
+ * @returns The matching capability, or `undefined` when no rule matches, the
+ *   provider declares no embedding capabilities, or `modelId` is an
+ *   unresolvable alias.
  * @public
  */
 export function resolveEmbeddingCapability(
   descriptor: IAiProviderDescriptor,
   modelId: string
 ): IAiEmbeddingModelCapability | undefined {
-  return (descriptor.embedding ?? [])
-    .filter((cap) => modelId.startsWith(cap.modelPrefix))
-    .reduce<IAiEmbeddingModelCapability | undefined>(
-      (best, cap) => (best && best.modelPrefix.length >= cap.modelPrefix.length ? best : cap),
-      undefined
-    );
+  return resolveCapabilityForModel(descriptor, modelId, descriptor.embedding);
 }
 
 // ============================================================================

--- a/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/registry.test.ts
@@ -509,6 +509,163 @@ describe('AiAssist.registry', () => {
     });
   });
 
+  describe('capability resolution — fgv model-alias guard', () => {
+    // Both capability resolvers prefix-match the model id, and every provider declares a
+    // `modelPrefix: ''` catch-all. Before the guard, an fgv alias (`@provider:role`) matched
+    // that catch-all and returned a *confidently wrong* capability — flipping the wire
+    // format on xAI and silently dropping `supportsDimensions` / `maxBatchSize` on OpenAI —
+    // rather than failing or returning `undefined`. These tests pin the alias form to the
+    // same capability the concrete id selects.
+
+    describe('an alias selects the same capability as the concrete id it names', () => {
+      test('openai image: @openai:image is gpt-image-, not the catch-all', () => {
+        const descriptor = AiAssist.getProviderDescriptor('openai').orThrow();
+        // Pre-guard this returned { modelPrefix: '', outputParamStyle: 'response-format' },
+        // which suppresses the reference-image affordance and picks the wrong output param.
+        expect(AiAssist.resolveImageCapability(descriptor, '@openai:image')).toMatchObject({
+          modelPrefix: 'gpt-image-',
+          format: 'openai-images',
+          acceptsImageReferenceInput: true,
+          outputParamStyle: 'output-format'
+        });
+      });
+
+      test('xai image: @xai-grok:imagine keeps the edits wire format', () => {
+        const descriptor = AiAssist.getProviderDescriptor('xai-grok').orThrow();
+        // Pre-guard this returned format 'xai-images' with acceptsImageReferenceInput false —
+        // a different wire format from the one the concrete id dispatches to.
+        expect(AiAssist.resolveImageCapability(descriptor, '@xai-grok:imagine')).toMatchObject({
+          modelPrefix: 'grok-imagine-',
+          format: 'xai-images-edits',
+          acceptsImageReferenceInput: true
+        });
+      });
+
+      test('openai embedding: @openai:embedding keeps dimensions + batch guard', () => {
+        const descriptor = AiAssist.getProviderDescriptor('openai').orThrow();
+        // Pre-guard this returned the catch-all, dropping supportsDimensions and the
+        // maxBatchSize guard that protects callers from an over-large batch.
+        expect(AiAssist.resolveEmbeddingCapability(descriptor, '@openai:embedding')).toMatchObject({
+          modelPrefix: 'text-embedding-3',
+          format: 'openai-embeddings',
+          supportsDimensions: true,
+          maxBatchSize: 2048
+        });
+      });
+
+      test('holds for every registered alias on every built-in provider', () => {
+        // The invariant sweep: whatever a provider's aliases map contains, the alias form and
+        // the concrete id it resolves to must select the identical capability object. This is
+        // the test that generalises the three cases above across the whole registry, so a
+        // future provider gaining a specific-prefix rule cannot silently reintroduce the gap.
+        for (const descriptor of AiAssist.getProviderDescriptors()) {
+          for (const alias of Object.keys(descriptor.aliases ?? {})) {
+            expect(AiAssist.resolveModelAlias(descriptor, alias)).toSucceedAndSatisfy((concrete) => {
+              expect(AiAssist.resolveImageCapability(descriptor, alias)).toEqual(
+                AiAssist.resolveImageCapability(descriptor, concrete)
+              );
+              expect(AiAssist.resolveEmbeddingCapability(descriptor, alias)).toEqual(
+                AiAssist.resolveEmbeddingCapability(descriptor, concrete)
+              );
+            });
+          }
+        }
+      });
+
+      test('a provider whose only rule is the catch-all is unaffected', () => {
+        // google-gemini declares a single catch-all for both modalities, so alias and concrete
+        // always agreed even pre-guard. Pinned so the guard is not credited with a behavior
+        // change it did not make.
+        const descriptor = AiAssist.getProviderDescriptor('google-gemini').orThrow();
+        expect(AiAssist.resolveImageCapability(descriptor, '@google-gemini:flash-image')).toMatchObject({
+          modelPrefix: '',
+          format: 'gemini-image-out'
+        });
+        expect(AiAssist.resolveEmbeddingCapability(descriptor, '@google-gemini:embedding')).toMatchObject({
+          modelPrefix: '',
+          format: 'gemini-embeddings'
+        });
+      });
+    });
+
+    describe('an unresolvable alias yields undefined rather than the catch-all', () => {
+      test('unregistered alias on a provider that declares an aliases map', () => {
+        const descriptor = AiAssist.getProviderDescriptor('openai').orThrow();
+        expect(AiAssist.resolveImageCapability(descriptor, '@openai:no-such-role')).toBeUndefined();
+        expect(AiAssist.resolveEmbeddingCapability(descriptor, '@openai:no-such-role')).toBeUndefined();
+      });
+
+      test('sigil-prefixed id on a provider that declares no aliases map at all', () => {
+        const descriptor: AiAssist.IAiProviderDescriptor = {
+          id: 'openai',
+          label: 'X',
+          buttonLabel: 'X',
+          needsSecret: true,
+          apiFormat: 'openai',
+          baseUrl: 'https://example.com',
+          defaultModel: 'gpt-image-1',
+          supportedTools: [],
+          corsRestricted: false,
+          streamingCorsRestricted: false,
+          acceptsImageInput: true,
+          thinkingMode: 'optional',
+          imageGeneration: [{ modelPrefix: '', format: 'openai-images' }],
+          embedding: [{ modelPrefix: '', format: 'openai-embeddings' }]
+        };
+        expect(AiAssist.resolveImageCapability(descriptor, '@openai:image')).toBeUndefined();
+        expect(AiAssist.resolveEmbeddingCapability(descriptor, '@openai:image')).toBeUndefined();
+      });
+
+      test('cyclic alias chain', () => {
+        const descriptor: AiAssist.IAiProviderDescriptor = {
+          id: 'openai',
+          label: 'X',
+          buttonLabel: 'X',
+          needsSecret: true,
+          apiFormat: 'openai',
+          baseUrl: 'https://example.com',
+          defaultModel: 'gpt-image-1',
+          supportedTools: [],
+          corsRestricted: false,
+          streamingCorsRestricted: false,
+          acceptsImageInput: true,
+          thinkingMode: 'optional',
+          aliases: { '@openai:a': '@openai:b', '@openai:b': '@openai:a' },
+          imageGeneration: [{ modelPrefix: '', format: 'openai-images' }],
+          embedding: [{ modelPrefix: '', format: 'openai-embeddings' }]
+        };
+        expect(AiAssist.resolveImageCapability(descriptor, '@openai:a')).toBeUndefined();
+        expect(AiAssist.resolveEmbeddingCapability(descriptor, '@openai:a')).toBeUndefined();
+      });
+    });
+
+    test('a concrete id containing an @ elsewhere is still matched verbatim', () => {
+      // Only a *leading* sigil marks an alias, so a raw provider id with an interior '@'
+      // must still prefix-match rather than being treated as an unresolvable alias.
+      const descriptor: AiAssist.IAiProviderDescriptor = {
+        id: 'openai-compat',
+        label: 'X',
+        buttonLabel: 'X',
+        needsSecret: false,
+        apiFormat: 'openai',
+        baseUrl: 'https://example.com',
+        defaultModel: '',
+        supportedTools: [],
+        corsRestricted: false,
+        streamingCorsRestricted: false,
+        acceptsImageInput: false,
+        thinkingMode: 'unsupported',
+        embedding: [
+          { modelPrefix: 'nomic-embed', format: 'openai-embeddings' },
+          { modelPrefix: '', format: 'openai-embeddings' }
+        ]
+      };
+      expect(AiAssist.resolveEmbeddingCapability(descriptor, 'nomic-embed@v1.5')).toMatchObject({
+        modelPrefix: 'nomic-embed'
+      });
+    });
+  });
+
   describe('allProviderIds', () => {
     test('contains all provider ids in same order as descriptors', () => {
       const descriptors = AiAssist.getProviderDescriptors();

--- a/samples/testbed/src/scenarios/imageGeneration/index.tsx
+++ b/samples/testbed/src/scenarios/imageGeneration/index.tsx
@@ -1,7 +1,7 @@
 /**
  * `image-generation` scenario — a web port of `samples/ai-image-gen-sample`'s image
- * mode. Provider + model picker (pre-filled from the `image` tier via
- * `AiAssist.resolveModel`), prompt form, and generated-image gallery, using
+ * mode. Provider + model picker (pre-filled with the concrete `image`-tier model id via
+ * `AiAssist.resolveProviderModel`), prompt form, and generated-image gallery, using
  * `@fgv/ts-app-shell`'s `useAiAssist` hook exactly as the sample does.
  *
  * The sample's `InMemoryKeyStore` + per-scenario API-key `<input>` are replaced by the
@@ -36,13 +36,20 @@ const IMAGE_PROVIDERS: ReadonlyArray<AiAssist.AiProviderId> = AiAssist.getProvid
   .filter((d) => AiAssist.supportsImageGeneration(d))
   .map((d) => d.id);
 
-/** Resolves the `image`-tier default model id for a provider (empty string if unknown). */
+/**
+ * Resolves the **concrete** `image`-tier default model id for a provider (empty string if
+ * unknown).
+ *
+ * Uses `AiAssist.resolveProviderModel` — the call-time chokepoint — rather than the bare
+ * `AiAssist.resolveModel` spec walk, so the returned id is post-alias. The bare walk yields
+ * the fgv alias form (e.g. `'@openai:image'`), which is the wrong value for both consumers
+ * here: the Model `<input>` shows it to the user alongside a fetched list of concrete ids
+ * (`gpt-image-1`, `dall-e-3`), and it feeds `AiAssist.resolveImageCapability`.
+ */
 function defaultModelFor(provider: AiAssist.AiProviderId): string {
-  const descriptor = AiAssist.getProviderDescriptor(provider).orDefault();
-  if (!descriptor) {
-    return '';
-  }
-  return AiAssist.resolveModel(descriptor.defaultModel, 'image');
+  return AiAssist.getProviderDescriptor(provider)
+    .onSuccess((descriptor) => AiAssist.resolveProviderModel(descriptor, undefined, 'image'))
+    .orDefault('');
 }
 
 function initialModelsByProvider(): ReadonlyMap<AiAssist.AiProviderId, string> {

--- a/samples/testbed/src/test/unit/scenarios/imageGeneration.test.tsx
+++ b/samples/testbed/src/test/unit/scenarios/imageGeneration.test.tsx
@@ -58,6 +58,50 @@ describe('imageGenerationScenario metadata', () => {
   test('defaultModelFor resolves the image tier for a known provider', () => {
     expect(defaultModelFor('openai').length).toBeGreaterThan(0);
   });
+
+  test('defaultModelFor returns the CONCRETE image model id, never the fgv alias form', () => {
+    // The bare `AiAssist.resolveModel(descriptor.defaultModel, 'image')` walk this replaced
+    // returned the alias (e.g. '@openai:image'). That value is shown in the Model <input>
+    // beside a fetched list of concrete ids, and it feeds resolveImageCapability.
+    for (const provider of IMAGE_PROVIDERS) {
+      const model = defaultModelFor(provider);
+      expect(model.startsWith(AiAssist.MODEL_ALIAS_SIGIL)).toBe(false);
+      const descriptor = AiAssist.getProviderDescriptor(provider).orThrow();
+      expect(AiAssist.resolveProviderModel(descriptor, undefined, 'image')).toSucceedWith(model);
+    }
+  });
+
+  test('every image provider default resolves a real capability, not the catch-all by accident', () => {
+    // The scenario branches on the resolved capability (`acceptsImageReferenceInput` gates the
+    // "use as reference" affordance; maxCount / acceptedSizes drive the form). Pin that the
+    // capability reached from defaultModelFor is the same one the concrete id selects — the
+    // combined assertion that would have caught the wrong-capability outcome end to end.
+    for (const provider of IMAGE_PROVIDERS) {
+      const descriptor = AiAssist.getProviderDescriptor(provider).orThrow();
+      const viaDefault = AiAssist.resolveImageCapability(descriptor, defaultModelFor(provider));
+      expect(viaDefault).toBeDefined();
+      const concrete = AiAssist.resolveProviderModel(descriptor, undefined, 'image').orThrow();
+      expect(viaDefault).toEqual(AiAssist.resolveImageCapability(descriptor, concrete));
+    }
+  });
+
+  test('the openai and xai defaults resolve their specific-prefix capabilities', () => {
+    // The two providers whose registry entries carry a specific prefix *and* a catch-all —
+    // i.e. the two where the pre-fix alias leak produced a materially different answer.
+    const openai = AiAssist.getProviderDescriptor('openai').orThrow();
+    expect(AiAssist.resolveImageCapability(openai, defaultModelFor('openai'))).toMatchObject({
+      modelPrefix: 'gpt-image-',
+      acceptsImageReferenceInput: true,
+      outputParamStyle: 'output-format'
+    });
+
+    const xai = AiAssist.getProviderDescriptor('xai-grok').orThrow();
+    expect(AiAssist.resolveImageCapability(xai, defaultModelFor('xai-grok'))).toMatchObject({
+      modelPrefix: 'grok-imagine-',
+      format: 'xai-images-edits',
+      acceptsImageReferenceInput: true
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The defect

`AiAssist.resolveImageCapability` and its sibling `resolveEmbeddingCapability` prefix-match the supplied model id against the descriptor's capability rules (longest `modelPrefix` wins) with **no `MODEL_ALIAS_SIGIL` handling and no alias resolution**.

Because every provider declares a catch-all rule with `modelPrefix: ''`, an fgv model alias (`@<provider>:<role>`) matched the catch-all and the function returned a **confidently wrong capability** rather than failing or returning `undefined`. Reported by PersonAIlity; the sibling embedding resolver had the identical flaw.

| Provider | Alias passed in | Returned (before) | Correct (from concrete id) |
|---|---|---|---|
| `openai` | `@openai:image` | `{modelPrefix:'', outputParamStyle:'response-format'}` | `{modelPrefix:'gpt-image-', acceptsImageReferenceInput:true, outputParamStyle:'output-format'}` |
| `xai-grok` | `@xai-grok:imagine` | `{format:'xai-images', acceptsImageReferenceInput:false}` | `{format:'xai-images-edits', acceptsImageReferenceInput:true}` |
| `openai` (embedding) | `@openai:embedding` | `{modelPrefix:''}` | `{modelPrefix:'text-embedding-3', supportsDimensions:true, maxBatchSize:2048}` |
| `google-gemini` | `@google-gemini:flash-image` | (single catch-all — no mismatch) | same |

The xAI row flips the **wire format** and `acceptsImageReferenceInput`; the embedding row silently drops `supportsDimensions` and the `maxBatchSize` guard. A consumer branching on these builds a wrong request.

**The library's own paths were already safe** — `apiClient.ts` and `embeddingClient.ts` both call `resolveProviderModel` before the capability lookup. Verified and left untouched. The hazard was exclusively for direct consumers of the exported helpers, which is what they are exported for.

## Design choice — resolve the alias inside the helper

Two designs were on the table. **Chose (b): resolve the alias first inside the helper**, via a shared `@internal` generic `resolveCapabilityForModel<TCapability extends { readonly modelPrefix: string }>`.

| Input | Before | After |
|---|---|---|
| Concrete provider id | correct | **unchanged** |
| Registered fgv alias | catch-all → **wrong capability** | correct (identical to the concrete id's) |
| Unregistered / cyclic alias | catch-all → wrong capability | `undefined` |

**Why not (a) (`Result<T>` return).** The decisive reason is a hard constraint: (a) forces edits to `apiClient.ts`, which the stream brief explicitly forbids ("verify only, do not change"), and to `embeddingClient.ts`, outside the declared file surface. There is no way to land it inside scope. Independent of that, (b) is the smaller consumer-facing change and makes *both* input forms correct rather than turning one into an error.

**On `undefined` for an unresolvable alias.** The brief's objection was that `undefined` collides with "no rule matched". That objection targets the *wrong-capability* outcome, which (b) eliminates outright — a sigil-prefixed string now either resolves to a concrete id (→ correct capability) or yields `undefined`; it can never reach the catch-all. An unresolvable alias names no model, so "no capability applies" is truthful rather than lossy, and it fails in the safe direction. Both callers already surface `undefined` as a loud `Result.fail`. Note that pre-fix, `undefined` was effectively **unreachable** for any provider with a catch-all — that unreachability *was* the bug; post-fix it becomes a meaningful signal.

**Non-breaking:** public signatures unchanged. `etc/ts-extras.api.md` regenerates **byte-identical to `release`** — hence no api.md diff in this PR, and no merge conflict on that file from this side.

## Testbed fix

`samples/testbed/src/scenarios/imageGeneration/index.tsx`: `defaultModelFor` switched from the bare `AiAssist.resolveModel(descriptor.defaultModel, 'image')` spec walk (which yields the alias form) to the `AiAssist.resolveProviderModel` chokepoint (which yields the concrete id).

The value has a third consumer beyond the capability lookup: `SettingsPanel` renders it as a user-editable `<input value={model}>` directly beside a fetched dropdown of concrete ids (`gpt-image-1`, `dall-e-3`). Showing `@openai:image` there is incoherent, and any user edit replaces it with a concrete id anyway. Wire-path safety is unaffected (the library resolves either form). Secondary benefit: the scenario is now correct **independently** of the library guard, so a regression in either layer alone is still caught. The rewrite also replaced an imperative `if (!descriptor)` guard with a Result chain.

## TSDoc (adjacent ask A) — doc-only

`@remarks` on `ModelSpecKey` and an added paragraph on `resolveProviderModel` record that `tools` and `thinking` are deliberately **not** model selectors — they are orthogonal request params riding on top of whatever model the tier selected, removed from `ModelSpecKey` when the quality-tier axis landed. Both tell a tool-path caller to pass a tier and **not** hand-roll a `resolveModel` + `resolveModelAlias` walk. This rule previously lived only in `.ai/instructions/LIBRARY_CAPABILITIES.md`, and its absence from the API surface had sent two consumers down that unnecessary walk. **No `'tools'` key was added.**

## Test that fails against pre-fix behavior

Verified empirically by temporarily reverting the guard: **7 of the new tests fail**, while **all 62 pre-existing registry tests still pass** — demonstrating the catch and the no-regression-for-concrete-ids property in one run. Coverage includes all three reported mismatches, all three unresolvable-alias cases (unregistered, no-aliases-map, cyclic), an interior-`@` concrete id, and a registry-wide **invariant sweep** asserting that for every alias on every built-in provider, the alias and its concrete target select the identical capability for both modalities — which will catch a future provider that adds a specific-prefix rule alongside a new alias.

## Gates

| Gate | `@fgv/ts-extras` | `@fgv/testbed` |
|---|---|---|
| `rushx build` | pass (no api-extractor warning) | pass |
| `rushx lint` | pass | pass |
| `rushx test` | pass, 100%; `registry.ts` 100/100/100/100 | pass, 100%; `scenarios/imageGeneration` 100% |
| `rushx fixlint` | run before final commit | run before final commit |
| `rush change --verify` | pass | n/a |

No coverage-closure pass was needed — the scenario-driven tests reached 100% unaided, so **no `c8 ignore` directives were added**. `code-reviewer` was still run before declaring coverage done, per the load-bearing ordering in TESTING_GUIDELINES.

## Layer-1 review summary

`code-reviewer` run on the final diff: **Approved — zero findings at P1, P2, and P3.**

It independently verified the gates and the file-scope list, and ran its own sweep for other alias-leak sites, clearing two candidates: `applyCapabilityConfig` (`apiClient.ts:1527`, `idPattern`-based) is fed only concrete ids returned by a live list-models API, and `mergeThinkingConfig`'s `resolvedModel` comes from `resolveProviderModel` at both call sites. Its conclusion matched mine — the two functions fixed here were the only vulnerable lookup sites in the packlet. It specifically endorsed the shared-helper factoring (the duplicated-flaw history is the argument *for* consolidating), the `.orDefault()` + early-return shape over a fuller Result chain (the failure detail is deliberately discarded because no caller distinguishes unknown-alias from cyclic-alias), and confirmed the TSDoc claims match the implementation.

## Surfaced for the orchestrator — deliberately not fixed here

1. **Two sibling exported predicates share the same alias-leak class.** `isResponsesOnlyModel` and `isAdaptiveThinkingModel` (both `@public`, both in `model.ts`) also prefix-match a caller-supplied id with no sigil handling. Concretely: `isAdaptiveThinkingModel(anthropicDescriptor, '@anthropic:sonnet')` returns `false` where the concrete `'claude-sonnet-5'` returns `true`. **Not fixed** because `model.ts` is TSDoc-only in this stream's brief and CODING_STANDARDS asks for a brief amendment before extending outside the declared surface. Lower priority than the capability bug: both are called internally only with already-resolved ids, both already document "concrete (already-resolved) model id" as a precondition, and the failure mode is a loud provider-side HTTP 400 rather than a silently wrong request body. Recommend a small follow-on stream owning `model.ts`.

2. **The open P3 TECH_DEBT entry (`docs/TECH_DEBT.md:164`) stays open** — it asks for exactly design (a), with trigger "next substantive change to the capability resolution path". This stream is that trigger, but the file-surface constraint defers it. Not edited (`docs/` is outside scope). The guard shipped here removes the *dangerous* half, leaving only the non-idiomatic-return half.

3. `docs/WORKSTREAMS.md` not updated — orchestrator-owned.

Stream artifacts: `.ai/tasks/active/ai-assist-alias-capability-guard/{brief,state,result}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD)_