### PR TITLE
docs(ts-agent-memory): pin the record-update merge contract (provenance)

### DIFF
--- a/.ai/tasks/active/agent-memory-provenance-contract-doc/brief.md
+++ b/.ai/tasks/active/agent-memory-provenance-contract-doc/brief.md
@@ -1,0 +1,73 @@
+# Stream brief — `agent-memory-provenance-contract-doc`
+
+**Branch:** `agent-memory-provenance-contract-doc` off `origin/release`
+**Shape:** documentation-only (no behavior change)
+
+## Context
+
+PersonAIlity (a consumer) asked a narrow yes/no about `@fgv/ts-agent-memory`: is the
+RFC-7386 merge-patch behavior over a record's `provenance` the **intended, stable
+contract** — or an incidental consequence of the current write policy's merge config?
+And is clearing a provenance **sub-key** via a `null` patch **sanctioned**?
+
+The orchestrator determined the answer is **yes on both halves** by reading the code and
+executing it. This stream's job is NOT to re-derive the answer or change behavior — it is
+to **document the guarantee where a consumer will find it**, so the next consumer doesn't
+have to ask.
+
+## Evidence supplied by the orchestrator (to be independently verified)
+
+`KnowledgeLwwPolicy.mutableFields` is `['body','tags','links','provenance','embeddingRef']`,
+declared under a TSDoc block headed "Merge-surface pin (resolves design-lock §5.3's
+body-vs-envelope muddle)" — a deliberately pinned contract, not a side effect.
+`applyUpdate` projects those fields into a record-level JSON view, applies an RFC-7386
+merge patch (`JsonEditor` with `MERGE_PATCH_OPTIONS`, `nullAsDelete: true`) over a clone,
+then `_rebuild` reassembles. `_rebuild` treats `body`/`tags`/`links`/`provenance` as
+**required** and fails loudly if a patch deleted one.
+
+| Patch | Expected |
+|---|---|
+| `{provenance: {note: null}}` | `note` removed; `source` / `confidence` preserved |
+| `{provenance: {confidence: 0.5}}` | per-key merge; `note` preserved |
+| `{provenance: null}` | fails: `... may not delete required field(s): provenance` |
+| `{tags: ['x']}` | provenance untouched |
+
+`MemoryCapCullPolicy` takes a caller-supplied `mutableFields`, so the guarantee's exact
+surface is policy-dependent — the doc must be precise and must not overclaim for a policy
+whose `mutableFields` the consumer chose.
+
+## Scope
+
+1. `libraries/ts-agent-memory/README.md` — add a record-update merge-contract section.
+2. TSDoc in `writePolicy.ts` — state the contract at the API surface (build on the
+   existing "Merge-surface pin" remark, don't replace it).
+3. Optional test pinning the four evidence rows so the doc cannot silently drift.
+
+**Hard constraint: NO behavior change.** If the documented guarantee does not hold in some
+case, STOP and report it prominently.
+
+## Files in scope
+
+- `libraries/ts-agent-memory/README.md`
+- `libraries/ts-agent-memory/src/packlets/types/writePolicy.ts` — TSDoc/comments only
+- `libraries/ts-agent-memory/src/test/**` — additive tests only
+- `libraries/ts-agent-memory/etc/*.api.md` (regenerated)
+- `common/changes/@fgv/ts-agent-memory/*.json`
+- `.ai/tasks/active/agent-memory-provenance-contract-doc/**`
+
+## Files explicitly out of scope
+
+- `libraries/ts-extras/**` (two concurrent streams own it)
+- `samples/testbed/**`
+- `docs/WORKSTREAMS.md` (orchestrator-owned)
+- Any behavioral code path in the store or policies
+
+## Acceptance criteria
+
+- [ ] `rushx build` / `rushx lint` / `rushx test` pass with 100% coverage
+- [ ] `rushx fixlint` run before the final commit
+- [ ] Added test pins all four behaviors in the evidence table
+- [ ] No behavior change — diff contains no change to merge/rebuild logic
+- [ ] `code-reviewer` run on the final diff; findings resolved or dispositioned
+- [ ] Rush change file added
+- [ ] PR opened targeting `release` (do NOT merge)

--- a/.ai/tasks/active/agent-memory-provenance-contract-doc/result.md
+++ b/.ai/tasks/active/agent-memory-provenance-contract-doc/result.md
@@ -82,10 +82,31 @@ is still stale** — it lists only the `types` and `converters` packlets while t
 also ships `store`, `index`, `retrieve`, `vector`, `observe`, `ingest`, and `tools`.
 Bringing it current is a separate doc chore, not this stream's scope.
 
+## Code-reviewer disposition (layer 1)
+
+Recommendation: *requires minor changes*. **No P1s.** The reviewer independently confirmed
+the no-behavior-change constraint and re-derived every merge behavior against the
+implementation.
+
+Both P2s were the same class — **a doc claiming a stronger guarantee than the committed
+tests establish**. Since this stream's whole deliverable is documenting a guarantee
+*accurately*, both were resolved by **adding the missing tests**, not by softening the prose.
+
+| # | Finding | Resolution |
+|---|---|---|
+| P2-1 | README says the provenance guarantees are "pinned by tests" for **both** `KnowledgeLwwPolicy` and `TemporalVersionedPolicy`, but only the former was covered. | Added a mirror `provenance merge contract (README-pinned)` describe to `temporalPolicy.test.ts` pinning the sub-key clear and the whole-block rejection. The README claim is now true for both named policies. |
+| P2-2 | The store-layer end-to-end claim and the `envelopeConverter`-rejects-`null` claim were asserted as fact but only manually verified. | Added `provenance merge contract through put (README-pinned)` to `fileTreeMemoryStore.test.ts`: one test drives put→put→reopen (omitted key preserved, `null` key cleared, cleared key does not resurface from persisted frontmatter), one pins the converter rejection site. |
+| P3 | `writePolicy.ts` said the store stamps `updated`/`seq`; the README bullet said `updated`/`seq`/`contentHash`. Both true, inconsistent enumeration. | Aligned the TSDoc to the three-field form (`contentHash` is in fact stamped in `_buildRecord`). |
+
+Every claim the README makes is now backed by a committed test.
+
 ## Gates
 
 - `rushx build` — pass (no `etc/*.api.md` movement; TSDoc `@remarks` on members does not
   shift the API report)
-- `rushx lint` — pass (`rushx fixlint` run before the final commit; no changes produced)
+- `rushx lint` — pass (`rushx fixlint` run before the final commit)
 - `rushx test` — pass, **100% statements / branches / functions / lines**
-- `code-reviewer` — run on the staged diff; see the PR description for the disposition
+- `code-reviewer` — run on the diff; no P1s, both P2s and the P3 resolved (table above)
+- No-behavior-change re-verified after the P3 TSDoc edit: comment-stripped `writePolicy.ts`
+  is still byte-identical to `origin/release`'s. Test diffs across all three files are
+  additive only (217 added, 0 removed).

--- a/.ai/tasks/active/agent-memory-provenance-contract-doc/result.md
+++ b/.ai/tasks/active/agent-memory-provenance-contract-doc/result.md
@@ -1,0 +1,91 @@
+# Result — `agent-memory-provenance-contract-doc`
+
+**Outcome:** delivered. Documentation + tests only; **no behavior change**.
+**Answer to PersonAIlity's question: YES on both halves, and the guarantee held under
+independent verification.** Nothing contradicts the orchestrator's evidence table.
+
+## The guarantee held
+
+I did not take the evidence table on faith. I built the package on this branch and executed
+all four rows against `lib/index.js`, then drove the same behavior end-to-end through
+`FileTreeMemoryStore` on an in-memory FileTree. Full detail in `state.md`. Summary:
+
+| Patch (`KnowledgeLwwPolicy.applyUpdate`) | Observed | Matches table |
+|---|---|---|
+| `{provenance: {note: null}}` | `{source:'agent', confidence:0.9}` | yes |
+| `{provenance: {confidence: 0.5}}` | `{source:'agent', confidence:0.5, note:'keep me'}` | yes |
+| `{provenance: null}` | fails `knowledge LWW: merge patch may not delete required field(s): provenance` | yes |
+| `{tags: ['x']}` | provenance untouched | yes |
+
+Plus: the existing record is not mutated in place, and a cleared sub-key survives the
+YAML-frontmatter serialize/reload round trip.
+
+## Three findings that extend (never contradict) the evidence table
+
+1. **Cross-policy parity.** `TemporalVersionedPolicy` — which the brief did not mention —
+   behaves identically on all four rows, as does `MemoryCapCullPolicy` when `provenance` is
+   declared mutable. All three share `MERGE_PATCH_OPTIONS`; only the error-message prefix
+   differs. So the contract is not `KnowledgeLwwPolicy`-specific; it is the shipped-policy
+   contract. The README documents it at that level and names the two policies with a
+   *pinned* (non-caller-supplied) surface.
+
+2. **The policy-dependence caveat is sharper than "the guarantee may not apply".** With
+   `MemoryCapCullPolicy.create({ mutableFields: ['body','tags'] })`, a provenance patch key
+   is not merely unguaranteed — it is **inert**. A sub-key `null` does not clear, and a
+   whole-block `null` is a **silent no-op, not an error**: the scoping loop drops the key
+   before the merge, and `_rebuild` only guards required fields that were declared mutable.
+   This is the one place a consumer could get a nasty surprise, so it is called out
+   explicitly in the README, in `IMemoryCapCullPolicyParams.mutableFields`, and pinned by
+   three new tests.
+
+3. **The whole-block delete is rejected at two different layers.** At the policy layer
+   `applyUpdate({provenance: null})` fails loudly. At the store layer the case is not
+   expressible at all: `IMemoryEnvelope.provenance` is non-nullable and
+   `envelopeConverter.convert({..., provenance: null})` fails with
+   `Field provenance: Cannot convert field "source" from non-object null`. The README says
+   which layer catches it rather than implying a single rejection site.
+
+## What shipped
+
+- **`README.md`** — new `## Record updates — the merge contract` section: RFC-7386 as a
+  pinned contract (not a merge-config artifact), per-key object merge, sub-key `null`
+  clearing, wholesale array replace, loud rejection of a required-field delete,
+  `embeddingRef`'s optional exception, out-of-surface keys ignored. Sub-sections for
+  `provenance` on the pinned surface (with a worked example) and for the policy-dependence
+  caveat.
+- **`writePolicy.ts` (TSDoc only)** — an `@remarks` on `IWritePolicy.applyUpdate` stating
+  the four semantics plus the policy-dependence rule at the API surface; a paragraph
+  appended to `KnowledgeLwwPolicy`'s existing "Merge-surface pin" remark (built on, not
+  replaced, per the brief); an `@remarks` on `IMemoryCapCullPolicyParams.mutableFields`
+  spelling out the caller-supplied-surface consequence.
+- **`writePolicy.test.ts` (additive only — 112 added, 0 removed)** — a
+  `provenance merge contract (README-pinned)` describe pinning all four evidence rows plus
+  no-in-place-mutation, and a `provenance guarantees are policy-dependent (README-pinned)`
+  describe pinning the inert-when-undeclared behavior and its restoration. Both name the
+  README so the doc cannot silently drift.
+- Rush change file (`patch`).
+
+## No behavior change — verified mechanically
+
+Beyond reading the diff (all three `writePolicy.ts` hunks sit inside `/** */` blocks), I
+stripped block and line comments plus blank lines from `origin/release`'s `writePolicy.ts`
+and from this branch's and compared: **identical**. No executable statement changed. The
+test diff is 112 added / 0 removed. No other source file was touched.
+
+## Out-of-scope observation (deliberately not fixed)
+
+The README's status banner claimed the package ships "no store, index, retrieval, observe,
+or vector code yet" — provably false; I drove the store end-to-end. Left alone it would
+have made the new section incoherent, so that one clause was corrected and the heading
+`B0 surface (this tier)` became `Foundational surface`. **The rest of the surface inventory
+is still stale** — it lists only the `types` and `converters` packlets while the package
+also ships `store`, `index`, `retrieve`, `vector`, `observe`, `ingest`, and `tools`.
+Bringing it current is a separate doc chore, not this stream's scope.
+
+## Gates
+
+- `rushx build` — pass (no `etc/*.api.md` movement; TSDoc `@remarks` on members does not
+  shift the API report)
+- `rushx lint` — pass (`rushx fixlint` run before the final commit; no changes produced)
+- `rushx test` — pass, **100% statements / branches / functions / lines**
+- `code-reviewer` — run on the staged diff; see the PR description for the disposition

--- a/.ai/tasks/active/agent-memory-provenance-contract-doc/state.md
+++ b/.ai/tasks/active/agent-memory-provenance-contract-doc/state.md
@@ -1,0 +1,86 @@
+# State — `agent-memory-provenance-contract-doc`
+
+## Verification (done before writing any docs)
+
+Built `@fgv/ts-agent-memory` on this branch and executed the four evidence rows against
+`lib/index.js` directly, plus store-level round trips. **The guarantee held in every case.**
+
+### Policy layer — `KnowledgeLwwPolicy.applyUpdate`
+
+Existing record provenance: `{ source: 'agent', confidence: 0.9, note: 'keep me' }`.
+
+| Patch | Observed |
+|---|---|
+| `{provenance: {note: null}}` | `{source:'agent', confidence:0.9}` — `note` cleared, siblings preserved |
+| `{provenance: {confidence: 0.5}}` | `{source:'agent', confidence:0.5, note:'keep me'}` — per-key merge |
+| `{provenance: null}` | FAILS: `knowledge LWW: merge patch may not delete required field(s): provenance` |
+| `{tags: ['x']}` | provenance untouched |
+
+Matches the orchestrator's table exactly. Also confirmed the existing record is **not
+mutated in place** (the clone-then-merge is real).
+
+### Cross-policy parity (not in the original evidence table)
+
+`TemporalVersionedPolicy` and `MemoryCapCullPolicy` (with `provenance` declared mutable)
+produce **identical** results on all four rows; only the error-message prefix differs
+(`temporal versioned:` / `memory cap-cull:`). All three share `MERGE_PATCH_OPTIONS`.
+
+### Policy-dependence (the precision point the brief called out)
+
+`MemoryCapCullPolicy.create({ mutableFields: ['body','tags'] })` — i.e. `provenance` NOT
+declared mutable — **ignores every provenance patch key silently**, including the
+whole-block `{provenance: null}`. It does not fail; the scoping loop drops the key before
+the merge, and `_rebuild` only guards required fields that are *declared mutable*.
+
+This is the load-bearing caveat for the README: the "sub-key `null` clears" and "whole-block
+`null` is rejected loudly" guarantees apply **only when `provenance` is on the policy's
+declared mutable surface**. It is pinned for `KnowledgeLwwPolicy` and
+`TemporalVersionedPolicy` (both hard-code the five-field surface); for
+`MemoryCapCullPolicy` it is the caller's `mutableFields` that decides.
+
+### Store layer — `FileTreeMemoryStore.put`
+
+End-to-end round trip through an in-memory FileTree with `KnowledgeIdentityCodec`:
+
+- put #1 provenance `{source:'agent', confidence:0.9, note:'keep me'}` → stored verbatim
+- put #2 provenance `{source:'agent', note:null}` → stored `{source:'agent', confidence:0.9}`
+- `get()` after → `{source:'agent', confidence:0.9}` (survives serialize/reload)
+
+Two things this pins that the policy-level table alone does not:
+
+1. The store builds the patch from the **incoming record's mutable-field values**
+   (`_projectMutablePatch`), so a key **absent** from the incoming provenance is
+   **preserved**, not deleted (`confidence: 0.9` survived a put that omitted it). Only an
+   explicit `null` deletes.
+2. The cleared sub-key round-trips through YAML-frontmatter persistence.
+
+### Where the whole-block `null` is rejected, per layer
+
+- **Policy layer:** `applyUpdate({provenance: null})` fails loudly (message above).
+- **Store layer:** unreachable — `IMemoryEnvelope.provenance` is typed non-nullable, and
+  `envelopeConverter.convert({..., provenance: null})` fails
+  (`Field provenance: Cannot convert field "source" from non-object null`).
+
+Both are loud rejections at different layers; neither silently accepts. Documented as such.
+
+## Decisions
+
+- **Doc placement.** README gets a `## Record updates — the merge contract` section
+  (consumer front door); `writePolicy.ts` gets a `@remarks` on `IWritePolicy.applyUpdate`
+  plus a sentence appended to `KnowledgeLwwPolicy`'s existing "Merge-surface pin" remark.
+  The existing remark is built on, not replaced, per the brief.
+- **Test placement.** Added to the existing `src/test/unit/types/writePolicy.test.ts` under
+  a dedicated `describe` naming the contract, rather than a new file — it sits next to the
+  existing merge tests it generalizes.
+- **Stale README status banner.** The banner claimed "no store, index, retrieval, observe,
+  or vector code yet", which is provably false (I drove the store end-to-end above). Left
+  alone would have made the new section incoherent, so the one false clause was corrected.
+  The rest of the README's surface inventory (the "B0 surface" listing) is still stale and
+  is deliberately NOT rewritten here — out of scope, flagged in `result.md` as a chore.
+
+## Surprises
+
+- None that contradict the evidence table. The only material addition is the
+  `MemoryCapCullPolicy`-with-narrow-`mutableFields` case, which does not contradict
+  anything — the brief anticipated exactly this policy-dependence and asked for precision
+  about it.

--- a/common/changes/@fgv/ts-agent-memory/agent-memory-provenance-contract-doc_2026-07-31-00-00.json
+++ b/common/changes/@fgv/ts-agent-memory/agent-memory-provenance-contract-doc_2026-07-31-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Document the RFC-7386 record-update merge contract (per-key merge, sub-key null clears, loud rejection of a required-field delete) in the README and at the IWritePolicy.applyUpdate API surface; pin the provenance behaviors with tests. Documentation and tests only — no behavior change.",
+      "type": "patch",
+      "packageName": "@fgv/ts-agent-memory"
+    }
+  ],
+  "packageName": "@fgv/ts-agent-memory",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-agent-memory/README.md
+++ b/libraries/ts-agent-memory/README.md
@@ -6,11 +6,12 @@ edges, content-hash dedup, and the optional-layer seams (vector / temporal /
 observe). It owns none of a consumer's processing, transformation, or
 composition logic.
 
-> **Status:** v0.1, under active development. The package is being built
-> knowledge-first. This tier (B0) ships the foundational type model and
-> converters only — no store, index, retrieval, observe, or vector code yet.
+> **Status:** under active development. The package is being built
+> knowledge-first. The surface listing below covers the foundational type model
+> and converters; the store, index, retrieval, observe, and vector layers ship
+> alongside them and are not itemized here.
 
-## B0 surface (this tier)
+## Foundational surface
 
 ### `types` packlet
 
@@ -33,6 +34,80 @@ composition logic.
   `envelopeYamlConverter` (YAML frontmatter), plus the `splitFrontmatter` /
   `joinFrontmatter` / `parseMemoryFile` / `serializeMemoryFile` helpers for
   the `---\n<yaml>\n---\n<body>` memory-file format.
+
+## Record updates — the merge contract
+
+When a `put` targets an `entityId` that already exists, the write is an
+**update**, not a replace. The store projects the incoming record's mutable
+fields into a patch and hands it to the kind's `IWritePolicy.applyUpdate`, which
+applies it as an **RFC-7386 JSON Merge Patch** over the policy's declared
+mutable surface. This is a **pinned contract**, not an artifact of the current
+merge configuration — the shipped policies compose `@fgv/ts-json`'s `JsonEditor`
+with `{ nullAsDelete: true, arrayMergeBehavior: 'replace' }` specifically to get
+RFC-7386 semantics, and `applyUpdate` documents them as the interface contract.
+
+Within the policy's declared mutable surface:
+
+- **Objects merge per key.** Keys you supply overwrite; keys you omit are
+  **preserved**, not dropped. An update that sets one provenance field leaves
+  every sibling field intact.
+- **An explicit `null` on a sub-key clears that sub-key.** This is the
+  sanctioned way to remove a single key from a nested object such as
+  `provenance`. The cleared key is gone from the persisted record and does not
+  reappear on reload.
+- **Arrays replace wholesale.** `tags` and `links` are not element-merged.
+- **A whole-block `null` on a required field is rejected loudly**, never
+  silently accepted. `body`, `tags`, `links`, and `provenance` are required; a
+  patch that deletes one fails with
+  `... merge patch may not delete required field(s): <names>`. (`embeddingRef`
+  is optional and *may* be cleared by a `null`, which restores it to absent
+  rather than to `null`.)
+- **Keys outside the mutable surface are ignored.** Identity and
+  transaction-time envelope fields (`id`, `entityId`, `kind`, `created`,
+  `updated`, `seq`, `contentHash`) are preserved verbatim; the store stamps
+  `updated` / `seq` / `contentHash` on write.
+
+### `provenance` is on the pinned surface
+
+`KnowledgeLwwPolicy` and `TemporalVersionedPolicy` both hard-code their mutable
+surface as `['body', 'tags', 'links', 'provenance', 'embeddingRef']`. For those
+policies the guarantees above apply to `provenance` specifically: per-key merge,
+sub-key clearing via `null`, and loud rejection of a whole-block delete are all
+part of the contract and are pinned by tests.
+
+```ts
+// existing.envelope.provenance: { source: 'agent', confidence: 0.9, note: 'stale' }
+
+// clear one sub-key; siblings survive
+policy.applyUpdate(existing, { provenance: { note: null } });
+// => provenance: { source: 'agent', confidence: 0.9 }
+
+// revise one sub-key; siblings survive
+policy.applyUpdate(existing, { provenance: { confidence: 0.5 } });
+// => provenance: { source: 'agent', confidence: 0.5, note: 'stale' }
+
+// delete the whole block — rejected, not silently accepted
+policy.applyUpdate(existing, { provenance: null });
+// => Result.fail('knowledge LWW: merge patch may not delete required field(s): provenance')
+```
+
+Going through the store rather than calling a policy directly, the same three
+cases are expressed as the `provenance` value on the record you `put`: include a
+key to set it, set a key to `null` to clear it, and omit a key to leave it
+alone. A whole-block delete is not expressible there at all —
+`IMemoryEnvelope.provenance` is non-nullable and `envelopeConverter` rejects
+`null` — so that case fails at the converter instead of at the policy. Either
+way it fails loudly.
+
+### The surface is policy-dependent
+
+`MemoryCapCullPolicy` takes its `mutableFields` from the caller, so **what it
+guarantees depends on what you declared**. A field you did not declare mutable
+is not merged at all: patch keys naming it are dropped before the merge runs, so
+a `null` on it neither clears anything nor raises an error — it is simply inert,
+and the existing value is preserved verbatim. If you want the guarantees above
+for `provenance` under a cap-cull policy, `provenance` must appear in the
+`mutableFields` you pass to `MemoryCapCullPolicy.create`.
 
 ## Conventions
 

--- a/libraries/ts-agent-memory/src/packlets/types/writePolicy.ts
+++ b/libraries/ts-agent-memory/src/packlets/types/writePolicy.ts
@@ -90,6 +90,27 @@ export interface IWritePolicy {
    * record. Called when admission is `accept` AND a record with the same
    * `entityId` already exists (an update, not a first write).
    *
+   * @remarks
+   * **RFC-7386 semantics are the contract here, not an artifact of the shipped
+   * policies' merge configuration.** Implementations are expected to honor them,
+   * and consumers may rely on them:
+   *
+   * - **Objects merge per key.** A supplied key overwrites; an omitted key is
+   *   PRESERVED, not dropped. Patching one key of a nested object (e.g. one
+   *   field of `provenance`) leaves its siblings intact.
+   * - **An explicit `null` on a sub-key clears exactly that sub-key.** This is
+   *   the sanctioned way to remove a single key from a nested object.
+   * - **Arrays replace wholesale** — `tags` / `links` are never element-merged.
+   * - **A whole-block `null` that would delete a REQUIRED field is rejected
+   *   loudly** (`Result.fail`), never silently accepted. `body` / `tags` /
+   *   `links` / `provenance` are required; `embeddingRef` is optional and a
+   *   `null` restores it to absent (NOT to `null`), so it stays hash-stable.
+   *
+   * Which fields these guarantees cover is **policy-dependent**: they apply to
+   * the fields the policy declares in {@link IWritePolicy.mutableFields}, and a
+   * field outside that list is inert — its patch key is dropped before the merge,
+   * so a `null` on it neither clears the value nor raises an error.
+   *
    * @param existing - The current persisted record.
    * @param patch - A partial JSON object in Merge Patch format. `null`
    * deletes the corresponding key; arrays replace wholesale; nested objects
@@ -134,12 +155,20 @@ const MERGE_PATCH_OPTIONS: Partial<IJsonEditorOptions> = {
  * identity and transaction-time envelope fields (`id`, `entityId`, `kind`,
  * `created`, `updated`, `seq`, `contentHash`) are NOT mutable and are
  * preserved verbatim; the store stamps `updated` / `seq` on write.
+ *
+ * Because the surface is pinned rather than caller-supplied, the RFC-7386
+ * guarantees documented on {@link IWritePolicy.applyUpdate} apply to every field
+ * listed above — in particular to `provenance`, whose keys merge individually, a
+ * `null` on any one of which clears that key alone, and a `null` on the whole
+ * block of which is rejected loudly (it is a required field). Consumers may
+ * depend on this; it is covered by tests.
  * @public
  */
 export class KnowledgeLwwPolicy implements IWritePolicy {
   /**
    * The knowledge mutable surface: the body plus the envelope metadata a
-   * consumer may revise without minting a new entity.
+   * consumer may revise without minting a new entity. Pinned, not
+   * caller-supplied — see the class remarks for what that guarantees.
    */
   public readonly mutableFields: ReadonlyArray<string> = [
     'body',
@@ -271,6 +300,15 @@ export interface IMemoryCapCullPolicyParams {
    * The fields a merge-patch update may touch (drawn from the record-level
    * mutable vocabulary: `body` / `tags` / `links` / `provenance` /
    * `embeddingRef`). Fields outside this list are immutable.
+   *
+   * @remarks
+   * This list — unlike {@link KnowledgeLwwPolicy}'s pinned surface — is
+   * caller-supplied, so it is what decides which fields get the RFC-7386
+   * guarantees documented on {@link IWritePolicy.applyUpdate}. Declare
+   * `provenance` here to get per-key provenance merging and `null` sub-key
+   * clearing; omit it and every provenance patch key is inert (dropped before
+   * the merge, so the existing value is preserved verbatim and even a
+   * whole-block `null` is a silent no-op rather than an error).
    */
   readonly mutableFields: ReadonlyArray<string>;
 }

--- a/libraries/ts-agent-memory/src/packlets/types/writePolicy.ts
+++ b/libraries/ts-agent-memory/src/packlets/types/writePolicy.ts
@@ -154,7 +154,7 @@ const MERGE_PATCH_OPTIONS: Partial<IJsonEditorOptions> = {
  * view, runs the merge over that view, then rebuilds a coherent record. The
  * identity and transaction-time envelope fields (`id`, `entityId`, `kind`,
  * `created`, `updated`, `seq`, `contentHash`) are NOT mutable and are
- * preserved verbatim; the store stamps `updated` / `seq` on write.
+ * preserved verbatim; the store stamps `updated` / `seq` / `contentHash` on write.
  *
  * Because the surface is pinned rather than caller-supplied, the RFC-7386
  * guarantees documented on {@link IWritePolicy.applyUpdate} apply to every field

--- a/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/store/fileTreeMemoryStore.test.ts
@@ -963,4 +963,79 @@ describe('FileTreeMemoryStore', () => {
       });
     });
   });
+
+  /**
+   * Pins the store-layer half of the provenance merge contract documented in the
+   * package README (§ "Record updates — the merge contract"). The policy-level
+   * behavior is pinned in `types/writePolicy.test.ts`; these tests pin the claims
+   * the README makes about reaching that behavior through `put` — namely that the
+   * patch is projected from the incoming record's provenance, so an omitted key is
+   * preserved while an explicit `null` clears, and that the cleared key stays gone
+   * across a reload rather than resurfacing from the persisted frontmatter.
+   */
+  describe('provenance merge contract through put (README-pinned)', () => {
+    /** A knowledge record carrying an explicit provenance block. */
+    function provenanceRecord(provenance: unknown, body: string): IMemoryRecord<unknown> {
+      return {
+        envelope: envelopeConverter
+          .convert({
+            id: 'doc-p',
+            entityId: 'doc-p',
+            kind: 'knowledge',
+            tags: [],
+            links: [],
+            created: 0,
+            updated: 0,
+            seq: 0,
+            contentHash: '',
+            provenance
+          })
+          .orThrow(),
+        body
+      };
+    }
+
+    test('an omitted key is preserved and an explicit null clears, surviving a reload', async () => {
+      const root = mutableRoot();
+      const store = createStore({ root }).orThrow();
+      (
+        await store.put(provenanceRecord({ source: 'agent', confidence: 0.9, note: 'stale' }, 'first body'))
+      ).orThrow();
+
+      // The second put omits `confidence` (must be preserved) and nulls `note`
+      // (must be cleared) — the per-key merge, driven through the store.
+      expect(
+        await store.put(provenanceRecord({ source: 'agent', note: null }, 'second body'))
+      ).toSucceedAndSatisfy((updated: IMemoryRecord<unknown>) => {
+        expect(updated.envelope.provenance).toEqual({ source: 'agent', confidence: 0.9 });
+      });
+
+      // A fresh store over the same root re-reads the persisted frontmatter: the
+      // cleared key must not resurface.
+      const reopened = createStore({ root }).orThrow();
+      expect(await reopened.get(knowledgeKind, 'doc-p' as EntityId)).toSucceedAndSatisfy((r) => {
+        expect(r?.envelope.provenance).toEqual({ source: 'agent', confidence: 0.9 });
+      });
+    });
+
+    test('a whole-block null provenance is not expressible — the converter rejects it', () => {
+      // The README says the whole-block delete fails at the converter rather than
+      // at the policy on the store path, because `IMemoryEnvelope.provenance` is
+      // non-nullable. Pin that rejection site.
+      expect(
+        envelopeConverter.convert({
+          id: 'doc-p',
+          entityId: 'doc-p',
+          kind: 'knowledge',
+          tags: [],
+          links: [],
+          created: 0,
+          updated: 0,
+          seq: 0,
+          contentHash: '',
+          provenance: null
+        })
+      ).toFailWith(/provenance/i);
+    });
+  });
 });

--- a/libraries/ts-agent-memory/src/test/unit/types/temporalPolicy.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/types/temporalPolicy.test.ts
@@ -92,5 +92,33 @@ describe('TemporalVersionedPolicy', () => {
         expect(updated.envelope.embeddingRef).toBe('vec-1');
       });
     });
+
+    /**
+     * Mirrors the `provenance merge contract (README-pinned)` block in
+     * `writePolicy.test.ts`. The package README states that the provenance
+     * guarantees hold for BOTH pinned-surface policies, so both must be pinned
+     * here — otherwise the README claims more than the tests establish.
+     */
+    describe('provenance merge contract (README-pinned)', () => {
+      function provenanceRecord(): IMemoryRecord<unknown> {
+        return makeRecord({
+          provenance: { source: 'agent', confidence: 0.9, note: 'stale' } as IProvenance
+        });
+      }
+
+      test('an explicit null on a sub-key clears that key and preserves its siblings', () => {
+        expect(policy.applyUpdate(provenanceRecord(), { provenance: { note: null } })).toSucceedAndSatisfy(
+          (updated) => {
+            expect(updated.envelope.provenance).toEqual({ source: 'agent', confidence: 0.9 });
+          }
+        );
+      });
+
+      test('a whole-block null is rejected loudly rather than silently accepted', () => {
+        expect(policy.applyUpdate(provenanceRecord(), { provenance: null })).toFailWith(
+          /may not delete required field\(s\): provenance/i
+        );
+      });
+    });
   });
 });

--- a/libraries/ts-agent-memory/src/test/unit/types/writePolicy.test.ts
+++ b/libraries/ts-agent-memory/src/test/unit/types/writePolicy.test.ts
@@ -149,6 +149,68 @@ describe('KnowledgeLwwPolicy', () => {
       );
     });
   });
+
+  /**
+   * Pins the provenance merge contract documented in the package README
+   * (§ "Record updates — the merge contract"). `provenance` is on this policy's
+   * PINNED mutable surface, so these four behaviors are guarantees a consumer
+   * may depend on — not incidental consequences of the merge configuration. If
+   * one of these ever changes, the README claim is wrong and must move with it.
+   */
+  describe('provenance merge contract (README-pinned)', () => {
+    /** `provenance` with one key to clear, one to revise, and one to leave alone. */
+    function provenanceRecord(): IMemoryRecord<unknown> {
+      return makeRecord({
+        provenance: { source: 'agent', confidence: 0.9, note: 'stale' } as IProvenance
+      });
+    }
+
+    test('an explicit null on a sub-key clears that key and preserves its siblings', () => {
+      expect(policy.applyUpdate(provenanceRecord(), { provenance: { note: null } })).toSucceedAndSatisfy(
+        (updated) => {
+          expect(updated.envelope.provenance).toEqual({ source: 'agent', confidence: 0.9 });
+        }
+      );
+    });
+
+    test('a sub-key revision merges per key and preserves untouched siblings', () => {
+      expect(policy.applyUpdate(provenanceRecord(), { provenance: { confidence: 0.5 } })).toSucceedAndSatisfy(
+        (updated) => {
+          expect(updated.envelope.provenance).toEqual({
+            source: 'agent',
+            confidence: 0.5,
+            note: 'stale'
+          });
+        }
+      );
+    });
+
+    test('a whole-block null is rejected loudly rather than silently accepted', () => {
+      expect(policy.applyUpdate(provenanceRecord(), { provenance: null })).toFailWith(
+        /may not delete required field\(s\): provenance/i
+      );
+    });
+
+    test('a patch that does not mention provenance leaves it untouched', () => {
+      expect(policy.applyUpdate(provenanceRecord(), { tags: ['x'] })).toSucceedAndSatisfy((updated) => {
+        expect(updated.envelope.provenance).toEqual({
+          source: 'agent',
+          confidence: 0.9,
+          note: 'stale'
+        });
+      });
+    });
+
+    test('the existing record is not mutated in place', () => {
+      const existing = provenanceRecord();
+      expect(policy.applyUpdate(existing, { provenance: { note: null } })).toSucceed();
+      expect(existing.envelope.provenance).toEqual({
+        source: 'agent',
+        confidence: 0.9,
+        note: 'stale'
+      });
+    });
+  });
 });
 
 describe('MemoryCapCullPolicy', () => {
@@ -328,6 +390,56 @@ describe('MemoryCapCullPolicy', () => {
       });
       expect(narrow.applyUpdate(existing, { body: { summary: 'x' } })).toSucceedAndSatisfy((updated) => {
         expect(updated.envelope.embeddingRef).toBe('vec-keep');
+      });
+    });
+
+    /**
+     * Pins the policy-dependence caveat the README states alongside the
+     * provenance merge contract: unlike {@link KnowledgeLwwPolicy}'s pinned
+     * surface, this policy's surface is caller-supplied, so a consumer who does
+     * not declare `provenance` mutable gets NEITHER the sub-key clear NOR the
+     * loud whole-block rejection — every provenance patch key is simply inert.
+     */
+    describe('provenance guarantees are policy-dependent (README-pinned)', () => {
+      const bodyOnly = (): MemoryCapCullPolicy =>
+        MemoryCapCullPolicy.create({ maxRecords: 5, mutableFields: ['body'] }).orThrow();
+
+      function undeclaredProvenanceRecord(): IMemoryRecord<unknown> {
+        return makeRecord(
+          {
+            id: 'turn-0' as MemoryId,
+            kind: 'summarized-turn' as Kind,
+            provenance: { source: 'agent', note: 'stale' } as IProvenance
+          },
+          { summary: 'old' }
+        );
+      }
+
+      test('a sub-key null is inert when provenance is not declared mutable', () => {
+        expect(
+          bodyOnly().applyUpdate(undeclaredProvenanceRecord(), { provenance: { note: null } })
+        ).toSucceedAndSatisfy((updated) => {
+          expect(updated.envelope.provenance).toEqual({ source: 'agent', note: 'stale' });
+        });
+      });
+
+      test('a whole-block null is a silent no-op, not an error, when provenance is not declared mutable', () => {
+        expect(
+          bodyOnly().applyUpdate(undeclaredProvenanceRecord(), { provenance: null })
+        ).toSucceedAndSatisfy((updated) => {
+          expect(updated.envelope.provenance).toEqual({ source: 'agent', note: 'stale' });
+        });
+      });
+
+      test('declaring provenance mutable restores both guarantees', () => {
+        expect(
+          policy.applyUpdate(undeclaredProvenanceRecord(), { provenance: { note: null } })
+        ).toSucceedAndSatisfy((updated) => {
+          expect(updated.envelope.provenance).toEqual({ source: 'agent' });
+        });
+        expect(policy.applyUpdate(undeclaredProvenanceRecord(), { provenance: null })).toFailWith(
+          /may not delete required field\(s\): provenance/i
+        );
       });
     });
   });


### PR DESCRIPTION
## Why

PersonAIlity (a consumer) asked a narrow yes/no about `@fgv/ts-agent-memory`: is the RFC-7386 merge-patch behavior over a record's `provenance` the **intended, stable contract**, or an incidental consequence of the write policy's merge configuration? And is clearing a provenance **sub-key** via a `null` patch **sanctioned**?

**Yes on both.** This PR documents that guarantee where a consumer will find it — README + TSDoc at the API surface — and pins it with tests so the doc cannot silently drift.

**Documentation and tests only. No behavior change.**

## The guarantee held under independent verification

I did not take the premise on faith. I built the package on this branch and executed the behaviors against `lib/index.js`, then drove the same path end-to-end through `FileTreeMemoryStore`.

`KnowledgeLwwPolicy.applyUpdate`, existing provenance `{source:'agent', confidence:0.9, note:'keep me'}`:

| Patch | Observed |
|---|---|
| `{provenance: {note: null}}` | `{source:'agent', confidence:0.9}` — `note` cleared, siblings preserved |
| `{provenance: {confidence: 0.5}}` | `{source:'agent', confidence:0.5, note:'keep me'}` — per-key merge |
| `{provenance: null}` | fails `knowledge LWW: merge patch may not delete required field(s): provenance` |
| `{tags: ['x']}` | provenance untouched |

Also confirmed: the existing record is not mutated in place, and a cleared sub-key survives the YAML-frontmatter serialize/reload round trip.

**Nothing contradicts the premise.** Three findings extend it:

1. **Cross-policy parity.** `TemporalVersionedPolicy` behaves identically on all four rows, as does `MemoryCapCullPolicy` when `provenance` is declared mutable. All three share `MERGE_PATCH_OPTIONS`; only the error-message prefix differs. The contract is the shipped-policy contract, not a `KnowledgeLwwPolicy` quirk.
2. **The policy-dependence caveat is sharper than "may not apply".** With `MemoryCapCullPolicy.create({ mutableFields: ['body','tags'] })`, a provenance patch key is **inert** — a sub-key `null` does not clear, and a whole-block `null` is a **silent no-op, not an error**. This is the one place a consumer could be surprised, so it is called out in the README, on `IMemoryCapCullPolicyParams.mutableFields`, and pinned by tests.
3. **The whole-block delete is rejected at two different layers.** Policy layer: `applyUpdate` fails loudly. Store layer: not expressible — `IMemoryEnvelope.provenance` is non-nullable and `envelopeConverter` rejects `null`. The README names which layer catches it.

## What changed

- **`README.md`** — new `## Record updates — the merge contract` section: RFC-7386 as a pinned contract, per-key object merge, sub-key `null` clearing, wholesale array replace, loud rejection of a required-field delete, `embeddingRef`'s optional exception, out-of-surface keys ignored. Sub-sections for `provenance` on the pinned surface (worked example) and for the policy-dependence caveat.
  - The status banner claimed the package ships "no store, index, retrieval, observe, or vector code yet" — provably false, and it would have made the new section incoherent, so that one clause was corrected. **The rest of the surface inventory is still stale** (it lists only `types`/`converters`) and is deliberately left alone — a separate doc chore.
- **`writePolicy.ts` — TSDoc only.** `@remarks` on `IWritePolicy.applyUpdate` stating the four semantics + the policy-dependence rule at the API surface; a paragraph appended to `KnowledgeLwwPolicy`'s existing "Merge-surface pin" remark (built on, not replaced); `@remarks` on `IMemoryCapCullPolicyParams.mutableFields`.
- **Tests — additive only (217 added, 0 removed).** `writePolicy.test.ts`, `temporalPolicy.test.ts`, and `fileTreeMemoryStore.test.ts` each gain a README-named describe pinning the behaviors the doc claims.

## No behavior change — verified mechanically

Beyond reading the diff (every `writePolicy.ts` hunk sits inside a `/** */` block), I stripped block/line comments and blank lines from `writePolicy.ts` on this branch and on `origin/release` and compared: **identical**. No executable statement changed. All three test diffs are additive.

## Review loop

**Layer 1 — `code-reviewer` on the diff.** Recommendation *requires minor changes*; **no P1s**. The reviewer independently confirmed the no-behavior-change constraint and re-derived every merge behavior against the implementation.

Both P2s were the same class — *a doc claiming a stronger guarantee than the committed tests establish*. Since this stream's deliverable is documenting a guarantee **accurately**, both were resolved by **adding the missing tests**, not by softening the prose:

| # | Finding | Resolution |
|---|---|---|
| P2-1 | README said the guarantees are "pinned by tests" for **both** pinned-surface policies, but only `KnowledgeLwwPolicy` was covered. | Added a mirror describe to `temporalPolicy.test.ts` pinning the sub-key clear and whole-block rejection. The claim is now true for both. |
| P2-2 | The store-layer end-to-end claim and the `envelopeConverter`-rejects-`null` claim were asserted as fact but only manually verified. | Added a store test driving put→put→reopen (omitted key preserved, `null` key cleared, cleared key does not resurface from persisted frontmatter) plus one pinning the converter rejection site. |
| P3 | `writePolicy.ts` said the store stamps `updated`/`seq`; README said `updated`/`seq`/`contentHash`. Both true, inconsistent. | Aligned the TSDoc to the three-field form. |

Every claim the README makes is now backed by a committed test.

**Layer 2 — Copilot:** not yet run; this is the first push.

## Gates

- `rushx build` — pass (no `etc/*.api.md` movement; `@remarks` on members does not shift the API report)
- `rushx lint` — pass (`rushx fixlint` run before the final commit)
- `rushx test` — pass, **100% statements / branches / functions / lines**
- Rush change file added (`patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD)_