### PR TITLE
feat(ts-extras): typed failure reasons for LLM JSON parse errors

### DIFF
--- a/.ai/tasks/active/ai-assist-fenced-json-diagnostics/brief.md
+++ b/.ai/tasks/active/ai-assist-fenced-json-diagnostics/brief.md
@@ -1,0 +1,80 @@
+# Stream brief — `ai-assist-fenced-json-diagnostics`
+
+Priority: **P3 / opportunistic** — no consumer is blocked.
+
+## Problem
+
+PersonAIlity reports that when an LLM returns malformed JSON, a
+**property-name-position** parse failure surfaces the bare `JSON.parse` engine
+message with no typed reason, no offending token, and no offset. Four cases are
+indistinguishable to a caller:
+
+1. unquoted key — `{ key: 1 }`
+2. single-quoted key — `{ 'key': 1 }`
+3. unterminated name — `{ "key: 1 }`
+4. elision — `{ , "key": 1 }` / `{ "a":1, , "b":2 }`
+
+They want opposite handling per case: some are cheaply repairable, some warrant
+a re-prompt, some should fail outright. Today they cannot branch.
+
+**Scoping note the consumer got right:** PR #573 added a truncation-aware
+message for an ADJACENT case — a structure that opened but never closed. That
+fires in the extractor (`findBalancedJsonSubstring`) BEFORE `JSON.parse` and
+does not touch the property-name-position case. Do not conflate; preserve
+existing truncation behavior exactly.
+
+## Scope
+
+Add a typed failure reason to the JSON-parse path carrying at minimum:
+- a discriminated `kind` covering the four cases plus a catch-all,
+- the offending token/character where determinable,
+- the offset/position where determinable.
+
+Design constraints:
+- Follow the `found`/`unclosed`/`none` discriminated-result precedent in
+  `jsonResponse.ts`.
+- Do NOT regress the #573 truncation message or the generic "no JSON-shaped
+  substring found" message.
+- Classification must be **conservative** — fall back to the catch-all rather
+  than guessing. A confident wrong classification is worse than an honest
+  unknown.
+- Do NOT build the classifier by scraping `error.message` if the case is
+  determinable structurally from input + offset (V8 message formats vary across
+  Node versions).
+- `@public`-documented, appears in the API report, additive only.
+
+## Files in scope
+
+- `libraries/ts-extras/src/packlets/ai-assist/jsonResponse.ts`
+- `libraries/ts-extras/src/packlets/ai-assist/index.ts` (new export only)
+- `libraries/ts-extras/src/test/unit/ai-assist/**`
+- `libraries/ts-extras/etc/ts-extras.api.md` (regenerate)
+- `common/changes/@fgv/ts-extras/*.json`
+- `.ai/tasks/active/ai-assist-fenced-json-diagnostics/**`
+
+## Files out of scope (parallel streams own these)
+
+- `ai-assist/registry.ts`, `ai-assist/model.ts` (`ai-assist-alias-capability-guard`)
+- `ai-assist/apiClient.ts`
+- `samples/testbed/**`
+- `libraries/ts-agent-memory/**`
+- `docs/WORKSTREAMS.md`
+
+Sibling streams also regenerate `etc/ts-extras.api.md`; that conflict is
+expected and the orchestrator resolves it at integration by rebuilding.
+
+## Acceptance criteria
+
+- [ ] `rushx build` / `rushx lint` / `rushx test` pass with 100% coverage in `libraries/ts-extras`
+- [ ] `rushx fixlint` run before the final commit
+- [ ] No `any`; fallible operations return `Result<T>`
+- [ ] Each of the four named cases has a test asserting its distinct typed reason
+- [ ] A test asserts the #573 truncation case is UNCHANGED, and one asserts the generic no-JSON case is UNCHANGED
+- [ ] `@fgv/ts-prompt-assist` still builds
+- [ ] Scenario-driven tests BEFORE chasing measured coverage; `code-reviewer` BEFORE the coverage-closure pass
+- [ ] `code-reviewer` run on the final diff; findings resolved or dispositioned
+- [ ] Rush change file added; `etc/ts-extras.api.md` regenerated
+
+## Deliverable
+
+Commit, push, open a PR targeting `release`. Do NOT merge.

--- a/.ai/tasks/active/ai-assist-fenced-json-diagnostics/result.md
+++ b/.ai/tasks/active/ai-assist-fenced-json-diagnostics/result.md
@@ -135,6 +135,20 @@ The reviewer independently confirmed the design call that
 `'unknown'` as an explicit floor, so wrapping it would mirror the `Result<void>`
 anti-pattern.
 
+## Layer-2 review (Copilot) — handed off, NOT dispositioned by this stream
+
+Copilot review round 1 was requested on PR #579 and the
+`copilot-pull-request-reviewer` check completed with conclusion `success` at
+19:27 UTC. **Its findings were not retrievable** — the shared GitHub token was
+over its API rate limit, so the review comments could not be enumerated by this
+stream.
+
+Round 1's findings are therefore **undispositioned as of this artifact**, and the
+**orchestrator owns the Copilot loop for #579** from here: pulling the round-1
+findings once the rate limit resets, resolving or dispositioning them, and
+recording the stop reason on the PR. Nothing else in this stream is waiting on
+that.
+
 ## Gates
 
 | Gate | Result |

--- a/.ai/tasks/active/ai-assist-fenced-json-diagnostics/result.md
+++ b/.ai/tasks/active/ai-assist-fenced-json-diagnostics/result.md
@@ -1,0 +1,173 @@
+# Result — `ai-assist-fenced-json-diagnostics`
+
+**Status:** complete. P3 / opportunistic; no consumer was blocked.
+
+## What shipped
+
+One new `@public` export pair on `@fgv/ts-extras`'s `AiAssist` surface:
+
+```ts
+type JsonParseFailureReason =
+  | { readonly kind: 'unquoted-property-name';       readonly token: string; readonly offset: number }
+  | { readonly kind: 'single-quoted-property-name';  readonly token: string; readonly offset: number }
+  | { readonly kind: 'unterminated-property-name';   readonly token: string; readonly offset: number }
+  | { readonly kind: 'elided-member';                readonly token: string; readonly offset: number }
+  | { readonly kind: 'unknown' };
+
+function classifyJsonParseFailure(text: string): JsonParseFailureReason;
+```
+
+Intended use is on the failure path:
+
+```ts
+const parsed = fencedStringifiedJson({ inner }).convert(raw);
+if (parsed.isFailure()) {
+  switch (classifyJsonParseFailure(raw).kind) { /* repair | re-prompt | fail */ }
+}
+```
+
+Files: `libraries/ts-extras/src/packlets/ai-assist/jsonResponse.ts` (implementation),
+`.../ai-assist/index.ts` (two exports), `etc/ts-extras.api.md` (regenerated),
+`src/test/unit/ai-assist/jsonParseDiagnostics.test.ts` (new), plus a Rush change file.
+
+## Classification strategy
+
+**Structural, never engine-message-derived.** The classifier does not call `JSON.parse`
+and never reads an `Error.message`. It preprocesses the input exactly as
+`extractJsonText` does (BOM strip, trim, fence unwrap), finds the first `{`/`[`
+outside a quoted string, then walks the JSON grammar with an explicit
+`value` / `name` / `colon` / `comma` expectation plus a container stack, reporting the
+first fault it can name. Verdicts are therefore stable across Node/V8 versions by
+construction, which was the brief's central constraint.
+
+`offset` is a 0-based index into the **original** `text` argument, not the extracted
+substring. A test helper (`expectOffsetPointsAtToken`) asserts
+`text.charAt(reason.offset) === reason.token.charAt(0)` on every classified case,
+including the BOM, preamble, fence, and fence-plus-indent variants — so the offset
+arithmetic is pinned by an invariant, not by hand-computed constants alone.
+
+## What could be classified confidently — all four named cases
+
+| Case | Input | Verdict |
+|---|---|---|
+| 1. unquoted key | `{ key: 1 }` | `unquoted-property-name`, token `key`, offset 2 |
+| 2. single-quoted key | `{ 'key': 1 }` | `single-quoted-property-name`, token `'key'`, offset 2 |
+| 3. unterminated name | `{ "key: 1 }` | `unterminated-property-name`, token `"key: 1 }`, offset 2 |
+| 4. elision | `{ , "key": 1 }`, `{ "a":1, , "b":2 }` | `elided-member`, token `,` |
+
+Array elision (`[1, , 2]`, `[, 1]`) is included as well — structurally identical to the
+object case and equally confident. The brief named only the property-name position;
+covering arrays was free.
+
+## Limits of the strategy (read this before trusting a verdict)
+
+**Case 3 carries the only heuristic, and it is deliberately narrow.** Two surprises
+shaped it:
+
+1. `{ "key: 1 }` **never reaches `JSON.parse`.** `findBalancedJsonSubstring` treats the
+   trailing `}` as *inside* the unterminated string, so `extractJsonText` fails first
+   with the PR #573 truncation message. The classifier still handles the case because it
+   scans from the opening `{` whether or not a balanced substring was found.
+2. An unterminated string at a name position is genuinely ambiguous with a mid-name
+   truncation (`{ "descripti`). The adopted discriminator: classify as
+   `unterminated-property-name` **only when the swallowed body contains a `:`** — text the
+   author plainly meant as the name/value separator. Without a `:`, return `unknown`. An
+   unterminated string at a *value* position is never classified (that is the truncation
+   shape) — a structural distinction, not a heuristic.
+
+Both limits are stated in the TSDoc.
+
+## Deliberately left in the catch-all
+
+Not guesses, not oversights — each would have been a scope expansion or a false-confidence
+risk:
+
+- **Truncation** — already named by `extractJsonText`; the classifier does not compete.
+- **Trailing comma** (`{ "a": 1, }`) — falls out of the scanner and would be highly
+  confident, but it is not one of the four named cases. The most natural follow-on if the
+  consumer wants a fifth kind.
+- **Missing colon** (`{"a" 1}`), **missing comma** (`{"a":1 "b":2}`), **elided value**
+  (`{"a": , }`), **mismatched delimiter** (`{"a": [1, 2}`).
+- **Smart quotes** (typographic `“key”`) — not an identifier start, so `unknown` rather
+  than a wrong `unquoted-property-name`.
+- **Non-ASCII unquoted names** (`{ ключ: 1 }`) — identifier recognition is ASCII-only;
+  documented in the TSDoc and pinned by a test.
+- **Unquoted array values** (`[a, b]`) — not a property-name position.
+- `NaN` / `Infinity` literals, bad number literals, duplicate keys.
+
+## What stayed unchanged (verified, not asserted)
+
+`extractJsonText` and `fencedStringifiedJson` are behaviourally identical. The PR #573
+truncation message and the generic "no JSON-shaped substring found" message both have
+dedicated regression tests, alongside a test pinning `fencedStringifiedJson`'s raw
+`failed to parse json` propagation.
+
+The one behaviour-adjacent edit is the `FENCED_BLOCK` regex, regrouped so the opening
+fence is group 1 and the body group 2. This was needed to map a body offset back onto the
+original text exactly. Equivalence was proven by a 6804-input fuzz over language tags,
+separators, CRLF, empty bodies, backtick-containing bodies, BOM/preamble prefixes and
+multi-fence suffixes: old group 1 ≡ new group 2, with identical match index and matched
+text, and group 1 always exactly the match prefix.
+
+`extractJsonText`'s strip-wrappers preamble now routes through the shared
+`locateJsonCandidate` (the layer-1 P2 fix) rather than inlining BOM/trim/fence handling.
+Its two failure messages and their order are preserved exactly; the shared helper returns
+`stripped` alongside `text` specifically so the "input is empty" vs "no JSON content
+found" distinction survives the extraction.
+
+## Layer-1 review (`code-reviewer` on the diff)
+
+**APPROVED — no P1 blockers.** No `any`, no unsafe-cast type checks, no
+Result-pattern violation, termination of the `for(;;)` scan verified. All five
+brief constraints independently verified, including an adversarial probe that
+found no confidently-wrong verdict.
+
+| Finding | Disposition |
+|---|---|
+| **P2** — `extractJsonText`'s strip-wrappers preamble and the classifier's offset-base computation were two independent implementations of the same step; nothing enforced they stay in sync | **Fixed.** Extracted `locateJsonCandidate(text) → { stripped, text, base }`, used by both. `stripped` is on the result so `extractJsonText` keeps its two distinct failure messages in the original order without recomputing BOM/trim. |
+| **P3-1** — the ~99.96% coverage gap at the single-quote token ternary is reachable and intentional, not a branch to eliminate | **Fixed.** Closed with a real scenario test (`{ 'key: 1 }`), not a directive. Coverage now 100% with no `c8 ignore`. |
+| **P3-2** — `IDENTIFIER_START`/`PART` are ASCII-only, so `{ ключ: 1 }` reports `'unknown'` | **Applied.** Noted in the `JsonParseFailureReason` TSDoc and pinned by a test. Behaviour unchanged — it is the conservative-by-design outcome. |
+| **P3-3** — a fenced body containing a literal triple backtick mis-slices (lazy `[\s\S]*?` stops early); confirmed **pre-existing**, inherited bit-for-bit | **Dispositioned + logged.** Out of scope for this stream; new `docs/TECH_DEBT.md` P3 entry with trigger, scope sketch, and the note that the classifier degrades to `'unknown'` rather than compounding it. |
+| **P3-4** — the offset-invariant helper wasn't called from three tests | **Applied.** `expectOffsetPointsAtToken` now runs on every classified case. |
+
+The reviewer independently confirmed the design call that
+`classifyJsonParseFailure` should **not** return `Result<T>` — it is total, with
+`'unknown'` as an explicit floor, so wrapping it would mirror the `Result<void>`
+anti-pattern.
+
+## Gates
+
+| Gate | Result |
+|---|---|
+| `rushx build` (`libraries/ts-extras`) | pass |
+| `rushx lint` | pass, clean |
+| `rushx fixlint` + `prettier` | run before the final commit |
+| `rushx test` | 2046 passing, 0 failing |
+| Coverage | statements / branches / functions / lines all **100%** |
+| `rush build --to @fgv/ts-prompt-assist` | pass |
+| `etc/ts-extras.api.md` | regenerated |
+| Rush change file | added (`minor`) |
+| No `any` | confirmed |
+
+Layer-1 ordering was honoured: scenario-driven tests first, `code-reviewer` on the diff
+before the coverage-closure pass, then the single remaining branch closed with a real
+scenario test (`{ 'key: 1 }` — an unterminated single-quoted name), not a directive. No
+`c8 ignore` directives were added.
+
+## Notes for the orchestrator
+
+- `etc/ts-extras.api.md` will conflict with the sibling `ai-assist-alias-capability-guard`
+  stream; resolve by rebuilding, as anticipated in the brief.
+- This stream added one `docs/TECH_DEBT.md` P3 entry (the pre-existing fence/backtick
+  mis-slice), at the reviewer's request. `docs/WORKSTREAMS.md` was not touched.
+- The new `{@link AiAssist.*}` references bake `ae-unresolved-link` warnings into the API
+  report. This is the file's established behaviour for namespace-scoped links (298 such
+  warnings predate this change, including on `extractJsonText` itself) — sibling-consistent,
+  and not the cross-package case the review checklist prohibits.
+- Base was `origin/release` @ `fbb08cd55`, not the `b689c99ca` named in the brief;
+  `release` had already advanced. No overlap with the stream's surface.
+
+## Left undone
+
+Nothing from the brief. The trailing-comma kind is the one obvious additive follow-on, and
+is intentionally deferred rather than forgotten.

--- a/.ai/tasks/active/ai-assist-fenced-json-diagnostics/state.md
+++ b/.ai/tasks/active/ai-assist-fenced-json-diagnostics/state.md
@@ -1,0 +1,109 @@
+# State — `ai-assist-fenced-json-diagnostics`
+
+## Base
+
+Brief named `release @ b689c99ca`. `origin/release` had already advanced to
+`fbb08cd55` ("deps: repair root rush shim lockfile; bump @microsoft/rush to
+5.178.0 (#575)") by the time this stream started. Branched from current
+`origin/release` per the brief's "branch from release" instruction. No conflict
+with the stream's files.
+
+## Decisions
+
+### D1 — Standalone classifier, not a change to `fencedStringifiedJson`
+
+The parse step lives inside `JsonBaseConverters.stringifiedJson`, which this
+stream does not own, and `Converter<T>.convert` returns `Result<T>` — a string
+message, with no channel for typed detail. Three shapes were considered:
+
+1. A `DetailedResult`-returning parse entry point. Rejected: `Converter` cannot
+   carry detail, so this would need a parallel non-Converter pipeline and a
+   consumer rewrite.
+2. An `onParseFailure?: (reason) => void` diagnostics hook on
+   `IFencedStringifiedJsonExtractorOptions`. Rejected: a void side-channel
+   callback fits poorly with Result discipline, and it forces a change to the
+   converter path — the exact place the brief says not to regress.
+3. **A standalone `classifyJsonParseFailure(text)` the caller invokes on the
+   failure path.** Chosen. Purely additive, zero risk to existing messages, and
+   it gives the consumer exactly the branch they asked for at the cost of one
+   extra line at the call site.
+
+Consequence: `fencedStringifiedJson` and `extractJsonText` behaviour is
+**byte-identical** to before. The only behavioural surface added is the new
+export.
+
+### D2 — Structural scanner, never `error.message`
+
+The brief forbids scraping the engine message when the case is structurally
+determinable. It is, for all four cases, so the classifier never calls
+`JSON.parse` at all and never reads an `Error`. `scanForParseFailure` walks the
+JSON grammar with an explicit `value` / `name` / `colon` / `comma` expectation
+plus a container stack, and reports the first fault it can name. Verdicts are
+therefore stable across Node/V8 versions by construction.
+
+### D3 — Case 3 (unterminated name) needs a guard, and gets one
+
+Surprise: `{ "key: 1 }` never reaches `JSON.parse`. `findBalancedJsonSubstring`
+treats the trailing `}` as *inside* the unterminated string, so the extractor
+returns `'unclosed'` and fails with the **#573 truncation message**. So case 3
+is intercepted upstream of the parse path entirely.
+
+The classifier still handles it, because it scans the candidate from the
+opening `{` regardless of whether the extractor found a balanced substring
+(hence the added `start` field on the `'found'`/`'unclosed'` arms of the
+internal `BalancedJsonScanResult`).
+
+But an unterminated string at name position is genuinely ambiguous with a
+mid-name truncation (`{ "descripti`). The conservative discriminator adopted:
+classify as `'unterminated-property-name'` **only when the swallowed body
+contains a `:`** — text the author plainly meant as the name/value separator.
+Without a `:`, return `'unknown'`. This is the one arm with a documented
+heuristic; it is stated plainly in the TSDoc and in `result.md`.
+
+An unterminated string at *value* position is never classified (it is the
+truncation shape), which is a structural distinction, not a heuristic.
+
+### D4 — Deliberately NOT classified
+
+Kept in the catch-all on purpose, to avoid scope creep and false confidence:
+
+- **Trailing comma** (`{ "a": 1, }`) — falls out of the scanner naturally and
+  would be highly confident, but it is not one of the four named cases. Noted
+  as a natural follow-on rather than shipped.
+- **Missing colon** (`{ "a" 1 }`), **value elision** (`{ "a": , }`), bad number
+  literals, duplicate keys.
+- **Truncation** — already diagnosed by the extractor; the classifier
+  deliberately does not compete with it.
+
+### D5 — `offset` is against the caller's original `text`
+
+Rather than against the extracted substring, so a consumer can slice/point at
+the original model output directly. Making that exact required capturing the
+opening fence as its own group, so `FENCED_BLOCK` gained a group: it is now
+`/(```[A-Za-z0-9_-]*\s*\r?\n)([\s\S]*?)\r?\n?```/` and `extractJsonText` reads
+`fenced[2]` instead of `fenced[1]`. Behaviour of `extractJsonText` is
+unchanged; only the group index moved. Existing fence tests cover this.
+
+### D6 — Array elision included
+
+`[1, , 2]` is the same structural signal as the object case and equally
+confident, so `'elided-member'` covers both. The brief named only the
+property-name position; including arrays is free and documented.
+
+### D7 — `locateJsonCandidate` is the single source of truth (post-review)
+
+Initially `extractJsonText`'s strip-wrappers preamble and the classifier's
+offset-base computation were two independent implementations of the same step.
+The `code-reviewer` pass flagged this as its only P2: they agree today, but
+nothing enforces that they stay in sync, and a desync would silently point a
+classified `offset` into text the extractor never parsed.
+
+Resolved by extracting `locateJsonCandidate(text): { stripped, text, base }`,
+used by both. `stripped` is on the result specifically so `extractJsonText` can
+keep its two distinct failure messages in the original order (empty input →
+"input is empty"; non-empty input with an empty fenced body → "no JSON content
+found") without recomputing the BOM/trim step.
+
+## Gates
+
+(filled in at exit — see `result.md`)

--- a/common/changes/@fgv/ts-extras/ai-assist-fenced-json-diagnostics_2026-07-31-00-00.json
+++ b/common/changes/@fgv/ts-extras/ai-assist-fenced-json-diagnostics_2026-07-31-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add AiAssist.classifyJsonParseFailure and the JsonParseFailureReason discriminated union, so a caller whose LLM returned malformed JSON can branch on a typed failure class (unquoted / single-quoted / unterminated property name, elided member, or an honest 'unknown' catch-all) with the offending token and its offset into the original text, instead of regex-matching an engine-specific JSON.parse message. Classification is structural (never reads the engine error string, so verdicts are stable across Node versions) and deliberately conservative. Purely additive: extractJsonText and fencedStringifiedJson behaviour and messages — including the truncation-aware unclosed-structure diagnosis — are unchanged.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -127,6 +127,17 @@ opportunistically when the right surface area is touched.
 
 ## P3 — Opportunistic cleanup
 
+- **[P3] `ai-assist` fence extraction mis-slices a fenced body that itself contains a triple backtick.**
+  `FENCED_BLOCK` in `libraries/ts-extras/src/packlets/ai-assist/jsonResponse.ts` is a single lazy-body regex (`([\s\S]*?)` between an opening fence and the first following ` ``` `). When a model emits a fenced JSON block whose *body* contains a literal triple backtick — most plausibly inside a string value, e.g. ` ```json\n{"snippet": "``` foo ```"}\n``` ` — the lazy body stops at the inner backticks and `extractJsonText` hands `JSON.parse` a truncated candidate. Long-standing and **not introduced by the `ai-assist-fenced-json-diagnostics` stream**: that stream only renumbered the regex's capture groups (opening fence became group 1, body group 2, so a body offset can be mapped back to the original text), verified behaviour-preserving over a 6804-input fuzz. The new `classifyJsonParseFailure` degrades safely here — it reports `'unknown'` rather than compounding the mis-slice with a confident wrong verdict.
+
+  **Trigger**: the next time fence extraction is touched, or the first time a consumer reports a fenced response with embedded backticks failing to parse. Not urgent — the failure is loud (a parse failure), not silent.
+
+  **Scope sketch**: harden the fence scan — prefer counting the opening run's backtick length and matching a closing run of at least that length at a line start (the CommonMark rule), instead of the current first-` ``` `-wins lazy match. Keep `extractJsonText`'s messages unchanged; `locateJsonCandidate` is already the single source of truth for the strip-wrappers step, so the change lands in one place and both the extractor and the classifier follow.
+
+  **Not a P4**: it produces a wrong parse candidate, not just a cosmetic wart — a consumer sees a confusing `JSON.parse` failure on output the model actually formed correctly.
+
+  **Reference**: `ai-assist-fenced-json-diagnostics` stream; code-reviewer pass on that diff (2026-07-31), P3 finding 3.
+
 - **[P3] `ts-agent-memory` L2 `createMemoryTools` duplicates the store's codec wiring instead of delegating.**
   `createMemoryTools({ codecs?, defaultCodec? })` (`libraries/ts-agent-memory/src/packlets/tools/memoryTools.ts`) accepts the per-kind identity codecs a second time, in addition to `FileTreeMemoryStore.create({ codecs })`. `memory_write` needs them because `IMemoryStore.put` (`fileTreeMemoryStore.ts:496-502`) validates `envelope.id === codec-derived idStem` and does not derive/stamp the id itself — so a caller building a new `IMemoryRecord` must compute the same `idStem` up front, which requires the same codec the store was constructed with. The testbed scenario passes the same `codecs` map to both constructors, illustrating the drift risk: a host that re-wires the store's codecs but forgets the mirrored `createMemoryTools` config gets a confusing "envelope id does not match codec-derived stem" failure at `put()` time. Scope isolation is NOT compromised (codec `scope` is derived deterministically from `kind`, not from agent input; a mismatch loudly rejects the write rather than writing cross-scope), so this is a DX/robustness smell, not a security gap.
 

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -164,10 +164,12 @@ declare namespace AiAssist {
         modelSpecKey,
         modelSpec,
         resolveEffectiveTools,
+        classifyJsonParseFailure,
         extractJsonText,
         fencedStringifiedJson,
         IFencedStringifiedJsonExtractorOptions,
         IFencedStringifiedJsonOptions,
+        JsonParseFailureReason,
         JsonTextExtractor,
         generateJsonCompletion,
         SMART_JSON_PROMPT_HINT,
@@ -374,6 +376,15 @@ function callProxiedImageGeneration(proxyUrl: string, params: IProviderImageGene
 
 // @public
 function callProxiedListModels(proxyUrl: string, params: IProviderListModelsParams): Promise<Result<ReadonlyArray<IAiModelInfo>>>;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+function classifyJsonParseFailure(text: string): JsonParseFailureReason;
 
 declare namespace Constants {
     export {
@@ -1994,6 +2005,29 @@ interface JarRecordParserOptions {
     // (undocumented)
     readonly fixedContinuationSize?: number;
 }
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+type JsonParseFailureReason = {
+    readonly kind: 'unquoted-property-name';
+    readonly token: string;
+    readonly offset: number;
+} | {
+    readonly kind: 'single-quoted-property-name';
+    readonly token: string;
+    readonly offset: number;
+} | {
+    readonly kind: 'unterminated-property-name';
+    readonly token: string;
+    readonly offset: number;
+} | {
+    readonly kind: 'elided-member';
+    readonly token: string;
+    readonly offset: number;
+} | {
+    readonly kind: 'unknown';
+};
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver

--- a/libraries/ts-extras/src/packlets/ai-assist/index.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/index.ts
@@ -164,10 +164,12 @@ export {
 export { resolveEffectiveTools } from './toolFormats';
 
 export {
+  classifyJsonParseFailure,
   extractJsonText,
   fencedStringifiedJson,
   type IFencedStringifiedJsonExtractorOptions,
   type IFencedStringifiedJsonOptions,
+  type JsonParseFailureReason,
   type JsonTextExtractor
 } from './jsonResponse';
 

--- a/libraries/ts-extras/src/packlets/ai-assist/jsonResponse.ts
+++ b/libraries/ts-extras/src/packlets/ai-assist/jsonResponse.ts
@@ -44,7 +44,11 @@ import { Converters as JsonBaseConverters, type JsonValue } from '@fgv/ts-json-b
  */
 export type JsonTextExtractor = (text: string) => Result<string>;
 
-const FENCED_BLOCK: RegExp = /```[A-Za-z0-9_-]*\s*\r?\n([\s\S]*?)\r?\n?```/;
+// Group 1 is the opening fence (marker, optional language tag, newline) and
+// group 2 is the fenced body. Group 1 is captured only so a caller that needs
+// to map a position inside the body back onto an offset in the original text
+// can add its length instead of re-deriving the fence header.
+const FENCED_BLOCK: RegExp = /(```[A-Za-z0-9_-]*\s*\r?\n)([\s\S]*?)\r?\n?```/;
 const BOM: RegExp = /^\uFEFF/;
 // Full RFC 8259 grammar so the extractor only succeeds when the entire
 // candidate parses as a JSON primitive (instead of just starting like one).
@@ -67,11 +71,14 @@ function stripBom(text: string): string {
  *   opening delimiter's type (the scan tracks the candidate's own `{`/`}`
  *   or `[`/`]` pair, not total mixed-delimiter nesting).
  * - `'none'`: no `{` or `[` was ever seen outside a quoted string.
+ *
+ * `start` (present on `'found'` and `'unclosed'`) is the index of the opening
+ * `{` or `[` within the scanned text.
  * @internal
  */
 type BalancedJsonScanResult =
-  | { readonly kind: 'found'; readonly value: string }
-  | { readonly kind: 'unclosed'; readonly depth: number }
+  | { readonly kind: 'found'; readonly value: string; readonly start: number }
+  | { readonly kind: 'unclosed'; readonly depth: number; readonly start: number }
   | { readonly kind: 'none' };
 
 function findBalancedJsonSubstring(text: string): BalancedJsonScanResult {
@@ -115,11 +122,52 @@ function findBalancedJsonSubstring(text: string): BalancedJsonScanResult {
     } else if (ch === close) {
       depth--;
       if (depth === 0) {
-        return { kind: 'found', value: text.slice(start, i + 1) };
+        return { kind: 'found', value: text.slice(start, i + 1), start };
       }
     }
   }
-  return start >= 0 ? { kind: 'unclosed', depth } : { kind: 'none' };
+  return start >= 0 ? { kind: 'unclosed', depth, start } : { kind: 'none' };
+}
+
+/**
+ * The JSON-shaped candidate located within raw model text, plus where it
+ * starts in that text.
+ * @internal
+ */
+interface IJsonCandidate {
+  /** The whole input after BOM strip and trim, before any fence unwrap. */
+  readonly stripped: string;
+  /** The candidate itself: the trimmed fenced body when fenced, else `stripped`. */
+  readonly text: string;
+  /** Index of `text`'s first character within the original input. */
+  readonly base: number;
+}
+
+/**
+ * Strips the wrappers a model adds around JSON — byte-order mark, surrounding
+ * whitespace, Markdown code fence — and reports where what is left starts in
+ * the original text.
+ *
+ * Single source of truth for that step: {@link extractJsonText} and
+ * {@link classifyJsonParseFailure} must agree on what the candidate is, or a
+ * classified `offset` would point into text the extractor never parsed.
+ * @internal
+ */
+function locateJsonCandidate(text: string): IJsonCandidate {
+  const noBom = stripBom(text);
+  const stripped = noBom.trim();
+  const strippedBase = text.length - noBom.length + (noBom.length - noBom.trimStart().length);
+
+  const fenced = FENCED_BLOCK.exec(stripped);
+  if (fenced === null) {
+    return { stripped, text: stripped, base: strippedBase };
+  }
+  const body = fenced[2];
+  return {
+    stripped,
+    text: body.trim(),
+    base: strippedBase + fenced.index + fenced[1].length + (body.length - body.trimStart().length)
+  };
 }
 
 /**
@@ -148,14 +196,12 @@ export const extractJsonText: JsonTextExtractor = (text: string): Result<string>
   if (typeof text !== 'string') {
     return fail('extractJsonText: input must be a string.');
   }
-  const stripped = stripBom(text).trim();
-  if (stripped.length === 0) {
+  const located = locateJsonCandidate(text);
+  if (located.stripped.length === 0) {
     return fail('extractJsonText: input is empty.');
   }
 
-  const fenced = FENCED_BLOCK.exec(stripped);
-  const candidate = fenced ? fenced[1].trim() : stripped;
-
+  const candidate = located.text;
   if (candidate.length === 0) {
     return fail('extractJsonText: no JSON content found.');
   }
@@ -180,6 +226,297 @@ export const extractJsonText: JsonTextExtractor = (text: string): Result<string>
 
   return fail('extractJsonText: no JSON-shaped substring found.');
 };
+
+/**
+ * Typed reason a JSON-shaped LLM response failed to parse, so a caller can
+ * branch on the failure class instead of regex-matching the engine's
+ * `JSON.parse` message (whose wording varies across V8 / Node versions).
+ *
+ * Every classified arm describes a fault at an **object property-name
+ * position** — the position an LLM most often gets wrong, and the one whose
+ * repair strategy differs most by case:
+ *
+ * - `'unquoted-property-name'`: a bare identifier where a quoted name belongs
+ *   (`{ key: 1 }`). `token` is the identifier run, `offset` its first
+ *   character. Identifier recognition is ASCII-only, so a non-ASCII bare name
+ *   (`{ ключ: 1 }`) reports `'unknown'` rather than being named.
+ * - `'single-quoted-property-name'`: a single-quoted name (`{ 'key': 1 }`).
+ *   `token` is the quoted literal (or just `'` if it never closes), `offset`
+ *   the opening quote.
+ * - `'unterminated-property-name'`: a name whose closing `"` is missing, and
+ *   whose body swallowed structural text (`{ "key: 1 }`). `token` is the
+ *   unterminated fragment, `offset` the opening quote.
+ * - `'elided-member'`: a `,` where a member is expected — a leading or doubled
+ *   comma in an object (`{ , "a": 1 }`, `{ "a":1, , "b":2 }`) or an array
+ *   (`[1, , 2]`). `token` is `','`, `offset` its position.
+ * - `'unknown'`: the catch-all. The scan reached the end of the text, or hit a
+ *   fault it cannot name with confidence, and reports nothing rather than
+ *   guessing. Truncated responses, missing colons, trailing commas, bad number
+ *   literals, and anything else not listed above land here.
+ *
+ * `offset` is a 0-based index into the `text` passed to
+ * {@link AiAssist.classifyJsonParseFailure}, not into the extracted substring.
+ * @public
+ */
+export type JsonParseFailureReason =
+  | { readonly kind: 'unquoted-property-name'; readonly token: string; readonly offset: number }
+  | { readonly kind: 'single-quoted-property-name'; readonly token: string; readonly offset: number }
+  | { readonly kind: 'unterminated-property-name'; readonly token: string; readonly offset: number }
+  | { readonly kind: 'elided-member'; readonly token: string; readonly offset: number }
+  | { readonly kind: 'unknown' };
+
+const UNKNOWN_PARSE_FAILURE: JsonParseFailureReason = { kind: 'unknown' };
+
+const JSON_WHITESPACE: RegExp = /[ \t\n\r]/;
+const IDENTIFIER_START: RegExp = /[A-Za-z0-9_$]/;
+const IDENTIFIER_PART: RegExp = /[A-Za-z0-9_$.-]/;
+// Characters that end an unquoted value run (`true`, `null`, a number, or
+// garbage). Includes ':' so a stray colon at a value position produces an
+// empty run — reported as 'unknown' — instead of being swallowed by a literal.
+const VALUE_RUN_TERMINATOR: RegExp = /[\s,}\]:"'{[]/;
+
+/** Where the parse scan currently is within the JSON grammar. @internal */
+type JsonScanExpectation = 'value' | 'name' | 'colon' | 'comma';
+
+/** Result of scanning a quoted run starting at a given opening quote. @internal */
+interface IQuotedRunScan {
+  readonly terminated: boolean;
+  /** Index just past the closing quote, or end of text when unterminated. */
+  readonly end: number;
+  /** Content between the quotes, exclusive. */
+  readonly body: string;
+}
+
+function scanQuotedRun(text: string, start: number, quote: string): IQuotedRunScan {
+  let escape = false;
+  for (let i = start + 1; i < text.length; i++) {
+    const ch = text.charAt(i);
+    if (escape) {
+      escape = false;
+    } else if (ch === '\\') {
+      escape = true;
+    } else if (ch === quote) {
+      return { terminated: true, end: i + 1, body: text.slice(start + 1, i) };
+    }
+  }
+  return { terminated: false, end: text.length, body: text.slice(start + 1) };
+}
+
+function skipJsonWhitespace(text: string, from: number): number {
+  let i = from;
+  while (i < text.length && JSON_WHITESPACE.test(text.charAt(i))) {
+    i++;
+  }
+  return i;
+}
+
+function scanRun(text: string, from: number, isPart: (ch: string) => boolean): string {
+  let i = from;
+  while (i < text.length && isPart(text.charAt(i))) {
+    i++;
+  }
+  return text.slice(from, i);
+}
+
+function classifyAtPropertyName(
+  text: string,
+  i: number,
+  base: number
+): { readonly reason: JsonParseFailureReason } | { readonly next: number } {
+  const ch = text.charAt(i);
+  if (ch === '"') {
+    const scan = scanQuotedRun(text, i, '"');
+    if (scan.terminated) {
+      return { next: scan.end };
+    }
+    // An unterminated name is only distinguishable from a mid-name truncation
+    // when the swallowed body contains structural text — a ':' the author
+    // plainly meant as the name/value separator. Without that, stay honest.
+    return scan.body.includes(':')
+      ? { reason: { kind: 'unterminated-property-name', token: text.slice(i), offset: base + i } }
+      : { reason: UNKNOWN_PARSE_FAILURE };
+  }
+  if (ch === "'") {
+    const scan = scanQuotedRun(text, i, "'");
+    return {
+      reason: {
+        kind: 'single-quoted-property-name',
+        token: scan.terminated ? text.slice(i, scan.end) : "'",
+        offset: base + i
+      }
+    };
+  }
+  if (ch === ',') {
+    return { reason: { kind: 'elided-member', token: ',', offset: base + i } };
+  }
+  if (IDENTIFIER_START.test(ch)) {
+    return {
+      reason: {
+        kind: 'unquoted-property-name',
+        token: scanRun(text, i, (c) => IDENTIFIER_PART.test(c)),
+        offset: base + i
+      }
+    };
+  }
+  return { reason: UNKNOWN_PARSE_FAILURE };
+}
+
+/**
+ * Walks `text` from `from` (the opening `{` or `[`) as a permissive JSON
+ * scanner, reporting the first fault it can name with confidence. Anything it
+ * cannot name — including a document that scans clean — yields `'unknown'`.
+ *
+ * The scan is structural: it never reads the engine's `JSON.parse` message, so
+ * its verdicts do not drift with the Node version.
+ * @internal
+ */
+function scanForParseFailure(text: string, from: number, base: number): JsonParseFailureReason {
+  const stack: Array<'object' | 'array'> = [];
+  let expect: JsonScanExpectation = 'value';
+  let i = from;
+
+  for (;;) {
+    i = skipJsonWhitespace(text, i);
+    if (i >= text.length) {
+      return UNKNOWN_PARSE_FAILURE;
+    }
+    const ch = text.charAt(i);
+    const top = stack[stack.length - 1];
+
+    if (expect === 'name') {
+      if (ch === '}') {
+        stack.pop();
+        i++;
+        expect = 'comma';
+        continue;
+      }
+      const outcome = classifyAtPropertyName(text, i, base);
+      if ('reason' in outcome) {
+        return outcome.reason;
+      }
+      i = outcome.next;
+      expect = 'colon';
+      continue;
+    }
+
+    if (expect === 'colon') {
+      if (ch !== ':') {
+        return UNKNOWN_PARSE_FAILURE;
+      }
+      i++;
+      expect = 'value';
+      continue;
+    }
+
+    if (expect === 'value') {
+      if (ch === '{' || ch === '[') {
+        stack.push(ch === '{' ? 'object' : 'array');
+        i++;
+        expect = ch === '{' ? 'name' : 'value';
+        continue;
+      }
+      if (ch === ']' && top === 'array') {
+        stack.pop();
+        i++;
+        expect = 'comma';
+        continue;
+      }
+      if (ch === ',') {
+        return top === 'array'
+          ? { kind: 'elided-member', token: ',', offset: base + i }
+          : UNKNOWN_PARSE_FAILURE;
+      }
+      if (ch === '"') {
+        const scan = scanQuotedRun(text, i, '"');
+        if (!scan.terminated) {
+          // Could equally be a truncated value; the extractor already names
+          // truncation, so do not compete with it here.
+          return UNKNOWN_PARSE_FAILURE;
+        }
+        i = scan.end;
+        expect = 'comma';
+        continue;
+      }
+      const literal = scanRun(text, i, (c) => !VALUE_RUN_TERMINATOR.test(c));
+      if (literal.length === 0) {
+        return UNKNOWN_PARSE_FAILURE;
+      }
+      i += literal.length;
+      expect = 'comma';
+      continue;
+    }
+
+    // expect === 'comma': a complete value just closed.
+    if (top === undefined) {
+      return UNKNOWN_PARSE_FAILURE;
+    }
+    if (ch === ',') {
+      i++;
+      expect = top === 'object' ? 'name' : 'value';
+      continue;
+    }
+    if ((ch === '}' && top === 'object') || (ch === ']' && top === 'array')) {
+      stack.pop();
+      i++;
+      continue;
+    }
+    return UNKNOWN_PARSE_FAILURE;
+  }
+}
+
+/**
+ * Classifies why a JSON-shaped LLM response would not parse, returning a
+ * {@link AiAssist.JsonParseFailureReason} a caller can branch on — repair the
+ * cheap cases, re-prompt the expensive ones, fail outright on the rest —
+ * instead of regex-matching an engine-specific `JSON.parse` message.
+ *
+ * Pass the same raw model text you handed
+ * {@link AiAssist.fencedStringifiedJson} or {@link AiAssist.extractJsonText};
+ * this applies the same BOM / whitespace / fence / preamble handling before
+ * scanning, and reports `offset` against that original text.
+ *
+ * Classification is **structural and deliberately conservative**. The scan
+ * walks the JSON grammar itself rather than reading the engine's error string,
+ * so its verdicts are stable across Node versions — and any fault it cannot
+ * name with confidence comes back as `'unknown'` rather than a guess. In
+ * particular an input that opened a structure and never closed it (the
+ * truncated-response shape {@link AiAssist.extractJsonText} already diagnoses)
+ * classifies as `'unknown'` here; the two diagnostics are complementary, not
+ * competing.
+ *
+ * This never fails and never repairs — it only names the fault. It is a
+ * diagnostic on the failure path, so calling it on text that parses fine is
+ * harmless but pointless: it returns `'unknown'`.
+ *
+ * @example
+ * ```ts
+ * const parsed = fencedStringifiedJson({ inner }).convert(raw);
+ * if (parsed.isFailure()) {
+ *   const reason = classifyJsonParseFailure(raw);
+ *   switch (reason.kind) {
+ *     case 'unquoted-property-name': // cheap to repair
+ *     case 'single-quoted-property-name':
+ *       break;
+ *     case 'elided-member':
+ *     case 'unterminated-property-name': // worth a re-prompt
+ *       break;
+ *     default: // 'unknown' — fail outright
+ *   }
+ * }
+ * ```
+ *
+ * @param text - Raw model output (the same string handed to the extractor).
+ * @returns A {@link AiAssist.JsonParseFailureReason}.
+ * @public
+ */
+export function classifyJsonParseFailure(text: string): JsonParseFailureReason {
+  const candidate = locateJsonCandidate(text);
+  const scan = findBalancedJsonSubstring(candidate.text);
+  if (scan.kind === 'none') {
+    return UNKNOWN_PARSE_FAILURE;
+  }
+  return scanForParseFailure(candidate.text, scan.start, candidate.base);
+}
 
 /**
  * Options shared by every {@link AiAssist.fencedStringifiedJson} call.

--- a/libraries/ts-extras/src/test/unit/ai-assist/jsonParseDiagnostics.test.ts
+++ b/libraries/ts-extras/src/test/unit/ai-assist/jsonParseDiagnostics.test.ts
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import { AiAssist } from '../../..';
+
+const { classifyJsonParseFailure, extractJsonText, fencedStringifiedJson } = AiAssist;
+
+const UNKNOWN: AiAssist.JsonParseFailureReason = { kind: 'unknown' };
+
+/**
+ * Asserts that `offset` actually points at `token`'s first character within
+ * the ORIGINAL input, which is the contract the offset carries.
+ */
+function expectOffsetPointsAtToken(text: string, reason: AiAssist.JsonParseFailureReason): void {
+  expect(reason.kind).not.toBe('unknown');
+  if (reason.kind !== 'unknown') {
+    expect(text.charAt(reason.offset)).toBe(reason.token.charAt(0));
+  }
+}
+
+describe('classifyJsonParseFailure', () => {
+  describe('the four property-name-position cases the consumer must tell apart', () => {
+    test('names an unquoted property name, with its identifier and offset', () => {
+      const text = '{ key: 1 }';
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'unquoted-property-name',
+        token: 'key',
+        offset: 2
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('names a single-quoted property name, with the quoted literal and offset', () => {
+      const text = "{ 'key': 1 }";
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'single-quoted-property-name',
+        token: "'key'",
+        offset: 2
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('names a single-quoted property name whose closing quote never arrives', () => {
+      // The single-quote run is invisible to the extractor's string tracking,
+      // so this reaches the classifier as a balanced object; the reason still
+      // names the case, falling back to a bare quote for the token.
+      const text = "{ 'key: 1 }";
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'single-quoted-property-name',
+        token: "'",
+        offset: 2
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('names an unterminated property name, with the swallowed fragment and offset', () => {
+      const text = '{ "key: 1 }';
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'unterminated-property-name',
+        token: '"key: 1 }',
+        offset: 2
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('names a leading elision in an object', () => {
+      const text = '{ , "key": 1 }';
+      expect(classifyJsonParseFailure(text)).toEqual({ kind: 'elided-member', token: ',', offset: 2 });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('names a doubled-comma elision between object members', () => {
+      const text = '{ "a":1, , "b":2 }';
+      expect(classifyJsonParseFailure(text)).toEqual({ kind: 'elided-member', token: ',', offset: 9 });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('gives the four cases four distinct kinds', () => {
+      const kinds = ['{ key: 1 }', "{ 'key': 1 }", '{ "key: 1 }', '{ , "key": 1 }'].map(
+        (t) => classifyJsonParseFailure(t).kind
+      );
+      expect(new Set(kinds).size).toBe(4);
+    });
+  });
+
+  describe('elision beyond the property-name position', () => {
+    test('names a doubled-comma elision in an array', () => {
+      const text = '[1, , 2]';
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'elided-member',
+        token: ',',
+        offset: 4
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('names a leading elision in an array', () => {
+      const text = '[, 1]';
+      expect(classifyJsonParseFailure(text)).toEqual({ kind: 'elided-member', token: ',', offset: 1 });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+  });
+
+  describe('faults nested inside the document', () => {
+    test('finds an unquoted name inside a nested object', () => {
+      const text = '{"a": {b: 1}}';
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'unquoted-property-name',
+        token: 'b',
+        offset: 7
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('finds an unquoted name after a well-formed member', () => {
+      const text = '{"a": 1, key: 2}';
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'unquoted-property-name',
+        token: 'key',
+        offset: 9
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('finds an unquoted name after a member whose name contains an escaped quote', () => {
+      const text = '{"a\\"b": 1, key: 2}';
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'unquoted-property-name',
+        token: 'key',
+        offset: 12
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('finds an unquoted name after arrays and literals', () => {
+      const text = '{"a": [1, 2], "b": true, c: null}';
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'unquoted-property-name',
+        token: 'c',
+        offset: 25
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+  });
+
+  describe('offsets are reported against the original input, not the extracted substring', () => {
+    test('accounts for a conversational preamble', () => {
+      const text = 'Here you go: { key: 1 }';
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'unquoted-property-name',
+        token: 'key',
+        offset: 15
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('accounts for a Markdown code fence', () => {
+      const text = '```json\n{ key: 1 }\n```';
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'unquoted-property-name',
+        token: 'key',
+        offset: 10
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('accounts for whitespace between the fence and the JSON', () => {
+      const text = '```json\n   { key: 1 }\n```';
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'unquoted-property-name',
+        token: 'key',
+        offset: 13
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+
+    test('accounts for a byte-order mark and leading whitespace', () => {
+      const text = '﻿  { key: 1 }';
+      expect(classifyJsonParseFailure(text)).toEqual({
+        kind: 'unquoted-property-name',
+        token: 'key',
+        offset: 5
+      });
+      expectOffsetPointsAtToken(text, classifyJsonParseFailure(text));
+    });
+  });
+
+  describe('conservative fallback: honest unknown rather than a confident guess', () => {
+    test('does not diagnose a truncated response (the extractor already names that case)', () => {
+      expect(classifyJsonParseFailure('{"unclosed":')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('{"outer":{"inner":1')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('[1,2,3')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose a name truncated mid-token as an unterminated name', () => {
+      // Indistinguishable from a token-cap truncation: no swallowed ':' to go on.
+      expect(classifyJsonParseFailure('{ "descripti')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose a value string truncated mid-token', () => {
+      expect(classifyJsonParseFailure('{"a": "some long val')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose input with no JSON structure at all', () => {
+      expect(classifyJsonParseFailure('I cannot help with that.')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('   \n  ')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('42 trailing text')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose a trailing comma (deliberately left in the catch-all)', () => {
+      expect(classifyJsonParseFailure('{"a": 1, }')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('[1, 2, ]')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose a missing colon', () => {
+      expect(classifyJsonParseFailure('{"a" 1}')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose a missing comma between members', () => {
+      expect(classifyJsonParseFailure('{"a":1 "b":2}')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose an elided value', () => {
+      expect(classifyJsonParseFailure('{"a": , "b": 1}')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('{"a": }')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose a single-quoted value', () => {
+      expect(classifyJsonParseFailure('{"a": \'x\'}')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose a property-name position it cannot name', () => {
+      expect(classifyJsonParseFailure('{ @foo: 1 }')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose a non-ASCII unquoted name (identifier recognition is ASCII-only)', () => {
+      expect(classifyJsonParseFailure('{ ключ: 1 }')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose a mismatched closing delimiter', () => {
+      expect(classifyJsonParseFailure('{"a": [1, 2}')).toEqual(UNKNOWN);
+    });
+
+    test('does not diagnose trailing content after a complete value', () => {
+      expect(classifyJsonParseFailure('{"a":1} and then some prose')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('[1,2] and then some prose')).toEqual(UNKNOWN);
+    });
+
+    test('returns unknown for input that parses cleanly (harmless but pointless)', () => {
+      expect(classifyJsonParseFailure('{}')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('[]')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('{"a":1}')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('[1,2]')).toEqual(UNKNOWN);
+      expect(classifyJsonParseFailure('{"a":{"b":[1,2]},"c":"text with { } and , inside"}')).toEqual(UNKNOWN);
+    });
+  });
+
+  describe('classification is structural, not engine-message-derived', () => {
+    test('agrees with JSON.parse on which inputs are broken', () => {
+      const broken = ['{ key: 1 }', "{ 'key': 1 }", '{ "key: 1 }', '{ , "key": 1 }', '[1, , 2]'];
+      for (const text of broken) {
+        expect(() => JSON.parse(text)).toThrow();
+        expect(classifyJsonParseFailure(text).kind).not.toBe('unknown');
+      }
+    });
+  });
+});
+
+describe('existing extractor diagnostics are unchanged by the classifier', () => {
+  test('the truncation-aware message (PR #573) still fires, verbatim, for an unclosed structure', () => {
+    expect(extractJsonText('{"unclosed":')).toFailWith(
+      /JSON structure opened but never closed \(depth 1 at end of input\).*truncated.*maxTokens/i
+    );
+    expect(extractJsonText('{"outer":{"inner":1')).toFailWith(
+      /JSON structure opened but never closed \(depth 2 at end of input\)/i
+    );
+    // The unterminated-name case reaches the extractor as an unclosed structure
+    // too, so it keeps the truncation message; the typed reason is the added
+    // channel, not a replacement.
+    expect(extractJsonText('{ "key: 1 }')).toFailWith(/JSON structure opened but never closed/i);
+  });
+
+  test('the generic no-JSON message still fires, with no false-positive truncation diagnosis', () => {
+    expect(extractJsonText('I cannot help with that.')).toFailWith(/no JSON-shaped substring found/i);
+    expect(extractJsonText('I cannot help with that.')).not.toFailWith(/truncated/i);
+  });
+
+  test('fence, preamble and trailing-prose extraction are unaffected', () => {
+    expect(extractJsonText('```json\n{"a":1}\n```')).toSucceedWith('{"a":1}');
+    expect(extractJsonText('```\n{"a":1}\n```')).toSucceedWith('{"a":1}');
+    expect(extractJsonText('Here you go: {"a":1}. Enjoy!')).toSucceedWith('{"a":1}');
+    expect(extractJsonText('```json\n\n```')).toFailWith(/no JSON content/i);
+  });
+
+  test('fencedStringifiedJson still propagates the raw parse failure unchanged', () => {
+    expect(fencedStringifiedJson().convert('{not valid json}')).toFailWith(/failed to parse json/i);
+  });
+});


### PR DESCRIPTION
Stream: `ai-assist-fenced-json-diagnostics` (**P3 / opportunistic** — no consumer is blocked).

## Problem

When an LLM returns malformed JSON, a **property-name-position** parse failure surfaces the bare `JSON.parse` engine message with no typed reason, no offending token, and no offset. PersonAIlity reports that four cases are therefore indistinguishable — and they want *opposite* handling per case (some are cheaply repairable, some warrant a re-prompt, some should fail outright).

## Failure taxonomy

New `@public` pair on the `AiAssist` surface:

```ts
type JsonParseFailureReason =
  | { readonly kind: 'unquoted-property-name';      readonly token: string; readonly offset: number }
  | { readonly kind: 'single-quoted-property-name'; readonly token: string; readonly offset: number }
  | { readonly kind: 'unterminated-property-name';  readonly token: string; readonly offset: number }
  | { readonly kind: 'elided-member';               readonly token: string; readonly offset: number }
  | { readonly kind: 'unknown' };

function classifyJsonParseFailure(text: string): JsonParseFailureReason;
```

Intended use — on the failure path, no change to any existing call:

```ts
const parsed = fencedStringifiedJson({ inner }).convert(raw);
if (parsed.isFailure()) {
  switch (classifyJsonParseFailure(raw).kind) { /* repair | re-prompt | fail */ }
}
```

All four named cases classify confidently:

| Case | Input | Verdict |
|---|---|---|
| unquoted key | `{ key: 1 }` | `unquoted-property-name`, token `key`, offset 2 |
| single-quoted key | `{ 'key': 1 }` | `single-quoted-property-name`, token `'key'`, offset 2 |
| unterminated name | `{ "key: 1 }` | `unterminated-property-name`, token `"key: 1 }`, offset 2 |
| elision | `{ , "key": 1 }`, `{ "a":1, , "b":2 }` | `elided-member`, token `,` |

Array elision (`[1, , 2]`, `[, 1]`) is covered too — structurally identical and equally confident.

## Classification strategy

**Structural, never engine-message-derived.** The classifier does not call `JSON.parse` and never reads an `Error.message`. It preprocesses exactly as `extractJsonText` does (BOM strip, trim, fence unwrap), finds the first `{`/`[` outside a quoted string, then walks the JSON grammar with an explicit `value` / `name` / `colon` / `comma` expectation plus a container stack, reporting the first fault it can name. Verdicts are stable across Node/V8 versions by construction — the brief's central constraint.

`offset` indexes the **original** `text` argument, not the extracted substring. A test helper asserts `text.charAt(reason.offset) === reason.token.charAt(0)` on every classified case (BOM, preamble, fence, fence-plus-indent variants included), so the offset arithmetic is pinned by an invariant rather than by hand-computed constants alone.

## Limits (please read before trusting a verdict)

Two surprises shaped case 3, and it carries the only heuristic:

1. **`{ "key: 1 }` never reaches `JSON.parse`.** `findBalancedJsonSubstring` treats the trailing `}` as *inside* the unterminated string, so `extractJsonText` fails first with the PR #573 truncation message. The classifier still handles it because it scans from the opening `{` whether or not a balanced substring was found.
2. An unterminated string at a name position is genuinely ambiguous with a mid-name truncation (`{ "descripti`). The discriminator adopted: classify as `unterminated-property-name` **only when the swallowed body contains a `:`** — text the author plainly meant as the name/value separator. Without a `:`, return `unknown`. An unterminated string at a *value* position is never classified (that is the truncation shape) — a structural distinction, not a heuristic.

Both limits are stated in the TSDoc.

### Deliberately left in the catch-all

Not oversights — each would be scope creep or a false-confidence risk:

- **Truncation** — already named by `extractJsonText`; the classifier does not compete.
- **Trailing comma** (`{ "a": 1, }`) — falls out of the scanner and would be highly confident, but is not one of the four named cases. The most natural additive follow-on.
- **Missing colon**, **missing comma**, **elided value**, **mismatched delimiter**.
- **Smart quotes** (typographic `“key”`) and **non-ASCII bare names** (`{ ключ: 1 }`) — `unknown` rather than a wrong `unquoted-property-name`. The ASCII-only scope is documented and tested.
- **Unquoted array values** (`[a, b]`) — not a property-name position.
- `NaN` / `Infinity` literals, bad number literals, duplicate keys.

## What stayed unchanged (verified, not asserted)

`extractJsonText` and `fencedStringifiedJson` are behaviourally identical. Dedicated regression tests pin the #573 truncation message, the generic "no JSON-shaped substring found" message, and `fencedStringifiedJson`'s raw `failed to parse json` propagation.

The one behaviour-adjacent edit is the `FENCED_BLOCK` regex, regrouped so the opening fence is group 1 and the body group 2 — needed to map a body offset back onto the original text exactly. **Equivalence proven** by a 6804-input fuzz over language tags, separators, CRLF, empty bodies, backtick-containing bodies, BOM/preamble prefixes and multi-fence suffixes: old group 1 ≡ new group 2, identical match index and matched text, group 1 always exactly the match prefix.

## Gates

| Gate | Result |
|---|---|
| `rushx build` (`libraries/ts-extras`) | pass |
| **`rushx lint`** | pass, clean |
| `rushx fixlint` + `rush prettier` | run before the final commit |
| `rushx test` | 2046 passing, 0 failing |
| Coverage | statements / branches / functions / lines all **100%** |
| `rush build --to @fgv/ts-prompt-assist` | pass |
| `etc/ts-extras.api.md` | regenerated |
| Rush change file | added (`minor`) |
| No `any`; fallible ops return `Result<T>` | confirmed |

Layer-1 ordering honoured: scenario-driven tests → `code-reviewer` → coverage closure. The single remaining branch was closed with a **real scenario test** (`{ 'key: 1 }`, an unterminated single-quoted name), not a directive. **No `c8 ignore` directives added.**

## Layer-1 review summary (`code-reviewer` on the diff)

**APPROVED — no P1 blockers.** No `any`, no unsafe-cast type checks, no Result-pattern violation; termination of the `for(;;)` scan verified (every branch returns or strictly advances). All five brief constraints independently verified, including an adversarial probe that found **no confidently-wrong verdict**.

| Finding | Disposition |
|---|---|
| **P2** — `extractJsonText`'s strip-wrappers preamble and the classifier's offset-base computation were two independent implementations of the same step; nothing enforced they stay in sync, and a desync would silently point a classified `offset` into text the extractor never parsed | **Fixed.** Extracted `locateJsonCandidate(text) → { stripped, text, base }`, used by both. `stripped` is on the result so `extractJsonText` keeps its two distinct failure messages in the original order without recomputing BOM/trim. |
| **P3-1** — the ~99.96% coverage gap at the single-quote token ternary is reachable and intentional, not a branch to eliminate | **Fixed** with a real scenario test; 100% coverage, no directive. |
| **P3-2** — identifier recognition is ASCII-only, so `{ ключ: 1 }` reports `unknown` | **Applied.** Noted in the TSDoc and pinned by a test. Behaviour unchanged — it is the conservative-by-design outcome. |
| **P3-3** — a fenced body containing a literal triple backtick mis-slices (lazy `[\s\S]*?` stops early); confirmed **pre-existing**, inherited bit-for-bit by the capture-group renumbering | **Dispositioned + logged.** Out of scope here; new `docs/TECH_DEBT.md` P3 entry with trigger and scope sketch. The classifier degrades to `unknown` rather than compounding it. |
| **P3-4** — the offset-invariant helper wasn't called from three tests | **Applied.** It now runs on every classified case. |

The reviewer independently confirmed the design call that `classifyJsonParseFailure` should **not** return `Result<T>`: it is total, with `unknown` as an explicit floor, so wrapping it would mirror the `Result<void>` anti-pattern — and it matches the `BalancedJsonScanResult` precedent in the same file.

## Notes for the orchestrator

- `etc/ts-extras.api.md` will conflict with the sibling `ai-assist-alias-capability-guard` stream; resolve by rebuilding, as anticipated in the brief.
- The new `{@link AiAssist.*}` references bake `ae-unresolved-link` warnings into the API report. This is the file's established behaviour for namespace-scoped links (298 such warnings predate this change, including on `extractJsonText` itself) — sibling-consistent, and not the cross-package case the review checklist prohibits.
- This stream touched `docs/TECH_DEBT.md` (one added P3 entry, at the reviewer's request). `docs/WORKSTREAMS.md` was not touched.
- Base is `origin/release` @ `fbb08cd55`, not the `b689c99ca` named in the brief — `release` had already advanced. No overlap with this stream's surface.

Stream artifacts are in `.ai/tasks/active/ai-assist-fenced-json-diagnostics/`.

Copilot review loop: not yet started — will be driven on this PR next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD)_