### PR TITLE
docs: all-up STATUS tracker, round-2 triage, and stream ledger entries

### DIFF
--- a/.ai/notes/cross-repo-handoffs/personaility-asks-2026-07-round2.md
+++ b/.ai/notes/cross-repo-handoffs/personaility-asks-2026-07-round2.md
@@ -1,0 +1,188 @@
+# PersonAIlity → fgv asks, 2026-07 round 2
+
+**Received:** 2026-07-28 (Erik relayed). **All non-blocking** per the consumer.
+**Triaged against:** `release` @ `b689c99ca` (post #570 / #573 / #574) — i.e. one alpha
+*ahead* of the `5.1.0-45` the consumer adopted.
+
+Every claim below was checked against the code, and where possible **executed** rather than
+read. Two of the four asks turn out to be already answered; one is real and broader than
+reported; one is real as described.
+
+---
+
+## 1. Model-alias sharp edges — `@fgv/ts-extras` ai-assist (consumer P0)
+
+### (A) `resolveProviderModel`'s `context` has no `'tools'` member
+
+**Verdict: working as designed. The consumer's conclusion ("must hand-compose") is
+incorrect — but the doc defect that produced it is real.**
+
+`ModelSpecKey` is `'base' | 'advanced' | 'frontier' | 'image' | 'embedding'`
+(`model.ts`). The absence of `'tools'` is deliberate: `tools` and `thinking` were
+**removed** from the key set when the quality-tier axis landed. The design rule is
+*composition, not competition* — tools (server-side tools) and thinking (reasoning effort)
+are orthogonal **request** params that ride on top of whatever model the tier selected;
+they never select a model.
+
+So the chokepoint **is** usable from the tool path:
+
+```ts
+// tool-path caller — pass the tier (or omit for base). No hand-composition needed.
+const model = AiAssist.resolveProviderModel(descriptor, modelOverride, tier).orThrow();
+// tools/thinking then ride on the request, independent of which model came back.
+```
+
+**But the doc gap is genuine and worth fixing.** `resolveProviderModel`'s TSDoc documents
+the *mechanism* (ModelSpecKey walk → alias resolution) and says nothing about the
+tools/thinking rule; that rule lives only in `LIBRARY_CAPABILITIES.md`. A consumer reading
+the API surface alone sees a key set that omits their case and reasonably concludes the
+chokepoint doesn't cover them. Two independent consumers hand-rolled the walk — that is
+evidence about the docs, not about the API.
+
+**Proposed action (additive, cheap):** a `@remarks` block on `resolveProviderModel`
+stating that `tools`/`thinking` are not model selectors and that tool-path callers pass a
+tier; plus a matching note on `ModelSpecKey` explaining why the two keys are absent
+(they were removed, so their absence looks like an oversight rather than a decision).
+
+### (B) `resolveImageCapability` matches raw prefixes with no alias guard
+
+**Verdict: confirmed real — and materially worse than reported. Also affects a sibling
+function the consumer did not test, and has an in-repo instance.**
+
+The report describes a confident *"not capable"*. What actually happens is worse: the
+alias form matches the catch-all `modelPrefix: ''` and returns a **different, wrong
+capability** — so the caller gets confident *wrong* metadata, not an obvious negative.
+
+Executed against `release`:
+
+| Provider | Alias form | Capability from alias | Capability from concrete id |
+|---|---|---|---|
+| `openai` | `@openai:image` | `{prefix:'', style:'response-format'}` | `{prefix:'gpt-image-', refs:true, style:'output-format'}` |
+| `xai-grok` | `@xai-grok:imagine` | `{format:'xai-images', refs:false}` | `{format:'xai-images-edits', refs:true}` |
+| `google-gemini` | `@google-gemini:flash-image` | *(no mismatch — single catch-all rule)* | same |
+
+Note the xAI row flips both the **wire format** (`xai-images` vs `xai-images-edits`) and
+`acceptsImageReferenceInput`. A consumer branching on those builds the wrong request.
+
+**The sibling has it too.** `resolveEmbeddingCapability` is the same prefix-match shape and
+the same hazard — untested by the consumer:
+
+| Provider | Alias form | From alias | From concrete |
+|---|---|---|---|
+| `openai` | `@openai:embedding` | `{prefix:'', format:'openai-embeddings'}` | `{prefix:'text-embedding-3', supportsDimensions:true, maxBatchSize:2048}` |
+
+So the alias form silently drops `supportsDimensions` and the `maxBatchSize` guard.
+
+**The library's own call path is safe.** `callProviderImageGeneration` resolves the alias
+(`apiClient.ts:1336`) *before* resolving capability (`:1341`). The hazard is exclusively
+for consumers calling the public helpers directly — which is what these are exported for.
+
+**In-repo instance (ours).** `samples/testbed`'s `image-generation` scenario does exactly
+this: `defaultModelFor` returns `AiAssist.resolveModel(descriptor.defaultModel, 'image')`
+— the **alias** form (`index.tsx:45`) — and feeds it to `resolveImageCapability`
+(`index.tsx:89`). Result: for the OpenAI and xAI defaults the scenario resolves the wrong
+capability, suppressing the "use as reference" affordance and offering the wrong
+size/quality options. Not published (it is a sample), but it is the scenario that just
+replaced the retired `ai-image-gen-sample`, so it should be fixed.
+
+**Proposed action:** make both capability resolvers alias-aware, or fail loudly when handed
+a `MODEL_ALIAS_SIGIL`-prefixed id. Failing loudly is the smaller change and matches the
+registry-gated posture everywhere else (an unregistered `@alias` already fails rather than
+hitting the wire); silently matching `''` is the outlier. Then fix the testbed call site.
+
+---
+
+## 2. Record-provenance merge contract — `@fgv/ts-agent-memory` (consumer P0)
+
+**Verdict: yes to both halves of the narrowed question. Evidence below.**
+
+**Is it intended and stable, or incidental?** Intended. `provenance` sits in
+`KnowledgeLwwPolicy.mutableFields` alongside `body` / `tags` / `links` / `embeddingRef`,
+under a TSDoc block headed **"Merge-surface pin (resolves design-lock §5.3's
+body-vs-envelope muddle)"** — it is a deliberately pinned contract that resolves a named
+design ambiguity, not a side effect of the current merge config.
+
+**Is clearing a provenance sub-key via `null` sanctioned?** Yes — and the block itself is
+protected. Executed against the built library:
+
+| Patch | Result |
+|---|---|
+| `{provenance: {note: null}}` | `note` removed; `source`/`confidence` preserved ✅ |
+| `{provenance: {confidence: 0.5}}` | per-key merge; `note` preserved ✅ |
+| `{provenance: null}` | **fails loudly**: `"knowledge LWW: merge patch may not delete required field(s): provenance"` |
+| `{tags: ['x']}` | provenance untouched ✅ |
+
+So: sub-key `null` clearing works per RFC-7386 and is safe to depend on; whole-block
+deletion is explicitly rejected rather than silently accepted. The per-key merge guarantee
+the consumer depends on holds.
+
+**Action: none in code.** This is an answer to relay, optionally with the guarantee written
+into the package README so the next consumer doesn't have to ask.
+
+---
+
+## 3. WebAuthn server/client — R11 / R12 (consumer P2)
+
+**Verdict: already shipped. This is a discovery failure, not a capability gap — and the
+open decision it carries (Q3) was decided and shipped 2.5 months ago.**
+
+The consumer reports "zero WebAuthn or passkey surface in any installed @fgv package."
+That is accurate *about their install set* and misleading as a conclusion:
+
+- **`@fgv/ts-extras-webauthn`** and **`@fgv/ts-web-extras-webauthn`** exist on `release`,
+  `shouldPublish: true`, version `5.1.0`.
+- They landed **2026-05-12** via #351 (crypto-batch-2 cluster) — roughly 2.5 months before
+  the `-45` alpha they adopted.
+- They are **separate packages**, not surface inside `@fgv/ts-extras` /
+  `@fgv/ts-web-extras`. R11/R12 were originally filed against those two packages, so a
+  search of the installed set finds nothing and looks like absence.
+
+The six primitives are exactly the four server-side (`generateRegistrationOptions`,
+`verifyRegistrationResponse`, `generateAuthenticationOptions`,
+`verifyAuthenticationResponse`) plus the two browser-side ceremony starters.
+
+**Q3 (wrap vs delegate) is already answered by what shipped:** a thin Result-integration
+boundary over `@simplewebauthn/*` — exception → `Result<T>` and nothing else. Ceremony
+orchestration, challenge management, credential storage, PRF helpers, and attestation
+policy are all **explicitly out of scope** and enumerated as such in the package README.
+That also disposes of the RP-ID adjudication concern: nothing in the shipped surface takes
+a position on RP-ID or native-passkey policy, so there is no decision left to defer.
+
+**Action: none for us** beyond confirming the packages are in the next alpha (they are —
+`shouldPublish: true`). For the consumer: install the two packages, and re-read the ask
+against the shipped README before re-filing.
+
+---
+
+## 4. `fencedStringifiedJson` failure diagnostics (consumer P3)
+
+**Verdict: real, accurately characterized, correctly prioritized.**
+
+A property-name-position parse failure still surfaces the bare `JSON.parse` message with no
+typed reason, offending token, or offset — so unquoted key / single-quoted key /
+unterminated name / elision are indistinguishable, and they do want opposite handling
+(repair vs re-prompt vs fail).
+
+The consumer's own caveat is correct and worth echoing: #573 added a distinct
+truncation-aware message for an adjacent case (structure opened but never closed → points
+at `truncated` / `maxTokens`), but it fires in the **extractor**, before `JSON.parse`, and
+does not touch the property-name-position case.
+
+**Proposed action:** a typed failure reason on the JSON path (discriminated, in the shape
+of the `found`/`unclosed`/`none` scan result #573 introduced) carrying reason + offset +
+offending token. Genuinely opportunistic — no consumer is blocked.
+
+---
+
+## Summary for the reply
+
+| Ask | Verdict | Work for us |
+|---|---|---|
+| (A) `'tools'` ModelSpecKey | By design; consumer's workaround unnecessary | TSDoc `@remarks` only |
+| (B) capability alias guard | **Real, broader than reported** (also `resolveEmbeddingCapability`; wrong-metadata not just false-negative) | Guard both resolvers + fix testbed call site |
+| Provenance merge contract | **Answered yes, both halves** (evidence above) | None; optionally document in README |
+| WebAuthn R11/R12 | **Already shipped** since 2026-05-12; separate packages | None; tell them to install |
+| Fenced-JSON diagnostics | Real, P3 | Typed failure reason, opportunistic |
+
+Net: one genuine bug to fix (B, plus its sibling and our own call site), two doc/relay
+answers, one opportunistic ergonomic improvement. Nothing blocks the current publish.

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -377,6 +377,42 @@ landed against the firmed seven-question contract (#561 / #562 / #563). **N-Ask8
 `@fgv/ts-agent-memory-sqlite-vec` is the persistent index it asked about. Both were
 non-blocking throughout, and with them the personaility→fgv ask queue is closed out.
 
+> **REOPENED (2026-07-28) — round 2.** A new batch of five asks arrived, all non-blocking.
+> Triage against `release` @ `b689c99ca` found that **two were already answered**: WebAuthn
+> R11/R12 shipped 2026-05-12 (#351) as the separate `@fgv/ts-extras-webauthn` /
+> `@fgv/ts-web-extras-webauthn` packages (the consumer searched inside `ts-extras` /
+> `ts-web-extras` and concluded absence), and the `@fgv/ts-agent-memory` provenance merge
+> contract is a deliberately pinned guarantee with sub-key `null` clearing sanctioned and
+> whole-block deletion rejected (verified by execution). One ask is a genuine bug, broader
+> than reported — see the capability-resolver entry below. Full triage with evidence:
+> [`.ai/notes/cross-repo-handoffs/personaility-asks-2026-07-round2.md`](../.ai/notes/cross-repo-handoffs/personaility-asks-2026-07-round2.md).
+
+### Alias-unsafe capability resolvers — `resolveImageCapability` / `resolveEmbeddingCapability`
+
+**Priority: the one real defect in the personaility round-2 batch.** Both functions
+prefix-match a raw model id with no alias resolution and no `MODEL_ALIAS_SIGIL` guard, so an
+fgv alias (`@openai:image`, `@xai-grok:imagine`, `@openai:embedding`) falls through to the
+catch-all `modelPrefix: ''` rule and returns a **confidently wrong capability** rather than
+failing. Verified by execution on `release`: the xAI image alias flips both the wire format
+(`xai-images` vs `xai-images-edits`) and `acceptsImageReferenceInput`; the OpenAI embedding
+alias silently drops `supportsDimensions` and the `maxBatchSize` guard.
+
+The library's own paths are safe (`callProviderImageGeneration` resolves the alias before
+resolving capability), so this is purely a hazard for consumers calling the exported helpers
+— which is what they exist for. `samples/testbed`'s `image-generation` scenario is an
+in-repo instance (`index.tsx:45` produces the alias form, `:89` consumes it).
+
+**Scope sketch**: make both resolvers alias-aware, or fail loudly on a sigil-prefixed id
+(the smaller change, and consistent with the registry-gated posture elsewhere — an
+unregistered `@alias` already fails rather than reaching the wire; silently matching `''` is
+the outlier). Then fix the testbed call site. Include a `@remarks` block on
+`resolveProviderModel` / `ModelSpecKey` noting that `tools` / `thinking` are deliberately
+not model selectors — the absence of a `'tools'` key reads as an oversight and has now sent
+two consumers down a hand-rolled-walk path they didn't need.
+
+**Not blocking**: the consumer is fixed and green on `-45`; no shipped `@fgv/*` code path
+is affected.
+
 ### Input-side `resolveHandle` (inverse of `handleFor`) — conditional, build-ready
 
 `createMemoryTools`' `handleFor` hook maps a record → an agent-visible mnemonic on

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,151 @@
+# All-up status — fgv
+
+**Last updated:** 2026-07-31 (orchestrator). Snapshot of everything in flight: open PRs,
+running agent streams, consumer asks, and what is blocking the next publish.
+
+This is the "what is happening right now" doc. `docs/WORKSTREAMS.md` is the per-stream
+kickoff ledger; `docs/FUTURE.md` and `docs/TECH_DEBT.md` are the deferred-work backlogs.
+
+---
+
+## Publish state
+
+**Last published alpha: `5.1.0-45`.** No `-46` tags exist — **the next alpha has not been
+published.** `release` has advanced four PRs past `-45` (#570, #573, #574, #575), so the
+publish is pending, not done.
+
+`prerelease` (PR #256, standing) mirrors `release` for the npm-publish workflow.
+
+**What `-46` will carry that `-45` does not:**
+
+| Change | PR | Note |
+|---|---|---|
+| Anthropic adaptive-thinking fix | #570 | `-45` **carries this bug** — Claude 5 + thinking HTTP 400s |
+| `AiAssist.providerApiKeySecretName` | #570 | new canonical provider-secret naming |
+| Caller-configurable `maxTokens` | #573 | + truncation-aware `extractJsonText` diagnosis |
+| xAI alias registry + `grok-4.5` advanced tier | #574 | live-verified by Erik |
+| `ai-image-gen-sample` retired | #574 | testbed is the canonical sample app |
+| Root rush shim lockfile repair | #575 | was invalid JSON; `npm ci` at repo root was broken |
+
+The adaptive-thinking fix is the one with consumer-visible urgency.
+
+---
+
+## Open PRs
+
+| PR | Title | Base | State |
+|---|---|---|---|
+| [#577](https://github.com/ErikFortune/fgv/pull/577) | `fix(ai-assist)`: guard capability resolvers against unresolved model aliases | `release` | 🔵 open — needs review |
+| [#576](https://github.com/ErikFortune/fgv/pull/576) | `docs`: triage personaility round-2 asks | `release` | 🔵 open — docs only |
+| [#256](https://github.com/ErikFortune/fgv/pull/256) | Prerelease branch changes | `release` | ⏸️ standing (publish plumbing) |
+| [#154](https://github.com/ErikFortune/fgv/pull/154) | Release branch | `main` | ⏸️ standing (promotion) |
+| [#572](https://github.com/ErikFortune/fgv/pull/572) | Bump `@microsoft/rush` 5.177.2 → 5.178.0 | `main` | 🟡 superseded on `release` by #575 |
+| [#567](https://github.com/ErikFortune/fgv/pull/567) | Bump `fast-xml-parser` 5.10.0 → 5.10.1 | `main` | 🟡 superseded on `release` by #575 |
+
+**Recently merged:** #570, #573, #574 (the pre-publish stack), #575 (root shim repair).
+
+**Note on #572 / #567:** both target `main` and only touch the repo-root rush bootstrap shim.
+`release` got the equivalent (and a repair of a pre-existing invalid lockfile) via #575. They
+will likely close as superseded once `release` merges up to `main`; no action before publish.
+
+---
+
+## Agent streams in flight
+
+Commissioned from the personaility round-2 triage. All branch from `release`, all open PRs
+against `release`, none self-merge.
+
+| Stream | State | Notes |
+|---|---|---|
+| `ai-assist-alias-capability-guard` | ✅ **PR #577 open** | The one real defect from round 2 |
+| `ai-assist-fenced-json-diagnostics` | 🔵 **resumed** | Agent stalled pre-commit overnight; work intact in worktree, resumed 2026-07-31 |
+| `agent-memory-provenance-contract-doc` | 🔵 **resumed** | Same — stalled pre-commit, work intact, resumed 2026-07-31 |
+
+**Overnight-stall postmortem.** Two of three agents completed their implementation work but
+stopped before committing. Nothing was lost — the worktrees retained the full diffs
+(`.claude/worktrees/agent-*`), and both were resumed from their transcripts with context
+intact. **Lesson: a stream is not "done" when the agent goes quiet — verify by branch push +
+PR existence, not by absence of a failure.** The check that surfaced this is cheap and worth
+making routine:
+
+```sh
+git ls-remote --heads origin <branch>   # did it push?
+git worktree list                        # is there uncommitted work stranded?
+git -C .claude/worktrees/agent-<id> status --short
+```
+
+---
+
+## Consumer asks — personaility
+
+### Round 2 (2026-07-28) — triaged, answered
+
+Full triage: `.ai/notes/cross-repo-handoffs/personaility-asks-2026-07-round2.md`.
+Reply draft: `.ai/notes/cross-repo-handoffs/personaility-reply-2026-07-round2.md`.
+
+| Ask | Verdict | Status |
+|---|---|---|
+| (A) no `'tools'` in `ModelSpecKey` | Working as designed; doc defect real | TSDoc in #577 |
+| (B) capability resolvers alias-unsafe | **Real, broader than reported** | PR #577 |
+| Provenance merge contract | **Answered yes, both halves** | Doc stream resumed |
+| WebAuthn R11 / R12 | **Already shipped** 2026-05-12 (#351) | Nothing to build |
+| Fenced-JSON diagnostics | Real, P3 | Stream resumed |
+
+### Round 3 (2026-07-31) — incoming
+
+| Ask | State |
+|---|---|
+| N-Ask5 Q3 — opaque `fragmentId` alongside the span | 🟡 assessed, not yet commissioned — see below |
+| (further asks) | ⏳ awaiting relay from Erik |
+
+**N-Ask5 Q3 assessment.** Accept. Type-level change is genuinely additive — `fragmentId?` on
+`IEmbeddedFragment` and `IVectorQueryHit`, and `FragmentEmbedder` is consumer-supplied so the
+id needs no new store plumbing. Two findings to carry back: (1) the SQLite schema change is
+**not** additive on disk — see the re-index policy below; (2) `IEmbeddedFragment.locator` is
+**required** on input while `IVectorQueryHit.locator` is optional on output, so a rewriting
+segmenter with no honest span must fabricate offsets — ask them whether `locator` should
+become optional on input when `fragmentId` is present.
+
+---
+
+## Policy: schema changes to persistent vector indexes require a full re-index
+
+**Decided 2026-07-31 (Erik).** Formalized here because the `@fgv/ts-agent-memory-sqlite-vec`
+indexes persist across process restarts, so any change to their `vec0` table shape is a
+migration event for existing databases.
+
+**The policy.** A change to the `vec0` schema of `SqliteVecVectorIndex` or
+`SqliteVecFragmentIndex` — adding, removing, or retyping a column, including auxiliary
+columns — **requires consumers to drop the table and re-index**. We do not ship in-place
+migrations for these tables.
+
+**Why this is acceptable.** `@fgv/ts-agent-memory` is on the active-development surface
+(breaking changes land freely without shims), the sqlite-vec package is new, and the vectors
+are always re-derivable from the records — a re-index costs embedding time, never data.
+
+**What the policy obliges us to do.** Because "no re-embedding on open" is the package's
+headline value, a consumer must not discover the migration as an opaque SQLite error:
+
+1. **Detect the schema mismatch on open** — the index already recovers the established
+   dimension by parsing the stored `CREATE VIRTUAL TABLE` SQL; the same parse can compare the
+   auxiliary-column set.
+2. **Fail loudly and actionably** — name the expected vs. found columns and say a re-index is
+   required. Today a widened `INSERT` against a narrower table surfaces as
+   `no such column: <name>` at statement-prepare time, which is not diagnosable.
+3. **Say it in the package README**, so it is a known contract rather than a surprise.
+
+**Current status:** not an issue in practice today — the fragment index shipped 2026-07-20
+and the only consumer is re-ingesting anyway as it moves to model-chosen segmentation. The
+policy is being formalized *before* the first schema change (the N-Ask5 Q3 `fragmentId`
+column) rather than after.
+
+---
+
+## What needs Erik
+
+1. **Review + merge #577** (capability-resolver guard) and **#576** (docs).
+2. **Publish `-46`** — carries the adaptive-thinking fix that `-45` is missing.
+3. **Relay the round-2 reply** to personaility.
+4. **Round-3 asks** — relay the rest of the batch so they can be scoped together (they may
+   share `vectorIndex.ts`, and overlapping streams on one file are the thing the
+   package-surface declarations exist to prevent).

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -242,6 +242,39 @@ Design-triage-implement shape is likely; new public API has real consequences.
 
 ---
 
+### `ai-assist-alias-capability-guard` 🔵
+
+**Status:** 🔵 in flight (overnight 2026-07-28). Branches from `release` @ `b689c99ca`. Consumer: PersonAIlity (round-2 ask B + A).
+**Package surface:** `@fgv/ts-extras/ai-assist` (`registry.ts`, `model.ts` TSDoc only), `samples/testbed` (`scenarios/imageGeneration/`).
+**Out-of-scope:** `packlets/ai-assist/jsonResponse.ts` (owned by `ai-assist-fenced-json-diagnostics`), all of `@fgv/ts-agent-memory`, `docs/WORKSTREAMS.md` (orchestrator-owned).
+**Brief:** `.ai/tasks/active/ai-assist-alias-capability-guard/brief.md`.
+
+**Mission.** `resolveImageCapability` and `resolveEmbeddingCapability` prefix-match a raw model id with no alias resolution and no `MODEL_ALIAS_SIGIL` guard, so an fgv alias falls through to the catch-all `modelPrefix: ''` and returns a **confidently wrong capability** — verified by execution: the xAI image alias flips both wire format and `acceptsImageReferenceInput`; the OpenAI embedding alias drops `supportsDimensions` + `maxBatchSize`. Guard both resolvers, fix the in-repo instance in the testbed image-generation scenario, and add the `@remarks` note that `tools`/`thinking` are deliberately not model selectors (ask A — the absence of a `'tools'` key has now sent two consumers down an unnecessary hand-rolled walk).
+
+---
+
+### `ai-assist-fenced-json-diagnostics` 🔵
+
+**Status:** 🔵 in flight (overnight 2026-07-28). Branches from `release` @ `b689c99ca`. Consumer: PersonAIlity (round-2 P3).
+**Package surface:** `@fgv/ts-extras/ai-assist` (`jsonResponse.ts` + its tests).
+**Out-of-scope:** `registry.ts`, `model.ts`, `apiClient.ts`, `samples/testbed`, `docs/WORKSTREAMS.md`.
+**Brief:** `.ai/tasks/active/ai-assist-fenced-json-diagnostics/brief.md`.
+
+**Mission.** A property-name-position `JSON.parse` failure surfaces the bare engine message with no typed reason, offending token, or offset — so unquoted key / single-quoted key / unterminated name / elision are indistinguishable, and they want opposite handling (repair vs re-prompt vs fail). Add a typed failure reason in the shape of the `found`/`unclosed`/`none` scan result that #573 introduced. Note #573's truncation diagnosis fires in the *extractor*, before `JSON.parse`, and does not cover this case.
+
+---
+
+### `agent-memory-provenance-contract-doc` 🔵
+
+**Status:** 🔵 in flight (overnight 2026-07-28). Branches from `release` @ `b689c99ca`. Consumer: PersonAIlity (round-2 P0, doc-only outcome).
+**Package surface:** `@fgv/ts-agent-memory` (README + `writePolicy.ts` TSDoc).
+**Out-of-scope:** all of `@fgv/ts-extras`, any behavior change to the merge path, `docs/WORKSTREAMS.md`.
+**Brief:** `.ai/tasks/active/agent-memory-provenance-contract-doc/brief.md`.
+
+**Mission.** The provenance merge contract is already correct and pinned — the ask is answered *yes* on both halves. Document the guarantee where a consumer will find it so the next one doesn't have to ask: per-key merge over `provenance`, sub-key `null` clearing sanctioned, whole-block `null` rejected loudly. **No behavior change** — this stream fails if the merge semantics move.
+
+---
+
 ## Completed workstreams
 
 ### `agent-memory-antagonist` ✅


### PR DESCRIPTION
**Replaces the durable half of #576, which had become a mixed bag.** Docs only.

#576 accumulated two different kinds of content: operational docs that are useful merged now, and consumer reply drafts that are still changing as the exchange with PersonAIlity continues. The reply drafts can't converge while the correspondence is live — the round-2 reply was already corrected once after #578's findings — so keeping them in the same PR held the tracker hostage to the conversation.

This PR is the durable half. The replies are stacked on top in a separate PR that stays open until the exchange settles.

## Contents

- **`docs/STATUS.md`** (new) — the all-up "what is happening right now" tracker. Complements `WORKSTREAMS.md` (per-stream kickoff) and `FUTURE.md`/`TECH_DEBT.md` (deferred backlogs). Covers:
  - **Publish state** — `-45` is the last published alpha; `-46` is unpublished and carries the Anthropic adaptive-thinking fix that `-45` is missing, plus `maxTokens`, the xAI alias registry, the sample retirement, and the root-shim repair.
  - Open PRs, including why the two dependabot PRs against `main` are superseded on `release` by #575.
  - Agent streams in flight.
  - Consumer asks and their verdicts.
  - **The persistent-index re-index policy** (below).
  - **An overnight-stall postmortem.**
- **`docs/FUTURE.md`** — reopens the PersonAIlity ask queue (closed out in the 2026-07 batch) and scopes the alias-unsafe capability-resolver defect that PR #577 fixes.
- **`docs/WORKSTREAMS.md`** — ledger entries for the three round-2 remediation streams, with package surfaces and out-of-scope declarations sized for parallel worktree runs.
- **`.ai/notes/cross-repo-handoffs/personaility-asks-2026-07-round2.md`** — the round-2 triage with its evidence tables.

## Two things worth reading rather than skimming

**The re-index policy** (`STATUS.md`). Formalized *before* the first schema change rather than after: a `vec0` schema change on the persistent vector/fragment indexes requires consumers to drop and re-index; we ship no in-place migrations. Vectors are re-derivable from records, so it costs embedding time and never data. The obligation it creates on us is to make the mismatch **diagnosable** — the index already parses its stored `CREATE VIRTUAL TABLE` SQL to recover the dimension, so the same parse can compare the auxiliary-column set and fail with expected-vs-found rather than the opaque `no such column` you'd get at statement-prepare time.

**The stall postmortem** (`STATUS.md`). Two of three overnight agents completed their implementation work and stopped before committing; nothing was lost, and both resumed from transcript with context intact. A second instance of the same class followed: agent-spawned `code-reviewer` sub-agents had no messaging tool, so their reports reached the orchestrator instead of the agent that commissioned them, leaving one agent blocked on a report that could never arrive. The lesson recorded is that **a stream is not "done" when an agent goes quiet — verify by branch push and PR existence, not by absence of a failure**, with the cheap check to do it.

## Gates

Docs only — no package touched, no change file required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD)_