### PR TITLE
docs: refresh all-up STATUS tracker

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # All-up status — fgv
 
-**Last updated:** 2026-07-31 (orchestrator). Snapshot of everything in flight: open PRs,
-running agent streams, consumer asks, and what is blocking the next publish.
+**Last updated:** 2026-07-31 (orchestrator, post-merge). Snapshot of everything in flight:
+open PRs, running agent streams, consumer asks, and what is blocking the next publish.
 
 This is the "what is happening right now" doc. `docs/WORKSTREAMS.md` is the per-stream
 kickoff ledger; `docs/FUTURE.md` and `docs/TECH_DEBT.md` are the deferred-work backlogs.
@@ -11,8 +11,8 @@ kickoff ledger; `docs/FUTURE.md` and `docs/TECH_DEBT.md` are the deferred-work b
 ## Publish state
 
 **Last published alpha: `5.1.0-45`.** No `-46` tags exist — **the next alpha has not been
-published.** `release` has advanced four PRs past `-45` (#570, #573, #574, #575), so the
-publish is pending, not done.
+published.** `release` is at `d792fb82d`, thirteen PRs past `-45`. The publish is the single
+highest-value open item.
 
 `prerelease` (PR #256, standing) mirrors `release` for the npm-publish workflow.
 
@@ -26,8 +26,14 @@ publish is pending, not done.
 | xAI alias registry + `grok-4.5` advanced tier | #574 | live-verified by Erik |
 | `ai-image-gen-sample` retired | #574 | testbed is the canonical sample app |
 | Root rush shim lockfile repair | #575 | was invalid JSON; `npm ci` at repo root was broken |
+| Capability resolvers guarded against unresolved aliases | #577 | consumer-reported; sibling embedding resolver had the same flaw |
+| Provenance merge-contract TSDoc | #578 | answers the round-2 consumer ask on record |
+| Typed JSON-parse failure reasons | #579 | + `classifyJsonParseFailure` non-string guard (#583) |
+| Derived record index injectable on the store | #582 | instrumentation seam, explicitly not a resident-memory fix |
+| Durable fragment identity (`fragmentId` + advisory `locator`) | #585 | round-3 ask 1 |
+| FileTree binary (raw bytes) capability | #586 | round-3 ask 2; three packages |
 
-The adaptive-thinking fix is the one with consumer-visible urgency.
+The adaptive-thinking fix is still the one with consumer-visible urgency.
 
 ---
 
@@ -35,14 +41,21 @@ The adaptive-thinking fix is the one with consumer-visible urgency.
 
 | PR | Title | Base | State |
 |---|---|---|---|
-| [#577](https://github.com/ErikFortune/fgv/pull/577) | `fix(ai-assist)`: guard capability resolvers against unresolved model aliases | `release` | 🔵 open — needs review |
-| [#576](https://github.com/ErikFortune/fgv/pull/576) | `docs`: triage personaility round-2 asks | `release` | 🔵 open — docs only |
+| [#584](https://github.com/ErikFortune/fgv/pull/584) | `docs`: refresh all-up STATUS tracker | `release` | 🔵 this doc |
+| [#581](https://github.com/ErikFortune/fgv/pull/581) | `docs`: personaility reply drafts | `release` | ⏸️ **HOLD — deliberately open** while the exchange is live |
 | [#256](https://github.com/ErikFortune/fgv/pull/256) | Prerelease branch changes | `release` | ⏸️ standing (publish plumbing) |
 | [#154](https://github.com/ErikFortune/fgv/pull/154) | Release branch | `main` | ⏸️ standing (promotion) |
 | [#572](https://github.com/ErikFortune/fgv/pull/572) | Bump `@microsoft/rush` 5.177.2 → 5.178.0 | `main` | 🟡 superseded on `release` by #575 |
 | [#567](https://github.com/ErikFortune/fgv/pull/567) | Bump `fast-xml-parser` 5.10.0 → 5.10.1 | `main` | 🟡 superseded on `release` by #575 |
 
-**Recently merged:** #570, #573, #574 (the pre-publish stack), #575 (root shim repair).
+**Merged 2026-07-31:** #570, #573, #574, #575 (pre-publish stack), #576, #577, #578, #579,
+#580, #582, #583, #585, #586.
+
+**Why #581 is open on purpose.** It carries the drafted replies to PersonAIlity, and the
+conversation is still live — round-3 answers landed 2026-07-31, plus a correction we owe them
+(below). Merging it would freeze a draft mid-exchange. It closes when the exchange settles.
+This split came out of #576 accumulating six commits of mixed durable-and-draft content:
+durable artifacts went to #580, drafts stayed here.
 
 **Note on #572 / #567:** both target `main` and only touch the repo-root rush bootstrap shim.
 `release` got the equivalent (and a repair of a pre-existing invalid lockfile) via #575. They
@@ -50,69 +63,125 @@ will likely close as superseded once `release` merges up to `main`; no action be
 
 ---
 
-## Agent streams in flight
+## Agent streams
 
-Commissioned from the personaility round-2 triage. All branch from `release`, all open PRs
-against `release`, none self-merge.
+All branched from `release`, all opened PRs against `release`, none self-merged.
 
-| Stream | State | Notes |
+| Stream | Ask | State |
 |---|---|---|
-| `ai-assist-alias-capability-guard` | ✅ **PR #577 open** | The one real defect from round 2 |
-| `ai-assist-fenced-json-diagnostics` | 🔵 **resumed** | Agent stalled pre-commit overnight; work intact in worktree, resumed 2026-07-31 |
-| `agent-memory-provenance-contract-doc` | 🔵 **resumed** | Same — stalled pre-commit, work intact, resumed 2026-07-31 |
+| `ai-assist-alias-capability-guard` | round-2 (B) | ✅ merged (#577) |
+| `ai-assist-fenced-json-diagnostics` | round-2 | ✅ merged (#579, follow-up #583) |
+| `agent-memory-provenance-contract-doc` | round-2 | ✅ merged (#578) |
+| `agent-memory-fragment-id` | round-3 #1 | ✅ merged (#585) |
+| `agent-memory-index-injection-seam` | round-3 #3 (part 1) | ✅ merged (#582) |
+| `filetree-bytes-capability` | round-3 #2 | ✅ merged (#586) |
+| `fetch-primitive-threat-model` | round-3 #5 | 🔵 **running** — design doc only, no implementation |
 
-**Overnight-stall postmortem.** Two of three agents completed their implementation work but
-stopped before committing. Nothing was lost — the worktrees retained the full diffs
-(`.claude/worktrees/agent-*`), and both were resumed from their transcripts with context
-intact. **Lesson: a stream is not "done" when the agent goes quiet — verify by branch push +
-PR existence, not by absence of a failure.** The check that surfaced this is cheap and worth
-making routine:
+### Review-loop notes worth keeping
 
-```sh
-git ls-remote --heads origin <branch>   # did it push?
-git worktree list                        # is there uncommitted work stranded?
-git -C .claude/worktrees/agent-<id> status --short
-```
+**Independent layer-1 passes earn their cost.** Four streams ran without an agent-spawn tool
+in their session and self-reviewed instead. Commissioning independent `code-reviewer` passes
+retroactively found: a real P2 on #582 (the temporal/cap-cull claims were asserted but never
+test-evidenced *with an injected index* — 100% measured coverage on those paths came from
+pre-existing tests using the default index, which said nothing about the seam), and clean
+approvals on #585 and #586. The #582 finding is the canonical
+coverage-measures-the-lines-you-have failure mode from `TESTING_GUIDELINES.md`.
+
+**Copilot's suppressed comments are worth reading.** Three separate suppressed (low-confidence)
+comments turned out correct and were fixed: the `ModelSpecKey` thinking-availability pointer
+(#577), `_resolveIndex` treating only `undefined` as absent while all eight sibling params use
+`??` (#582), and the file-item binary guards' TSDoc claiming a guarantee the guard does not
+give (#586, where Copilot and the independent reviewer converged on the same point from
+opposite directions).
+
+**Two stall modes observed 2026-07-30/31**, both now covered by standing brief language:
+
+1. *Stalled pre-commit.* Agents completed implementation but stopped before committing. Nothing
+   was lost — worktrees retained the diffs and both resumed from transcript.
+   **A stream is not "done" when the agent goes quiet — verify by branch push + PR existence.**
+   ```sh
+   git ls-remote --heads origin <branch>   # did it push?
+   git worktree list                        # is there uncommitted work stranded?
+   git -C .claude/worktrees/agent-<id> status --short
+   ```
+2. *Sub-agent deadlock.* An implementing agent spawned a reviewer that had no tool to message
+   its parent — it reported to the top-level orchestrator instead, and the parent waited on a
+   message that could never arrive. Every brief now carries an explicit **"do not block waiting
+   for a spawned sub-agent to report"** note.
+
+**Verify agent-reported CI claims.** One stream reported CI "stalled ~80 minutes, stalled-runner
+signature." It had not stalled: checks started two minutes after its final push and completed
+normally. "CI is stalled" is the kind of claim that stops a human from looking, so it is worth
+one API call to confirm.
+
+**Known sandbox artifact.** `mutableFsTree.test.ts` › "returns permission-denied for read-only
+file" fails locally because this container runs as **root** (uid 0), which bypasses the `chmod`
+the test relies on. It passes in CI. Not a finding against any branch.
 
 ---
 
 ## Consumer asks — personaility
 
-### Round 2 (2026-07-28) — triaged, answered
+### Round 2 (2026-07-28) — closed
 
-Full triage: `.ai/notes/cross-repo-handoffs/personaility-asks-2026-07-round2.md`.
-Reply draft: `.ai/notes/cross-repo-handoffs/personaility-reply-2026-07-round2.md`.
+Triage: `.ai/notes/cross-repo-handoffs/personaility-asks-2026-07-round2.md`.
+Reply: `.ai/notes/cross-repo-handoffs/personaility-reply-2026-07-round2.md`.
 
 | Ask | Verdict | Status |
 |---|---|---|
-| (A) no `'tools'` in `ModelSpecKey` | Working as designed; doc defect real | TSDoc in #577 |
-| (B) capability resolvers alias-unsafe | **Real, broader than reported** | PR #577 |
-| Provenance merge contract | **Answered yes, both halves** | Doc stream resumed |
+| (A) no `'tools'` in `ModelSpecKey` | Working as designed; doc defect real | ✅ #577 |
+| (B) capability resolvers alias-unsafe | **Real, broader than reported** | ✅ #577 |
+| Provenance merge contract | **Answered yes, both halves** | ✅ #578 |
 | WebAuthn R11 / R12 | **Already shipped** 2026-05-12 (#351) | Nothing to build |
-| Fenced-JSON diagnostics | Real, P3 | Stream resumed |
+| Fenced-JSON diagnostics | Real, P3 | ✅ #579 + #583 |
 
-### Round 3 (2026-07-31) — incoming
+### Round 3 (2026-07-31) — four of five shipped
 
-| Ask | State |
-|---|---|
-| N-Ask5 Q3 — opaque `fragmentId` alongside the span | 🟡 assessed, not yet commissioned — see below |
-| (further asks) | ⏳ awaiting relay from Erik |
+Consolidated reply, their answers, and our correction:
+`.ai/notes/cross-repo-handoffs/personaility-reply-2026-07-round3-rollup.md`.
 
-**N-Ask5 Q3 assessment.** Accept. Type-level change is genuinely additive — `fragmentId?` on
-`IEmbeddedFragment` and `IVectorQueryHit`, and `FragmentEmbedder` is consumer-supplied so the
-id needs no new store plumbing. Two findings to carry back: (1) the SQLite schema change is
-**not** additive on disk — see the re-index policy below; (2) `IEmbeddedFragment.locator` is
-**required** on input while `IVectorQueryHit.locator` is optional on output, so a rewriting
-segmenter with no honest span must fabricate offsets — ask them whether `locator` should
-become optional on input when `fragmentId` is present.
+| # | Ask | Decision | Status |
+|---|---|---|---|
+| 1 | N-Ask5 Q3 — opaque `fragmentId` | Accepted as specified, plus their `locator?` follow-up | ✅ #585 |
+| 2 | FileTree bytes path | Accepted — as a **capability interface**, not widened core interfaces | ✅ #586 |
+| 3 | Record index seam | Accepted, **split in two** — most of it already existed | ✅ #582 (part 1); part 2 design-gated |
+| 4 | Provenance query axis | Accepted, as the sharper version of their option 1 | ⏸️ sequenced with ask 3 part 2 |
+| 5 | `Result`-returning fetch primitive | Accepted, **design-first** — the ask as written has an SSRF hole | 🔵 threat model in flight |
+
+**Their four answers, all binding on the streams:**
+
+1. **Self-describing hits** — not needed; "you know which index you queried" is sufficient.
+2. **Strict text decoding** — bytes + docstring is enough. No `getRawContentsStrict`, no
+   `strictTextDecoding` flag.
+3. **DNS rebinding** — a documented limit is accepted, **but the API must keep pinned-IP
+   connection additive** (option or swappable resolver), so closing it later is not breaking.
+4. **Ask 3 priority** — take the injection point early, framed as an **instrumentation** seam
+   rather than an experimentation one. #582's TSDoc says exactly that, in those words.
+
+**Corrections in both directions.**
+
+*They corrected us twice.* "Neither field is a discriminant" was too strong — the *pair*
+discriminates, so the accurate claim is that **no single field** does. And `httpTreeAccessors`
+does have a real named consumer: a hosted built-in corpus for agent creation.
+
+*We owe them one correction.* Our round-3 reply justified flagging `httpTreeAccessors` by
+saying "bytes are *more* natural there (`response.arrayBuffer()`)." **That was wrong.** It
+preloads from a JSON REST API whose `contents` field is typed `string`, and the whole
+`IFileTreeAccessors` read surface is synchronous, so `arrayBuffer()` can never be reached from
+`getFileBytes`. Their use case is still served, but **binary corpus content is not safe through
+that adapter today** — the bytes it returns are a UTF-8 encode of an already-decoded string.
+Recorded in the rollup; goes back with the next reply.
+
+**Sequencing constraint.** Asks 3 and 4 both rewrite `MemoryIndex`, so they are one sequenced
+work item and must not run as parallel streams.
 
 ---
 
 ## Policy: schema changes to persistent vector indexes require a full re-index
 
-**Decided 2026-07-31 (Erik).** Formalized here because the `@fgv/ts-agent-memory-sqlite-vec`
-indexes persist across process restarts, so any change to their `vec0` table shape is a
-migration event for existing databases.
+**Decided 2026-07-31 (Erik).** Formalized because the `@fgv/ts-agent-memory-sqlite-vec` indexes
+persist across process restarts, so any change to their `vec0` table shape is a migration event
+for existing databases.
 
 **The policy.** A change to the `vec0` schema of `SqliteVecVectorIndex` or
 `SqliteVecFragmentIndex` — adding, removing, or retyping a column, including auxiliary
@@ -123,29 +192,27 @@ migrations for these tables.
 (breaking changes land freely without shims), the sqlite-vec package is new, and the vectors
 are always re-derivable from the records — a re-index costs embedding time, never data.
 
-**What the policy obliges us to do.** Because "no re-embedding on open" is the package's
-headline value, a consumer must not discover the migration as an opaque SQLite error:
+**What the policy obliges us to do**, because "no re-embedding on open" is the package's
+headline value and a consumer must not meet the migration as an opaque SQLite error:
 
 1. **Detect the schema mismatch on open** — the index already recovers the established
-   dimension by parsing the stored `CREATE VIRTUAL TABLE` SQL; the same parse can compare the
+   dimension by parsing the stored `CREATE VIRTUAL TABLE` SQL; the same parse compares the
    auxiliary-column set.
-2. **Fail loudly and actionably** — name the expected vs. found columns and say a re-index is
-   required. Today a widened `INSERT` against a narrower table surfaces as
-   `no such column: <name>` at statement-prepare time, which is not diagnosable.
+2. **Fail loudly and actionably** — name expected vs. found columns and say a re-index is
+   required, rather than surfacing `no such column: <name>` at statement-prepare time.
 3. **Say it in the package README**, so it is a known contract rather than a surprise.
 
-**Current status:** not an issue in practice today — the fragment index shipped 2026-07-20
-and the only consumer is re-ingesting anyway as it moves to model-chosen segmentation. The
-policy is being formalized *before* the first schema change (the N-Ask5 Q3 `fragmentId`
-column) rather than after.
+**Status: implemented.** #585 was the first schema change under this policy and carries all
+three obligations — `SqliteVecFragmentIndex.create` now rejects a pre-existing wrong-schema
+table at create time with a diagnosable message, and the README gained an "Upgrading" section.
+The policy was formalized *before* its first exercise rather than after.
 
 ---
 
 ## What needs Erik
 
-1. **Review + merge #577** (capability-resolver guard) and **#576** (docs).
-2. **Publish `-46`** — carries the adaptive-thinking fix that `-45` is missing.
-3. **Relay the round-2 reply** to personaility.
-4. **Round-3 asks** — relay the rest of the batch so they can be scoped together (they may
-   share `vectorIndex.ts`, and overlapping streams on one file are the thing the
-   package-surface declarations exist to prevent).
+1. **Publish `-46`.** Thirteen PRs past `-45`, and `-45` carries the adaptive-thinking bug.
+   Everything else is downstream of this.
+2. **Merge #584** (this doc). #581 stays open by design.
+3. **Nothing else is blocked on you.** The one running stream produces a design doc for review,
+   not code.


### PR DESCRIPTION
Doc-only refresh of `docs/STATUS.md` (introduced in #580) to reflect the last several hours.

## What changed

- **Merges recorded** — #576, #578, #579, #580 moved to the merged list; #578 and #579 added to the `-46` payload table.
- **New PRs listed** — #582 (index injection seam), #583 (`classifyJsonParseFailure` non-string guard), and #581 with an explicit note on **why it is deliberately held open** rather than looking like a stalled PR.
- **#577 marked Erik-reviewed** and cleared to merge on green, so its state is unambiguous to anyone reading the tracker.
- **Round-3 consumer asks are now a complete table** — all five relayed, decided, and mapped to work — plus their four answers to our open questions, which are now binding constraints on the running streams (notably: pinned-IP connection must stay additive; no `getRawContentsStrict`; the injection seam is framed as *instrumentation*, not experimentation).
- **Two corrections the consumer made to us** are recorded, including that `httpTreeAccessors` has a real named use case after all — which is why it became the priority adapter in the bytes stream.
- **Two newly commissioned streams** added: `filetree-bytes-capability` and `fetch-primitive-threat-model` (design-only).
- **Sequencing constraint made explicit** — asks 3 and 4 both rewrite `MemoryIndex` and must not run as parallel streams.

## New postmortem content

The existing "stalled before commit" postmortem is retained. Added a **second stall mode observed the same night**: an implementing agent spawned a reviewer sub-agent that had no tool to message its parent, so it reported to the top-level orchestrator instead and the parent waited on a message that could never arrive. Every brief now carries an explicit "do not block waiting for a spawned sub-agent to report" note; recording it here so the reason survives the briefs.

No code, no gates to run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD)_