### PR TITLE
feat(ts-extras): safer-fetch address classification (stream S2a)

### DIFF
--- a/common/changes/@fgv/ts-extras/safer-fetch-address-classification_2026-08-01-00-00.json
+++ b/common/changes/@fgv/ts-extras/safer-fetch-address-classification_2026-08-01-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "Add the safer-fetch packlet's address-classification layer: classifyAddress plus the blockPrivateNetworks() and allowAnyAddress() IAddressPolicy factories. Pure and synchronous - no name resolution, transport or I/O. Covers the IPv4-mapped, IPv4-compatible, NAT64 and 6to4 IPv6 embeddings and the shortened/octal/hexadecimal/decimal IPv4 literal forms, and enforces a reject-if-any contract over a resolved address list",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-extras"
+}

--- a/libraries/ts-extras/src/packlets/safer-fetch/addressClassification.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/addressClassification.ts
@@ -25,7 +25,7 @@
 // disables for the same reason in `crypto-utils/keystore` and `ts-random`.
 /* eslint-disable no-bitwise */
 
-import { Result, fail, succeed } from '@fgv/ts-utils';
+import { type Result, fail, succeed } from '@fgv/ts-utils';
 
 /**
  * The address family of a parsed IP address literal.

--- a/libraries/ts-extras/src/packlets/safer-fetch/addressClassification.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/addressClassification.ts
@@ -96,6 +96,17 @@ export type Ipv4EmbeddingKind =
   | '6to4';
 
 /**
+ * The IPv4 address an IPv6 address embedded, and the way it embedded it.
+ * @public
+ */
+export interface IEmbeddedIpv4 {
+  /** The encoding that carried the IPv4 address. */
+  readonly kind: Ipv4EmbeddingKind;
+  /** The dotted-quad form of the embedded IPv4 address. */
+  readonly address: string;
+}
+
+/**
  * The result of classifying a single IP address literal.
  * @public
  */
@@ -118,10 +129,11 @@ export interface IClassifiedAddress {
    * address.
    */
   readonly classification: AddressClassification;
-  /** Present when `classification` was derived from an embedded IPv4 address. */
-  readonly embedding?: Ipv4EmbeddingKind;
-  /** The dotted-quad form of the embedded IPv4 address, when `embedding` is present. */
-  readonly embeddedIpv4?: string;
+  /**
+   * Present exactly when `classification` was derived from an IPv4 address
+   * embedded in this IPv6 address, and absent otherwise.
+   */
+  readonly embeddedIpv4?: IEmbeddedIpv4;
 }
 
 interface IIpv4Range {
@@ -204,6 +216,13 @@ function parseIpv4Component(text: string): number | undefined {
     digits = text.slice(1);
   }
 
+  // The WHATWG IPv4 number parser returns 0 when stripping the radix prefix
+  // leaves nothing behind, so a bare `0x` is zero: `127.0x.1` is `127.0.0.1`.
+  // Rejecting it here would leave a live encoding bypass.
+  if (digits.length === 0) {
+    return 0;
+  }
+
   const allowed: RegExp = radix === 16 ? /^[0-9a-fA-F]+$/ : radix === 8 ? /^[0-7]+$/ : /^[0-9]+$/;
   if (!allowed.test(digits)) {
     return undefined;
@@ -280,8 +299,12 @@ function parseStrictDottedQuad(text: string): number | undefined {
 /**
  * Parses a colon-separated run of IPv6 groups, allowing a trailing embedded
  * dotted-quad IPv4 literal which expands to the final two groups.
+ *
+ * @param allowEmbeddedIpv4 - whether this run may end in a dotted-quad IPv4
+ * literal. Only the run that ends the whole address may, so the run *before* a
+ * `::` never does: `1.2.3.4::` is malformed, not `102:304::`.
  */
-function parseIpv6Groups(text: string): number[] | undefined {
+function parseIpv6Groups(text: string, allowEmbeddedIpv4: boolean): number[] | undefined {
   if (text.length === 0) {
     return [];
   }
@@ -291,7 +314,7 @@ function parseIpv6Groups(text: string): number[] | undefined {
   for (let i: number = 0; i < parts.length; i++) {
     const part: string = parts[i];
     if (part.indexOf('.') >= 0) {
-      if (i !== parts.length - 1) {
+      if (!allowEmbeddedIpv4 || i !== parts.length - 1) {
         return undefined;
       }
       const embedded: number | undefined = parseStrictDottedQuad(part);
@@ -320,8 +343,8 @@ function parseIpv6(text: string): Uint8Array | undefined {
     if (text.indexOf('::', doubleColon + 1) >= 0) {
       return undefined;
     }
-    const head: number[] | undefined = parseIpv6Groups(text.slice(0, doubleColon));
-    const tail: number[] | undefined = parseIpv6Groups(text.slice(doubleColon + 2));
+    const head: number[] | undefined = parseIpv6Groups(text.slice(0, doubleColon), false);
+    const tail: number[] | undefined = parseIpv6Groups(text.slice(doubleColon + 2), true);
     if (head === undefined || tail === undefined) {
       return undefined;
     }
@@ -331,7 +354,7 @@ function parseIpv6(text: string): Uint8Array | undefined {
     }
     groups = head.concat(new Array<number>(elided).fill(0), tail);
   } else {
-    groups = parseIpv6Groups(text);
+    groups = parseIpv6Groups(text, true);
     if (groups === undefined || groups.length !== 8) {
       return undefined;
     }
@@ -479,8 +502,7 @@ function classifyIpv6Bytes(bytes: Uint8Array): IClassifiedAddress {
       canonical,
       family: 'ipv6',
       classification: classifyIpv4Value(embedding.value),
-      embedding: embedding.kind,
-      embeddedIpv4: ipv4ToString(embedding.value)
+      embeddedIpv4: { kind: embedding.kind, address: ipv4ToString(embedding.value) }
     };
   }
 
@@ -499,19 +521,23 @@ function classifyIpv6Bytes(bytes: Uint8Array): IClassifiedAddress {
 
 /**
  * Normalizes the textual forms an address can arrive in before parsing:
- * surrounding whitespace, the square brackets a URL `hostname` carries for an
- * IPv6 literal, and an IPv6 zone identifier (`%eth0`).
+ * surrounding whitespace and the square brackets a URL `hostname` carries for
+ * an IPv6 literal. A zone identifier is *not* stripped here — it is stripped on
+ * the IPv6 path only, because `8.8.8.8%something` is not an address with a zone
+ * and must fail rather than be read as `8.8.8.8`.
  */
 function normalizeAddressText(address: string): string {
-  let text: string = address.trim();
+  const text: string = address.trim();
   if (text.length > 1 && text[0] === '[' && text[text.length - 1] === ']') {
-    text = text.slice(1, -1);
-  }
-  const zone: number = text.indexOf('%');
-  if (zone >= 0) {
-    text = text.slice(0, zone);
+    return text.slice(1, -1);
   }
   return text;
+}
+
+/** Strips an IPv6 zone identifier (`fe80::1%eth0`). */
+function stripIpv6Zone(text: string): string {
+  const zone: number = text.indexOf('%');
+  return zone >= 0 ? text.slice(0, zone) : text;
 }
 
 /**
@@ -548,7 +574,7 @@ export function classifyAddress(address: string): Result<IClassifiedAddress> {
   }
 
   if (text.indexOf(':') >= 0) {
-    const bytes: Uint8Array | undefined = parseIpv6(text);
+    const bytes: Uint8Array | undefined = parseIpv6(stripIpv6Zone(text));
     if (bytes === undefined) {
       return fail(`"${address}": not a valid IPv6 address literal`);
     }

--- a/libraries/ts-extras/src/packlets/safer-fetch/addressClassification.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/addressClassification.ts
@@ -562,6 +562,16 @@ function stripIpv6Zone(text: string): string {
  * A trailing dot is accepted on an IPv4 literal (`127.0.0.1.`), matching URL
  * hostname normalization.
  *
+ * **Classify a URL's `hostname`, never the raw URL text.** This function does
+ * not apply IDNA/Unicode normalization, and that step is not cosmetic: the
+ * platform's URL parser reads `http://１２７.０.０.１/`, `http://127。0。0。1/` and
+ * even `http://⑫7.0.0.1/` as the host `127.0.0.1`, because IDNA normalizes
+ * fullwidth digits, the ideographic full stop and circled numbers to their
+ * ASCII equivalents. Handed one of those strings directly this function fails —
+ * which is fail-closed, but only because the caller is then expected to treat
+ * "not a literal" as "resolve it as a name". Reading `new URL(...).hostname`
+ * gets the normalization for free and is the only supported use.
+ *
  * @param address - the address literal to classify.
  * @returns `Success` with the {@link IClassifiedAddress | classification},
  * or `Failure` if the supplied text is not a well-formed IP address literal.

--- a/libraries/ts-extras/src/packlets/safer-fetch/addressClassification.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/addressClassification.ts
@@ -1,0 +1,570 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Address classification is prefix arithmetic: every range test is a mask and a
+// compare, and every IPv6 group/byte conversion is a shift. Spelling those as
+// arithmetic instead would be strictly harder to audit against the RFCs, which
+// is the opposite of what this file needs. The repo already takes per-site
+// disables for the same reason in `crypto-utils/keystore` and `ts-random`.
+/* eslint-disable no-bitwise */
+
+import { Result, fail, succeed } from '@fgv/ts-utils';
+
+/**
+ * The address family of a parsed IP address literal.
+ * @public
+ */
+export type AddressFamily = 'ipv4' | 'ipv6';
+
+/**
+ * The security-relevant classification of an IP address.
+ *
+ * `'public'` is the only classification that describes an address which is
+ * globally routable on the public internet; every other value names a
+ * special-purpose range that a server-side fetch reaching untrusted input
+ * should not be able to reach by default.
+ *
+ * @public
+ */
+export type AddressClassification =
+  /** Globally routable unicast — the only classification a default guard permits. */
+  | 'public'
+  /** `0.0.0.0/8` and `::` — "this host on this network"; routes to localhost on Linux. */
+  | 'unspecified'
+  /** `127.0.0.0/8` and `::1`. */
+  | 'loopback'
+  /**
+   * `169.254.0.0/16` and `fe80::/10`. The IPv4 range contains the cloud
+   * instance-metadata endpoint (`169.254.169.254`) and is the single
+   * highest-value SSRF target.
+   */
+  | 'link-local'
+  /** RFC 1918 — `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`. */
+  | 'private'
+  /** RFC 4193 IPv6 unique-local — `fc00::/7`. */
+  | 'unique-local'
+  /** RFC 6598 carrier-grade NAT — `100.64.0.0/10`. Frequently carrier or container internal. */
+  | 'carrier-grade-nat'
+  /** RFC 2544 benchmarking — `198.18.0.0/15`. */
+  | 'benchmarking'
+  /** Documentation ranges — `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`, `2001:db8::/32`. */
+  | 'documentation'
+  /** IETF protocol assignments — `192.0.0.0/24` and `2001::/23`. */
+  | 'protocol-assignment'
+  /** `224.0.0.0/4` and `ff00::/8`. */
+  | 'multicast'
+  /** `255.255.255.255/32`. */
+  | 'broadcast'
+  /** Every other special-purpose or future-use range (e.g. `240.0.0.0/4`, `fec0::/10`). */
+  | 'reserved';
+
+/**
+ * The way an IPv6 address carried the IPv4 address whose classification was used.
+ *
+ * Each of these is a documented SSRF bypass: an address such as
+ * `::ffff:169.254.169.254` is an IPv6 address by family, but the address the
+ * connection actually reaches is the embedded IPv4 one, so the embedded
+ * address is what must be classified.
+ *
+ * @public
+ */
+export type Ipv4EmbeddingKind =
+  /** `::ffff:0:0/96` — the IPv4-mapped IPv6 form. */
+  | 'ipv4-mapped'
+  /** `::/96` — the deprecated (RFC 4291) IPv4-compatible form. */
+  | 'ipv4-compatible'
+  /** `64:ff9b::/96` — the RFC 6052 well-known NAT64 prefix. */
+  | 'nat64'
+  /** `2002::/16` — the RFC 3056 6to4 form, whose IPv4 lives in bits 16..47. */
+  | '6to4';
+
+/**
+ * The result of classifying a single IP address literal.
+ * @public
+ */
+export interface IClassifiedAddress {
+  /** The address exactly as supplied to {@link classifyAddress}. */
+  readonly address: string;
+  /**
+   * A canonical textual form of the address: dotted-quad for IPv4, and
+   * lowercase RFC 5952 hex-group form (with `::` run compression) for IPv6.
+   * Note that IPv6 addresses embedding an IPv4 address canonicalize to their
+   * hex-group form (`::ffff:a9fe:a9fe`), not to the dotted-quad mixed form;
+   * `embeddedIpv4` carries the readable IPv4 value.
+   */
+  readonly canonical: string;
+  /** The address family of the literal as supplied — never the embedded family. */
+  readonly family: AddressFamily;
+  /**
+   * The classification used for policy decisions. For an IPv6 address that
+   * embeds an IPv4 address, this is the classification of the *embedded* IPv4
+   * address.
+   */
+  readonly classification: AddressClassification;
+  /** Present when `classification` was derived from an embedded IPv4 address. */
+  readonly embedding?: Ipv4EmbeddingKind;
+  /** The dotted-quad form of the embedded IPv4 address, when `embedding` is present. */
+  readonly embeddedIpv4?: string;
+}
+
+interface IIpv4Range {
+  readonly network: number;
+  readonly prefixLength: number;
+  readonly classification: AddressClassification;
+}
+
+interface IIpv6Range {
+  /** Leading bytes of the prefix; length is `ceil(prefixLength / 8)`. */
+  readonly prefix: ReadonlyArray<number>;
+  readonly prefixLength: number;
+  readonly classification: AddressClassification;
+}
+
+/**
+ * IPv4 special-purpose ranges, most specific first. The broadcast address is
+ * listed ahead of `240.0.0.0/4` because it falls inside it.
+ */
+const IPV4_RANGES: ReadonlyArray<IIpv4Range> = [
+  { network: 0xffffffff, prefixLength: 32, classification: 'broadcast' },
+  { network: 0x00000000, prefixLength: 8, classification: 'unspecified' },
+  { network: 0x0a000000, prefixLength: 8, classification: 'private' },
+  { network: 0x64400000, prefixLength: 10, classification: 'carrier-grade-nat' },
+  { network: 0x7f000000, prefixLength: 8, classification: 'loopback' },
+  { network: 0xa9fe0000, prefixLength: 16, classification: 'link-local' },
+  { network: 0xac100000, prefixLength: 12, classification: 'private' },
+  { network: 0xc0000000, prefixLength: 24, classification: 'protocol-assignment' },
+  { network: 0xc0000200, prefixLength: 24, classification: 'documentation' },
+  { network: 0xc0586300, prefixLength: 24, classification: 'reserved' },
+  { network: 0xc0a80000, prefixLength: 16, classification: 'private' },
+  { network: 0xc6120000, prefixLength: 15, classification: 'benchmarking' },
+  { network: 0xc6336400, prefixLength: 24, classification: 'documentation' },
+  { network: 0xcb007100, prefixLength: 24, classification: 'documentation' },
+  { network: 0xe0000000, prefixLength: 4, classification: 'multicast' },
+  { network: 0xf0000000, prefixLength: 4, classification: 'reserved' }
+];
+
+/**
+ * IPv6 special-purpose ranges, most specific first. Ranges whose addresses
+ * embed an IPv4 address are handled separately, before this table is consulted,
+ * and anything outside global unicast (`2000::/3`) that matches nothing here is
+ * classified `'reserved'` — so this table only needs to name the ranges that
+ * deserve a more specific classification than that fallback gives them.
+ */
+const IPV6_RANGES: ReadonlyArray<IIpv6Range> = [
+  { prefix: [0x20, 0x01, 0x0d, 0xb8], prefixLength: 32, classification: 'documentation' },
+  { prefix: [0x20, 0x01, 0x00], prefixLength: 23, classification: 'protocol-assignment' },
+  { prefix: [0x3f, 0xff, 0x00], prefixLength: 20, classification: 'documentation' },
+  { prefix: [0xfc], prefixLength: 7, classification: 'unique-local' },
+  { prefix: [0xfe, 0x80], prefixLength: 10, classification: 'link-local' },
+  { prefix: [0xff], prefixLength: 8, classification: 'multicast' }
+];
+
+/** The first three bits of a global unicast IPv6 address (`2000::/3`). */
+const IPV6_GLOBAL_UNICAST_MASK: number = 0xe0;
+const IPV6_GLOBAL_UNICAST_VALUE: number = 0x20;
+
+/**
+ * Parses one component of an IPv4 literal using `inet_aton` conventions: a
+ * `0x`/`0X` prefix selects hexadecimal, an otherwise-leading `0` selects octal,
+ * and anything else is decimal.
+ *
+ * This is deliberately permissive about *radix* because the WHATWG URL parser
+ * is: `http://0177.0.0.1/` and `http://2130706433/` are both `127.0.0.1`, and a
+ * classifier that only understands dotted decimal is bypassed by either.
+ */
+function parseIpv4Component(text: string): number | undefined {
+  if (text.length === 0) {
+    return undefined;
+  }
+
+  let radix: number = 10;
+  let digits: string = text;
+  if (text.length > 1 && (text[1] === 'x' || text[1] === 'X') && text[0] === '0') {
+    radix = 16;
+    digits = text.slice(2);
+  } else if (text.length > 1 && text[0] === '0') {
+    radix = 8;
+    digits = text.slice(1);
+  }
+
+  const allowed: RegExp = radix === 16 ? /^[0-9a-fA-F]+$/ : radix === 8 ? /^[0-7]+$/ : /^[0-9]+$/;
+  if (!allowed.test(digits)) {
+    return undefined;
+  }
+
+  const value: number = Number.parseInt(digits, radix);
+  return Number.isSafeInteger(value) ? value : undefined;
+}
+
+/**
+ * Parses an IPv4 literal in any of the forms the platform URL parser accepts
+ * (`a.b.c.d`, `a.b.c`, `a.b`, `a`), returning the address as an unsigned 32-bit
+ * value. The final component absorbs all remaining bytes, so `127.1` is
+ * `127.0.0.1` and `2130706433` is also `127.0.0.1`.
+ */
+function parseIpv4(text: string): number | undefined {
+  const parts: string[] = text.split('.');
+  if (parts.length > 4) {
+    return undefined;
+  }
+
+  const values: number[] = [];
+  for (const part of parts) {
+    const value: number | undefined = parseIpv4Component(part);
+    if (value === undefined) {
+      return undefined;
+    }
+    values.push(value);
+  }
+
+  const leading: number = values.length - 1;
+  for (let i: number = 0; i < leading; i++) {
+    if (values[i] > 0xff) {
+      return undefined;
+    }
+  }
+  if (values[leading] > Math.pow(256, 4 - leading) - 1) {
+    return undefined;
+  }
+
+  let address: number = values[leading];
+  for (let i: number = 0; i < leading; i++) {
+    address += values[i] * Math.pow(256, 3 - i);
+  }
+  return address >>> 0;
+}
+
+/**
+ * Parses a strict dotted-quad IPv4 literal — exactly four decimal components,
+ * each `0..255`, with no octal or hexadecimal forms. This is the grammar RFC
+ * 4291 permits for the IPv4 tail of an IPv6 literal, and it is deliberately
+ * stricter than {@link parseIpv4}: an unparseable literal fails closed.
+ */
+function parseStrictDottedQuad(text: string): number | undefined {
+  const parts: string[] = text.split('.');
+  if (parts.length !== 4) {
+    return undefined;
+  }
+
+  let address: number = 0;
+  for (const part of parts) {
+    if (!/^(0|[1-9][0-9]{0,2})$/.test(part)) {
+      return undefined;
+    }
+    const value: number = Number.parseInt(part, 10);
+    if (value > 0xff) {
+      return undefined;
+    }
+    address = address * 256 + value;
+  }
+  return address >>> 0;
+}
+
+/**
+ * Parses a colon-separated run of IPv6 groups, allowing a trailing embedded
+ * dotted-quad IPv4 literal which expands to the final two groups.
+ */
+function parseIpv6Groups(text: string): number[] | undefined {
+  if (text.length === 0) {
+    return [];
+  }
+
+  const parts: string[] = text.split(':');
+  const groups: number[] = [];
+  for (let i: number = 0; i < parts.length; i++) {
+    const part: string = parts[i];
+    if (part.indexOf('.') >= 0) {
+      if (i !== parts.length - 1) {
+        return undefined;
+      }
+      const embedded: number | undefined = parseStrictDottedQuad(part);
+      if (embedded === undefined) {
+        return undefined;
+      }
+      groups.push((embedded >>> 16) & 0xffff, embedded & 0xffff);
+      continue;
+    }
+    if (!/^[0-9a-fA-F]{1,4}$/.test(part)) {
+      return undefined;
+    }
+    groups.push(Number.parseInt(part, 16));
+  }
+  return groups;
+}
+
+/**
+ * Parses an IPv6 literal into its 16 constituent bytes.
+ */
+function parseIpv6(text: string): Uint8Array | undefined {
+  const doubleColon: number = text.indexOf('::');
+  let groups: number[] | undefined;
+
+  if (doubleColon >= 0) {
+    if (text.indexOf('::', doubleColon + 1) >= 0) {
+      return undefined;
+    }
+    const head: number[] | undefined = parseIpv6Groups(text.slice(0, doubleColon));
+    const tail: number[] | undefined = parseIpv6Groups(text.slice(doubleColon + 2));
+    if (head === undefined || tail === undefined) {
+      return undefined;
+    }
+    const elided: number = 8 - head.length - tail.length;
+    if (elided < 1) {
+      return undefined;
+    }
+    groups = head.concat(new Array<number>(elided).fill(0), tail);
+  } else {
+    groups = parseIpv6Groups(text);
+    if (groups === undefined || groups.length !== 8) {
+      return undefined;
+    }
+  }
+
+  const bytes: Uint8Array = new Uint8Array(16);
+  for (let i: number = 0; i < 8; i++) {
+    bytes[i * 2] = (groups[i] >>> 8) & 0xff;
+    bytes[i * 2 + 1] = groups[i] & 0xff;
+  }
+  return bytes;
+}
+
+function ipv4ToString(address: number): string {
+  return [(address >>> 24) & 0xff, (address >>> 16) & 0xff, (address >>> 8) & 0xff, address & 0xff].join('.');
+}
+
+/**
+ * Renders the RFC 5952 canonical text form of an IPv6 address: lowercase, no
+ * leading zeros in a group, and the leftmost longest run of two or more
+ * all-zero groups replaced by `::`.
+ */
+function ipv6ToString(bytes: Uint8Array): string {
+  const groups: number[] = [];
+  for (let i: number = 0; i < 8; i++) {
+    groups.push((bytes[i * 2] << 8) | bytes[i * 2 + 1]);
+  }
+
+  let bestStart: number = -1;
+  let bestLength: number = 0;
+  let runStart: number = -1;
+  let runLength: number = 0;
+  for (let i: number = 0; i < 8; i++) {
+    if (groups[i] === 0) {
+      if (runStart < 0) {
+        runStart = i;
+        runLength = 0;
+      }
+      runLength++;
+      if (runLength > bestLength) {
+        bestStart = runStart;
+        bestLength = runLength;
+      }
+    } else {
+      runStart = -1;
+      runLength = 0;
+    }
+  }
+
+  const rendered: string[] = groups.map((g) => g.toString(16));
+  if (bestLength < 2) {
+    return rendered.join(':');
+  }
+  const head: string = rendered.slice(0, bestStart).join(':');
+  const tail: string = rendered.slice(bestStart + bestLength).join(':');
+  return `${head}::${tail}`;
+}
+
+function classifyIpv4Value(address: number): AddressClassification {
+  for (const range of IPV4_RANGES) {
+    const mask: number = (0xffffffff << (32 - range.prefixLength)) >>> 0;
+    if ((address & mask) >>> 0 === range.network) {
+      return range.classification;
+    }
+  }
+  return 'public';
+}
+
+function matchesIpv6Range(bytes: Uint8Array, range: IIpv6Range): boolean {
+  const fullBytes: number = range.prefixLength >>> 3;
+  for (let i: number = 0; i < fullBytes; i++) {
+    if (bytes[i] !== range.prefix[i]) {
+      return false;
+    }
+  }
+  const remainingBits: number = range.prefixLength & 7;
+  if (remainingBits === 0) {
+    return true;
+  }
+  const mask: number = (0xff << (8 - remainingBits)) & 0xff;
+  return (bytes[fullBytes] & mask) === (range.prefix[fullBytes] & mask);
+}
+
+function allZero(bytes: Uint8Array, start: number, end: number): boolean {
+  for (let i: number = start; i < end; i++) {
+    if (bytes[i] !== 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function readIpv4At(bytes: Uint8Array, offset: number): number {
+  return (
+    ((bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3]) >>> 0
+  );
+}
+
+interface IIpv6Embedding {
+  readonly kind: Ipv4EmbeddingKind;
+  readonly value: number;
+}
+
+/**
+ * Detects the IPv4 address embedded in an IPv6 address, if any. `::` and `::1`
+ * are excluded before the IPv4-compatible check so that the unspecified and
+ * loopback addresses keep their own classifications.
+ */
+function detectIpv6Embedding(bytes: Uint8Array): IIpv6Embedding | undefined {
+  if (allZero(bytes, 0, 10) && bytes[10] === 0xff && bytes[11] === 0xff) {
+    return { kind: 'ipv4-mapped', value: readIpv4At(bytes, 12) };
+  }
+  if (
+    bytes[0] === 0x00 &&
+    bytes[1] === 0x64 &&
+    bytes[2] === 0xff &&
+    bytes[3] === 0x9b &&
+    allZero(bytes, 4, 12)
+  ) {
+    return { kind: 'nat64', value: readIpv4At(bytes, 12) };
+  }
+  if (bytes[0] === 0x20 && bytes[1] === 0x02) {
+    return { kind: '6to4', value: readIpv4At(bytes, 2) };
+  }
+  if (allZero(bytes, 0, 12)) {
+    return { kind: 'ipv4-compatible', value: readIpv4At(bytes, 12) };
+  }
+  return undefined;
+}
+
+function classifyIpv6Bytes(bytes: Uint8Array): IClassifiedAddress {
+  const canonical: string = ipv6ToString(bytes);
+
+  if (allZero(bytes, 0, 16)) {
+    return { address: canonical, canonical, family: 'ipv6', classification: 'unspecified' };
+  }
+  if (allZero(bytes, 0, 15) && bytes[15] === 0x01) {
+    return { address: canonical, canonical, family: 'ipv6', classification: 'loopback' };
+  }
+
+  const embedding: IIpv6Embedding | undefined = detectIpv6Embedding(bytes);
+  if (embedding !== undefined) {
+    return {
+      address: canonical,
+      canonical,
+      family: 'ipv6',
+      classification: classifyIpv4Value(embedding.value),
+      embedding: embedding.kind,
+      embeddedIpv4: ipv4ToString(embedding.value)
+    };
+  }
+
+  for (const range of IPV6_RANGES) {
+    if (matchesIpv6Range(bytes, range)) {
+      return { address: canonical, canonical, family: 'ipv6', classification: range.classification };
+    }
+  }
+
+  // Only `2000::/3` is assigned as global unicast. Everything else that reached
+  // this point is unassigned or reserved for future use, so it is never public.
+  const classification: AddressClassification =
+    (bytes[0] & IPV6_GLOBAL_UNICAST_MASK) === IPV6_GLOBAL_UNICAST_VALUE ? 'public' : 'reserved';
+  return { address: canonical, canonical, family: 'ipv6', classification };
+}
+
+/**
+ * Normalizes the textual forms an address can arrive in before parsing:
+ * surrounding whitespace, the square brackets a URL `hostname` carries for an
+ * IPv6 literal, and an IPv6 zone identifier (`%eth0`).
+ */
+function normalizeAddressText(address: string): string {
+  let text: string = address.trim();
+  if (text.length > 1 && text[0] === '[' && text[text.length - 1] === ']') {
+    text = text.slice(1, -1);
+  }
+  const zone: number = text.indexOf('%');
+  if (zone >= 0) {
+    text = text.slice(0, zone);
+  }
+  return text;
+}
+
+/**
+ * Classifies a single IP address literal.
+ *
+ * The function is pure, synchronous, and deterministic — it performs no name
+ * resolution and no I/O. Input that is not an IP address literal (a DNS
+ * hostname, for instance) fails; callers that accept hostnames should treat a
+ * failure here as "not a literal" and resolve the name, then classify each
+ * resolved address.
+ *
+ * Accepted forms:
+ *
+ * - dotted-quad IPv4 (`169.254.169.254`)
+ * - the shortened and non-decimal IPv4 forms the WHATWG URL parser accepts
+ *   (`127.1`, `2130706433`, `0177.0.0.1`, `0x7f.1`)
+ * - IPv6, with or without `::` compression, optionally bracketed as a URL
+ *   `hostname` is (`[::1]`) and optionally carrying a zone id (`fe80::1%eth0`)
+ * - IPv6 forms that embed an IPv4 address — IPv4-mapped, IPv4-compatible,
+ *   NAT64 and 6to4 — which are classified by their embedded IPv4 address
+ *
+ * A trailing dot is accepted on an IPv4 literal (`127.0.0.1.`), matching URL
+ * hostname normalization.
+ *
+ * @param address - the address literal to classify.
+ * @returns `Success` with the {@link IClassifiedAddress | classification},
+ * or `Failure` if the supplied text is not a well-formed IP address literal.
+ * @public
+ */
+export function classifyAddress(address: string): Result<IClassifiedAddress> {
+  const text: string = normalizeAddressText(address);
+  if (text.length === 0) {
+    return fail(`"${address}": not a valid IP address literal (empty)`);
+  }
+
+  if (text.indexOf(':') >= 0) {
+    const bytes: Uint8Array | undefined = parseIpv6(text);
+    if (bytes === undefined) {
+      return fail(`"${address}": not a valid IPv6 address literal`);
+    }
+    return succeed({ ...classifyIpv6Bytes(bytes), address });
+  }
+
+  const v4Text: string = text.length > 1 && text[text.length - 1] === '.' ? text.slice(0, -1) : text;
+  const value: number | undefined = parseIpv4(v4Text);
+  if (value === undefined) {
+    return fail(`"${address}": not a valid IP address literal`);
+  }
+  const canonical: string = ipv4ToString(value);
+  return succeed({
+    address,
+    canonical,
+    family: 'ipv4',
+    classification: classifyIpv4Value(value)
+  });
+}

--- a/libraries/ts-extras/src/packlets/safer-fetch/addressPolicy.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/addressPolicy.ts
@@ -91,8 +91,8 @@ const PUBLIC_OR_LOOPBACK: ReadonlySet<AddressClassification> = new Set<AddressCl
 
 function describeAddress(classified: IClassifiedAddress): string {
   const embedded: string =
-    classified.embedding !== undefined
-      ? ` via ${classified.embedding} ${String(classified.embeddedIpv4)}`
+    classified.embeddedIpv4 !== undefined
+      ? ` via ${classified.embeddedIpv4.kind} ${classified.embeddedIpv4.address}`
       : '';
   return `${classified.canonical} is ${classified.classification}${embedded}`;
 }

--- a/libraries/ts-extras/src/packlets/safer-fetch/addressPolicy.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/addressPolicy.ts
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { Result, fail, mapResults, succeed } from '@fgv/ts-utils';
+import { AddressClassification, IClassifiedAddress, classifyAddress } from './addressClassification';
+
+/**
+ * The evidence behind an allowed address-policy decision.
+ * @public
+ */
+export interface IAddressCheckVerdict {
+  /** The {@link IAddressPolicy.name | name} of the policy that produced the verdict. */
+  readonly policy: string;
+  /**
+   * The classification of every address the policy examined, in the order
+   * supplied. Empty for {@link allowAnyAddress}, which classifies nothing.
+   */
+  readonly addresses: ReadonlyArray<IClassifiedAddress>;
+}
+
+/**
+ * A pure, synchronous decision over a set of IP addresses.
+ *
+ * A policy performs no name resolution and no I/O: a caller resolves a
+ * hostname to its addresses and hands the whole list to
+ * {@link IAddressPolicy.checkAddresses}. The list contract is
+ * **reject-if-any** — a hostname that resolves to one public and one private
+ * address is disallowed, because without connect-time address pinning there is
+ * no guarantee which address the connection will use.
+ *
+ * @public
+ */
+export interface IAddressPolicy {
+  /**
+   * A stable, greppable identifier for the posture this policy implements.
+   * Surfaced in the failure message when an address is disallowed.
+   */
+  readonly name: string;
+
+  /**
+   * Decides whether a connection may be made to a destination that resolved to
+   * `addresses`.
+   *
+   * @param addresses - every address the destination resolved to, or the
+   * single literal address when the destination was an IP literal.
+   * @returns `Success` with the {@link IAddressCheckVerdict | verdict} when
+   * *every* address is permitted, `Failure` naming every address that is not.
+   * An empty list is a failure for any policy that offers a guarantee: nothing
+   * was verified, so nothing may be reached.
+   */
+  checkAddresses(addresses: ReadonlyArray<string>): Result<IAddressCheckVerdict>;
+}
+
+/**
+ * Options for {@link blockPrivateNetworks}.
+ * @public
+ */
+export interface IBlockPrivateNetworksOptions {
+  /**
+   * Permits `127.0.0.0/8` and `::1` (and their IPv4-mapped forms). Off by
+   * default: the polarity that ships a guard permitting `http://127.0.0.1:6379/`
+   * so a local-development convenience keeps working is the wrong one. A
+   * caller talking to a local sidecar opts in here, and the opt-in is
+   * independently greppable at the call site.
+   */
+  readonly allowLoopback?: boolean;
+}
+
+const PUBLIC_ONLY: ReadonlySet<AddressClassification> = new Set<AddressClassification>(['public']);
+const PUBLIC_OR_LOOPBACK: ReadonlySet<AddressClassification> = new Set<AddressClassification>([
+  'public',
+  'loopback'
+]);
+
+function describeAddress(classified: IClassifiedAddress): string {
+  const embedded: string =
+    classified.embedding !== undefined
+      ? ` via ${classified.embedding} ${String(classified.embeddedIpv4)}`
+      : '';
+  return `${classified.canonical} is ${classified.classification}${embedded}`;
+}
+
+function checkOneAddress(
+  policyName: string,
+  allowed: ReadonlySet<AddressClassification>,
+  address: string
+): Result<IClassifiedAddress> {
+  return classifyAddress(address)
+    .withErrorFormat((message) => `${policyName}: ${message}`)
+    .onSuccess((classified) =>
+      allowed.has(classified.classification)
+        ? succeed(classified)
+        : fail(`${policyName}: ${describeAddress(classified)} and is not allowed`)
+    );
+}
+
+function checkAllAddresses(
+  policyName: string,
+  allowed: ReadonlySet<AddressClassification>,
+  addresses: ReadonlyArray<string>
+): Result<IAddressCheckVerdict> {
+  if (addresses.length === 0) {
+    return fail(`${policyName}: no addresses to check - the destination cannot be verified`);
+  }
+  return mapResults(addresses.map((address) => checkOneAddress(policyName, allowed, address))).onSuccess(
+    (classified) => succeed({ policy: policyName, addresses: classified })
+  );
+}
+
+/**
+ * Creates the recommended address policy: every address must be a globally
+ * routable public unicast address.
+ *
+ * Rejected, in both their plain and their IPv6-embedded encodings: loopback,
+ * the link-local range that carries the cloud instance-metadata endpoint
+ * (`169.254.169.254`), RFC 1918 private ranges, IPv6 unique-local, carrier-grade
+ * NAT (`100.64.0.0/10`), the unspecified address, multicast, broadcast,
+ * benchmarking, documentation and every other reserved range. The encoding
+ * bypasses covered are IPv4-mapped IPv6 (`::ffff:169.254.169.254`),
+ * IPv4-compatible IPv6, NAT64 (`64:ff9b::a9fe:a9fe`), 6to4 (`2002:a9fe:a9fe::`)
+ * and the shortened / octal / hexadecimal / decimal IPv4 literal forms
+ * (`127.1`, `0177.0.0.1`, `0x7f.1`, `2130706433`).
+ *
+ * **What this does not protect against.** The policy classifies addresses a
+ * caller has already resolved; it cannot see the address the connection
+ * ultimately uses. A hostile DNS server that answers the resolution with a
+ * public address and the connect with a private one is not stopped by this
+ * policy — closing that requires connecting to a pinned address. The policy
+ * also says nothing about scheme, host, port, redirects or response content.
+ *
+ * @param options - optional {@link IBlockPrivateNetworksOptions | relaxations}
+ * of the default posture.
+ * @returns the policy. Construction cannot fail.
+ * @public
+ */
+export function blockPrivateNetworks(options?: IBlockPrivateNetworksOptions): IAddressPolicy {
+  const allowLoopback: boolean = options?.allowLoopback === true;
+  const name: string = allowLoopback ? 'blockPrivateNetworks(allowLoopback)' : 'blockPrivateNetworks';
+  const allowed: ReadonlySet<AddressClassification> = allowLoopback ? PUBLIC_OR_LOOPBACK : PUBLIC_ONLY;
+  return {
+    name,
+    checkAddresses: (addresses: ReadonlyArray<string>): Result<IAddressCheckVerdict> =>
+      checkAllAddresses(name, allowed, addresses)
+  };
+}
+
+/**
+ * Creates a policy that permits every address, including loopback, link-local
+ * and private ones.
+ *
+ * **This policy provides no protection whatsoever.** It classifies nothing,
+ * rejects nothing, and never fails — not even for an empty address list or an
+ * address that is not a well-formed literal. It exists so that choosing to go
+ * without an address guarantee is a deliberate, named, greppable act at the
+ * call site rather than something reachable by omission, and so that tests and
+ * genuinely trusted-input paths do not hand-roll something worse.
+ *
+ * It is the only correct choice in a browser, where neither name resolution nor
+ * redirect interposition is available and no address guarantee is possible.
+ *
+ * @returns the policy.
+ * @public
+ */
+export function allowAnyAddress(): IAddressPolicy {
+  const name: string = 'allowAnyAddress';
+  return {
+    name,
+    checkAddresses: (): Result<IAddressCheckVerdict> => succeed({ policy: name, addresses: [] })
+  };
+}

--- a/libraries/ts-extras/src/packlets/safer-fetch/addressPolicy.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/addressPolicy.ts
@@ -18,8 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { Result, fail, mapResults, succeed } from '@fgv/ts-utils';
-import { AddressClassification, IClassifiedAddress, classifyAddress } from './addressClassification';
+import { type Result, fail, mapResults, succeed } from '@fgv/ts-utils';
+import {
+  type AddressClassification,
+  type IClassifiedAddress,
+  classifyAddress
+} from './addressClassification';
 
 /**
  * The evidence behind an allowed address-policy decision.
@@ -182,6 +186,11 @@ export function allowAnyAddress(): IAddressPolicy {
   const name: string = 'allowAnyAddress';
   return {
     name,
+    // The parameter is deliberately not declared. This policy does not read the
+    // addresses, and an unused `_addresses` would both restate that less
+    // clearly and cut against the repo's "don't rename unused variables to
+    // `_var`" rule. Parameter bivariance makes the zero-arg form a complete
+    // implementation of `IAddressPolicy`.
     checkAddresses: (): Result<IAddressCheckVerdict> => succeed({ policy: name, addresses: [] })
   };
 }

--- a/libraries/ts-extras/src/packlets/safer-fetch/index.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/index.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * A safer `fetch` primitive with an explicit threat model.
+ *
+ * This barrel currently carries the runtime-agnostic address-classification
+ * layer: {@link classifyAddress} plus the {@link IAddressPolicy} factories
+ * {@link blockPrivateNetworks} and {@link allowAnyAddress}. Everything here is
+ * pure, synchronous and deterministic — no name resolution, no transport, no
+ * clock.
+ *
+ * @packageDocumentation
+ */
+
+export * from './addressClassification';
+export * from './addressPolicy';

--- a/libraries/ts-extras/src/test/unit/safer-fetch/addressClassification.test.ts
+++ b/libraries/ts-extras/src/test/unit/safer-fetch/addressClassification.test.ts
@@ -459,5 +459,22 @@ describe('classifyAddress', () => {
     test('the failing message quotes the address exactly as supplied', () => {
       expect(classifyAddress('metadata.internal')).toFailWith(/"metadata\.internal"/);
     });
+
+    // The platform's URL parser applies IDNA/Unicode normalization, so every
+    // string below is the host `127.0.0.1` once it has been through `new URL`.
+    // This function deliberately does not do that normalization — it classifies
+    // a `hostname`, which has already had it. Handed the raw text it fails,
+    // which is fail-closed only because the caller then resolves it as a name.
+    // These cases pin that boundary so it cannot drift silently.
+    test.each([['１２７.０.０.１'], ['127。0。0。1'], ['⑫7.0.0.1']])(
+      'does not itself normalize %s, which the URL parser reads as 127.0.0.1',
+      (address) => {
+        expect(new URL(`http://${address}/`).hostname).toBe('127.0.0.1');
+        expect(classifyAddress(address)).toFail();
+        expect(classifyAddress(new URL(`http://${address}/`).hostname)).toSucceedAndSatisfy((classified) => {
+          expect(classified.classification).toBe('loopback');
+        });
+      }
+    );
   });
 });

--- a/libraries/ts-extras/src/test/unit/safer-fetch/addressClassification.test.ts
+++ b/libraries/ts-extras/src/test/unit/safer-fetch/addressClassification.test.ts
@@ -1,0 +1,464 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import {
+  AddressClassification,
+  AddressFamily,
+  Ipv4EmbeddingKind,
+  classifyAddress
+} from '../../../packlets/safer-fetch';
+
+interface ICase {
+  readonly address: string;
+  readonly classification: AddressClassification;
+  readonly canonical?: string;
+  readonly family?: AddressFamily;
+  readonly embedding?: Ipv4EmbeddingKind;
+  readonly embeddedIpv4?: string;
+}
+
+function expectClassification(testCase: ICase): void {
+  expect(classifyAddress(testCase.address)).toSucceedAndSatisfy((classified) => {
+    expect(classified.classification).toBe(testCase.classification);
+    expect(classified.address).toBe(testCase.address);
+    expect(classified.family).toBe(testCase.family ?? 'ipv4');
+    if (testCase.canonical !== undefined) {
+      expect(classified.canonical).toBe(testCase.canonical);
+    }
+    expect(classified.embedding).toBe(testCase.embedding);
+    expect(classified.embeddedIpv4).toBe(testCase.embeddedIpv4);
+  });
+}
+
+function runCases(cases: ReadonlyArray<ICase>): void {
+  for (const testCase of cases) {
+    test(`${testCase.address} classifies as ${testCase.classification}`, () => {
+      expectClassification(testCase);
+    });
+  }
+}
+
+describe('classifyAddress', () => {
+  describe('IPv4 special-purpose ranges, at their boundaries', () => {
+    // Every rejected range from the threat model's § 3.6 table is tested at both
+    // edges, and the addresses immediately below and above each range are tested
+    // as public. A classifier that rejects everything passes a one-directional
+    // suite and would push consumers straight to `allowAnyAddress()`.
+    runCases([
+      { address: '0.0.0.0', classification: 'unspecified' },
+      { address: '0.255.255.255', classification: 'unspecified' },
+      { address: '1.0.0.0', classification: 'public' },
+
+      { address: '9.255.255.255', classification: 'public' },
+      { address: '10.0.0.0', classification: 'private' },
+      { address: '10.1.2.3', classification: 'private' },
+      { address: '10.255.255.255', classification: 'private' },
+      { address: '11.0.0.0', classification: 'public' },
+
+      // CGNAT: 100.64.0.0/10 is 100.64.0.0 - 100.127.255.255. Off-by-one on the
+      // mask is the classic error, so both edges plus both neighbours are here.
+      { address: '100.63.255.255', classification: 'public' },
+      { address: '100.64.0.0', classification: 'carrier-grade-nat' },
+      { address: '100.64.0.1', classification: 'carrier-grade-nat' },
+      { address: '100.127.255.255', classification: 'carrier-grade-nat' },
+      { address: '100.128.0.0', classification: 'public' },
+      { address: '100.128.0.1', classification: 'public' },
+
+      { address: '126.255.255.255', classification: 'public' },
+      { address: '127.0.0.0', classification: 'loopback' },
+      { address: '127.0.0.1', classification: 'loopback' },
+      { address: '127.255.255.255', classification: 'loopback' },
+      { address: '128.0.0.0', classification: 'public' },
+
+      // Link-local carries the cloud instance-metadata endpoint.
+      { address: '169.253.255.255', classification: 'public' },
+      { address: '169.254.0.0', classification: 'link-local' },
+      { address: '169.254.169.254', classification: 'link-local' },
+      { address: '169.254.255.255', classification: 'link-local' },
+      { address: '169.255.0.0', classification: 'public' },
+
+      { address: '172.15.255.255', classification: 'public' },
+      { address: '172.16.0.0', classification: 'private' },
+      { address: '172.31.255.255', classification: 'private' },
+      { address: '172.32.0.0', classification: 'public' },
+
+      { address: '192.0.0.0', classification: 'protocol-assignment' },
+      { address: '192.0.0.255', classification: 'protocol-assignment' },
+      { address: '192.0.1.0', classification: 'public' },
+      { address: '192.0.2.0', classification: 'documentation' },
+      { address: '192.0.2.255', classification: 'documentation' },
+      { address: '192.0.3.0', classification: 'public' },
+
+      { address: '192.88.98.255', classification: 'public' },
+      { address: '192.88.99.1', classification: 'reserved' },
+      { address: '192.88.100.0', classification: 'public' },
+
+      { address: '192.167.255.255', classification: 'public' },
+      { address: '192.168.0.0', classification: 'private' },
+      { address: '192.168.255.255', classification: 'private' },
+      { address: '192.169.0.0', classification: 'public' },
+
+      { address: '198.17.255.255', classification: 'public' },
+      { address: '198.18.0.0', classification: 'benchmarking' },
+      { address: '198.19.255.255', classification: 'benchmarking' },
+      { address: '198.20.0.0', classification: 'public' },
+
+      { address: '198.51.99.255', classification: 'public' },
+      { address: '198.51.100.5', classification: 'documentation' },
+      { address: '198.51.101.0', classification: 'public' },
+
+      { address: '203.0.112.255', classification: 'public' },
+      { address: '203.0.113.5', classification: 'documentation' },
+      { address: '203.0.114.0', classification: 'public' },
+
+      { address: '223.255.255.255', classification: 'public' },
+      { address: '224.0.0.1', classification: 'multicast' },
+      { address: '239.255.255.255', classification: 'multicast' },
+      { address: '240.0.0.0', classification: 'reserved' },
+      { address: '255.255.255.254', classification: 'reserved' },
+      { address: '255.255.255.255', classification: 'broadcast' },
+
+      { address: '8.8.8.8', classification: 'public' },
+      { address: '93.184.216.34', classification: 'public' }
+    ]);
+  });
+
+  describe('IPv4 literal encodings the URL parser accepts', () => {
+    // `0177.0.0.1` is `127.0.0.1`; so is `2130706433`. A guard that string-matches
+    // on `127.` or `10.` is bypassed by every row here — and, in the other
+    // direction, wrongly rejects `010.0.0.1`, which is 8.0.0.1 and public.
+    runCases([
+      { address: '2130706433', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '0177.0.0.1', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '0x7f.1', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '0x7f000001', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '0X7F000001', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '127.1', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '127.0.1', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '0177.0.0.01', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '127.0.0.1.', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '  127.0.0.1  ', classification: 'loopback', canonical: '127.0.0.1' },
+
+      { address: '2852039166', classification: 'link-local', canonical: '169.254.169.254' },
+      { address: '0xa9fea9fe', classification: 'link-local', canonical: '169.254.169.254' },
+      { address: '0251.0376.0251.0376', classification: 'link-local', canonical: '169.254.169.254' },
+      { address: '169.254.43518', classification: 'link-local', canonical: '169.254.169.254' },
+
+      { address: '0x0a.0.0.1', classification: 'private', canonical: '10.0.0.1' },
+      { address: '0xc0a80001', classification: 'private', canonical: '192.168.0.1' },
+      { address: '0144.100.0.1', classification: 'carrier-grade-nat', canonical: '100.100.0.1' },
+
+      // The other direction: these superficially resemble private literals but
+      // are public once the radix rules are applied.
+      { address: '010.0.0.1', classification: 'public', canonical: '8.0.0.1' },
+      { address: '0172.16.0.1', classification: 'public', canonical: '122.16.0.1' },
+      { address: '134744072', classification: 'public', canonical: '8.8.8.8' },
+      { address: '0x08080808', classification: 'public', canonical: '8.8.8.8' },
+      { address: '4294967295', classification: 'broadcast', canonical: '255.255.255.255' },
+
+      // A trailing dot is stripped and the remaining components are then read
+      // with the usual "final component absorbs the rest" rule, which is what
+      // the URL parser does: `1.2.3.` is `1.2.0.3`, not `1.2.3.0`.
+      { address: '1.2.3.', classification: 'public', canonical: '1.2.0.3' }
+    ]);
+  });
+
+  describe('IPv6 ranges', () => {
+    runCases([
+      { address: '::', classification: 'unspecified', canonical: '::', family: 'ipv6' },
+      { address: '0:0:0:0:0:0:0:0', classification: 'unspecified', canonical: '::', family: 'ipv6' },
+      { address: '::1', classification: 'loopback', canonical: '::1', family: 'ipv6' },
+      { address: '[::1]', classification: 'loopback', canonical: '::1', family: 'ipv6' },
+      { address: '0:0:0:0:0:0:0:1', classification: 'loopback', canonical: '::1', family: 'ipv6' },
+
+      { address: 'fc00::', classification: 'unique-local', family: 'ipv6' },
+      { address: 'fd00::1', classification: 'unique-local', family: 'ipv6' },
+      { address: 'fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', classification: 'unique-local', family: 'ipv6' },
+      { address: 'fb00::1', classification: 'reserved', family: 'ipv6' },
+
+      { address: 'fe80::1', classification: 'link-local', family: 'ipv6' },
+      { address: 'fe80::1%eth0', classification: 'link-local', family: 'ipv6' },
+      { address: 'febf:ffff::', classification: 'link-local', family: 'ipv6' },
+      { address: 'fec0::1', classification: 'reserved', family: 'ipv6' },
+      { address: 'fe00::1', classification: 'reserved', family: 'ipv6' },
+
+      { address: 'ff00::', classification: 'multicast', family: 'ipv6' },
+      { address: 'ff02::1', classification: 'multicast', family: 'ipv6' },
+
+      { address: '2001::1', classification: 'protocol-assignment', family: 'ipv6' },
+      { address: '2001:1ff:ffff::', classification: 'protocol-assignment', family: 'ipv6' },
+      { address: '2001:200::', classification: 'public', family: 'ipv6' },
+      { address: '2001:db8::1', classification: 'documentation', family: 'ipv6' },
+      { address: '2001:db9::1', classification: 'public', family: 'ipv6' },
+      { address: '3fff::1', classification: 'documentation', family: 'ipv6' },
+      { address: '3fff:1000::', classification: 'public', family: 'ipv6' },
+
+      // Only 2000::/3 is assigned as global unicast; everything else that
+      // matched no special-purpose range is reserved, never public.
+      { address: '2606:4700::1111', classification: 'public', family: 'ipv6' },
+      { address: '2000::', classification: 'public', family: 'ipv6' },
+      { address: '3fff:ffff::', classification: 'public', family: 'ipv6' },
+      { address: '1fff::1', classification: 'reserved', family: 'ipv6' },
+      { address: '4000::1', classification: 'reserved', family: 'ipv6' },
+      { address: '100::1', classification: 'reserved', family: 'ipv6' },
+      { address: '64:ff9b::1:0:1', classification: 'reserved', family: 'ipv6' }
+    ]);
+  });
+
+  describe('IPv6 forms that embed an IPv4 address', () => {
+    // The single most common bypass: `::ffff:169.254.169.254` must classify as
+    // link-local, not as "some IPv6 address".
+    runCases([
+      {
+        address: '::ffff:169.254.169.254',
+        classification: 'link-local',
+        canonical: '::ffff:a9fe:a9fe',
+        family: 'ipv6',
+        embedding: 'ipv4-mapped',
+        embeddedIpv4: '169.254.169.254'
+      },
+      {
+        address: '::ffff:a9fe:a9fe',
+        classification: 'link-local',
+        canonical: '::ffff:a9fe:a9fe',
+        family: 'ipv6',
+        embedding: 'ipv4-mapped',
+        embeddedIpv4: '169.254.169.254'
+      },
+      {
+        address: '::FFFF:127.0.0.1',
+        classification: 'loopback',
+        canonical: '::ffff:7f00:1',
+        family: 'ipv6',
+        embedding: 'ipv4-mapped',
+        embeddedIpv4: '127.0.0.1'
+      },
+      {
+        address: '::ffff:10.0.0.1',
+        classification: 'private',
+        family: 'ipv6',
+        embedding: 'ipv4-mapped',
+        embeddedIpv4: '10.0.0.1'
+      },
+      {
+        address: '::ffff:100.64.0.1',
+        classification: 'carrier-grade-nat',
+        family: 'ipv6',
+        embedding: 'ipv4-mapped',
+        embeddedIpv4: '100.64.0.1'
+      },
+      // Other direction: a mapped public address stays public.
+      {
+        address: '::ffff:8.8.8.8',
+        classification: 'public',
+        family: 'ipv6',
+        embedding: 'ipv4-mapped',
+        embeddedIpv4: '8.8.8.8'
+      },
+      {
+        address: '::ffff:100.128.0.1',
+        classification: 'public',
+        family: 'ipv6',
+        embedding: 'ipv4-mapped',
+        embeddedIpv4: '100.128.0.1'
+      },
+
+      // NAT64, RFC 6052 well-known prefix.
+      {
+        address: '64:ff9b::169.254.169.254',
+        classification: 'link-local',
+        canonical: '64:ff9b::a9fe:a9fe',
+        family: 'ipv6',
+        embedding: 'nat64',
+        embeddedIpv4: '169.254.169.254'
+      },
+      {
+        address: '64:ff9b::a9fe:a9fe',
+        classification: 'link-local',
+        family: 'ipv6',
+        embedding: 'nat64',
+        embeddedIpv4: '169.254.169.254'
+      },
+      {
+        address: '64:ff9b::8.8.8.8',
+        classification: 'public',
+        family: 'ipv6',
+        embedding: 'nat64',
+        embeddedIpv4: '8.8.8.8'
+      },
+
+      // 6to4 — the IPv4 address lives in bits 16..47, not the low 32.
+      {
+        address: '2002:a9fe:a9fe::',
+        classification: 'link-local',
+        family: 'ipv6',
+        embedding: '6to4',
+        embeddedIpv4: '169.254.169.254'
+      },
+      {
+        address: '2002:7f00:1::1',
+        classification: 'loopback',
+        family: 'ipv6',
+        embedding: '6to4',
+        embeddedIpv4: '127.0.0.1'
+      },
+      {
+        address: '2002:5db8:d822::1',
+        classification: 'public',
+        family: 'ipv6',
+        embedding: '6to4',
+        embeddedIpv4: '93.184.216.34'
+      },
+
+      // Deprecated IPv4-compatible form (`::a.b.c.d`).
+      {
+        address: '::7f00:1',
+        classification: 'loopback',
+        family: 'ipv6',
+        embedding: 'ipv4-compatible',
+        embeddedIpv4: '127.0.0.1'
+      },
+      {
+        address: '::169.254.169.254',
+        classification: 'link-local',
+        canonical: '::a9fe:a9fe',
+        family: 'ipv6',
+        embedding: 'ipv4-compatible',
+        embeddedIpv4: '169.254.169.254'
+      },
+      {
+        address: '::0.0.0.2',
+        classification: 'unspecified',
+        family: 'ipv6',
+        embedding: 'ipv4-compatible',
+        embeddedIpv4: '0.0.0.2'
+      },
+      {
+        address: '::8.8.8.8',
+        classification: 'public',
+        family: 'ipv6',
+        embedding: 'ipv4-compatible',
+        embeddedIpv4: '8.8.8.8'
+      },
+
+      // `::ffff:0:0:0/96` (IPv4-translated) is only meaningful inside a
+      // translator, so it is rejected outright rather than decoded.
+      { address: '::ffff:0:a9fe:a9fe', classification: 'reserved', family: 'ipv6' }
+    ]);
+
+    test('the unspecified and loopback addresses are not decoded as IPv4-compatible', () => {
+      expect(classifyAddress('::')).toSucceedAndSatisfy((classified) => {
+        expect(classified.classification).toBe('unspecified');
+        expect(classified.embedding).toBeUndefined();
+      });
+      expect(classifyAddress('::1')).toSucceedAndSatisfy((classified) => {
+        expect(classified.classification).toBe('loopback');
+        expect(classified.embedding).toBeUndefined();
+      });
+    });
+  });
+
+  describe('canonical form', () => {
+    test.each([
+      ['0:0:0:0:0:0:0:1', '::1'],
+      ['0:0:0:0:0:0:0:0', '::'],
+      ['2001:0db8:0000:0000:0000:0000:0000:0001', '2001:db8::1'],
+      ['2001:DB8::1', '2001:db8::1'],
+      // RFC 5952: the leftmost of two equally long zero runs is the one compressed.
+      ['2001:db8:0:0:1:0:0:1', '2001:db8::1:0:0:1'],
+      ['1:0:0:0:2:0:0:3', '1::2:0:0:3'],
+      ['1:2:3:4:5:6:7:8', '1:2:3:4:5:6:7:8'],
+      // RFC 5952: a single zero group is never compressed.
+      ['0:1:2:3:4:5:6:7', '0:1:2:3:4:5:6:7'],
+      ['1:2:3:4:5:6:7:0', '1:2:3:4:5:6:7:0'],
+      ['ff00::', 'ff00::'],
+      ['::ffff:1.2.3.4', '::ffff:102:304']
+    ])('%s canonicalizes to %s', (address, canonical) => {
+      expect(classifyAddress(address)).toSucceedAndSatisfy((classified) => {
+        expect(classified.canonical).toBe(canonical);
+      });
+    });
+
+    test('an IPv4 literal canonicalizes to dotted-quad regardless of the form supplied', () => {
+      expect(classifyAddress('0x7f.1')).toSucceedAndSatisfy((classified) => {
+        expect(classified.canonical).toBe('127.0.0.1');
+        expect(classified.address).toBe('0x7f.1');
+      });
+    });
+  });
+
+  describe('input that is not an IP address literal', () => {
+    test.each([
+      ['', /empty/i],
+      ['   ', /empty/i],
+      ['%eth0', /empty/i],
+      ['example.com', /not a valid IP address/i],
+      ['localhost', /not a valid IP address/i],
+      ['LOCALHOST.', /not a valid IP address/i],
+      ['metadata.google.internal', /not a valid IP address/i],
+      ['1.2.3.4.5', /not a valid IP address/i],
+      ['256.0.0.1', /not a valid IP address/i],
+      ['1.2.3.256', /not a valid IP address/i],
+      ['08.0.0.1', /not a valid IP address/i],
+      ['0x.1', /not a valid IP address/i],
+      ['0xzz', /not a valid IP address/i],
+      ['-1.0.0.1', /not a valid IP address/i],
+      ['1.2..3', /not a valid IP address/i],
+      ['.', /not a valid IP address/i],
+      ['..', /not a valid IP address/i],
+      ['4294967296', /not a valid IP address/i],
+      ['999999999999999999999999', /not a valid IP address/i],
+      ['127.0.0.1/8', /not a valid IP address/i]
+    ])('%s fails', (address, pattern) => {
+      expect(classifyAddress(address)).toFailWith(pattern);
+    });
+
+    test.each([
+      ['1::2::3'],
+      [':::'],
+      ['::1::'],
+      ['1:2:3:4:5:6:7'],
+      ['1:2:3:4:5:6:7:8:9'],
+      ['1:2:3:4:5:6:7:8::'],
+      ['12345::'],
+      ['gggg::1'],
+      ['::ffff:0177.0.0.1'],
+      ['::ffff:127.0.0.1.5'],
+      ['::1.2.3'],
+      ['::1.2.3.256'],
+      ['::0x7f.0.0.1'],
+      ['1.2.3.4:5'],
+      ['::1.2.3.4:5'],
+      ['[::1'],
+      ['::1]'],
+      [':1:2:3:4:5:6:7:8'],
+      ['1:2:3:4:5:6:7:8:'],
+      [':']
+    ])('%s fails as an IPv6 literal', (address) => {
+      expect(classifyAddress(address)).toFailWith(/not a valid IPv6 address literal/i);
+    });
+
+    test('the failing message quotes the address exactly as supplied', () => {
+      expect(classifyAddress('metadata.internal')).toFailWith(/"metadata\.internal"/);
+    });
+  });
+});

--- a/libraries/ts-extras/src/test/unit/safer-fetch/addressClassification.test.ts
+++ b/libraries/ts-extras/src/test/unit/safer-fetch/addressClassification.test.ts
@@ -23,7 +23,7 @@ import '@fgv/ts-utils-jest';
 import {
   AddressClassification,
   AddressFamily,
-  Ipv4EmbeddingKind,
+  IEmbeddedIpv4,
   classifyAddress
 } from '../../../packlets/safer-fetch';
 
@@ -32,8 +32,7 @@ interface ICase {
   readonly classification: AddressClassification;
   readonly canonical?: string;
   readonly family?: AddressFamily;
-  readonly embedding?: Ipv4EmbeddingKind;
-  readonly embeddedIpv4?: string;
+  readonly embeddedIpv4?: IEmbeddedIpv4;
 }
 
 function expectClassification(testCase: ICase): void {
@@ -44,8 +43,7 @@ function expectClassification(testCase: ICase): void {
     if (testCase.canonical !== undefined) {
       expect(classified.canonical).toBe(testCase.canonical);
     }
-    expect(classified.embedding).toBe(testCase.embedding);
-    expect(classified.embeddedIpv4).toBe(testCase.embeddedIpv4);
+    expect(classified.embeddedIpv4).toEqual(testCase.embeddedIpv4);
   });
 }
 
@@ -163,6 +161,15 @@ describe('classifyAddress', () => {
       { address: '0251.0376.0251.0376', classification: 'link-local', canonical: '169.254.169.254' },
       { address: '169.254.43518', classification: 'link-local', canonical: '169.254.169.254' },
 
+      // Stripping the radix prefix can leave nothing behind, and the WHATWG
+      // number parser reads that as zero — so a bare `0x` is `0` and
+      // `127.0x.1` is `127.0.0.1`. Rejecting it would leave a live bypass.
+      { address: '127.0x.1', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '0177.0x.1', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '0x7f.0X.0x.1', classification: 'loopback', canonical: '127.0.0.1' },
+      { address: '0x', classification: 'unspecified', canonical: '0.0.0.0' },
+      { address: '169.254.0x.0xfe', classification: 'link-local', canonical: '169.254.0.254' },
+
       { address: '0x0a.0.0.1', classification: 'private', canonical: '10.0.0.1' },
       { address: '0xc0a80001', classification: 'private', canonical: '192.168.0.1' },
       { address: '0144.100.0.1', classification: 'carrier-grade-nat', canonical: '100.100.0.1' },
@@ -233,53 +240,46 @@ describe('classifyAddress', () => {
         classification: 'link-local',
         canonical: '::ffff:a9fe:a9fe',
         family: 'ipv6',
-        embedding: 'ipv4-mapped',
-        embeddedIpv4: '169.254.169.254'
+        embeddedIpv4: { kind: 'ipv4-mapped', address: '169.254.169.254' }
       },
       {
         address: '::ffff:a9fe:a9fe',
         classification: 'link-local',
         canonical: '::ffff:a9fe:a9fe',
         family: 'ipv6',
-        embedding: 'ipv4-mapped',
-        embeddedIpv4: '169.254.169.254'
+        embeddedIpv4: { kind: 'ipv4-mapped', address: '169.254.169.254' }
       },
       {
         address: '::FFFF:127.0.0.1',
         classification: 'loopback',
         canonical: '::ffff:7f00:1',
         family: 'ipv6',
-        embedding: 'ipv4-mapped',
-        embeddedIpv4: '127.0.0.1'
+        embeddedIpv4: { kind: 'ipv4-mapped', address: '127.0.0.1' }
       },
       {
         address: '::ffff:10.0.0.1',
         classification: 'private',
         family: 'ipv6',
-        embedding: 'ipv4-mapped',
-        embeddedIpv4: '10.0.0.1'
+        embeddedIpv4: { kind: 'ipv4-mapped', address: '10.0.0.1' }
       },
       {
         address: '::ffff:100.64.0.1',
         classification: 'carrier-grade-nat',
         family: 'ipv6',
-        embedding: 'ipv4-mapped',
-        embeddedIpv4: '100.64.0.1'
+        embeddedIpv4: { kind: 'ipv4-mapped', address: '100.64.0.1' }
       },
       // Other direction: a mapped public address stays public.
       {
         address: '::ffff:8.8.8.8',
         classification: 'public',
         family: 'ipv6',
-        embedding: 'ipv4-mapped',
-        embeddedIpv4: '8.8.8.8'
+        embeddedIpv4: { kind: 'ipv4-mapped', address: '8.8.8.8' }
       },
       {
         address: '::ffff:100.128.0.1',
         classification: 'public',
         family: 'ipv6',
-        embedding: 'ipv4-mapped',
-        embeddedIpv4: '100.128.0.1'
+        embeddedIpv4: { kind: 'ipv4-mapped', address: '100.128.0.1' }
       },
 
       // NAT64, RFC 6052 well-known prefix.
@@ -288,22 +288,19 @@ describe('classifyAddress', () => {
         classification: 'link-local',
         canonical: '64:ff9b::a9fe:a9fe',
         family: 'ipv6',
-        embedding: 'nat64',
-        embeddedIpv4: '169.254.169.254'
+        embeddedIpv4: { kind: 'nat64', address: '169.254.169.254' }
       },
       {
         address: '64:ff9b::a9fe:a9fe',
         classification: 'link-local',
         family: 'ipv6',
-        embedding: 'nat64',
-        embeddedIpv4: '169.254.169.254'
+        embeddedIpv4: { kind: 'nat64', address: '169.254.169.254' }
       },
       {
         address: '64:ff9b::8.8.8.8',
         classification: 'public',
         family: 'ipv6',
-        embedding: 'nat64',
-        embeddedIpv4: '8.8.8.8'
+        embeddedIpv4: { kind: 'nat64', address: '8.8.8.8' }
       },
 
       // 6to4 — the IPv4 address lives in bits 16..47, not the low 32.
@@ -311,22 +308,19 @@ describe('classifyAddress', () => {
         address: '2002:a9fe:a9fe::',
         classification: 'link-local',
         family: 'ipv6',
-        embedding: '6to4',
-        embeddedIpv4: '169.254.169.254'
+        embeddedIpv4: { kind: '6to4', address: '169.254.169.254' }
       },
       {
         address: '2002:7f00:1::1',
         classification: 'loopback',
         family: 'ipv6',
-        embedding: '6to4',
-        embeddedIpv4: '127.0.0.1'
+        embeddedIpv4: { kind: '6to4', address: '127.0.0.1' }
       },
       {
         address: '2002:5db8:d822::1',
         classification: 'public',
         family: 'ipv6',
-        embedding: '6to4',
-        embeddedIpv4: '93.184.216.34'
+        embeddedIpv4: { kind: '6to4', address: '93.184.216.34' }
       },
 
       // Deprecated IPv4-compatible form (`::a.b.c.d`).
@@ -334,30 +328,26 @@ describe('classifyAddress', () => {
         address: '::7f00:1',
         classification: 'loopback',
         family: 'ipv6',
-        embedding: 'ipv4-compatible',
-        embeddedIpv4: '127.0.0.1'
+        embeddedIpv4: { kind: 'ipv4-compatible', address: '127.0.0.1' }
       },
       {
         address: '::169.254.169.254',
         classification: 'link-local',
         canonical: '::a9fe:a9fe',
         family: 'ipv6',
-        embedding: 'ipv4-compatible',
-        embeddedIpv4: '169.254.169.254'
+        embeddedIpv4: { kind: 'ipv4-compatible', address: '169.254.169.254' }
       },
       {
         address: '::0.0.0.2',
         classification: 'unspecified',
         family: 'ipv6',
-        embedding: 'ipv4-compatible',
-        embeddedIpv4: '0.0.0.2'
+        embeddedIpv4: { kind: 'ipv4-compatible', address: '0.0.0.2' }
       },
       {
         address: '::8.8.8.8',
         classification: 'public',
         family: 'ipv6',
-        embedding: 'ipv4-compatible',
-        embeddedIpv4: '8.8.8.8'
+        embeddedIpv4: { kind: 'ipv4-compatible', address: '8.8.8.8' }
       },
 
       // `::ffff:0:0:0/96` (IPv4-translated) is only meaningful inside a
@@ -368,11 +358,11 @@ describe('classifyAddress', () => {
     test('the unspecified and loopback addresses are not decoded as IPv4-compatible', () => {
       expect(classifyAddress('::')).toSucceedAndSatisfy((classified) => {
         expect(classified.classification).toBe('unspecified');
-        expect(classified.embedding).toBeUndefined();
+        expect(classified.embeddedIpv4).toBeUndefined();
       });
       expect(classifyAddress('::1')).toSucceedAndSatisfy((classified) => {
         expect(classified.classification).toBe('loopback');
-        expect(classified.embedding).toBeUndefined();
+        expect(classified.embeddedIpv4).toBeUndefined();
       });
     });
   });
@@ -410,7 +400,12 @@ describe('classifyAddress', () => {
     test.each([
       ['', /empty/i],
       ['   ', /empty/i],
-      ['%eth0', /empty/i],
+      ['[]', /empty/i],
+      // A zone identifier belongs to IPv6 only, so this must fail rather than
+      // be read as 8.8.8.8.
+      ['%eth0', /not a valid IP address/i],
+      ['8.8.8.8%eth0', /not a valid IP address/i],
+      ['127.0.0.1%eth0', /not a valid IP address/i],
       ['example.com', /not a valid IP address/i],
       ['localhost', /not a valid IP address/i],
       ['LOCALHOST.', /not a valid IP address/i],
@@ -419,7 +414,6 @@ describe('classifyAddress', () => {
       ['256.0.0.1', /not a valid IP address/i],
       ['1.2.3.256', /not a valid IP address/i],
       ['08.0.0.1', /not a valid IP address/i],
-      ['0x.1', /not a valid IP address/i],
       ['0xzz', /not a valid IP address/i],
       ['-1.0.0.1', /not a valid IP address/i],
       ['1.2..3', /not a valid IP address/i],
@@ -448,6 +442,11 @@ describe('classifyAddress', () => {
       ['::0x7f.0.0.1'],
       ['1.2.3.4:5'],
       ['::1.2.3.4:5'],
+      // An embedded IPv4 tail may only end the whole address, so this is
+      // malformed rather than `102:304::`.
+      ['1.2.3.4::'],
+      ['1.2.3.4::5'],
+      ['1:2:1.2.3.4::5'],
       ['[::1'],
       ['::1]'],
       [':1:2:3:4:5:6:7:8'],

--- a/libraries/ts-extras/src/test/unit/safer-fetch/addressClassification.test.ts
+++ b/libraries/ts-extras/src/test/unit/safer-fetch/addressClassification.test.ts
@@ -21,9 +21,9 @@
 import '@fgv/ts-utils-jest';
 
 import {
-  AddressClassification,
-  AddressFamily,
-  IEmbeddedIpv4,
+  type AddressClassification,
+  type AddressFamily,
+  type IEmbeddedIpv4,
   classifyAddress
 } from '../../../packlets/safer-fetch';
 

--- a/libraries/ts-extras/src/test/unit/safer-fetch/addressPolicy.test.ts
+++ b/libraries/ts-extras/src/test/unit/safer-fetch/addressPolicy.test.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import { IAddressPolicy, allowAnyAddress, blockPrivateNetworks } from '../../../packlets/safer-fetch';
+
+describe('blockPrivateNetworks', () => {
+  const policy: IAddressPolicy = blockPrivateNetworks();
+
+  test('is named for the posture it implements', () => {
+    expect(policy.name).toBe('blockPrivateNetworks');
+    expect(blockPrivateNetworks({}).name).toBe('blockPrivateNetworks');
+    expect(blockPrivateNetworks({ allowLoopback: false }).name).toBe('blockPrivateNetworks');
+    expect(blockPrivateNetworks({ allowLoopback: true }).name).toBe('blockPrivateNetworks(allowLoopback)');
+  });
+
+  describe('addresses it permits', () => {
+    test.each([
+      ['8.8.8.8'],
+      ['93.184.216.34'],
+      ['100.128.0.1'],
+      ['172.32.0.1'],
+      ['169.255.0.1'],
+      ['2606:4700::1111'],
+      ['::ffff:8.8.8.8'],
+      ['64:ff9b::8.8.8.8'],
+      ['2002:5db8:d822::1'],
+      ['010.0.0.1'],
+      ['134744072']
+    ])('permits %s', (address) => {
+      expect(policy.checkAddresses([address])).toSucceedAndSatisfy((verdict) => {
+        expect(verdict.policy).toBe('blockPrivateNetworks');
+        expect(verdict.addresses).toHaveLength(1);
+        expect(verdict.addresses[0].classification).toBe('public');
+      });
+    });
+
+    test('permits a list in which every address is public, preserving order', () => {
+      expect(policy.checkAddresses(['8.8.8.8', '1.1.1.1', '2606:4700::1111'])).toSucceedAndSatisfy(
+        (verdict) => {
+          expect(verdict.addresses.map((a) => a.canonical)).toEqual([
+            '8.8.8.8',
+            '1.1.1.1',
+            '2606:4700::1111'
+          ]);
+        }
+      );
+    });
+  });
+
+  describe('addresses it blocks', () => {
+    test.each([
+      ['127.0.0.1', /loopback/i],
+      ['127.1', /loopback/i],
+      ['0177.0.0.1', /loopback/i],
+      ['2130706433', /loopback/i],
+      ['0x7f.1', /loopback/i],
+      ['0.0.0.0', /unspecified/i],
+      ['10.0.0.5', /private/i],
+      ['172.16.0.1', /private/i],
+      ['192.168.1.1', /private/i],
+      ['169.254.169.254', /link-local/i],
+      ['100.64.0.1', /carrier-grade-nat/i],
+      ['198.18.0.1', /benchmarking/i],
+      ['192.0.2.1', /documentation/i],
+      ['192.0.0.1', /protocol-assignment/i],
+      ['224.0.0.1', /multicast/i],
+      ['240.0.0.1', /reserved/i],
+      ['255.255.255.255', /broadcast/i],
+      ['::1', /loopback/i],
+      ['::', /unspecified/i],
+      ['fe80::1', /link-local/i],
+      ['fd00::1', /unique-local/i],
+      ['ff02::1', /multicast/i],
+      ['2001:db8::1', /documentation/i],
+      ['::ffff:169.254.169.254', /link-local/i],
+      ['::ffff:127.0.0.1', /loopback/i],
+      ['::7f00:1', /loopback/i],
+      ['64:ff9b::a9fe:a9fe', /link-local/i],
+      ['2002:a9fe:a9fe::', /link-local/i]
+    ])('blocks %s', (address, pattern) => {
+      expect(policy.checkAddresses([address])).toFailWith(pattern);
+      expect(policy.checkAddresses([address])).toFailWith(/blockPrivateNetworks/);
+      expect(policy.checkAddresses([address])).toFailWith(/is not allowed/);
+    });
+
+    test('names the embedding when the classification came from an embedded IPv4 address', () => {
+      expect(policy.checkAddresses(['::ffff:169.254.169.254'])).toFailWith(/ipv4-mapped 169\.254\.169\.254/);
+      expect(policy.checkAddresses(['2002:a9fe:a9fe::'])).toFailWith(/6to4 169\.254\.169\.254/);
+      expect(policy.checkAddresses(['64:ff9b::a9fe:a9fe'])).toFailWith(/nat64 169\.254\.169\.254/);
+      expect(policy.checkAddresses(['::7f00:1'])).toFailWith(/ipv4-compatible 127\.0\.0\.1/);
+    });
+
+    test('reports the canonical form of the address it rejected', () => {
+      expect(policy.checkAddresses(['0177.0.0.1'])).toFailWith(/127\.0\.0\.1 is loopback/);
+    });
+  });
+
+  describe('the list contract is reject-if-any', () => {
+    test('rejects when any resolved address is disallowed, not only the first', () => {
+      expect(policy.checkAddresses(['8.8.8.8', '169.254.169.254'])).toFailWith(/169\.254\.169\.254/);
+      expect(policy.checkAddresses(['169.254.169.254', '8.8.8.8'])).toFailWith(/169\.254\.169\.254/);
+      expect(policy.checkAddresses(['8.8.8.8', '1.1.1.1', '10.0.0.1'])).toFailWith(/10\.0\.0\.1/);
+    });
+
+    test('reports every disallowed address, not just the first', () => {
+      expect(policy.checkAddresses(['10.0.0.1', '8.8.8.8', '127.0.0.1'])).toFailWith(
+        /10\.0\.0\.1 is private/
+      );
+      expect(policy.checkAddresses(['10.0.0.1', '8.8.8.8', '127.0.0.1'])).toFailWith(
+        /127\.0\.0\.1 is loopback/
+      );
+    });
+
+    test('fails when the address list is empty rather than vacuously allowing it', () => {
+      expect(policy.checkAddresses([])).toFailWith(/no addresses to check/i);
+    });
+
+    test('fails closed when an address is not a well-formed literal', () => {
+      expect(policy.checkAddresses(['not-an-address'])).toFailWith(/not a valid IP address/i);
+      expect(policy.checkAddresses(['8.8.8.8', '1::2::3'])).toFailWith(/not a valid IPv6 address/i);
+      expect(policy.checkAddresses(['not-an-address'])).toFailWith(/blockPrivateNetworks/);
+    });
+  });
+
+  describe('allowLoopback', () => {
+    const loopbackOk: IAddressPolicy = blockPrivateNetworks({ allowLoopback: true });
+
+    test.each([['127.0.0.1'], ['127.1'], ['0177.0.0.1'], ['::1'], ['::ffff:127.0.0.1'], ['::7f00:1']])(
+      'permits %s',
+      (address) => {
+        expect(loopbackOk.checkAddresses([address])).toSucceedAndSatisfy((verdict) => {
+          expect(verdict.policy).toBe('blockPrivateNetworks(allowLoopback)');
+          expect(verdict.addresses[0].classification).toBe('loopback');
+        });
+      }
+    );
+
+    test('relaxes loopback only — every other range stays blocked', () => {
+      expect(loopbackOk.checkAddresses(['169.254.169.254'])).toFailWith(/link-local/i);
+      expect(loopbackOk.checkAddresses(['10.0.0.1'])).toFailWith(/private/i);
+      expect(loopbackOk.checkAddresses(['0.0.0.0'])).toFailWith(/unspecified/i);
+      expect(loopbackOk.checkAddresses(['100.64.0.1'])).toFailWith(/carrier-grade-nat/i);
+      expect(loopbackOk.checkAddresses(['fd00::1'])).toFailWith(/unique-local/i);
+      expect(loopbackOk.checkAddresses([])).toFailWith(/no addresses to check/i);
+    });
+
+    test('still permits public addresses', () => {
+      expect(loopbackOk.checkAddresses(['8.8.8.8'])).toSucceed();
+    });
+  });
+});
+
+describe('allowAnyAddress', () => {
+  const policy: IAddressPolicy = allowAnyAddress();
+
+  test('is named so that the absence of protection is greppable at the call site', () => {
+    expect(policy.name).toBe('allowAnyAddress');
+  });
+
+  test.each([
+    [['127.0.0.1']],
+    [['169.254.169.254']],
+    [['::ffff:169.254.169.254']],
+    [['10.0.0.1', '8.8.8.8']],
+    [['not-an-address']],
+    [[]]
+  ])('permits %j', (addresses) => {
+    expect(policy.checkAddresses(addresses)).toSucceedAndSatisfy((verdict) => {
+      expect(verdict.policy).toBe('allowAnyAddress');
+      expect(verdict.addresses).toEqual([]);
+    });
+  });
+});

--- a/libraries/ts-extras/src/test/unit/safer-fetch/addressPolicy.test.ts
+++ b/libraries/ts-extras/src/test/unit/safer-fetch/addressPolicy.test.ts
@@ -20,7 +20,7 @@
 
 import '@fgv/ts-utils-jest';
 
-import { IAddressPolicy, allowAnyAddress, blockPrivateNetworks } from '../../../packlets/safer-fetch';
+import { type IAddressPolicy, allowAnyAddress, blockPrivateNetworks } from '../../../packlets/safer-fetch';
 
 describe('blockPrivateNetworks', () => {
   const policy: IAddressPolicy = blockPrivateNetworks();


### PR DESCRIPTION
Stream **S2a** of the safer-fetch feature. Implements the pure address-classification layer described in `.claude/project/fetch-primitive-threat-model.md` § 3.6, plus the `blockPrivateNetworks()` / `allowAnyAddress()` policy factories built on it.

Everything here is **pure, synchronous and deterministic** — no DNS, no transport, no entry points, no I/O, no clock.

## What ships

`libraries/ts-extras/src/packlets/safer-fetch/`

| Export | |
|---|---|
| `classifyAddress(address): Result<IClassifiedAddress>` | string in, verdict out |
| `blockPrivateNetworks(options?): IAddressPolicy` | the recommended posture; `{ allowLoopback: true }` is the local-sidecar opt-in |
| `allowAnyAddress(): IAddressPolicy` | the named, greppable no-guarantee escape hatch |
| `AddressClassification` / `AddressFamily` / `Ipv4EmbeddingKind` / `IEmbeddedIpv4` / `IClassifiedAddress` / `IAddressCheckVerdict` / `IBlockPrivateNetworksOptions` | supporting types |

### The list contract is reject-if-any

`IAddressPolicy.checkAddresses(addresses)` fails if **any** address is disallowed, and reports **every** offending one (via `mapResults`). An **empty list is a failure** for `blockPrivateNetworks` — reject-if-any over an empty list would vacuously allow, which is exactly the shape of an implied-but-absent guarantee. An unparseable address is also a failure (fail-closed).

## Bypass coverage

Every row of § 3.6's table, tested **in both directions** — the bypass form is rejected *and* the legitimate public address that superficially resembles it is accepted:

| § 3.6 row | Covered | Both directions |
|---|---|---|
| IPv4-mapped IPv6 (`::ffff:169.254.169.254`) | ✅ | `::ffff:8.8.8.8`, `::ffff:100.128.0.1` accepted |
| NAT64 (`64:ff9b::a9fe:a9fe`) | ✅ | `64:ff9b::8.8.8.8` accepted |
| Decimal / octal / hex literals | ✅ | `010.0.0.1` (= 8.0.0.1) and `0172.16.0.1` (= 122.16.0.1) accepted as public |
| Unspecified (`0.0.0.0`, `::`) | ✅ | |
| CGNAT `100.64.0.0/10` | ✅ | `100.63.255.255` **and** `100.128.0.0` accepted |
| Link-local v6 `fe80::/10` | ✅ | |
| Unique-local v6 `fc00::/7` | ✅ | `fb00::1` correctly outside |
| Multi-record hostnames | ✅ | expressed as the reject-if-any list contract |
| Trailing dot / IDN / case | ✅ | `127.0.0.1.`, `::FFFF:127.0.0.1`, `0X7F000001`; the IDN half is a documented boundary — see below |

Every rejected CIDR is tested at **both edges plus both neighbours** (e.g. `169.253.255.255` / `169.254.0.0` / `169.254.255.255` / `169.255.0.0`).

### Three bypass classes § 3's table does not enumerate

Found while testing; all three are handled and tested:

1. **6to4 (`2002::/16`)** — embeds an IPv4 address in bits **16..47**, not the low 32. `2002:a9fe:a9fe::` is the metadata endpoint. Not in the table.
2. **IPv4-compatible IPv6 (`::/96`)** — the deprecated RFC 4291 form. `::a9fe:a9fe` / `::7f00:1`. The table lists only the *mapped* form.
3. **`::ffff:0:0:0/96` (RFC 6145 IPv4-translated)** — rejected outright rather than decoded, since it is only meaningful inside a translator.

### One place the design's range list is materially incomplete

§ 3.6 lists the IPv6 rejects as `::/128`, `::1/128`, `fc00::/7`, `fe80::/10`, `ff00::/8`. That leaves **everything outside `2000::/3` classified as public** — `fe00::1`, `1fff::1`, `4000::1`, `100::1` (discard-only) all pass. Only `2000::/3` is assigned as global unicast, so the fallback here is **`reserved`, never `public`**, and the range table only names the ranges that deserve a more specific classification. Also classified: `192.88.99.0/24`, `198.51.100.0/24` and `203.0.113.0/24` (TEST-NET-2/3), `2001::/23`, `2001:db8::/32`, `3fff::/20`.

### The IDNA boundary is documented and pinned, not implemented

The platform's URL parser applies IDNA/Unicode normalization, so `http://１２７.０.０.１/`, `http://127。0。0。1/` and even `http://⑫7.0.0.1/` **all have the host `127.0.0.1`**. `classifyAddress` deliberately does *not* do that normalization — it classifies a `hostname`, which has already had it. Handed the raw text it fails, which is fail-closed only because the caller then resolves it as a name. Tests pin both directions so the boundary cannot drift silently, and the TSDoc states the rule: **classify `new URL(...).hostname`, never the raw URL text.**

## Verification beyond the unit suite

A differential harness compared `classifyAddress` against the platform's own WHATWG URL parser over **4405 inputs** (cross-product of radix/length/edge components, plus IPv6 forms), asserting that anything the platform reads as an IP literal is (a) accepted and (b) canonicalized identically.

**Result: 0 security-relevant mismatches.** The 80 remaining diffs are all whitespace-only over-*acceptances* (`"127.1 "` — the URL constructor throws, we trim and accept); classification is by value, so over-acceptance can only produce more rejection, never less.

The 16 IPv4 range constants were also re-derived independently from their dotted-quad forms and checked for prefix alignment (a non-aligned network constant silently never matches).

## Layer 1 — code review

**No `code-reviewer` agent-spawn tool was available in this session, and the `security-review` skill failed on `origin/HEAD` resolution.** Per the brief I did not block: I ran a manual pass against `CODE_REVIEW_CHECKLIST.md` plus the differential harness above. Findings **found and fixed before the first review request**:

| Pri | Finding | Resolution |
|---|---|---|
| **P1** | **`0x` with an empty remainder is `0` in the WHATWG IPv4 number parser, so `127.0x.1` is `127.0.0.1`.** The classifier rejected it — a live encoding bypass. | Fixed; `0x`/`0X`/`0x.` forms now parse as zero and are tested. |
| P2 | A zone identifier is IPv6-only; `8.8.8.8%eth0` was being read as `8.8.8.8` | Zone stripping moved to the IPv6 path; the IPv4 form now fails. |
| P2 | An embedded IPv4 tail was accepted before a `::`, so `1.2.3.4::` parsed as `102:304::` | Only the run that ends the address may carry a dotted quad. |
| P2 | `embedding` / `embeddedIpv4` were correlated but typed independently, forcing a `String()` coercion for a state the code never produces | Folded into one optional `embeddedIpv4: IEmbeddedIpv4`. |
| P3 | `(address & mask) >>> 0 === range.network` relied on operator precedence | Parenthesized — a security-critical comparison shouldn't need the reader to recall JS precedence. |
| P3 | 18 `no-bitwise` warnings | File-level disable with justification, matching the existing `crypto-utils/keystore` and `ts-random` precedent. Range tests *are* mask-and-compare; spelling them as arithmetic would be harder to audit against the RFCs. |

Checklist status: no `any`, no casts of any kind, no `throw`, no `orThrow`, no `Result<void>`; `mapResults` for the array path; `.withErrorFormat().onSuccess()` chaining; contextual error messages (policy name + canonical address + classification + embedding); no cross-package `{@link}`.

**Dispositioned, not fixed:** the private parse helpers return `T | undefined` rather than `Result<T>`. Deliberate — they are per-component parsing internals where a `Result` per character class would be noise, and every failure is converted to a contextual `fail()` at the single public boundary.

## Layer 2 — Copilot review loop

**Copilot review loop driven by implementer; stopped at 2 rounds on diminishing returns.**

**Round 1** — 5 comments, **all P3 style, zero correctness findings**. Four asked for `type`-only import markers; applied across the packlet and both test files. The fifth asked `allowAnyAddress`'s `checkAddresses` to declare the `addresses` parameter it ignores; **dispositioned with reasoning recorded inline and [replied on the thread](https://github.com/ErikFortune/fgv/pull/592#discussion_r3695012905)** — parameter bivariance already makes the zero-arg form a complete implementation, an unused `_addresses` would cut against `CODING_STANDARDS.md` § "Don't rename unused variables to `_var`", and for the deliberately-uncomfortable no-guarantee escape hatch a signature that cannot see the addresses is the strongest statement that nothing is examined.

**Round 2** — requested on the round-1 fixes; the reviewer job stalled `in_progress` for ~35 minutes without submitting a review.

**Stop reasoning.** Per `CODING_STANDARDS.md` § "Round count is not the signal — substantive value per round is", round 1's finding profile was already squarely in nitpick territory — five comments across two style classes, no correctness or anti-pattern issues. That matches the doc's own stop example ("Round 2 surfaces only … stop now; the loop is in nitpick territory regardless of round count"). The substantive class of finding this file is exposed to — runtime encoding edges — was covered instead by the layer-1 differential harness, which found the one real bypass (`0x`) that neither a reads-against-intent pass nor a style reviewer would have.

## Gates

All verified locally on the pushed HEAD:

- `rushx build` ✅ no warnings; no new API Extractor warnings; `etc/ts-extras.api.md` **unchanged** — see coordination note
- `rushx lint` ✅ clean; `rushx fixlint` run before every commit
- `rushx test` ✅ **2326 tests, 100% statements / branches / functions / lines across the whole package**; the two new files are 100% with no `c8 ignore` directives
- Rush change file ✅

⚠️ **This PR gets no CI.** `.github/workflows/ci.yml` triggers only on `pull_request` into `main`, `release`, `prerelease` and `hotfix` — a PR into `integration/safer-fetch` matches none of them, and the only check run here is the Copilot reviewer. CI will first exercise this code on the integration→`release` PR. Flagging it so the orchestrator's "refuse to advance on `conclusion: failure`" gate is not satisfied by an empty check list.

## Coordination notes for S1 / S2b

**I deliberately did not touch any file S1 owns.** `src/index.ts`, `src/index.browser.ts` and `package.json` are untouched, so nothing here is reachable from the package entry point yet and `etc/ts-extras.api.md` is unchanged. **S1 (or the integrator) needs to add the `SaferFetch` namespace to both root barrels and the `./safer-fetch` conditional export, and regenerate `api.md`.** The only file with any collision risk is `src/packlets/safer-fetch/index.ts`, which here is two `export *` lines.

**The layering question S2b must resolve.** `blockPrivateNetworks()` / `allowAnyAddress()` here return an **`IAddressPolicy`** (pure, synchronous, over an address *list*), **not** the design's `IAddressGuard` (async, over an `IRequestHop` chain, needs DNS) — because `IAddressGuard`, `IRequestHop` and `IGuardVerdict` are S1-owned types that do not exist on this branch, and holding the parallel line meant not inventing them. S2b's job is the thin wrapper:

```ts
// S2b, nodeGuard.ts
const policy = blockPrivateNetworks(options);
// resolve chain[chain.length - 1].url.hostname → addresses
policy.checkAddresses(addresses)   // reject-if-any, already correct
```

If the orchestrator would rather the guard factories carry these names, S2b should rename this layer rather than re-implement it — the classification and the reject-if-any contract are the parts that are hard to get right.

**Things S2b should know:**
- `classifyAddress` fails on a DNS hostname. That failure is the signal "not a literal, go resolve it" — do **not** treat it as a block.
- Classify the URL's **`hostname`**, never the raw URL text — the platform has already applied both IPv4-literal canonicalization (`new URL('http://0177.0.0.1/').hostname` is `127.0.0.1`) and IDNA normalization (`⑫7.0.0.1` → `127.0.0.1`). Then classify each DNS-resolved address as well.
- `IClassifiedAddress.canonical` is stable and suitable for chain evidence / dedupe. For an IPv6 address embedding IPv4 it is the hex-group form (`::ffff:a9fe:a9fe`); `embeddedIpv4.address` carries the readable dotted quad.
- An empty resolved-address list is already a failure. Don't add a second check.
- The failure messages are precise by design (canonical address, classification, embedding) and therefore an internal-network scanning oracle per § 8 / L4. They belong in `blocked-by-guard.detail` and in logs — **never echoed to an untrusted caller.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD