### PR TITLE
docs: threat-model corrections from S1 and S2a implementation

### DIFF
--- a/.claude/project/fetch-primitive-threat-model.md
+++ b/.claude/project/fetch-primitive-threat-model.md
@@ -283,6 +283,46 @@ Ranges to reject (v4): `0.0.0.0/8`, `10/8`, `100.64/10`, `127/8`,
 (v6): `::/128`, `::1/128`, `fc00::/7`, `fe80::/10`, `ff00::/8`, plus
 v4-mapped and NAT64 embeddings of the above.
 
+#### Corrections from implementation (S2a, PR #592)
+
+The table above was written against intent. Implementing it — and running a
+differential harness against the platform's own WHATWG URL parser over 4405
+inputs — found four gaps. Each is verified, not asserted; the `node -e` one-liners
+that demonstrate them are reproducible.
+
+**Three additional v4-in-v6 embeddings.** The table lists only the *mapped* form.
+Also required:
+
+| Bypass | Example | Note |
+|---|---|---|
+| **6to4** `2002::/16` | `2002:a9fe:a9fe::` | Embeds v4 in bits 16..47 — this **is** the metadata endpoint |
+| **IPv4-compatible** `::/96` | `::a9fe:a9fe` | Deprecated but still parsed; distinct from the mapped form |
+| **RFC 6145 translated** `::ffff:0:0:0/96` | | Third embedding shape |
+
+**The v6 reject list leaves most of IPv6 classified as public.** Only `2000::/3`
+is assigned global unicast, so a classifier using the reject list alone treats
+`fe00::1`, `1fff::1`, `4000::1` and `100::1` as public — verified: all four pass
+through `new URL()` unchanged and match no listed range. **The v6 fallback must be
+`reserved`, never `public`:** classify what is *known* global unicast and reject
+the rest, rather than rejecting a list and permitting the remainder. This inverts
+the table's polarity for v6 and is the more consequential of the four.
+
+**`0x` with an empty remainder is `0`.** `http://127.0x.1/` has hostname
+`127.0.0.1`. So does `http://0x7f.1/`; `http://127.0x/` is `127.0.0.0`. This was a
+live bypass in S2a's first draft, found by the differential harness rather than by
+review — no reads-against-intent pass would have produced it.
+
+**IDNA is an address-level concern, not only a hostname-allowlist one.** The row
+above files unicode homographs under allowlist matching, which understates it:
+`http://⑫7.0.0.1/`, `http://１２７.０.０.１/` and `http://127。0。0。1/` all have
+hostname `127.0.0.1` after WHATWG normalization. The digits and the separators
+both normalize.
+
+**The operational consequence of the last two:** classify `url.hostname` — the
+parser's normalized output — and **never** raw URL text. Every one of these forms
+is already canonical by the time `hostname` is read, and every one of them defeats
+text matching.
+
 ### 3.7 Out of scope for the guard
 
 - **DNS rebinding.** Documented limit; seam present. See §7 and §13.

--- a/.claude/project/fetch-primitive-threat-model.md
+++ b/.claude/project/fetch-primitive-threat-model.md
@@ -323,6 +323,37 @@ parser's normalized output — and **never** raw URL text. Every one of these fo
 is already canonical by the time `hostname` is read, and every one of them defeats
 text matching.
 
+#### Further corrections from implementation (S1, PR #594)
+
+S1 hit four places where the design was internally inconsistent or silent about
+ownership. Recorded because S2b and S3 inherit them.
+
+**`IFetchTransport.fetch` returned the wrong type** — corrected inline at § 6.1.
+§ 6.1 declared `Promise<Response>` while § 7's pin-interlock snippet does
+`return fail(...)`. Both could not be true.
+
+**Scheme enforcement had no stated owner.** Resolved as a split: the **core**
+refuses everything that is not `http:`/`https:` — at the caller's URL, at a
+request guard's replacement URL, and at the address guard's verdict URL — while
+choosing *between* `http:` and `https:`, and port allowlisting, stay with the
+address guard. The split is forced: if the core mandated `https:`, an
+`allowInsecureHttp` option on the address policy could not exist.
+
+**A guard's verdict URL is used verbatim, by necessity.** § 6.1 says guards may
+normalize but must not retarget. Enforcing that with origin-equality would reject
+exactly the normalizations § 3.6 *requires* — trailing-dot stripping, IDN to
+punycode. So "must not retarget" is a documented contract rather than an enforced
+invariant, with one exception: the verdict's **scheme** is re-checked. This is
+sound only because guards are trusted first-party code and a malicious in-process
+caller is out of scope per § 3.3. **If that ever stops being true, this is the
+line that breaks.**
+
+**Guard evaluation counts against the headers deadline.** `headersTimeoutMs` runs
+from the start of the attempt, so an address guard doing DNS spends that budget.
+The alternative — starting the clock after guards — would leave a hanging guard
+outside the only deadline bounding "time to a usable response." Documented on the
+option rather than changed.
+
 ### 3.7 Out of scope for the guard
 
 - **DNS rebinding.** Documented limit; seam present. See §7 and §13.
@@ -642,7 +673,11 @@ export interface IGuardVerdict {
  */
 export interface IFetchTransport {
   readonly name: string;
-  fetch(url: URL, init: RequestInit, hints: IFetchTransportHints): Promise<Response>;
+  // CORRECTED (S1, PR #594): was `Promise<Response>`, which contradicted § 7 —
+  // the pin interlock there does `return fail(...)`, and a bare Response cannot
+  // carry a failure. The interlock must be a Result, not a throw, and the repo
+  // standard is Result<T> for fallible operations.
+  fetch(url: URL, init: RequestInit, hints: IFetchTransportHints): Promise<Result<Response>>;
 }
 
 /** @public */


### PR DESCRIPTION
The threat model was written against intent. Two streams then implemented it, and between them found **eight** places where the spec was incomplete, internally contradictory, or silent about ownership. This PR records all of them so S2b and S3 inherit a corrected spec.

Every claim below is verified — reproducible `node -e` one-liners, not reports relayed.

## From S2a (#592) — §3.6's bypass table

Found by a differential harness over 4405 inputs against the platform's own WHATWG URL parser.

**1. Three v4-in-v6 embeddings beyond the mapped form.** The table listed only `::ffff:…`. Also required: **6to4** (`2002::/16` — embeds v4 in bits 16..47, so `2002:a9fe:a9fe::` *is* the metadata endpoint), **IPv4-compatible** (`::/96`), and **RFC 6145 translated** (`::ffff:0:0:0/96`).

**2. The v6 reject list leaves most of IPv6 classified as public — the most consequential of the eight.** Only `2000::/3` is assigned global unicast, so a deny-list check treats `fe00::1`, `1fff::1`, `4000::1` and `100::1` as public. Verified: all four pass `new URL()` unchanged and match no listed range. The fix inverts the polarity for v6 — classify known global unicast, reject the rest, so the fallback is `reserved` rather than `public`. A deny-list is the wrong shape for a space that is overwhelmingly unassigned.

**3. `0x` with an empty remainder is `0`.** `http://127.0x.1/` has hostname `127.0.0.1`. A **live bypass in S2a's first draft**, caught by the harness rather than by review — the class no reads-against-intent pass produces, since the code looks right and the spec was silent.

**4. IDNA is address-level, not only allowlist-level.** `http://⑫7.0.0.1/`, `http://１２７.０.０.１/` and `http://127。0。0。1/` all normalize to hostname `127.0.0.1` — digits *and* separators.

→ **Operational consequence:** classify `url.hostname`, never raw URL text. Every form above is already canonical by the time `hostname` is read, and every one defeats text matching.

## From S1 (#594) — signature and ownership

**5. `IFetchTransport.fetch` declared the wrong type.** §6.1 said `Promise<Response>`; §7's pin-interlock snippet does `return fail(...)`. Both cannot be true — a bare `Response` cannot carry a failure. Corrected inline to `Promise<Result<Response>>`.

**6. Scheme enforcement had no stated owner.** Resolved as a split: the **core** refuses anything but `http:`/`https:` at all three URL entry points (caller, request-guard replacement, address-guard verdict); choosing *between* them, plus port allowlisting, stays with the address guard. The split is forced — a core mandating `https:` would make S2a's `allowInsecureHttp` impossible.

**7. A guard's verdict URL is used verbatim, by necessity.** §6.1 says guards may normalize but must not retarget. Enforcing that via origin-equality would reject exactly the trailing-dot and IDN normalizations §3.6 *requires*. So it is a documented contract rather than an enforced invariant, with the scheme re-checked as the one exception. This is sound only because guards are trusted first-party code per §3.3 — **flagged in the doc as the line that breaks if that assumption ever changes.**

**8. Guard evaluation counts against the headers deadline.** An address guard doing DNS spends that budget. The alternative — starting the clock after guards — would leave a hanging guard outside the only deadline bounding "time to a usable response."

## Why this targets `integration/safer-fetch`

The design merged to `release` via #587. These corrections land on the integration branch so they squash down with the feature they describe, and so **S2b reads the corrected spec** — it inherits items 5–8 directly and cannot wire resolution correctly without item 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD