### PR TITLE
docs: design for the async Result family in ts-utils

### DIFF
--- a/.claude/project/async-result-family-design.md
+++ b/.claude/project/async-result-family-design.md
@@ -115,7 +115,7 @@ export type AsyncDeferredResult<T> = () => Promise<Result<T>>;
 
 /** @public */
 export interface IAsyncResultOptions {
-  /** Maximum operations in flight at once. See § 4, OQ-2. */
+  /** Maximum operations in flight at once. Defaults to `DEFAULT_RESULT_CONCURRENCY`. */
   readonly concurrency?: number;
   /** Optional aggregator, matching the sync family's third parameter. */
   readonly aggregatedErrors?: IMessageAggregator;
@@ -145,12 +145,24 @@ export function allSucceedAsync<T>(
 Each mirrors its sync sibling's name, parameter order, and fold. A caller who knows the sync
 family knows these.
 
-**Why `Iterable<() => Promise<Result<T>>>` and not `(items, fn)`.** The `() =>` is one extra
-character at the call site and it makes the deferral *visible*. Given that "why can't I just
-pass promises" is the exact misunderstanding that produced this ask, a signature that answers
-the question by its shape is worth more than the brevity. It also matches how the family
-already reads — `Iterable<X>` in, folded value out — and `firstSuccess` already accepts thunks.
-A `(items, fn)` convenience can be layered on later additively if call sites want it (OQ-3).
+Each also carries an `(items, fn, options?)` overload (OQ-3):
+
+```typescript
+export function mapResultsAsync<TItem, T>(
+  items: Iterable<TItem>,
+  fn: (item: TItem, index: number) => Promise<Result<T>>,
+  options?: IAsyncResultOptions
+): Promise<Result<T[]>>;
+```
+
+**Both forms earn their place.** The thunk form makes deferral *visible* — given that "why
+can't I just pass promises" is the misunderstanding that produced this design, a signature that
+answers the question by its shape is worth the extra `() =>`. It also matches how the family
+already reads (`Iterable<X>` in, folded value out) and mirrors `firstSuccess`, which already
+accepts thunks. The `(items, fn)` form makes materialized work *structurally inexpressible* —
+there is nowhere to put an already-started promise. And they cover different cases: `(items,
+fn)` is N applications of one operation, thunks are N different operations, and heterogeneous
+fan-out has no natural `items` array.
 
 **Results stay in input order** regardless of completion order, for all five. Out-of-order
 results would be a silent correctness trap for anyone zipping them back against their inputs.
@@ -167,7 +179,15 @@ export function populateObjectAsync<T>(
   options?: PopulateObjectOptions<T>,
   aggregatedErrors?: IMessageAggregator
 ): Promise<Result<T>>;
+
+export function firstSuccessAsync<T>(
+  work: Iterable<AsyncDeferredResult<T>>,
+  aggregatedErrors?: IMessageAggregator
+): Promise<Result<T>>;
 ```
+
+Note neither takes `IAsyncResultOptions`. They are transitively async (§ 2c) — serial by
+contract — so a `concurrency` field would be a lie in the type signature.
 
 Serial by construction, same `order` semantics. **Deliberately no `concurrency`** — offering
 one would imply initializers are independent, which the `Partial<T>` contract says they are
@@ -177,7 +197,7 @@ not.
 
 ## 4. Open questions
 
-OQ-1 is resolved; four remain.
+**All five resolved.** Retained with their reasoning, since three of the five reversed at least once during review.
 
 **OQ-1 — `firstSuccessAsync` — RESOLVED: ship it, serial, with no concurrency option.**
 
@@ -223,29 +243,81 @@ that this would **not** serve it: `chainWalker` treats a store failure as fatal 
 advances on a *missing* record. That is "first found," not "first success" — a different
 contract, and not a call site to migrate.
 
-**OQ-2 — default `concurrency`.** Unbounded default reproduces the exact bug the primitive
-exists to prevent, for any caller who does not think about it. A required parameter is safe but
-heavy for a general-purpose utility. A small default (4? 8?) is safe but arbitrary. Note the
-safer-fetch precedent (D-3): required-then-relax is the direction that can be loosened later
-without a break, whereas permissive-then-tighten cannot. **My lean: default 1 is wrong (that is
-just a serial loop), unbounded is wrong, so either required or a documented small default.**
+**OQ-2 — default `concurrency` — RESOLVED: optional, with a documented default.**
 
-**OQ-3 — `(items, fn)` convenience overload.** Ship now or wait for a call site to want it?
-Additive either way. My lean: wait.
+`concurrency?: number` on `IAsyncResultOptions`, defaulting to a documented constant exported
+alongside it (so callers can read and reference it rather than guessing). The default must be
+finite — an unbounded default would reproduce the exact bug the primitive exists to prevent for
+any caller who does not think about it.
 
-**OQ-4 — cancellation.** Should a failure stop scheduling remaining work? The sync family has
-no notion — `mapResults` evaluates nothing, it folds. For async, "keep going and aggregate all
-errors" matches `mapResults`' contract; "stop on first failure" matches what most callers want
-from a bounded pool. `allSucceedAsync` in particular has an obvious short-circuit. Related:
-should any of these take an `AbortSignal`? **My lean: match the sync contract (aggregate all)
-for the `map*` family, and leave `AbortSignal` out of v1** — but flag that this makes
-`allSucceedAsync` slower than a hand-rolled version in the failure case.
+**OQ-3 — `(items, fn)` convenience overload — RESOLVED: ship it.**
 
-**OQ-5 — is `ts-utils` the right home?** It is a **stable, non-active-development** surface, so
-this is purely additive and carries compatibility obligations from the day it ships. The
-alternative is `ts-extras`. My lean is `ts-utils` — this is core `Result` vocabulary, the sync
-siblings live there, and splitting the family across packages to avoid a stability obligation
-would be the tail wagging the dog.
+The question asked was what the risk is. Having looked at it concretely, it is low:
+
+- **Overload ambiguity is smaller than it first appears.** The forms are `(work, options?)` and
+  `(items, fn, options?)`; the second argument discriminates cleanly (a function versus an
+  options object), and a single-argument call can only be the thunk form. `populateObject`
+  already carries overloads, so this is a familiar shape in this file.
+- The one genuinely ambiguous case is a `TItem` that is *itself* a function type, where both
+  readings could type-check. It is rare, and it surfaces as a type error rather than silent
+  wrong behaviour.
+- **Real cost is surface, not correctness**: two documented forms and two test paths on a
+  stable package.
+
+There is also a benefit that argues for it beyond convenience: **`(items, fn)` makes
+materialized work structurally inexpressible.** The caller supplies data and a function; there
+is no place to put an already-started promise. Given that "why can't I just pass promises" is
+the misunderstanding that produced this whole design, the form that makes the mistake
+unsayable is worth having.
+
+The two forms serve genuinely different cases and neither subsumes the other: `(items, fn)` is
+N applications of *one* operation; thunks are N *different* operations. Heterogeneous fan-out
+has no natural `items` array.
+
+**OQ-4 — cancellation — RESOLVED: defer it. Retrofitting is safe, which was worth checking.**
+
+The question asked what a retrofit looks like. It splits in two, and both halves are cheaper
+than expected:
+
+*Scheduler-level abort* (stop launching new work) is purely additive — an optional `signal`
+field on `IAsyncResultOptions`, which already exists.
+
+*Work-level abort* (hand each operation a signal so in-flight work can cancel itself) means
+widening `AsyncDeferredResult<T>` from `() => Promise<Result<T>>` to
+`(signal: AbortSignal) => Promise<Result<T>>`. **That widening is not a breaking change**, and
+this is the load-bearing fact: TypeScript accepts a zero-argument function where one taking
+arguments is expected, so every existing `() => doThing()` call site keeps compiling. Verified
+against the repo's own `tsc`, in both directions:
+
+```
+// () => X  assignable to  (s: AbortSignal) => X       — OK, no error
+// (s: AbortSignal) => X  assignable to  () => X       — error TS2322:
+//   Target signature provides too few arguments. Expected 1 or more, but got 0.
+```
+
+The narrowing direction is the one that fails, and we would never need it. The only code a
+retrofit could break is code that *itself invokes* an `AsyncDeferredResult` value — i.e. a
+consumer reimplementing the scheduler, which is neither expected nor supported.
+
+So there is no need to pre-commit the signature defensively. Ship without cancellation; add it
+if a consumer asks.
+
+Failure behaviour, separately: the `map*` family **keeps scheduling and aggregates every
+error**, matching the sync contract. `allSucceedAsync` is the one member with an obvious
+short-circuit, and it deliberately does not take it — consistency with `allSucceed`'s
+aggregate-everything contract beats a faster failure path.
+
+**OQ-5 — home and release tag — RESOLVED: `ts-utils`, tagged `@public`.**
+
+This is core `Result` vocabulary and the sync siblings live there; splitting the family across
+packages to dodge a stability obligation would be the tail wagging the dog.
+
+**Tagged `@public`, not `@beta`.** The entire release line is pre-release, so `@beta` on an
+individual export adds no information — and PR #588 established that stale `@beta` tags carry
+real cost: promoting `DetailedResult` removed **168** `ae-incompatible-release-tags` warnings
+from `ts-utils.api.md`, every one produced by a `@public` signature referencing a `@beta` type.
+Shipping new `@beta` exports that `@public` code will reference would manufacture that same
+liability from day one.
 
 ---
 

--- a/.claude/project/async-result-family-design.md
+++ b/.claude/project/async-result-family-design.md
@@ -1,0 +1,202 @@
+# The async Result family — design
+
+**Status:** design only. No implementation.
+**Package:** `@fgv/ts-utils`, `base` packlet.
+**Origin:** PersonAIlity asked for "N independent async `Result`-returning operations with a
+concurrency bound." Rather than add one function, this sweeps the whole
+`mapResults` / `populateObject` family and asks what making it properly async looks like.
+
+---
+
+## 1. The gap is real — verified, not assumed
+
+The consumer's analysis of `populateObject` was checked against the source and is exactly
+right on all three counts:
+
+- `FieldInitializers<T> = { [key in keyof T]: (state: Partial<T>) => Result<T[key]> }`
+  (`mapResults.ts:216`) — synchronous, no promise anywhere in the type.
+- It builds a keyed heterogeneous object, not a homogeneous array of N identical operations.
+- Its `order` option threads `Partial<T>` through a serial loop so each initializer sees the
+  previously-populated fields. That is **dependency sequencing, deliberately serial** — the
+  opposite of what a concurrency-bounded fan-out needs.
+
+And the negative holds: **`grep` for `concurrency` / `maxConcurrent` / `semaphore` / `inFlight`
+across all of `ts-utils` returns nothing.** There is no scheduler in the library.
+
+## 2. What the sweep found that the original ask did not
+
+**a) The blocker is structural, and it is the same one in every family member.**
+
+Every existing helper takes `Iterable<Result<T>>` — *already-materialized* results:
+
+| Helper | Input | Output |
+|---|---|---|
+| `mapResults<T>` | `Iterable<Result<T>>` | `Result<T[]>` — all-or-aggregate |
+| `mapDetailedResults<T,TD>` | `Iterable<DetailedResult<T,TD>>` + `ignore: TD[]` | `Result<T[]>` |
+| `mapSuccess<T>` | `Iterable<Result<T>>` | `Result<T[]>` — successes only |
+| `mapFailures<T>` | `Iterable<Result<T>>` | `string[]` |
+| `allSucceed<T>` | `Iterable<Result<unknown>>` + `successValue` | `Result<T>` |
+| `firstSuccess<T>` | `Iterable<Result<T> \| DeferredResult<T>>` | `Result<T>` |
+| `populateObject<T>` | `FieldInitializers<T>` | `Result<T>` |
+
+For synchronous code, materializing is free — the work already happened. **For async,
+materializing means the promise has already started.** So `mapResultsAsync(promises)` cannot
+bound anything; by the time it is called, all N operations are in flight. This is precisely the
+consumer's point about `succeed(promise)`, and it generalizes: *no async sibling in this family
+can take materialized work.* Every one must take deferred work.
+
+**b) The family already has the answer, in one member.**
+
+`firstSuccess` is the only helper that accepts `DeferredResult<T> = () => Result<T>`
+(`result.ts:38`) — because it short-circuits, so it must not evaluate what it may not need.
+
+That is the exact shape the async siblings require, for a different reason: laziness is what
+makes bounding possible. **The deferral concept is already in the library and already
+exported.** The async family is `AsyncDeferredResult<T> = () => Promise<Result<T>>` — a sibling
+of an existing type, not a new concept.
+
+**c) The family does not transpose uniformly. It splits three ways.**
+
+This is the core finding, and it is why "add async variants" is the wrong framing:
+
+| Class | Members | What async does to it |
+|---|---|---|
+| **Bounded-parallel collectors** | `mapResults`, `mapDetailedResults`, `mapSuccess`, `mapFailures`, `allSucceed` | Mechanical. All five want the *same* scheduler and differ only in how they fold results. |
+| **Short-circuiter** | `firstSuccess` | **Semantics change.** "First" is unambiguous serially; under a bound > 1 it means either first-in-order or first-to-settle, and they differ. Needs a decision, not a transposition. |
+| **Inherently serial** | `populateObject` | Wants async support but **not** a concurrency bound. Each initializer sees `Partial<T>`, so it is serial by contract. A `concurrency` option here would be meaningless at best and a correctness trap at worst. |
+
+The five collectors are one primitive plus five folds. That is the shape of the work.
+
+**d) There are in-repo consumers today, hand-rolling it unbounded.**
+
+The ask is not only external. `ts-agent-memory`'s `HybridRetriever`:
+
+```ts
+const perRetriever: Result<ReadonlyArray<IMemoryRecord<unknown>>>[] = await Promise.all(
+  this._retrievers.map((retriever) => retriever.retrieve(this._projectQuery(query, retriever)))
+);
+return mapResults(perRetriever)
+```
+
+That is `mapResultsAsync` with unbounded concurrency, spelled out by hand — `Promise.all` then
+`mapResults`. `ts-prompt-assist`'s observer fan-out and `ts-bcp47`'s registry loader are the
+same shape. **This addresses the "ships with no in-repo consumer" concern directly:** the
+primitive has at least three internal call sites that can migrate, in addition to the external
+ask.
+
+---
+
+## 3. Proposed shape
+
+```typescript
+/** A unit of async work, deferred so a scheduler can decide when to start it. @public */
+export type AsyncDeferredResult<T> = () => Promise<Result<T>>;
+
+/** @public */
+export interface IAsyncResultOptions {
+  /** Maximum operations in flight at once. See § 4, OQ-2. */
+  readonly concurrency?: number;
+  /** Optional aggregator, matching the sync family's third parameter. */
+  readonly aggregatedErrors?: IMessageAggregator;
+}
+
+export function mapResultsAsync<T>(
+  work: Iterable<AsyncDeferredResult<T>>, options?: IAsyncResultOptions
+): Promise<Result<T[]>>;
+
+export function mapDetailedResultsAsync<T, TD>(
+  work: Iterable<() => Promise<DetailedResult<T, TD>>>, ignore: TD[], options?: IAsyncResultOptions
+): Promise<Result<T[]>>;
+
+export function mapSuccessAsync<T>(
+  work: Iterable<AsyncDeferredResult<T>>, options?: IAsyncResultOptions
+): Promise<Result<T[]>>;
+
+export function mapFailuresAsync<T>(
+  work: Iterable<AsyncDeferredResult<T>>, options?: IAsyncResultOptions
+): Promise<string[]>;
+
+export function allSucceedAsync<T>(
+  work: Iterable<AsyncDeferredResult<unknown>>, successValue: T, options?: IAsyncResultOptions
+): Promise<Result<T>>;
+```
+
+Each mirrors its sync sibling's name, parameter order, and fold. A caller who knows the sync
+family knows these.
+
+**Why `Iterable<() => Promise<Result<T>>>` and not `(items, fn)`.** The `() =>` is one extra
+character at the call site and it makes the deferral *visible*. Given that "why can't I just
+pass promises" is the exact misunderstanding that produced this ask, a signature that answers
+the question by its shape is worth more than the brevity. It also matches how the family
+already reads — `Iterable<X>` in, folded value out — and `firstSuccess` already accepts thunks.
+A `(items, fn)` convenience can be layered on later additively if call sites want it (OQ-3).
+
+**Results stay in input order** regardless of completion order, for all five. Out-of-order
+results would be a silent correctness trap for anyone zipping them back against their inputs.
+
+**`populateObject` gets an async sibling with no `concurrency` option:**
+
+```typescript
+export type AsyncFieldInitializers<T> = {
+  [key in keyof T]: (state: Partial<T>) => Promise<Result<T[key]>>;
+};
+
+export function populateObjectAsync<T>(
+  initializers: AsyncFieldInitializers<T>,
+  options?: PopulateObjectOptions<T>,
+  aggregatedErrors?: IMessageAggregator
+): Promise<Result<T>>;
+```
+
+Serial by construction, same `order` semantics. **Deliberately no `concurrency`** — offering
+one would imply initializers are independent, which the `Partial<T>` contract says they are
+not.
+
+---
+
+## 4. Open questions
+
+**OQ-1 — `firstSuccessAsync`: what does "first" mean?** Three defensible answers: (a) first *in
+order* — run bounded, return the earliest-indexed success, which requires waiting for earlier
+work even after a later one succeeds; (b) first *to settle* successfully — return as soon as
+any succeeds; (c) don't ship it. (b) is what most callers picture and is cheapest; (a) is
+deterministic and matches the sync semantics exactly. **They differ observably**, so this is a
+real choice. My lean is (b) with the name saying so — but I would rather have your call than
+guess, and (c) is respectable given no consumer has asked for it.
+
+**OQ-2 — default `concurrency`.** Unbounded default reproduces the exact bug the primitive
+exists to prevent, for any caller who does not think about it. A required parameter is safe but
+heavy for a general-purpose utility. A small default (4? 8?) is safe but arbitrary. Note the
+safer-fetch precedent (D-3): required-then-relax is the direction that can be loosened later
+without a break, whereas permissive-then-tighten cannot. **My lean: default 1 is wrong (that is
+just a serial loop), unbounded is wrong, so either required or a documented small default.**
+
+**OQ-3 — `(items, fn)` convenience overload.** Ship now or wait for a call site to want it?
+Additive either way. My lean: wait.
+
+**OQ-4 — cancellation.** Should a failure stop scheduling remaining work? The sync family has
+no notion — `mapResults` evaluates nothing, it folds. For async, "keep going and aggregate all
+errors" matches `mapResults`' contract; "stop on first failure" matches what most callers want
+from a bounded pool. `allSucceedAsync` in particular has an obvious short-circuit. Related:
+should any of these take an `AbortSignal`? **My lean: match the sync contract (aggregate all)
+for the `map*` family, and leave `AbortSignal` out of v1** — but flag that this makes
+`allSucceedAsync` slower than a hand-rolled version in the failure case.
+
+**OQ-5 — is `ts-utils` the right home?** It is a **stable, non-active-development** surface, so
+this is purely additive and carries compatibility obligations from the day it ships. The
+alternative is `ts-extras`. My lean is `ts-utils` — this is core `Result` vocabulary, the sync
+siblings live there, and splitting the family across packages to avoid a stability obligation
+would be the tail wagging the dog.
+
+---
+
+## 5. Scope note
+
+Five collectors + `populateObjectAsync` + one scheduler. The scheduler is the only novel logic;
+the five folds are near-copies of their sync siblings against a different input shape. Estimate
+is **one session**, plus the in-repo migrations (`HybridRetriever`, the prompt-assist observer
+fan-out, the bcp47 loader) which are optional and separable.
+
+**Not in scope:** retry, timeout, or backoff inside the scheduler — those are orthogonal and
+belong to the caller's work function. A scheduler that also retries is two primitives wearing
+one coat.

--- a/.claude/project/async-result-family-design.md
+++ b/.claude/project/async-result-family-design.md
@@ -62,7 +62,7 @@ This is the core finding, and it is why "add async variants" is the wrong framin
 | Class | Members | What async does to it |
 |---|---|---|
 | **Bounded-parallel collectors** | `mapResults`, `mapDetailedResults`, `mapSuccess`, `mapFailures`, `allSucceed` | Mechanical. All five want the *same* scheduler and differ only in how they fold results. |
-| **Inherently serial** | `populateObject`, `firstSuccess` | Want async support but **not** a concurrency bound — they are serial by contract, for different reasons. |
+| **Transitively async** | `populateObject`, `firstSuccess` | The *algorithm* stays synchronous — serial, short-circuiting. Only the primitives they call are async, so the asynchronicity is inherited, not intrinsic. They want `await`, **never** a concurrency bound. |
 
 The five collectors are one primitive plus five folds. That is the shape of the work.
 
@@ -71,12 +71,18 @@ would be meaningless at best and a correctness trap at worst, since offering one
 initializers are independent when the contract says they are not.
 
 `firstSuccess` is serial because **"first" *means* "do not do work you do not need."** An
-earlier draft of this document put it in a third class, treating first-in-order vs.
-first-to-settle as an open semantic choice under a concurrency bound. That was wrong. Running
-N operations and picking the earliest-indexed success is not the short-circuit contract
-preserved under parallelism — it is a *different operation* that does N units of work to
-report one, with whatever side effects those N carry. The short-circuit contract admits
-exactly one implementation: await the first, and on failure await the next.
+earlier draft put it in a third class, treating first-in-order vs. first-to-settle as an open
+semantic choice under a concurrency bound. That was wrong. Running N operations and picking the
+earliest-indexed success is not the short-circuit contract preserved under parallelism — it is
+a *different operation* that does N units of work to report one, with whatever side effects
+those N carry. The short-circuit contract admits exactly one implementation: await the first,
+and on failure await the next.
+
+**"Transitively async" is the load-bearing idea for this class.** These are synchronous
+algorithms that happen to call asynchronous primitives. That framing has a direct API
+consequence: neither member should accept `IAsyncResultOptions`, because a `concurrency` field
+on an operation that is serial by definition is a lie in the type signature. They take an
+aggregator and nothing else.
 
 (The first-to-settle variant is a real thing — it is `Promise.any` with `Result` folding — but
 it is a distinct primitive that would want a distinct name. Nobody has asked for it, and it is
@@ -173,27 +179,49 @@ not.
 
 OQ-1 is resolved; four remain.
 
-**OQ-1 — `firstSuccessAsync` — RESOLVED: do not ship it.**
+**OQ-1 — `firstSuccessAsync` — RESOLVED: ship it, serial, with no concurrency option.**
 
-Per § 2(c) it could only ever be a serial loop, so the "bounded concurrency" motivation that
-drives this whole design does not apply to it. That leaves one honest justification — the sync
-version aggregates *every* attempt's failure message when all attempts fail, which a
-hand-rolled loop typically forgets — and that is not enough on its own.
+This reversed twice, so the reasoning is recorded rather than just the answer.
 
-The deciding evidence is adoption. **`firstSuccess` has zero production callers in this
-repository.** Of 34 references, 32 are in its own test file and 2 are generated `.d.ts`
-output. The synchronous version has not earned its place in-repo since it shipped; adding an
-async sibling for a pattern with no demonstrated demand, which no consumer has requested, is
-speculative surface on a stable package.
+It is **not** part of the bounded-concurrency story — per § 2(c) it is transitively async, so
+the motivation driving the rest of this design does not apply to it. It belongs here only
+because it is a family member that needs `await`.
 
-The nearest in-repo shape is `ts-prompt-assist`'s `chainWalker`, and examining it reinforces
-the cut rather than undermining it: it walks a scope chain serially and stops at the first
-*found* record, but a store failure is **fatal** — it aborts the walk rather than falling
-through to the next scope. That is "first found," not "first success," and
-`firstSuccessAsync` would not have served it. The one real fallback-shaped walk in the repo
-has a different contract.
+The first pass at this question cut it, on the evidence that **`firstSuccess` has zero
+production callers in this repository** — of 34 references, 32 are its own tests and 2 are
+generated `.d.ts`. That evidence was read backwards. The repository performs *all* file I/O
+through `FileTree`, which is asynchronous, so every naturally fallback-shaped job here is
+async and **the synchronous version is structurally incapable of serving any of them.** Zero
+adoption of a synchronous tool for an inherently asynchronous job is not evidence that the job
+does not exist; it is evidence that the tool never fit.
 
-If a consumer later asks with a concrete use case, this is additive and cheap to revisit.
+The motivating case: *load the first of an ordered list of `n` candidate files* — a local
+override before a default, or a search path walked in precedence order. Serial is not a
+compromise there, it is the requirement: the whole point is not to read the later files when
+an earlier one answers.
+
+**Honest caveat on strength of evidence.** Unlike the five collectors — which have three
+existing hand-rolled call sites in-repo — this one has **no existing call site**. A search for
+serial candidate-file fallbacks across all of `libraries/` and `tools/` found none. It ships on
+a named prospective use case, not demonstrated demand. That is a weaker justification, and it
+is the reason to keep the surface minimal: a serial loop plus the error aggregation a
+hand-rolled version invariably forgets.
+
+```typescript
+export function firstSuccessAsync<T>(
+  work: Iterable<AsyncDeferredResult<T>>,
+  aggregatedErrors?: IMessageAggregator
+): Promise<Result<T>>;
+```
+
+**No options bag, and deliberately so** — a `concurrency` field on an operation that is serial
+by definition would be a lie in the type signature. When every attempt fails, the failure
+carries *every* attempt's message, matching the sync sibling.
+
+The nearest in-repo shape remains `ts-prompt-assist`'s `chainWalker`, and it is worth recording
+that this would **not** serve it: `chainWalker` treats a store failure as fatal and only
+advances on a *missing* record. That is "first found," not "first success" — a different
+contract, and not a call site to migrate.
 
 **OQ-2 — default `concurrency`.** Unbounded default reproduces the exact bug the primitive
 exists to prevent, for any caller who does not think about it. A required parameter is safe but
@@ -223,7 +251,7 @@ would be the tail wagging the dog.
 
 ## 5. Scope note
 
-Five collectors + `populateObjectAsync` + one scheduler (no `firstSuccessAsync`, per OQ-1). The scheduler is the only novel logic;
+Five collectors + `populateObjectAsync` + `firstSuccessAsync` + one scheduler. The scheduler is the only novel logic;
 the five folds are near-copies of their sync siblings against a different input shape. Estimate
 is **one session**, plus the in-repo migrations (`HybridRetriever`, the prompt-assist observer
 fan-out, the bcp47 loader) which are optional and separable.

--- a/.claude/project/async-result-family-design.md
+++ b/.claude/project/async-result-family-design.md
@@ -55,17 +55,32 @@ makes bounding possible. **The deferral concept is already in the library and al
 exported.** The async family is `AsyncDeferredResult<T> = () => Promise<Result<T>>` — a sibling
 of an existing type, not a new concept.
 
-**c) The family does not transpose uniformly. It splits three ways.**
+**c) The family does not transpose uniformly. It splits two ways.**
 
 This is the core finding, and it is why "add async variants" is the wrong framing:
 
 | Class | Members | What async does to it |
 |---|---|---|
 | **Bounded-parallel collectors** | `mapResults`, `mapDetailedResults`, `mapSuccess`, `mapFailures`, `allSucceed` | Mechanical. All five want the *same* scheduler and differ only in how they fold results. |
-| **Short-circuiter** | `firstSuccess` | **Semantics change.** "First" is unambiguous serially; under a bound > 1 it means either first-in-order or first-to-settle, and they differ. Needs a decision, not a transposition. |
-| **Inherently serial** | `populateObject` | Wants async support but **not** a concurrency bound. Each initializer sees `Partial<T>`, so it is serial by contract. A `concurrency` option here would be meaningless at best and a correctness trap at worst. |
+| **Inherently serial** | `populateObject`, `firstSuccess` | Want async support but **not** a concurrency bound — they are serial by contract, for different reasons. |
 
 The five collectors are one primitive plus five folds. That is the shape of the work.
+
+`populateObject` is serial because each initializer sees `Partial<T>`; a `concurrency` option
+would be meaningless at best and a correctness trap at worst, since offering one implies the
+initializers are independent when the contract says they are not.
+
+`firstSuccess` is serial because **"first" *means* "do not do work you do not need."** An
+earlier draft of this document put it in a third class, treating first-in-order vs.
+first-to-settle as an open semantic choice under a concurrency bound. That was wrong. Running
+N operations and picking the earliest-indexed success is not the short-circuit contract
+preserved under parallelism — it is a *different operation* that does N units of work to
+report one, with whatever side effects those N carry. The short-circuit contract admits
+exactly one implementation: await the first, and on failure await the next.
+
+(The first-to-settle variant is a real thing — it is `Promise.any` with `Result` folding — but
+it is a distinct primitive that would want a distinct name. Nobody has asked for it, and it is
+not proposed here.)
 
 **d) There are in-repo consumers today, hand-rolling it unbounded.**
 
@@ -156,13 +171,29 @@ not.
 
 ## 4. Open questions
 
-**OQ-1 — `firstSuccessAsync`: what does "first" mean?** Three defensible answers: (a) first *in
-order* — run bounded, return the earliest-indexed success, which requires waiting for earlier
-work even after a later one succeeds; (b) first *to settle* successfully — return as soon as
-any succeeds; (c) don't ship it. (b) is what most callers picture and is cheapest; (a) is
-deterministic and matches the sync semantics exactly. **They differ observably**, so this is a
-real choice. My lean is (b) with the name saying so — but I would rather have your call than
-guess, and (c) is respectable given no consumer has asked for it.
+OQ-1 is resolved; four remain.
+
+**OQ-1 — `firstSuccessAsync` — RESOLVED: do not ship it.**
+
+Per § 2(c) it could only ever be a serial loop, so the "bounded concurrency" motivation that
+drives this whole design does not apply to it. That leaves one honest justification — the sync
+version aggregates *every* attempt's failure message when all attempts fail, which a
+hand-rolled loop typically forgets — and that is not enough on its own.
+
+The deciding evidence is adoption. **`firstSuccess` has zero production callers in this
+repository.** Of 34 references, 32 are in its own test file and 2 are generated `.d.ts`
+output. The synchronous version has not earned its place in-repo since it shipped; adding an
+async sibling for a pattern with no demonstrated demand, which no consumer has requested, is
+speculative surface on a stable package.
+
+The nearest in-repo shape is `ts-prompt-assist`'s `chainWalker`, and examining it reinforces
+the cut rather than undermining it: it walks a scope chain serially and stops at the first
+*found* record, but a store failure is **fatal** — it aborts the walk rather than falling
+through to the next scope. That is "first found," not "first success," and
+`firstSuccessAsync` would not have served it. The one real fallback-shaped walk in the repo
+has a different contract.
+
+If a consumer later asks with a concrete use case, this is additive and cheap to revisit.
 
 **OQ-2 — default `concurrency`.** Unbounded default reproduces the exact bug the primitive
 exists to prevent, for any caller who does not think about it. A required parameter is safe but
@@ -192,7 +223,7 @@ would be the tail wagging the dog.
 
 ## 5. Scope note
 
-Five collectors + `populateObjectAsync` + one scheduler. The scheduler is the only novel logic;
+Five collectors + `populateObjectAsync` + one scheduler (no `firstSuccessAsync`, per OQ-1). The scheduler is the only novel logic;
 the five folds are near-copies of their sync siblings against a different input shape. Estimate
 is **one session**, plus the in-repo migrations (`HybridRetriever`, the prompt-assist observer
 fan-out, the bcp47 loader) which are optional and separable.


### PR DESCRIPTION
Design only — no implementation. Sweeps the `mapResults` / `populateObject` family rather than adding the single helper PersonAIlity asked for.

## Their analysis is correct — verified against source

All three `populateObject` claims hold exactly: `FieldInitializers<T> = { [key in keyof T]: (state: Partial<T>) => Result<T[key]> }` at `mapResults.ts:216`, fully synchronous, and the `order` option threads `Partial<T>` through a serial loop — dependency sequencing, the opposite of a bounded fan-out. And the negative holds: **grep for `concurrency` / `maxConcurrent` / `semaphore` / `inFlight` across all of `ts-utils` returns nothing.**

## Four things the sweep found that the narrow ask would have missed

**1. The blocker is structural and uniform.** Every family member takes already-materialized `Result`s. Synchronously that's free — the work already happened. **For async, materializing means the promise already started**, so `mapResultsAsync(promises)` can't bound anything. Their `succeed(promise)` observation generalizes: *no* async sibling can take materialized work. Every one must take deferred work.

**2. The family already contains the answer.** `firstSuccess` is the one member that accepts `DeferredResult<T> = () => Result<T>` — because short-circuiting requires laziness. The async family needs the same shape for a *different* reason: laziness is what makes bounding possible. So `AsyncDeferredResult<T> = () => Promise<Result<T>>` is a sibling of an existing exported type, not a new concept.

**3. The family splits three ways under async** — which is why "add async variants" is the wrong framing:

| Class | Members | Effect |
|---|---|---|
| Bounded-parallel collectors | `mapResults`, `mapDetailedResults`, `mapSuccess`, `mapFailures`, `allSucceed` | Mechanical — one scheduler, five folds |
| Short-circuiter | `firstSuccess` | **Semantics change** — first-in-order vs first-to-settle differ observably under a bound |
| Inherently serial | `populateObject` | Wants async, **must not** get a `concurrency` option — offering one implies initializers are independent, which `Partial<T>` says they are not |

**4. There are three in-repo consumers hand-rolling it unbounded today.** `HybridRetriever` is literally `Promise.all(...)` then `mapResults(...)` — `mapResultsAsync` spelled out by hand. The prompt-assist observer fan-out and the bcp47 registry loader are the same shape. Unlike safer-fetch, this one ships with real internal consumers.

## Five open questions

Each has a lean and reasoning in the doc; these two are the ones I'd most like your call on:

- **OQ-1 — what does "first" mean in `firstSuccessAsync`?** First-in-order (deterministic, matches sync exactly, but waits on earlier work after a later success) vs first-to-settle (cheaper, what most callers picture). They differ observably. Third option: don't ship it — no consumer has asked.
- **OQ-2 — default `concurrency`.** Unbounded reproduces the exact bug for anyone who doesn't think about it. Required is safe but heavy for a general utility. A small default is safe but arbitrary. Noted the safer-fetch **D-3** precedent: required-then-relax loosens without a break; permissive-then-tighten doesn't.

Also open: the `(items, fn)` convenience overload, cancellation/`AbortSignal` semantics, and whether `ts-utils`' stable surface is the right home (my lean: yes — splitting the family to dodge a stability obligation would be the tail wagging the dog).

## Scope

One session — the scheduler is the only novel logic; the five folds are near-copies against a different input shape. In-repo migrations are separable and optional.

**Explicitly not in scope:** retry, timeout, or backoff inside the scheduler. A scheduler that also retries is two primitives wearing one coat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD)_