### PR TITLE
feat(safer-fetch): DNS resolution, per-hop address guard, redirect walk (S2b)

### DIFF
--- a/common/changes/@fgv/ts-extras/safer-fetch-redirect-walk_2026-08-04-00-00.json
+++ b/common/changes/@fgv/ts-extras/safer-fetch-redirect-walk_2026-08-04-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@fgv/ts-extras",
+      "comment": "SaferFetch: join the core to the address classifier and make the guard load-bearing. Adds blockPrivateNetworks() — a Node-only, DNS-resolving IAddressGuard that classifies url.hostname (resolving it only when it is not already an IP literal) and delegates every resolved address to the reject-if-any policy, with an injectable HostResolver seam so no test touches the network; a rejected lookup becomes a Failure, never a throw. Adds redirectPolicy: 'validate-each-hop', which walks redirects with redirect: 'manual' and runs the full address guard on every hop before any connection, resolving Location against the hop that sent it; plus maxRedirects (default 5), whole-chain loop detection, Fetch-standard method/body rewriting (301/302 convert POST to GET and drop the body, 303 converts any non-GET/HEAD, 307/308 preserve both), and monotonic credential stripping on cross-origin hops (authorization/cookie/proxy-authorization plus the new sensitiveHeaders option, matched case-insensitively) so an A -> B -> A chain never re-attaches the credential. IRequestHop.status is now populated, and connectedAddress is recorded once a guard pins and the transport accepts it. BREAKING (unreleased surface): the policy-layer factory blockPrivateNetworks is renamed blockPrivateNetworksPolicy, freeing the unsuffixed name for the guard callers actually pass to saferFetch* — unsuffixed factories now uniformly return an IAddressGuard and Policy-suffixed ones an IAddressPolicy. Also fixes a defect the walk exposed: headersTimeoutMs is documented as per-attempt but was retired for the whole call by the first hop's headers, so later hops had no headers deadline; it is now re-armed per attempt. Default redirect policy remains 'reject'. DNS rebinding remains an open, documented limit — IGuardVerdict.pinnedAddress stays undefined and platformFetchTransport still fails rather than ignore a pin.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@fgv/ts-extras",
+  "email": "noreply@anthropic.com"
+}

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -349,6 +349,9 @@ function allowContentTypes(types: ReadonlyArray<string>): Result<IResponseHeader
 const allProviderIds: ReadonlyArray<AiProviderId>;
 
 // @public
+const ALWAYS_STRIPPED_HEADERS: ReadonlyArray<string>;
+
+// @public
 function anthropicEffortToBudgetTokens(effort: NonNullable<IAnthropicThinkingConfig['effort']>): number;
 
 // @public
@@ -378,10 +381,15 @@ function base64UrlNoPadDecode(encoded: string): Result<Uint8Array>;
 // @public
 function base64UrlNoPadEncode(data: Uint8Array): string;
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+function blockPrivateNetworks(options?: IBlockPrivateNetworksGuardOptions): IAddressGuard;
+
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IBlockPrivateNetworksOptions"
 //
 // @public
-function blockPrivateNetworks(options?: IBlockPrivateNetworksOptions): IAddressPolicy;
+function blockPrivateNetworksPolicy(options?: IBlockPrivateNetworksOptions): IAddressPolicy;
 
 // @public
 function callProviderCompletion(params: IProviderCompletionParams): Promise<Result<IAiCompletionResponse>>;
@@ -618,6 +626,9 @@ const DEFAULT_HEADERS_TIMEOUT_MS: number;
 const DEFAULT_KEYSTORE_ITERATIONS: number;
 
 // @public
+const DEFAULT_MAX_REDIRECTS: number;
+
+// @public
 const DEFAULT_MAX_RESPONSE_BYTES: number;
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "IProviderListModelsParams"
@@ -788,7 +799,18 @@ type FetchFailureReason =
     readonly guard: string;
     readonly detail: string;
 }
-/** A redirect status was received under a redirect policy that rejects redirects. */
+/**
+* A redirect status was received that this call would not follow: the policy is `'reject'`,
+* or the response carried no usable `Location`, or following it would revisit a URL already
+* in the chain.
+*
+* @remarks
+* The three are deliberately one kind. Splitting them would buy a caller almost nothing and
+* would widen the scanning oracle this taxonomy already is — and the two follow-time cases
+* are facts about the chain the redirecting server produced, not about the network behind
+* this process. "The chain got too long" is a different question and stays
+* `'too-many-redirects'`.
+*/
 | {
     readonly kind: 'redirect-rejected';
     readonly url: string;
@@ -969,6 +991,11 @@ function hexDecode(encoded: string): Result<Uint8Array>;
 //
 // @public
 function hexEncode(data: Uint8Array): string;
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+type HostResolver = (hostname: string) => Promise<Result<ReadonlyArray<string>>>;
 
 // @public
 class HpkeProvider {
@@ -1411,7 +1438,15 @@ interface IArgon2idProvider {
     argon2id(password: Uint8Array | string, salt: Uint8Array, params: IArgon2idParams, options?: IArgon2idKeyingOptions): Promise<Result<Uint8Array>>;
 }
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "blockPrivateNetworks"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+interface IBlockPrivateNetworksGuardOptions extends IBlockPrivateNetworksOptions {
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly resolve?: HostResolver;
+}
+
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@fgv/ts-extras" does not have an export "blockPrivateNetworksPolicy"
 //
 // @public
 interface IBlockPrivateNetworksOptions {
@@ -2120,6 +2155,7 @@ interface IRequestGuard {
 // @public
 interface IRequestHop {
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     readonly connectedAddress?: string;
     readonly status?: number;
     readonly url: URL;
@@ -2209,6 +2245,8 @@ interface ISaferFetchOptions {
     readonly headersTimeoutMs?: number;
     readonly logger?: Logging.ILogger;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly maxRedirects?: number;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     readonly maxResponseBytes?: number;
     readonly method?: SaferFetchMethod;
     readonly redirectPolicy?: SaferFetchRedirectPolicy;
@@ -2216,6 +2254,8 @@ interface ISaferFetchOptions {
     readonly responseBodyGuard?: IResponseBodyGuard;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     readonly responseHeadersGuard?: IResponseHeadersGuard;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+    readonly sensitiveHeaders?: ReadonlyArray<string>;
     readonly signal?: AbortSignal;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
     readonly timeoutMs?: number;
@@ -2771,6 +2811,11 @@ class NodeCryptoProvider implements ICryptoProvider {
 // @public
 const nodeCryptoProvider: NodeCryptoProvider;
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+//
+// @public
+const nodeHostResolver: HostResolver;
+
 // @public
 type OpenAiThinkingModelNames = 'o3' | 'o4-mini' | 'o3-deep-research' | 'o4-mini-deep-research' | 'gpt-5' | 'gpt-5.1' | 'gpt-5.2' | 'gpt-5.4-mini' | 'gpt-5.5' | 'gpt-5.5-pro' | 'gpt-5.6-sol' | 'gpt-5.6-terra' | 'gpt-5.6-luna' | 'gpt-5-pro';
 
@@ -2916,7 +2961,9 @@ function resolveProviderModel(descriptor: IAiProviderDescriptor, modelOverride: 
 
 declare namespace SaferFetch {
     export {
+        ALWAYS_STRIPPED_HEADERS,
         DEFAULT_HEADERS_TIMEOUT_MS,
+        DEFAULT_MAX_REDIRECTS,
         DEFAULT_MAX_RESPONSE_BYTES,
         DEFAULT_TIMEOUT_MS,
         REDIRECT_STATUSES,
@@ -2946,10 +2993,14 @@ declare namespace SaferFetch {
         saferFetchText,
         ISaferFetchJsonOptions,
         allowAnyAddressPolicy,
-        blockPrivateNetworks,
+        blockPrivateNetworksPolicy,
         IAddressCheckVerdict,
         IAddressPolicy,
         IBlockPrivateNetworksOptions,
+        blockPrivateNetworks,
+        nodeHostResolver,
+        HostResolver,
+        IBlockPrivateNetworksGuardOptions,
         classifyAddress,
         AddressClassification,
         AddressFamily,
@@ -2977,7 +3028,7 @@ function saferFetchJson<T>(url: string | URL, options: ISaferFetchJsonOptions<T>
 type SaferFetchMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
 // @public
-type SaferFetchRedirectPolicy = 'reject';
+type SaferFetchRedirectPolicy = 'reject' | 'validate-each-hop';
 
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 //

--- a/libraries/ts-extras/etc/ts-extras.api.md
+++ b/libraries/ts-extras/etc/ts-extras.api.md
@@ -810,6 +810,12 @@ type FetchFailureReason =
 * are facts about the chain the redirecting server produced, not about the network behind
 * this process. "The chain got too long" is a different question and stays
 * `'too-many-redirects'`.
+*
+* `url` is always the URL that **issued** the rejected redirect — the hop this call actually
+* requested and got a 3xx back from — never the `Location` target it pointed at. That holds
+* for all three cases, including the revisit case, where the target is the URL already in the
+* chain and naming it here would make the same field mean two different things. The target is
+* named in the message instead. `status` is the redirect status that was received.
 */
 | {
     readonly kind: 'redirect-rejected';

--- a/libraries/ts-extras/src/packlets/safer-fetch/addressPolicy.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/addressPolicy.ts
@@ -73,7 +73,7 @@ export interface IAddressPolicy {
 }
 
 /**
- * Options for {@link blockPrivateNetworks}.
+ * Options shared by {@link blockPrivateNetworksPolicy} and the address guard built over it.
  * @public
  */
 export interface IBlockPrivateNetworksOptions {
@@ -149,14 +149,23 @@ function checkAllAddresses(
  * policy — closing that requires connecting to a pinned address. The policy
  * also says nothing about scheme, host, port, redirects or response content.
  *
+ * This is the **policy-layer** factory. It is not what a safer-fetch call's
+ * `addressGuard` option takes: an entry point takes an `IAddressGuard`, which is
+ * the asynchronous, hop-chain-aware, name-resolving half. `blockPrivateNetworks`
+ * (Node only) is the guard that resolves a hostname and delegates every resolved
+ * address to this policy; reach for that unless you are classifying an address
+ * list you already hold.
+ *
  * @param options - optional {@link IBlockPrivateNetworksOptions | relaxations}
  * of the default posture.
  * @returns the policy. Construction cannot fail.
  * @public
  */
-export function blockPrivateNetworks(options?: IBlockPrivateNetworksOptions): IAddressPolicy {
+export function blockPrivateNetworksPolicy(options?: IBlockPrivateNetworksOptions): IAddressPolicy {
   const allowLoopback: boolean = options?.allowLoopback === true;
-  const name: string = allowLoopback ? 'blockPrivateNetworks(allowLoopback)' : 'blockPrivateNetworks';
+  const name: string = allowLoopback
+    ? 'blockPrivateNetworksPolicy(allowLoopback)'
+    : 'blockPrivateNetworksPolicy';
   const allowed: ReadonlySet<AddressClassification> = allowLoopback ? PUBLIC_OR_LOOPBACK : PUBLIC_ONLY;
   return {
     name,

--- a/libraries/ts-extras/src/packlets/safer-fetch/deadline.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/deadline.ts
@@ -95,8 +95,36 @@ export class DeadlineWatch {
   }
 
   /**
-   * Records that response headers have arrived: the headers deadline no longer applies, and a
-   * subsequent overall-deadline expiry is a body-phase timeout rather than an overall one.
+   * Records that a new attempt is starting: the headers deadline is (re)armed from now.
+   *
+   * @remarks
+   * The headers deadline is **per attempt**, and a redirect walk makes more than one. Without a
+   * re-arm, {@link DeadlineWatch.headersReceived} on the first hop would retire the headers
+   * deadline for the whole call, leaving every later hop bounded only by the overall deadline —
+   * so a chain whose second host simply never answers would hang for the overall budget instead
+   * of failing as `timeout.phase === 'headers'`.
+   *
+   * Called before the address guard rather than before the connect, because guard evaluation
+   * (a DNS resolution, in the shipped guard) is part of the time a caller waits for a usable
+   * response and is deliberately inside this budget.
+   *
+   * The overall deadline is untouched: it spans the whole call, redirects included.
+   */
+  public attemptStarted(): void {
+    if (this._cause !== undefined) {
+      return;
+    }
+    if (this._headersTimer !== undefined) {
+      clearTimeout(this._headersTimer);
+    }
+    this._headersTimer = setTimeout(() => this._stop('headers'), this._headersTimeoutMs);
+    this._inBodyPhase = false;
+  }
+
+  /**
+   * Records that response headers have arrived: the headers deadline no longer applies to this
+   * attempt, and a subsequent overall-deadline expiry is a body-phase timeout rather than an
+   * overall one.
    */
   public headersReceived(): void {
     if (this._headersTimer !== undefined) {

--- a/libraries/ts-extras/src/packlets/safer-fetch/defaults.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/defaults.ts
@@ -52,6 +52,35 @@ export const DEFAULT_MAX_RESPONSE_BYTES: number = 5 * 1024 * 1024;
 export const REDIRECT_STATUSES: ReadonlyArray<number> = [301, 302, 303, 307, 308];
 
 /**
+ * Default cap on redirect hops followed under `'validate-each-hop'`.
+ *
+ * @remarks
+ * Five is enough for the ordinary shortener-then-canonicalize-then-CDN chains real services
+ * produce and small enough that a chain designed to burn budget is refused quickly. Every hop
+ * costs a full guard evaluation — including a DNS resolution — against the same overall
+ * deadline, so the cap bounds work, not just politeness.
+ * @public
+ */
+export const DEFAULT_MAX_REDIRECTS: number = 5;
+
+/**
+ * Header names dropped on every cross-origin redirect hop, whatever the caller configured.
+ *
+ * @remarks
+ * Turning on manual redirects makes this primitive responsible for a rule the platform was
+ * applying for free: browsers and `curl` both strip credential headers when a redirect leaves
+ * the origin, and a hand-rolled loop that replays them hands `Authorization: Bearer …` to
+ * whatever host the redirect names. Callers add their own names with
+ * `ISaferFetchOptions.sensitiveHeaders`; these three are not removable.
+ * @public
+ */
+export const ALWAYS_STRIPPED_HEADERS: ReadonlyArray<string> = [
+  'authorization',
+  'cookie',
+  'proxy-authorization'
+];
+
+/**
  * URL schemes this primitive will ever request.
  *
  * @remarks

--- a/libraries/ts-extras/src/packlets/safer-fetch/failureReason.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/failureReason.ts
@@ -62,7 +62,18 @@ export type FetchFailureReason =
       readonly guard: string;
       readonly detail: string;
     }
-  /** A redirect status was received under a redirect policy that rejects redirects. */
+  /**
+   * A redirect status was received that this call would not follow: the policy is `'reject'`,
+   * or the response carried no usable `Location`, or following it would revisit a URL already
+   * in the chain.
+   *
+   * @remarks
+   * The three are deliberately one kind. Splitting them would buy a caller almost nothing and
+   * would widen the scanning oracle this taxonomy already is — and the two follow-time cases
+   * are facts about the chain the redirecting server produced, not about the network behind
+   * this process. "The chain got too long" is a different question and stays
+   * `'too-many-redirects'`.
+   */
   | { readonly kind: 'redirect-rejected'; readonly url: string; readonly status: number }
   /**
    * The platform returned an opaque redirect, whose `Location` is not readable. This is

--- a/libraries/ts-extras/src/packlets/safer-fetch/failureReason.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/failureReason.ts
@@ -73,6 +73,12 @@ export type FetchFailureReason =
    * are facts about the chain the redirecting server produced, not about the network behind
    * this process. "The chain got too long" is a different question and stays
    * `'too-many-redirects'`.
+   *
+   * `url` is always the URL that **issued** the rejected redirect — the hop this call actually
+   * requested and got a 3xx back from — never the `Location` target it pointed at. That holds
+   * for all three cases, including the revisit case, where the target is the URL already in the
+   * chain and naming it here would make the same field mean two different things. The target is
+   * named in the message instead. `status` is the redirect status that was received.
    */
   | { readonly kind: 'redirect-rejected'; readonly url: string; readonly status: number }
   /**

--- a/libraries/ts-extras/src/packlets/safer-fetch/index.browser.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/index.browser.ts
@@ -21,22 +21,24 @@
 /**
  * An HTTP fetch primitive with an explicit threat model (browser version).
  *
- * The entire packlet is runtime-agnostic and contains no `node:` imports, so this barrel is
- * currently identical in content to the Node one. It exists as a distinct barrel because the
- * Node-only address guards land beside the core, and this is the file that must **not** export
- * them.
+ * This barrel deliberately omits `blockPrivateNetworks` and the resolver seam beneath it: that
+ * module imports `node:dns/promises`, and exporting it here would pull a Node builtin into a
+ * browser bundle. Everything else in the packlet is runtime-agnostic and is exported from both.
  *
  * Note: the resolved-address (private-IP) guard and per-hop redirect revalidation are NOT
  * available in a browser, and not for want of implementation. There is no browser API that
  * returns a hostname's A/AAAA records, nothing in `fetch` or `Response` exposes the peer
  * address, and `redirect: 'manual'` yields an opaque response whose `Location` is not
- * readable. `allowAnyAddress()` is the honest choice there, and its name says so.
+ * readable — a `'validate-each-hop'` call there fails as `'redirect-opaque'` rather than
+ * quietly following anything. `allowAnyAddress()` is the honest choice, and its name says so.
  *
  * @packageDocumentation
  */
 
 export {
+  ALWAYS_STRIPPED_HEADERS,
   DEFAULT_HEADERS_TIMEOUT_MS,
+  DEFAULT_MAX_REDIRECTS,
   DEFAULT_MAX_RESPONSE_BYTES,
   DEFAULT_TIMEOUT_MS,
   REDIRECT_STATUSES,

--- a/libraries/ts-extras/src/packlets/safer-fetch/index.browser.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/index.browser.ts
@@ -23,7 +23,15 @@
  *
  * This barrel deliberately omits `blockPrivateNetworks` and the resolver seam beneath it: that
  * module imports `node:dns/promises`, and exporting it here would pull a Node builtin into a
- * browser bundle. Everything else in the packlet is runtime-agnostic and is exported from both.
+ * browser bundle.
+ *
+ * That is not the only difference. The address-classification layer — `classifyAddress`, and the
+ * pure synchronous policies `allowAnyAddressPolicy` / `blockPrivateNetworksPolicy` — is
+ * runtime-agnostic but is currently exported from the Node barrel only. Nothing prevents a
+ * browser from using it; it simply has not been part of this barrel's surface, and widening a
+ * public surface is left to the stream that owns the browser packlet. What ships here today is
+ * the entry points, the guard/transport seams, `allowAnyAddress`, `allowContentTypes`, and the
+ * shared types and constants.
  *
  * Note: the resolved-address (private-IP) guard and per-hop redirect revalidation are NOT
  * available in a browser, and not for want of implementation. There is no browser API that

--- a/libraries/ts-extras/src/packlets/safer-fetch/index.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/index.ts
@@ -36,7 +36,9 @@
  */
 
 export {
+  ALWAYS_STRIPPED_HEADERS,
   DEFAULT_HEADERS_TIMEOUT_MS,
+  DEFAULT_MAX_REDIRECTS,
   DEFAULT_MAX_RESPONSE_BYTES,
   DEFAULT_TIMEOUT_MS,
   REDIRECT_STATUSES,
@@ -69,24 +71,29 @@ export { platformFetchTransport } from './transport';
 
 export { saferFetchBytes, saferFetchJson, saferFetchText, type ISaferFetchJsonOptions } from './saferFetch';
 
-// The address-classification layer, exported through the packlet entry point like everything
-// else here.
-//
-// One name is deconflicted: this layer's `allowAnyAddressPolicy` returns a pure, synchronous
-// `IAddressPolicy` over an already-resolved address list, while `allowAnyAddress` above returns
-// the async, hop-chain-aware `IAddressGuard` that entry points actually accept. They are
-// different types at different layers and cannot share a name.
-//
-// `blockPrivateNetworks` keeps its unsuffixed name and currently returns an `IAddressPolicy`.
-// S2b adds the guard that resolves a hostname and delegates to it, and decides at that point
-// whether the unsuffixed name should move to the guard layer.
+// Two layers, one naming rule: an **unsuffixed** factory returns the asynchronous,
+// hop-chain-aware, name-resolving `IAddressGuard` that an entry point's `addressGuard` option
+// takes (`allowAnyAddress`, `blockPrivateNetworks`), while a **`Policy`-suffixed** factory
+// returns the pure, synchronous `IAddressPolicy` over an already-resolved address list that such
+// a guard delegates to (`allowAnyAddressPolicy`, `blockPrivateNetworksPolicy`). The unsuffixed
+// names are the ones callers reach for, which is why they are the ones that fit the call site.
 export {
   allowAnyAddressPolicy,
-  blockPrivateNetworks,
+  blockPrivateNetworksPolicy,
   type IAddressCheckVerdict,
   type IAddressPolicy,
   type IBlockPrivateNetworksOptions
 } from './addressPolicy';
+
+// Node only — it resolves names, and no browser API returns a hostname's A/AAAA records. This
+// is the one module in the packlet that performs I/O, and the reason this barrel and the browser
+// barrel differ at all.
+export {
+  blockPrivateNetworks,
+  nodeHostResolver,
+  type HostResolver,
+  type IBlockPrivateNetworksGuardOptions
+} from './nodeAddressGuard';
 
 export {
   classifyAddress,

--- a/libraries/ts-extras/src/packlets/safer-fetch/model.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/model.ts
@@ -41,6 +41,14 @@ export type SaferFetchMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELE
  * Following hops also makes this primitive responsible for credential stripping — see
  * `ISaferFetchOptions.sensitiveHeaders`.
  *
+ * **`'validate-each-hop'` is accepted by the browser barrel but cannot succeed there, and fails
+ * loudly rather than degrading.** The type is shared because one core serves both runtimes; the
+ * runtime is not. A browser's `redirect: 'manual'` yields an opaque response — `type` is
+ * `'opaqueredirect'`, `status` is `0`, and `Location` is not readable — so the first redirect
+ * fails as `'redirect-opaque'`. That is the honest outcome: the hop information does not exist
+ * on the browser side of the API, so there is nothing to guard and nothing to follow. Use
+ * `'reject'` there, or handle `'redirect-opaque'`.
+ *
  * A mode that defers to the platform's own redirect following is deliberately absent on Node:
  * it would put hops on the wire that the guard never saw.
  * @public

--- a/libraries/ts-extras/src/packlets/safer-fetch/model.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/model.ts
@@ -30,16 +30,22 @@ export type SaferFetchMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELE
  * How redirects are handled.
  *
  * @remarks
- * `'reject'` fails on any redirect status and is the only mode with an equivalent
- * guarantee on every runtime — a browser cannot inspect a redirect hop at all, so a
+ * `'reject'` fails on any redirect status. It is the default, and the only mode with an
+ * equivalent guarantee on every runtime — a browser cannot inspect a redirect hop at all, so a
  * per-hop revalidating mode is not implementable there.
  *
- * This union is deliberately narrow in this release: only `'reject'` ships. Modes that
- * follow hops arrive with the per-hop revalidation that makes them safe, and widening a
- * union of accepted values is an additive change.
+ * `'validate-each-hop'` follows redirects with `redirect: 'manual'` and runs the **full address
+ * guard on every hop before any connection is made**, resolving `Location` against the hop that
+ * sent it. Redirect handling and the address check are one mechanism, not two: a guard that
+ * validated only the caller's URL is defeated by a single `302` to `http://169.254.169.254/`.
+ * Following hops also makes this primitive responsible for credential stripping — see
+ * `ISaferFetchOptions.sensitiveHeaders`.
+ *
+ * A mode that defers to the platform's own redirect following is deliberately absent on Node:
+ * it would put hops on the wire that the guard never saw.
  * @public
  */
-export type SaferFetchRedirectPolicy = 'reject';
+export type SaferFetchRedirectPolicy = 'reject' | 'validate-each-hop';
 
 /**
  * One hop in a redirect chain. Entry 0 is the caller's original request.
@@ -52,7 +58,14 @@ export interface IRequestHop {
   readonly status?: number;
   /**
    * The address actually connected to on this hop, when address pinning was in effect.
-   * Always `undefined` in this release — see {@link SaferFetch.IGuardVerdict.pinnedAddress}.
+   *
+   * @remarks
+   * Populated from the address guard's {@link SaferFetch.IGuardVerdict.pinnedAddress} once the
+   * transport has accepted it — which is sound because a transport that cannot honor a pin is
+   * required to fail rather than connect by hostname, so a completed request with a pin set is
+   * evidence the pin held. **Undefined throughout this release**, since no shipped guard pins
+   * and {@link SaferFetch.platformFetchTransport} cannot honor one; the field is where the
+   * rebinding defense's per-hop evidence will live.
    */
   readonly connectedAddress?: string;
 }
@@ -313,9 +326,36 @@ export interface ISaferFetchOptions {
   readonly maxResponseBytes?: number;
 
   /**
-   * How redirects are handled. Default — and, in this release, only — `'reject'`.
+   * How redirects are handled. Defaults to `'reject'`.
+   *
+   * @remarks
+   * The conservative default is deliberate, and is the same polarity as `addressGuard` having no
+   * default: one core serves both runtimes, `'reject'` is the only mode whose guarantee is
+   * identical on each, and following a redirect chain into hosts the caller never named is a
+   * posture worth spelling at the call site. Callers ingesting real-world URLs want
+   * `'validate-each-hop'`.
    */
   readonly redirectPolicy?: SaferFetchRedirectPolicy;
+
+  /**
+   * Cap on redirect hops followed under `'validate-each-hop'`. Default
+   * {@link SaferFetch.DEFAULT_MAX_REDIRECTS} (5). Must be a non-negative integer; `0` refuses
+   * to follow any redirect.
+   */
+  readonly maxRedirects?: number;
+
+  /**
+   * Additional header names to drop on a cross-origin redirect hop, on top of the always-dropped
+   * `authorization`, `cookie` and `proxy-authorization`
+   * ({@link SaferFetch.ALWAYS_STRIPPED_HEADERS}).
+   *
+   * @remarks
+   * Matching is case-insensitive. Use this for bearer-equivalent headers a deployment invented —
+   * `x-api-key`, `x-auth-token`, a signed-request header. Stripping is **monotonic**: once a hop
+   * has left an origin the headers are gone for the rest of the chain, so an `A` → `B` → `A`
+   * chain does not hand the credential back to `A` after `B` has watched it leave.
+   */
+  readonly sensitiveHeaders?: ReadonlyArray<string>;
 
   /** Defaults to {@link SaferFetch.platformFetchTransport}. */
   readonly transport?: IFetchTransport;

--- a/libraries/ts-extras/src/packlets/safer-fetch/model.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/model.ts
@@ -34,6 +34,12 @@ export type SaferFetchMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELE
  * equivalent guarantee on every runtime — a browser cannot inspect a redirect hop at all, so a
  * per-hop revalidating mode is not implementable there.
  *
+ * The *guarantee* is equivalent on both runtimes; the failure **reason** is not. Every call uses
+ * `redirect: 'manual'`, so on Node a rejected redirect surfaces as `'redirect-rejected'` carrying
+ * the status, while in a browser the response is opaque — `type` is `'opaqueredirect'` and
+ * `status` is `0`, so there is no status to report — and the same redirect surfaces as
+ * `'redirect-opaque'`. Callers that branch on the reason under `'reject'` must handle both.
+ *
  * `'validate-each-hop'` follows redirects with `redirect: 'manual'` and runs the **full address
  * guard on every hop before any connection is made**, resolving `Location` against the hop that
  * sent it. Redirect handling and the address check are one mechanism, not two: a guard that

--- a/libraries/ts-extras/src/packlets/safer-fetch/nodeAddressGuard.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/nodeAddressGuard.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// This module is **Node-only**: it imports `node:dns/promises` for its default resolver, so it
+// is deliberately absent from the packlet's browser barrel. It is also the only module in the
+// packlet that performs I/O.
+
+import { captureAsyncResult, fail, succeed, type Result } from '@fgv/ts-utils';
+import { lookup } from 'node:dns/promises';
+
+import { classifyAddress } from './addressClassification';
+import {
+  blockPrivateNetworksPolicy,
+  type IAddressPolicy,
+  type IBlockPrivateNetworksOptions
+} from './addressPolicy';
+import type { IAddressGuard, IGuardVerdict, IRequestHop } from './model';
+
+/**
+ * Resolves a hostname to every address it names.
+ *
+ * @remarks
+ * Injectable so that the resolving half of an address guard is testable without a network — a
+ * guard test that performs a real lookup fails in CI for reasons unrelated to the guard, and a
+ * guard test that could reach `169.254.169.254` is worse than flaky.
+ *
+ * An implementation must return a `Failure` rather than reject: `node:dns` rejects on
+ * `ENOTFOUND`, `EAI_AGAIN` and friends, and an entry point documented to always return a
+ * `Result` must not let that escape as a throw. {@link SaferFetch.nodeHostResolver} converts.
+ *
+ * @param hostname - The host to resolve, with no surrounding brackets.
+ * @public
+ */
+export type HostResolver = (hostname: string) => Promise<Result<ReadonlyArray<string>>>;
+
+/**
+ * The default {@link SaferFetch.HostResolver}: `node:dns`'s `lookup`, returning every address.
+ *
+ * @remarks
+ * `lookup` rather than `resolve4`/`resolve6` deliberately. `lookup` goes through the operating
+ * system's resolver — the same path `fetch`'s connect takes — so it sees `/etc/hosts`, `nsswitch`
+ * ordering, and any local override. `resolve4` queries DNS directly and would miss a
+ * `hosts`-file entry pointing an allowlisted name at `127.0.0.1`, which is a bypass rather than
+ * a curiosity.
+ *
+ * `all: true` because the list contract is reject-if-any: a name resolving to one public and one
+ * private address must be refused, and asking for one address would hide the second.
+ *
+ * A rejected lookup (`ENOTFOUND`, `EAI_AGAIN`, …) becomes a `Failure`, never a throw.
+ * @public
+ */
+export const nodeHostResolver: HostResolver = async (
+  hostname: string
+): Promise<Result<ReadonlyArray<string>>> => {
+  return captureAsyncResult(async () => lookup(hostname, { all: true, verbatim: true }))
+    .withErrorFormat((message) => `failed to resolve "${hostname}": ${message}`)
+    .onSuccess((entries) => succeed(entries.map((entry) => entry.address)));
+};
+
+/**
+ * Options for {@link SaferFetch.blockPrivateNetworks}.
+ * @public
+ */
+export interface IBlockPrivateNetworksGuardOptions extends IBlockPrivateNetworksOptions {
+  /**
+   * Name resolution. Defaults to {@link SaferFetch.nodeHostResolver}.
+   *
+   * @remarks
+   * Present so the guard is unit-testable with no network. It is **not** a hook through which
+   * DNS rebinding can be closed: swapping the resolver changes only the address the guard
+   * validates, while the transport still connects by hostname and resolves again. Closing that
+   * requires a pinning transport — see `IGuardVerdict.pinnedAddress`.
+   */
+  readonly resolve?: HostResolver;
+}
+
+/**
+ * Resolves a hop's hostname if it is not already an IP literal, and hands every resolved address
+ * to the policy.
+ *
+ * A `classifyAddress` failure means "this is not an IP literal, so resolve it" — it never means
+ * "block". Treating an unparseable literal as hostile would reject every ordinary hostname.
+ */
+async function _addressesFor(
+  hostname: string,
+  resolve: HostResolver
+): Promise<Result<ReadonlyArray<string>>> {
+  // Classify `url.hostname`, never raw URL text. By the time the WHATWG parser has produced a
+  // hostname, `127.0x.1` is already `127.0.0.1`, `⑫7.0.0.1` is already `127.0.0.1`, and
+  // `::ffff:169.254.169.254` is already `::ffff:a9fe:a9fe`. Text matching misses all three.
+  const literal = classifyAddress(hostname);
+  return literal.isSuccess() ? succeed([hostname]) : resolve(hostname);
+}
+
+/**
+ * Creates the recommended address guard: resolves each hop's host and requires every resolved
+ * address to be globally routable public unicast.
+ *
+ * @remarks
+ * **Node only** — it resolves names, and no browser API returns a hostname's A/AAAA records.
+ * `allowAnyAddress()` is the honest choice there, and its name says so.
+ *
+ * This is the guard an entry point's `addressGuard` option takes. It is the resolving,
+ * hop-chain-aware half; the judgement itself belongs to
+ * {@link SaferFetch.blockPrivateNetworksPolicy}, which this guard delegates to unchanged. Keeping
+ * the adversarial classification matrix in one pure, synchronous implementation is what makes
+ * "did the address check run, and run correctly?" answerable by reading one file.
+ *
+ * The guard is invoked **once per redirect hop**, on the last entry of the chain. Hop 0 is not a
+ * special case: a guard that only validated the initial URL is defeated by a single `302` to
+ * `http://169.254.169.254/`.
+ *
+ * **What this does not protect against.** It validates a resolved address and the transport then
+ * re-resolves, so hostile DNS can answer the two lookups differently — the documented
+ * DNS-rebinding limit, which is open in this release. It does not narrow the scheme beyond the
+ * core's refusal of everything that is not `http:`/`https:`, and it applies no host or port
+ * allowlist; a strict host allowlist remains the recommended posture and is the caller's to add
+ * as an additional guard.
+ *
+ * @param options - optional relaxations of the default posture, plus the resolver seam.
+ * @returns the guard. Construction cannot fail.
+ * @public
+ */
+export function blockPrivateNetworks(options?: IBlockPrivateNetworksGuardOptions): IAddressGuard {
+  const allowLoopback: boolean = options?.allowLoopback === true;
+  const resolve: HostResolver = options?.resolve ?? nodeHostResolver;
+  const policy: IAddressPolicy = blockPrivateNetworksPolicy({ allowLoopback });
+  const name: string = allowLoopback ? 'blockPrivateNetworks(allowLoopback)' : 'blockPrivateNetworks';
+
+  return {
+    name,
+    check: async (chain: ReadonlyArray<IRequestHop>): Promise<Result<IGuardVerdict>> => {
+      const hop = chain[chain.length - 1] ?? undefined;
+      if (hop === undefined) {
+        return fail(`${name}: hop chain is empty.`);
+      }
+      return (await _addressesFor(hop.url.hostname, resolve))
+        .withErrorFormat((message) => `${name}: ${message}`)
+        .onSuccess((addresses) => policy.checkAddresses(addresses))
+        .onSuccess(() =>
+          // `pinnedAddress` is deliberately left undefined. The guard validated a resolved
+          // address, but `platformFetchTransport` connects by hostname and would have to fail
+          // rather than honor a pin — so claiming one here would either break every call or,
+          // worse, advertise a rebinding defense that is not in place.
+          succeed({ url: hop.url })
+        );
+    }
+  };
+}

--- a/libraries/ts-extras/src/packlets/safer-fetch/nodeAddressGuard.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/nodeAddressGuard.ts
@@ -151,6 +151,14 @@ export function blockPrivateNetworks(options?: IBlockPrivateNetworksGuardOptions
       if (hop === undefined) {
         return fail(`${name}: hop chain is empty.`);
       }
+      // The format applies to the resolution failure only, and deliberately does not wrap the
+      // policy's. The two layers are named separately on purpose: this guard is the resolving,
+      // chain-aware half and reports as `blockPrivateNetworks(...)`, while the pure classifier
+      // beneath it reports as `blockPrivateNetworksPolicy(...)`. A reader of either message can
+      // therefore tell which layer said no — whether DNS failed or an address was classified and
+      // refused — which is the distinction the guard/policy split exists to make legible.
+      // Flattening both to the guard name would read as more consistent and carry strictly less
+      // information. `FetchFailureReason.blocked-by-guard.guard` names the guard either way.
       return (await _addressesFor(hop.url.hostname, resolve))
         .withErrorFormat((message) => `${name}: ${message}`)
         .onSuccess((addresses) => policy.checkAddresses(addresses))

--- a/libraries/ts-extras/src/packlets/safer-fetch/redirect.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/redirect.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { captureResult, type Result } from '@fgv/ts-utils';
+
+import { ALWAYS_STRIPPED_HEADERS } from './defaults';
+import type { SaferFetchMethod } from './model';
+
+/** Headers describing a body that is about to be dropped, so they must go with it. */
+const BODY_DESCRIBING_HEADERS: ReadonlyArray<string> = ['content-type', 'content-length'];
+
+/**
+ * Builds the set of header names to drop on a cross-origin hop.
+ *
+ * @remarks
+ * Lowercased on the way in so the comparison is case-insensitive: HTTP header names are, and a
+ * request guard returning a replacement request spelled `Authorization` must not slip a
+ * credential past a set keyed on `authorization`.
+ * @internal
+ */
+export function sensitiveHeaderSet(extra?: ReadonlyArray<string>): ReadonlySet<string> {
+  return new Set<string>([...ALWAYS_STRIPPED_HEADERS, ...(extra ?? [])].map((n) => n.toLowerCase()));
+}
+
+/**
+ * Resolves a `Location` header against the URL of the hop that sent it.
+ *
+ * @remarks
+ * Resolved against the **current** hop, not the caller's original URL: a relative `Location` on
+ * the third hop of a chain is relative to the third hop.
+ * @internal
+ */
+export function resolveLocation(location: string, base: URL): Result<URL> {
+  return captureResult(() => new URL(location, base)).withErrorFormat(
+    (message) => `cannot resolve redirect target "${location}": ${message}`
+  );
+}
+
+/** The request to issue on the next hop. @internal */
+export interface IRedirectRewrite {
+  readonly method: SaferFetchMethod;
+  /** Header names are lowercased; credential headers are absent on a cross-origin hop. */
+  readonly headers: Record<string, string>;
+  readonly body: string | Uint8Array | undefined;
+  /** Whether this hop left the previous hop's origin, and so dropped credential headers. */
+  readonly crossOrigin: boolean;
+}
+
+/** Inputs to {@link rewriteForRedirect}. @internal */
+export interface IRedirectRewriteParams {
+  /** The URL that was requested and answered with the redirect. */
+  readonly from: URL;
+  /** The already-resolved redirect target. */
+  readonly to: URL;
+  readonly status: number;
+  readonly method: SaferFetchMethod;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: string | Uint8Array | undefined;
+  readonly sensitiveHeaders: ReadonlySet<string>;
+}
+
+/**
+ * Derives the next hop's method, headers and body from the hop that redirected.
+ *
+ * @remarks
+ * **Method and body** follow the platform, because a primitive that redirects differently from
+ * `fetch` surprises callers in a way no documentation repairs. Per the Fetch standard: `301` and
+ * `302` convert a `POST` to a `GET` and drop the body, and leave every other method alone; `303`
+ * converts anything that is not already `GET`/`HEAD`; `307` and `308` preserve both. `status` is
+ * on `IRequestHop` for exactly this reason. A dropped body takes `Content-Type` and
+ * `Content-Length` with it — describing a body that is no longer there is not a rounding error
+ * on a request a guard is about to inspect.
+ *
+ * **Credential stripping is monotonic.** The comparison is against the hop that redirected, and
+ * the headers carried in are the *previous hop's* headers, not the caller's original set. That
+ * distinction is the whole game: `A`(authenticated) → `B` → `A` must not re-attach on the final
+ * hop. Re-deriving each hop's headers from the caller's original request and comparing to the
+ * caller's original origin finds the last hop same-origin with `A` and hands the token back —
+ * after `B` has already observed the chain. It reviews as correct and it is a real leak.
+ * @internal
+ */
+export function rewriteForRedirect(params: IRedirectRewriteParams): IRedirectRewrite {
+  const crossOrigin: boolean = params.to.origin !== params.from.origin;
+  const method: SaferFetchMethod = _rewriteMethod(params.status, params.method);
+  const dropsBody: boolean = method !== params.method;
+  const drop: ReadonlySet<string> = new Set<string>([
+    ...(crossOrigin ? params.sensitiveHeaders : []),
+    ...(dropsBody ? BODY_DESCRIBING_HEADERS : [])
+  ]);
+
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(params.headers)) {
+    const lowered = name.toLowerCase();
+    if (!drop.has(lowered)) {
+      headers[lowered] = value;
+    }
+  }
+
+  return { method, headers, body: dropsBody ? undefined : params.body, crossOrigin };
+}
+
+function _rewriteMethod(status: number, method: SaferFetchMethod): SaferFetchMethod {
+  if ((status === 301 || status === 302) && method === 'POST') {
+    return 'GET';
+  }
+  if (status === 303 && method !== 'GET' && method !== 'HEAD') {
+    return 'GET';
+  }
+  return method;
+}

--- a/libraries/ts-extras/src/packlets/safer-fetch/redirect.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/redirect.ts
@@ -59,8 +59,6 @@ export interface IRedirectRewrite {
   /** Header names are lowercased; credential headers are absent on a cross-origin hop. */
   readonly headers: Record<string, string>;
   readonly body: string | Uint8Array | undefined;
-  /** Whether this hop left the previous hop's origin, and so dropped credential headers. */
-  readonly crossOrigin: boolean;
 }
 
 /** Inputs to {@link rewriteForRedirect}. @internal */
@@ -113,7 +111,7 @@ export function rewriteForRedirect(params: IRedirectRewriteParams): IRedirectRew
     }
   }
 
-  return { method, headers, body: dropsBody ? undefined : params.body, crossOrigin };
+  return { method, headers, body: dropsBody ? undefined : params.body };
 }
 
 function _rewriteMethod(status: number, method: SaferFetchMethod): SaferFetchMethod {

--- a/libraries/ts-extras/src/packlets/safer-fetch/saferFetch.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/saferFetch.ts
@@ -37,6 +37,7 @@ import { parseCharset, parseContentLength } from './contentType';
 import { DeadlineWatch, type DeadlineStopCause } from './deadline';
 import {
   DEFAULT_HEADERS_TIMEOUT_MS,
+  DEFAULT_MAX_REDIRECTS,
   DEFAULT_MAX_RESPONSE_BYTES,
   DEFAULT_TIMEOUT_MS,
   REDIRECT_STATUSES,
@@ -51,8 +52,10 @@ import type {
   ISaferFetchRequest,
   ISaferFetchResponse,
   ISaferFetchResponseHead,
-  SaferFetchMethod
+  SaferFetchMethod,
+  SaferFetchRedirectPolicy
 } from './model';
+import { resolveLocation, rewriteForRedirect, sensitiveHeaderSet } from './redirect';
 import { platformFetchTransport } from './transport';
 
 /** Every entry point's carrier: a value, or a machine-readable reason it failed. */
@@ -76,10 +79,41 @@ interface IResolvedCallOptions {
   readonly timeoutMs: number;
   readonly headersTimeoutMs: number;
   readonly maxResponseBytes: number;
+  readonly redirectPolicy: SaferFetchRedirectPolicy;
+  readonly maxRedirects: number;
+  /** Lowercased; the always-stripped three unioned with the caller's additions. */
+  readonly sensitiveHeaders: ReadonlySet<string>;
   readonly logger: Logging.ILogger;
 }
 
+/**
+ * What one attempt produced: either the response this call was after, or a redirect to follow.
+ *
+ * @remarks
+ * A discriminated union rather than a sentinel because the redirect branch carries fields the
+ * final branch does not have and vice versa — and because the alternative, letting `_receive`
+ * decide whether to recurse, would put the hop loop inside the response-handling path where the
+ * hop cap and the credential rule are much harder to see.
+ */
+type AttemptOutcome =
+  | { readonly kind: 'final'; readonly bytes: Uint8Array; readonly head: ISaferFetchResponseHead }
+  | { readonly kind: 'redirect'; readonly status: number; readonly location: string };
+
+/** One completed attempt, with the URL that was actually requested. */
+interface IAttempt {
+  /**
+   * The URL the transport was given — the address guard's cleared, possibly normalized URL,
+   * not necessarily the spelling the caller or a `Location` header used. This is what a relative
+   * `Location` resolves against, and what lands in `urlChain`.
+   */
+  readonly url: URL;
+  readonly connectedAddress: string | undefined;
+  readonly outcome: AttemptOutcome;
+}
+
 const METHODS_WITHOUT_BODY: ReadonlyArray<SaferFetchMethod> = ['GET', 'HEAD'];
+
+const REDIRECT_POLICIES: ReadonlyArray<SaferFetchRedirectPolicy> = ['reject', 'validate-each-hop'];
 
 function _succeed<T>(value: T): Outcome<T> {
   return succeedWithDetail<T, FetchFailureReason>(value);
@@ -202,6 +236,24 @@ function _resolveCallOptions(options: ISaferFetchOptions): Outcome<IResolvedCall
     }
   }
 
+  // `String(...)` and a lookup rather than a literal comparison, so that a JavaScript caller
+  // supplying a policy this release does not implement is rejected instead of silently getting a
+  // different one. The lookup also narrows to the union with no cast.
+  const requestedPolicy = String(options.redirectPolicy ?? 'reject');
+  const redirectPolicy = REDIRECT_POLICIES.find((p) => p === requestedPolicy);
+  if (redirectPolicy === undefined) {
+    return _unknown<IResolvedCallOptions>(
+      `redirectPolicy "${requestedPolicy}" is not supported; expected ${REDIRECT_POLICIES.join(' or ')}.`
+    );
+  }
+
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  if (!Number.isInteger(maxRedirects) || maxRedirects < 0) {
+    return _unknown<IResolvedCallOptions>(
+      `maxRedirects must be a non-negative integer; got ${maxRedirects}.`
+    );
+  }
+
   return _succeed({
     method,
     headers: _lowercaseHeaders(options.headers ?? {}),
@@ -209,6 +261,9 @@ function _resolveCallOptions(options: ISaferFetchOptions): Outcome<IResolvedCall
     timeoutMs,
     headersTimeoutMs,
     maxResponseBytes,
+    redirectPolicy,
+    maxRedirects,
+    sensitiveHeaders: sensitiveHeaderSet(options.sensitiveHeaders),
     logger: options.logger ?? new Logging.NoOpLogger()
   });
 }
@@ -306,21 +361,33 @@ async function _receive(
   guards: IResolvedGuards,
   resolved: IResolvedCallOptions,
   watch: DeadlineWatch
-): Promise<Outcome<IRawOutcome>> {
+): Promise<Outcome<AttemptOutcome>> {
   if (response.type === 'opaqueredirect') {
     _discardBody(response);
-    return _fail<IRawOutcome>(
+    return _fail<AttemptOutcome>(
       { kind: 'redirect-opaque' },
       'the platform returned an opaque redirect, whose target cannot be inspected or guarded.'
     );
   }
 
   if (REDIRECT_STATUSES.includes(response.status)) {
+    // The body of a redirect is never the body this call wanted, and leaving it unconsumed holds
+    // the connection open for the whole rest of the chain.
     _discardBody(response);
-    return _fail<IRawOutcome>(
-      { kind: 'redirect-rejected', url: url.toString(), status: response.status },
-      `${url.toString()} redirected with status ${response.status}; redirects are rejected.`
-    );
+    if (resolved.redirectPolicy === 'reject') {
+      return _fail<AttemptOutcome>(
+        { kind: 'redirect-rejected', url: url.toString(), status: response.status },
+        `${url.toString()} redirected with status ${response.status}; redirects are rejected.`
+      );
+    }
+    const location = response.headers.get('location') ?? undefined;
+    if (location === undefined || location.trim().length === 0) {
+      return _fail<AttemptOutcome>(
+        { kind: 'redirect-rejected', url: url.toString(), status: response.status },
+        `${url.toString()} redirected with status ${response.status} but sent no usable Location header.`
+      );
+    }
+    return _succeed<AttemptOutcome>({ kind: 'redirect', status: response.status, location });
   }
 
   const headers = _readHeaders(response);
@@ -338,7 +405,7 @@ async function _receive(
 
   if (!response.ok) {
     _discardBody(response);
-    return _fail<IRawOutcome>(
+    return _fail<AttemptOutcome>(
       // `bodyPreview` is deliberately never populated: error bodies routinely echo request
       // content, including credentials.
       { kind: 'http-status', status: response.status, statusText: response.statusText },
@@ -350,18 +417,18 @@ async function _receive(
   const headGuarded = await watch.race(_capture(() => guards.responseHeaders.check(head, chain)));
   if (headGuarded.stopped) {
     _discardBody(response);
-    return _stopped<IRawOutcome>(watch, headGuarded.cause);
+    return _stopped<AttemptOutcome>(watch, headGuarded.cause);
   }
   if (headGuarded.value.isFailure()) {
     _discardBody(response);
     const accepted = guards.responseHeaders.acceptedContentTypes ?? undefined;
     if (accepted !== undefined) {
-      return _fail<IRawOutcome>(
+      return _fail<AttemptOutcome>(
         { kind: 'unsupported-content-type', contentType: head.contentType, accepted },
         `${url.toString()}: ${headGuarded.value.message}`
       );
     }
-    return _blocked<IRawOutcome>(
+    return _blocked<AttemptOutcome>(
       'response-headers',
       url,
       hop,
@@ -372,15 +439,15 @@ async function _receive(
 
   const body = await _readCappedBody(response, head, resolved.maxResponseBytes, watch);
   if (body.isFailure()) {
-    return _propagate<Uint8Array, IRawOutcome>(body);
+    return _propagate<Uint8Array, AttemptOutcome>(body);
   }
 
   const bodyGuarded = await watch.race(_capture(() => guards.responseBody.check(body.value, head)));
   if (bodyGuarded.stopped) {
-    return _stopped<IRawOutcome>(watch, bodyGuarded.cause);
+    return _stopped<AttemptOutcome>(watch, bodyGuarded.cause);
   }
   if (bodyGuarded.value.isFailure()) {
-    return _blocked<IRawOutcome>(
+    return _blocked<AttemptOutcome>(
       'response-body',
       url,
       hop,
@@ -389,7 +456,7 @@ async function _receive(
     );
   }
 
-  return _succeed({ bytes: body.value, head, urlChain: [url.toString()] });
+  return _succeed<AttemptOutcome>({ kind: 'final', bytes: body.value, head });
 }
 
 async function _connect(
@@ -399,17 +466,19 @@ async function _connect(
   options: ISaferFetchOptions,
   resolved: IResolvedCallOptions,
   watch: DeadlineWatch
-): Promise<Outcome<IRawOutcome>> {
+): Promise<Outcome<IAttempt>> {
   const transport = options.transport ?? platformFetchTransport;
 
   // The address guard runs immediately before the connect, and after the request guard, so a
-  // request guard that returned a replacement request cannot route around it.
+  // request guard that returned a replacement request cannot route around it. It runs on every
+  // hop, not only the first: a `302` to `http://169.254.169.254/` is exactly what a guard that
+  // only saw the caller's URL would miss.
   const verdict = await watch.race(_capture(() => guards.address.check(chain)));
   if (verdict.stopped) {
-    return _stopped<IRawOutcome>(watch, verdict.cause);
+    return _stopped<IAttempt>(watch, verdict.cause);
   }
   if (verdict.value.isFailure()) {
-    return _blocked<IRawOutcome>(
+    return _blocked<IAttempt>(
       'address',
       request.url,
       chain.length - 1,
@@ -422,7 +491,7 @@ async function _connect(
   // scheme is re-checked because normalization must never be able to widen it.
   const cleared = _checkScheme(verdict.value.value.url);
   if (cleared.isFailure()) {
-    return _propagate<URL, IRawOutcome>(cleared);
+    return _propagate<URL, IAttempt>(cleared);
   }
   const url = cleared.value;
   const pinnedAddress = verdict.value.value.pinnedAddress ?? undefined;
@@ -444,14 +513,14 @@ async function _connect(
 
   const sent = await watch.race(_capture(() => transport.fetch(url, init, { pinnedAddress })));
   if (sent.stopped) {
-    return _stopped<IRawOutcome>(watch, sent.cause);
+    return _stopped<IAttempt>(watch, sent.cause);
   }
   if (sent.value.isFailure()) {
     // No `watch.cause` re-check here: a stop resolves every in-flight race the instant it
     // fires, so reaching this line means the transport settled *before* we gave up. Reporting
     // it as a network failure is the honest answer — relabelling it as a timeout because the
     // deadline expired a microsecond later would be the taxonomy lying about which came first.
-    return _fail<IRawOutcome>(
+    return _fail<IAttempt>(
       { kind: 'network', detail: sent.value.message },
       `transport "${transport.name}" failed: ${sent.value.message}`
     );
@@ -461,7 +530,79 @@ async function _connect(
   // Downstream guards see the chain as it was actually requested, so the URL a response guard
   // reads is the URL the address guard cleared — not the pre-normalization spelling.
   const requested: ReadonlyArray<IRequestHop> = [...chain.slice(0, -1), { ...chain[chain.length - 1], url }];
-  return _receive(sent.value.value, url, requested, guards, resolved, watch);
+  return (await _receive(sent.value.value, url, requested, guards, resolved, watch)).onSuccess((outcome) =>
+    // The pin is recorded only once the transport has accepted it. A transport that cannot honor
+    // a pin is required to fail rather than connect by hostname, so a settled request with a pin
+    // set is evidence the pin held — which is the only basis on which recording it would be
+    // honest.
+    _succeed({ url, connectedAddress: pinnedAddress, outcome })
+  );
+}
+
+/**
+ * Derives the next hop's request from a redirect, or explains why the chain stops here.
+ *
+ * @remarks
+ * The hop cap is checked before the target is resolved: a chain that has already run out of
+ * budget stops for that reason, whatever the `Location` header happens to contain.
+ *
+ * Loop detection compares against every URL already requested, not just the previous one.
+ * `A→B→A→B` passes every per-hop check while consuming the whole budget, and a cap alone would
+ * let it — which is the same reason the address guard is handed the chain rather than a counter.
+ */
+function _nextHop(
+  from: URL,
+  completed: ReadonlyArray<IRequestHop>,
+  redirect: { readonly status: number; readonly location: string },
+  request: ISaferFetchRequest,
+  resolved: IResolvedCallOptions
+): Outcome<ISaferFetchRequest> {
+  const followed = completed.length;
+  if (followed >= resolved.maxRedirects) {
+    return _fail<ISaferFetchRequest>(
+      { kind: 'too-many-redirects', hops: followed + 1, limit: resolved.maxRedirects },
+      `redirect chain exceeded the limit of ${resolved.maxRedirects} hops.`
+    );
+  }
+
+  const located = resolveLocation(redirect.location, from);
+  if (located.isFailure()) {
+    return _fail<ISaferFetchRequest>(
+      { kind: 'invalid-url', url: redirect.location, detail: located.message },
+      `invalid redirect target: ${located.message}`
+    );
+  }
+  const cleared = _checkScheme(located.value);
+  if (cleared.isFailure()) {
+    return _propagate<URL, ISaferFetchRequest>(cleared);
+  }
+  const to = cleared.value;
+
+  const visited: ReadonlyArray<string> = [...completed.map((h) => h.url.toString()), from.toString()];
+  if (visited.includes(to.toString())) {
+    return _fail<ISaferFetchRequest>(
+      { kind: 'redirect-rejected', url: to.toString(), status: redirect.status },
+      `${from.toString()} redirected with status ${redirect.status} to a URL already in the chain.`
+    );
+  }
+
+  // Headers come from the request that was actually sent on this hop, never from the caller's
+  // original set — that carry-forward is what makes credential stripping monotonic.
+  const rewritten = rewriteForRedirect({
+    from,
+    to,
+    status: redirect.status,
+    method: request.method,
+    headers: request.headers,
+    body: request.body,
+    sensitiveHeaders: resolved.sensitiveHeaders
+  });
+  return _succeed({
+    url: to,
+    method: rewritten.method,
+    headers: rewritten.headers,
+    ...(rewritten.body !== undefined ? { body: rewritten.body } : {})
+  });
 }
 
 async function _execute(url: string | URL, options: ISaferFetchOptions): Promise<Outcome<IRawOutcome>> {
@@ -477,16 +618,6 @@ async function _execute(url: string | URL, options: ISaferFetchOptions): Promise
   }
   const guards = resolvedGuards.value;
 
-  // `String(...)` rather than a literal comparison so that a JavaScript caller supplying a
-  // policy this release does not implement is rejected instead of silently getting a different
-  // one. Widening the union later stays additive.
-  const policy = String(options.redirectPolicy ?? 'reject');
-  if (policy !== 'reject') {
-    return _unknown<IRawOutcome>(
-      `redirectPolicy "${policy}" is not supported; this release rejects all redirects.`
-    );
-  }
-
   const parsed = _parseUrl(url);
   if (parsed.isFailure()) {
     return _propagate<URL, IRawOutcome>(parsed);
@@ -494,32 +625,78 @@ async function _execute(url: string | URL, options: ISaferFetchOptions): Promise
 
   const watch = new DeadlineWatch(resolved.timeoutMs, resolved.headersTimeoutMs, options.signal);
   try {
-    const initial: ISaferFetchRequest = {
+    let request: ISaferFetchRequest = {
       url: parsed.value,
       method: resolved.method,
       headers: resolved.headers,
       ...(resolved.body !== undefined ? { body: resolved.body } : {})
     };
+    /** Hops already requested and redirected away from, oldest first. */
+    const completed: IRequestHop[] = [];
 
-    const guarded = await watch.race(_capture(() => guards.request.check(initial, [{ url: initial.url }])));
-    if (guarded.stopped) {
-      return _stopped<IRawOutcome>(watch, guarded.cause);
-    }
-    if (guarded.value.isFailure()) {
-      return _blocked<IRawOutcome>('request', initial.url, 0, guards.request.name, guarded.value.message);
-    }
+    for (;;) {
+      // Re-arms the per-attempt headers deadline. Without this, the first hop's
+      // `headersReceived()` would retire it for the whole call and a later host that never
+      // answers would be bounded only by the overall deadline.
+      watch.attemptStarted();
 
-    const request = guarded.value.value;
-    const rechecked = _checkScheme(request.url);
-    if (rechecked.isFailure()) {
-      return _propagate<URL, IRawOutcome>(rechecked);
-    }
+      const guarded = await watch.race(
+        _capture(() => guards.request.check(request, [...completed, { url: request.url }]))
+      );
+      if (guarded.stopped) {
+        return _stopped<IRawOutcome>(watch, guarded.cause);
+      }
+      if (guarded.value.isFailure()) {
+        return _blocked<IRawOutcome>(
+          'request',
+          request.url,
+          completed.length,
+          guards.request.name,
+          guarded.value.message
+        );
+      }
 
-    const outcome = await _connect(request, [{ url: request.url }], guards, options, resolved, watch);
-    if (outcome.isFailure()) {
-      resolved.logger.detail(`saferFetch: ${request.url.toString()} failed: ${outcome.message}`);
+      const checked = guarded.value.value;
+      const rechecked = _checkScheme(checked.url);
+      if (rechecked.isFailure()) {
+        return _propagate<URL, IRawOutcome>(rechecked);
+      }
+
+      const attempted = await _connect(
+        checked,
+        [...completed, { url: checked.url }],
+        guards,
+        options,
+        resolved,
+        watch
+      );
+      if (attempted.isFailure()) {
+        resolved.logger.detail(`saferFetch: ${checked.url.toString()} failed: ${attempted.message}`);
+        return _propagate<IAttempt, IRawOutcome>(attempted);
+      }
+      const attempt = attempted.value;
+
+      if (attempt.outcome.kind === 'final') {
+        return _succeed({
+          bytes: attempt.outcome.bytes,
+          head: attempt.outcome.head,
+          urlChain: [...completed.map((h) => h.url.toString()), attempt.url.toString()]
+        });
+      }
+
+      const next = _nextHop(attempt.url, completed, attempt.outcome, checked, resolved);
+      if (next.isFailure()) {
+        resolved.logger.detail(`saferFetch: ${attempt.url.toString()} failed: ${next.message}`);
+        return _propagate<ISaferFetchRequest, IRawOutcome>(next);
+      }
+
+      completed.push({
+        url: attempt.url,
+        status: attempt.outcome.status,
+        ...(attempt.connectedAddress !== undefined ? { connectedAddress: attempt.connectedAddress } : {})
+      });
+      request = next.value;
     }
-    return outcome;
   } finally {
     watch.dispose();
   }
@@ -566,6 +743,11 @@ function _decodeText(raw: IRawOutcome): Outcome<string> {
  * **The failure detail is an internal-network scanning oracle.** Log it; do not echo it, or
  * any string derived from it, to an untrusted caller. The detail is structured precisely so
  * that mapping it to a coarse public code is trivial.
+ *
+ * **Redirects are rejected unless you ask for them.** `redirectPolicy: 'validate-each-hop'`
+ * follows them, runs the address guard on every hop before any connection, and drops credential
+ * headers the first time the chain leaves an origin — and never restores them, so an
+ * `A` → `B` → `A` chain does not hand the token back to `A`.
  *
  * @param url - The URL to fetch. Only `http:` and `https:` are ever requested; every other
  * scheme fails as `'invalid-url'`.

--- a/libraries/ts-extras/src/packlets/safer-fetch/saferFetch.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/saferFetch.ts
@@ -254,6 +254,30 @@ function _resolveCallOptions(options: ISaferFetchOptions): Outcome<IResolvedCall
     );
   }
 
+  // Same reasoning as `redirectPolicy` above, and the stakes are higher: these name the headers
+  // that get stripped on a cross-origin hop. A JavaScript caller can pass anything, and a
+  // non-string entry would throw out of an API contracted to only ever return a `Result`.
+  // Coercing instead of rejecting would be worse than either — `String(123)` is a header name
+  // that silently never matches, so a caller who fumbled the type would believe a credential was
+  // being stripped while it was carried across origins. A non-array is rejected for the same
+  // reason: spreading a bare string would enumerate it into single characters.
+  const extraSensitive = options.sensitiveHeaders;
+  if (extraSensitive !== undefined) {
+    if (!Array.isArray(extraSensitive)) {
+      return _unknown<IResolvedCallOptions>(
+        `sensitiveHeaders must be an array of header names; got ${typeof extraSensitive}.`
+      );
+    }
+    // `findIndex`, not `find`: an array containing `undefined` is itself invalid, and `find`
+    // cannot distinguish that from "no offender".
+    const badIndex = extraSensitive.findIndex((n) => typeof n !== 'string');
+    if (badIndex >= 0) {
+      return _unknown<IResolvedCallOptions>(
+        `sensitiveHeaders[${badIndex}] must be a string header name; got ${typeof extraSensitive[badIndex]}.`
+      );
+    }
+  }
+
   return _succeed({
     method,
     headers: _lowercaseHeaders(options.headers ?? {}),

--- a/libraries/ts-extras/src/packlets/safer-fetch/saferFetch.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/saferFetch.ts
@@ -581,8 +581,10 @@ function _nextHop(
   const visited: ReadonlyArray<string> = [...completed.map((h) => h.url.toString()), from.toString()];
   if (visited.includes(to.toString())) {
     return _fail<ISaferFetchRequest>(
-      { kind: 'redirect-rejected', url: to.toString(), status: redirect.status },
-      `${from.toString()} redirected with status ${redirect.status} to a URL already in the chain.`
+      { kind: 'redirect-rejected', url: from.toString(), status: redirect.status },
+      `${from.toString()} redirected with status ${
+        redirect.status
+      } to ${to.toString()}, which is already in the chain.`
     );
   }
 

--- a/libraries/ts-extras/src/packlets/safer-fetch/saferFetch.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/saferFetch.ts
@@ -602,6 +602,23 @@ function _nextHop(
   }
   const to = cleared.value;
 
+  // KNOWN LIMIT — detection is exact-match, and the two sides are not normalized alike.
+  // `completed` holds guard-CLEARED URLs, while `to` is the freshly resolved `Location` that the
+  // guard has not seen yet. A guard that normalizes — `IGuardVerdict.url` explicitly permits
+  // lowercasing a host, stripping a trailing dot, punycoding an IDN — can therefore produce a
+  // stored URL that a later raw target does not match, and the repeat runs to `maxRedirects`
+  // instead of being caught here.
+  //
+  // Not reachable with any guard this package ships: neither `allowAnyAddress` nor
+  // `blockPrivateNetworks` normalizes, and the WHATWG parser has already lowercased hosts and
+  // punycoded IDNs on both sides. Bounded when it is reachable — every hop is still fully
+  // address-guarded, so the cost is a longer walk, not a bypass.
+  //
+  // The fix is to compare like with like, checking after the guard clears the hop so the
+  // cleared URL is the identity on both sides. That means splitting the guard step out of
+  // `_connect`, which is S3's to do. Special-casing trailing dots here would be worse than
+  // leaving it: this layer does not own normalization and cannot anticipate what a custom guard
+  // does, so it would advertise a completeness it would not have.
   const visited: ReadonlyArray<string> = [...completed.map((h) => h.url.toString()), from.toString()];
   if (visited.includes(to.toString())) {
     return _fail<ISaferFetchRequest>(

--- a/libraries/ts-extras/src/packlets/safer-fetch/saferFetch.ts
+++ b/libraries/ts-extras/src/packlets/safer-fetch/saferFetch.ts
@@ -755,6 +755,25 @@ function _toResponse<T>(value: T, raw: IRawOutcome): ISaferFetchResponse<T> {
   };
 }
 
+/**
+ * Applies the caller's parser to the decoded body.
+ *
+ * @remarks
+ * Exists for the same reason as {@link _decodeText}: it is the boundary where a plain
+ * `Result` from a `Converter` becomes a `DetailedResult` carrying a `FetchFailureReason`.
+ * Isolating that conversion in a named helper is what lets the entry points stay chained.
+ */
+function _parseJson<T>(text: string, parser: Converter<T | JsonValue>): Outcome<T | JsonValue> {
+  const parsed = parser.convert(text);
+  if (parsed.isFailure()) {
+    return _fail<T | JsonValue>(
+      { kind: 'parse', detail: parsed.message },
+      `failed to parse response as JSON: ${parsed.message}`
+    );
+  }
+  return _succeed(parsed.value);
+}
+
 function _decodeText(raw: IRawOutcome): Outcome<string> {
   const charset = parseCharset(raw.head.contentType) ?? 'utf-8';
   // `fatal: true` so an unknown charset, or a byte sequence invalid in the declared one,
@@ -805,11 +824,7 @@ export async function saferFetchBytes(
   url: string | URL,
   options: ISaferFetchOptions
 ): Promise<DetailedResult<ISaferFetchResponse<Uint8Array>, FetchFailureReason>> {
-  const raw = await _execute(url, options);
-  if (raw.isFailure()) {
-    return _propagate<IRawOutcome, ISaferFetchResponse<Uint8Array>>(raw);
-  }
-  return _succeed(_toResponse(raw.value.bytes, raw.value));
+  return (await _execute(url, options)).onSuccess((raw) => _succeed(_toResponse(raw.bytes, raw)));
 }
 
 /**
@@ -833,15 +848,11 @@ export async function saferFetchText(
   url: string | URL,
   options: ISaferFetchOptions
 ): Promise<DetailedResult<ISaferFetchResponse<string>, FetchFailureReason>> {
-  const raw = await _execute(url, options);
-  if (raw.isFailure()) {
-    return _propagate<IRawOutcome, ISaferFetchResponse<string>>(raw);
-  }
-  const text = _decodeText(raw.value);
-  if (text.isFailure()) {
-    return _propagate<string, ISaferFetchResponse<string>>(text);
-  }
-  return _succeed(_toResponse(text.value, raw.value));
+  // Nested rather than flat: `_toResponse` needs both the decoded text and the raw outcome it
+  // came from, and nesting is what keeps `raw` in scope for it.
+  return (await _execute(url, options)).onSuccess((raw) =>
+    _decodeText(raw).onSuccess((text) => _succeed(_toResponse(text, raw)))
+  );
 }
 
 /**
@@ -907,26 +918,17 @@ export async function saferFetchJson<T>(
   url: string | URL,
   options: ISaferFetchOptions | ISaferFetchJsonOptions<T>
 ): Promise<DetailedResult<ISaferFetchResponse<T | JsonValue>, FetchFailureReason>> {
-  const raw = await _execute(url, options);
-  if (raw.isFailure()) {
-    return _propagate<IRawOutcome, ISaferFetchResponse<T | JsonValue>>(raw);
-  }
-  const text = _decodeText(raw.value);
-  if (text.isFailure()) {
-    return _propagate<string, ISaferFetchResponse<T | JsonValue>>(text);
-  }
-
   const converter = (options as Partial<ISaferFetchJsonOptions<T>>).converter ?? undefined;
   const parser: Converter<T | JsonValue> =
     converter !== undefined
       ? JsonBaseConverters.stringifiedJson<T>(converter)
       : JsonBaseConverters.stringifiedJson();
-  const parsed = parser.convert(text.value);
-  if (parsed.isFailure()) {
-    return _fail<ISaferFetchResponse<T | JsonValue>>(
-      { kind: 'parse', detail: parsed.message },
-      `failed to parse response as JSON: ${parsed.message}`
-    );
-  }
-  return _succeed(_toResponse(parsed.value, raw.value));
+
+  // Nested for the same reason as `saferFetchText`: the response needs the raw outcome as well
+  // as the parsed value, and nesting is what keeps `raw` in scope.
+  return (await _execute(url, options)).onSuccess((raw) =>
+    _decodeText(raw).onSuccess((text) =>
+      _parseJson(text, parser).onSuccess((parsed) => _succeed(_toResponse(parsed, raw)))
+    )
+  );
 }

--- a/libraries/ts-extras/src/test/unit/safer-fetch/addressPolicy.test.ts
+++ b/libraries/ts-extras/src/test/unit/safer-fetch/addressPolicy.test.ts
@@ -23,17 +23,19 @@ import '@fgv/ts-utils-jest';
 import {
   type IAddressPolicy,
   allowAnyAddressPolicy,
-  blockPrivateNetworks
+  blockPrivateNetworksPolicy
 } from '../../../packlets/safer-fetch';
 
-describe('blockPrivateNetworks', () => {
-  const policy: IAddressPolicy = blockPrivateNetworks();
+describe('blockPrivateNetworksPolicy', () => {
+  const policy: IAddressPolicy = blockPrivateNetworksPolicy();
 
   test('is named for the posture it implements', () => {
-    expect(policy.name).toBe('blockPrivateNetworks');
-    expect(blockPrivateNetworks({}).name).toBe('blockPrivateNetworks');
-    expect(blockPrivateNetworks({ allowLoopback: false }).name).toBe('blockPrivateNetworks');
-    expect(blockPrivateNetworks({ allowLoopback: true }).name).toBe('blockPrivateNetworks(allowLoopback)');
+    expect(policy.name).toBe('blockPrivateNetworksPolicy');
+    expect(blockPrivateNetworksPolicy({}).name).toBe('blockPrivateNetworksPolicy');
+    expect(blockPrivateNetworksPolicy({ allowLoopback: false }).name).toBe('blockPrivateNetworksPolicy');
+    expect(blockPrivateNetworksPolicy({ allowLoopback: true }).name).toBe(
+      'blockPrivateNetworksPolicy(allowLoopback)'
+    );
   });
 
   describe('addresses it permits', () => {
@@ -51,7 +53,7 @@ describe('blockPrivateNetworks', () => {
       ['134744072']
     ])('permits %s', (address) => {
       expect(policy.checkAddresses([address])).toSucceedAndSatisfy((verdict) => {
-        expect(verdict.policy).toBe('blockPrivateNetworks');
+        expect(verdict.policy).toBe('blockPrivateNetworksPolicy');
         expect(verdict.addresses).toHaveLength(1);
         expect(verdict.addresses[0].classification).toBe('public');
       });
@@ -102,7 +104,7 @@ describe('blockPrivateNetworks', () => {
       ['2002:a9fe:a9fe::', /link-local/i]
     ])('blocks %s', (address, pattern) => {
       expect(policy.checkAddresses([address])).toFailWith(pattern);
-      expect(policy.checkAddresses([address])).toFailWith(/blockPrivateNetworks/);
+      expect(policy.checkAddresses([address])).toFailWith(/blockPrivateNetworksPolicy/);
       expect(policy.checkAddresses([address])).toFailWith(/is not allowed/);
     });
 
@@ -141,18 +143,18 @@ describe('blockPrivateNetworks', () => {
     test('fails closed when an address is not a well-formed literal', () => {
       expect(policy.checkAddresses(['not-an-address'])).toFailWith(/not a valid IP address/i);
       expect(policy.checkAddresses(['8.8.8.8', '1::2::3'])).toFailWith(/not a valid IPv6 address/i);
-      expect(policy.checkAddresses(['not-an-address'])).toFailWith(/blockPrivateNetworks/);
+      expect(policy.checkAddresses(['not-an-address'])).toFailWith(/blockPrivateNetworksPolicy/);
     });
   });
 
   describe('allowLoopback', () => {
-    const loopbackOk: IAddressPolicy = blockPrivateNetworks({ allowLoopback: true });
+    const loopbackOk: IAddressPolicy = blockPrivateNetworksPolicy({ allowLoopback: true });
 
     test.each([['127.0.0.1'], ['127.1'], ['0177.0.0.1'], ['::1'], ['::ffff:127.0.0.1'], ['::7f00:1']])(
       'permits %s',
       (address) => {
         expect(loopbackOk.checkAddresses([address])).toSucceedAndSatisfy((verdict) => {
-          expect(verdict.policy).toBe('blockPrivateNetworks(allowLoopback)');
+          expect(verdict.policy).toBe('blockPrivateNetworksPolicy(allowLoopback)');
           expect(verdict.addresses[0].classification).toBe('loopback');
         });
       }

--- a/libraries/ts-extras/src/test/unit/safer-fetch/nodeAddressGuard.test.ts
+++ b/libraries/ts-extras/src/test/unit/safer-fetch/nodeAddressGuard.test.ts
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import { fail, succeed, type Result } from '@fgv/ts-utils';
+
+import { SaferFetch } from '../../..';
+
+const { blockPrivateNetworks, nodeHostResolver } = SaferFetch;
+
+/** Records what it was asked to resolve, so "was this even a lookup?" is assertable. */
+interface IRecordingResolver {
+  readonly resolve: SaferFetch.HostResolver;
+  readonly hostnames: ReadonlyArray<string>;
+}
+
+function resolvesTo(...addresses: ReadonlyArray<string>): IRecordingResolver {
+  const hostnames: string[] = [];
+  return {
+    hostnames,
+    resolve: async (hostname: string): Promise<Result<ReadonlyArray<string>>> => {
+      hostnames.push(hostname);
+      return succeed(addresses);
+    }
+  };
+}
+
+function resolverFails(message: string): SaferFetch.HostResolver {
+  return async (): Promise<Result<ReadonlyArray<string>>> => fail(message);
+}
+
+/** The guard reads only the last hop, so a one-entry chain is a complete input. */
+function chainTo(url: string): ReadonlyArray<SaferFetch.IRequestHop> {
+  return [{ url: new URL(url) }];
+}
+
+describe('blockPrivateNetworks (address guard)', () => {
+  describe('identity', () => {
+    test('names itself after the factory, and says so when loopback is permitted', () => {
+      expect(blockPrivateNetworks().name).toBe('blockPrivateNetworks');
+      expect(blockPrivateNetworks({}).name).toBe('blockPrivateNetworks');
+      expect(blockPrivateNetworks({ allowLoopback: false }).name).toBe('blockPrivateNetworks');
+      expect(blockPrivateNetworks({ allowLoopback: true }).name).toBe('blockPrivateNetworks(allowLoopback)');
+    });
+  });
+
+  describe('IP literals', () => {
+    test('classifies a literal without resolving it', async () => {
+      const resolver = resolvesTo('10.0.0.1');
+      const guard = blockPrivateNetworks({ resolve: resolver.resolve });
+      await expect(guard.check(chainTo('https://93.184.216.34/x'))).resolves.toSucceedAndSatisfy(
+        (verdict: SaferFetch.IGuardVerdict) => {
+          expect(verdict.url.toString()).toBe('https://93.184.216.34/x');
+          // A literal that was resolved anyway would have picked up the resolver's private
+          // address and been rejected — so this also proves the literal short-circuit.
+          expect(verdict.pinnedAddress).toBeUndefined();
+        }
+      );
+      expect(resolver.hostnames).toEqual([]);
+    });
+
+    test('blocks the cloud metadata endpoint', async () => {
+      await expect(
+        blockPrivateNetworks().check(chainTo('http://169.254.169.254/latest/meta-data/'))
+      ).resolves.toFailWith(/blockPrivateNetworks.*169\.254\.169\.254 is link-local/);
+    });
+
+    test('blocks a bracketed IPv6 literal, and permits loopback only on request', async () => {
+      await expect(blockPrivateNetworks().check(chainTo('https://[::1]:8443/'))).resolves.toFailWith(
+        /is loopback/
+      );
+      await expect(
+        blockPrivateNetworks({ allowLoopback: true }).check(chainTo('https://[::1]:8443/'))
+      ).resolves.toSucceed();
+    });
+
+    test.each([
+      ['octal', 'http://0177.0.0.1/'],
+      ['decimal', 'http://2130706433/'],
+      ['empty hex remainder', 'http://127.0x.1/'],
+      ['IPv4-mapped IPv6', 'http://[::ffff:169.254.169.254]/'],
+      ['6to4', 'http://[2002:a9fe:a9fe::]/'],
+      ['NAT64', 'http://[64:ff9b::a9fe:a9fe]/'],
+      ['unspecified', 'http://0.0.0.0/'],
+      ['fullwidth digits', 'http://１２７.０.０.１/']
+    ])('blocks the %s encoding of a private address', async (__name: string, url: string) => {
+      // Every one of these is already canonical by the time the WHATWG parser has produced a
+      // hostname, which is exactly why the guard classifies `url.hostname` and never raw text.
+      const resolver = resolvesTo('93.184.216.34');
+      const guard = blockPrivateNetworks({ resolve: resolver.resolve });
+      await expect(guard.check(chainTo(url))).resolves.toFail();
+      expect(resolver.hostnames).toEqual([]);
+    });
+  });
+
+  describe('hostnames', () => {
+    test('resolves the hostname and permits a public address', async () => {
+      const resolver = resolvesTo('93.184.216.34');
+      const guard = blockPrivateNetworks({ resolve: resolver.resolve });
+      await expect(guard.check(chainTo('https://example.com/thing'))).resolves.toSucceedAndSatisfy(
+        (verdict: SaferFetch.IGuardVerdict) => {
+          expect(verdict.url.toString()).toBe('https://example.com/thing');
+        }
+      );
+      expect(resolver.hostnames).toEqual(['example.com']);
+    });
+
+    test('rejects if ANY resolved address is disallowed, not if the first is', async () => {
+      const guard = blockPrivateNetworks({ resolve: resolvesTo('93.184.216.34', '169.254.169.254').resolve });
+      await expect(guard.check(chainTo('https://rebind.example/'))).resolves.toFailWith(
+        /169\.254\.169\.254 is link-local/
+      );
+    });
+
+    test('rejects a hostname that resolves to nothing', async () => {
+      const guard = blockPrivateNetworks({ resolve: resolvesTo().resolve });
+      await expect(guard.check(chainTo('https://void.example/'))).resolves.toFailWith(
+        /no addresses to check/
+      );
+    });
+
+    test('reports a resolution failure as a guard failure, never as a throw', async () => {
+      const guard = blockPrivateNetworks({ resolve: resolverFails('getaddrinfo ENOTFOUND nope.example') });
+      await expect(guard.check(chainTo('https://nope.example/'))).resolves.toFailWith(
+        /blockPrivateNetworks.*ENOTFOUND/
+      );
+    });
+
+    test('resolves the last hop of a chain, not the first', async () => {
+      const resolver = resolvesTo('93.184.216.34');
+      const guard = blockPrivateNetworks({ resolve: resolver.resolve });
+      const chain: ReadonlyArray<SaferFetch.IRequestHop> = [
+        { url: new URL('https://first.example/'), status: 302 },
+        { url: new URL('https://second.example/') }
+      ];
+      await expect(guard.check(chain)).resolves.toSucceed();
+      expect(resolver.hostnames).toEqual(['second.example']);
+    });
+
+    test('fails on an empty chain rather than guessing at a destination', async () => {
+      await expect(blockPrivateNetworks().check([])).resolves.toFailWith(/hop chain is empty/);
+    });
+  });
+});
+
+describe('nodeHostResolver', () => {
+  // Both cases are answered by the resolver stack without a DNS query — `localhost` from the
+  // hosts file, and a name past the protocol's 255-octet limit rejected by `getaddrinfo` before
+  // it asks anyone. A unit test that resolved a real name would fail in CI for reasons unrelated
+  // to this code.
+  test('returns every address a name resolves to', async () => {
+    await expect(nodeHostResolver('localhost')).resolves.toSucceedAndSatisfy(
+      (addresses: ReadonlyArray<string>) => {
+        expect(addresses.length).toBeGreaterThan(0);
+        for (const address of addresses) {
+          expect(['127.0.0.1', '::1']).toContain(address);
+        }
+      }
+    );
+  });
+
+  test('reports a rejected lookup as a Failure', async () => {
+    await expect(nodeHostResolver('a'.repeat(300))).resolves.toFailWith(/failed to resolve/);
+  });
+});

--- a/libraries/ts-extras/src/test/unit/safer-fetch/saferFetchRedirect.test.ts
+++ b/libraries/ts-extras/src/test/unit/safer-fetch/saferFetchRedirect.test.ts
@@ -1,0 +1,673 @@
+// Copyright (c) 2026 Erik Fortune
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import '@fgv/ts-utils-jest';
+
+import { fail, succeed, type Result } from '@fgv/ts-utils';
+
+import { SaferFetch } from '../../..';
+import { mockTransport, type IMockTransport, type IRecordedCall } from './mockTransport';
+
+const { allowAnyAddress, blockPrivateNetworks, saferFetchText } = SaferFetch;
+
+const START: string = 'https://start.example/first';
+
+function options(
+  transport: SaferFetch.IFetchTransport,
+  overrides?: Partial<SaferFetch.ISaferFetchOptions>
+): SaferFetch.ISaferFetchOptions {
+  return {
+    addressGuard: allowAnyAddress(),
+    transport,
+    redirectPolicy: 'validate-each-hop',
+    ...overrides
+  };
+}
+
+function redirect(status: number, location: string): Response {
+  return new Response(null, { status, headers: { location } });
+}
+
+function ok(text: string): Response {
+  return new Response(text, { headers: { 'content-type': 'text/plain; charset=utf-8' } });
+}
+
+/** One scripted answer: a URL, and the response to give when it is requested. */
+type ScriptEntry = readonly [string, () => Response];
+
+/**
+ * A transport that answers by URL. Anything not scripted returns a `200` naming itself, so a
+ * chain that wandered somewhere unexpected shows up as the wrong body rather than as a hang.
+ *
+ * Entries rather than an object literal because the keys are URLs, which no identifier naming
+ * convention accepts. The responses are thunks because a chain may request the same URL twice
+ * and a `Response` body is a single-use stream.
+ */
+function scripted(...script: ReadonlyArray<ScriptEntry>): IMockTransport {
+  const responders = new Map<string, () => Response>(script);
+  return mockTransport((call: IRecordedCall) => {
+    const key = call.url.toString();
+    const responder = responders.get(key);
+    return succeed(responder !== undefined ? responder() : ok(`unscripted:${key}`));
+  });
+}
+
+function headersOf(call: IRecordedCall): Headers {
+  // Built from what the transport was actually handed, so the assertion is about the wire and
+  // not about an internal record we happen to keep.
+  return new Headers(call.init.headers);
+}
+
+function requestedUrls(transport: IMockTransport): ReadonlyArray<string> {
+  return transport.calls.map((c) => c.url.toString());
+}
+
+/** An address guard that records every chain it was shown. */
+interface IObservingGuard {
+  readonly guard: SaferFetch.IAddressGuard;
+  readonly chains: ReadonlyArray<ReadonlyArray<SaferFetch.IRequestHop>>;
+}
+
+function observingGuard(pinnedAddress?: string): IObservingGuard {
+  const chains: ReadonlyArray<SaferFetch.IRequestHop>[] = [];
+  return {
+    chains,
+    guard: {
+      name: 'observing',
+      check: async (
+        chain: ReadonlyArray<SaferFetch.IRequestHop>
+      ): Promise<Result<SaferFetch.IGuardVerdict>> => {
+        chains.push(chain.map((hop) => ({ ...hop })));
+        return succeed({
+          url: chain[chain.length - 1].url,
+          ...(pinnedAddress !== undefined ? { pinnedAddress } : {})
+        });
+      }
+    }
+  };
+}
+
+/** A `blockPrivateNetworks` guard whose resolution is scripted, so no test touches DNS. */
+function guardResolving(map: Readonly<Record<string, ReadonlyArray<string>>>): SaferFetch.IAddressGuard {
+  return blockPrivateNetworks({
+    resolve: async (hostname: string): Promise<Result<ReadonlyArray<string>>> =>
+      succeed(map[hostname] ?? ['93.184.216.34'])
+  });
+}
+
+describe('saferFetch redirect walk', () => {
+  describe('policy', () => {
+    test("'reject' is the default and fails on a redirect without following it", async () => {
+      const transport = scripted([START, () => redirect(302, 'https://elsewhere.example/')]);
+      await expect(
+        saferFetchText(START, { addressGuard: allowAnyAddress(), transport })
+      ).resolves.toFailWithDetail(/redirects are rejected/, {
+        kind: 'redirect-rejected',
+        url: START,
+        status: 302
+      });
+      expect(transport.calls).toHaveLength(1);
+    });
+
+    test.each([
+      ['negative', -1],
+      ['fractional', 1.5],
+      ['infinite', Number.POSITIVE_INFINITY]
+    ])('rejects a %s maxRedirects', async (__name: string, maxRedirects: number) => {
+      const transport = scripted();
+      await expect(saferFetchText(START, options(transport, { maxRedirects }))).resolves.toFailWith(
+        /maxRedirects must be a non-negative integer/
+      );
+      expect(transport.calls).toHaveLength(0);
+    });
+  });
+
+  describe('following', () => {
+    test('follows a hop and reports every URL requested', async () => {
+      const transport = scripted(
+        [START, () => redirect(302, 'https://end.example/second')],
+        ['https://end.example/second', () => ok('arrived')]
+      );
+      await expect(saferFetchText(START, options(transport))).resolves.toSucceedAndSatisfy(
+        (response: SaferFetch.ISaferFetchResponse<string>) => {
+          expect(response.value).toBe('arrived');
+          expect(response.urlChain).toEqual([START, 'https://end.example/second']);
+        }
+      );
+      expect(requestedUrls(transport)).toEqual([START, 'https://end.example/second']);
+    });
+
+    test.each([301, 302, 303, 307, 308])('follows a %d', async (status: number) => {
+      const transport = scripted(
+        [START, () => redirect(status, 'https://end.example/second')],
+        ['https://end.example/second', () => ok('arrived')]
+      );
+      await expect(saferFetchText(START, options(transport))).resolves.toSucceedAndSatisfy(
+        (response: SaferFetch.ISaferFetchResponse<string>) => {
+          expect(response.value).toBe('arrived');
+        }
+      );
+    });
+
+    test('resolves a relative Location against the hop that sent it, not the original URL', async () => {
+      const transport = scripted(
+        [START, () => redirect(302, 'https://mid.example/a/b')],
+        ['https://mid.example/a/b', () => redirect(302, 'c')],
+        ['https://mid.example/a/c', () => ok('relative')]
+      );
+      await expect(saferFetchText(START, options(transport))).resolves.toSucceedAndSatisfy(
+        (response: SaferFetch.ISaferFetchResponse<string>) => {
+          expect(response.value).toBe('relative');
+          expect(response.urlChain).toEqual([START, 'https://mid.example/a/b', 'https://mid.example/a/c']);
+        }
+      );
+    });
+
+    test('sends every hop with redirect: manual so the platform follows nothing', async () => {
+      const transport = scripted(
+        [START, () => redirect(302, 'https://end.example/second')],
+        ['https://end.example/second', () => ok('arrived')]
+      );
+      await expect(saferFetchText(START, options(transport))).resolves.toSucceed();
+      for (const call of transport.calls) {
+        expect(call.init.redirect).toBe('manual');
+      }
+    });
+  });
+
+  describe('the guard runs on every hop', () => {
+    test('a 302 to the metadata endpoint is blocked at the hop and never reaches the transport', async () => {
+      const transport = scripted([
+        START,
+        () => redirect(302, 'http://169.254.169.254/latest/meta-data/iam/security-credentials/')
+      ]);
+      await expect(
+        saferFetchText(START, options(transport, { addressGuard: guardResolving({}) }))
+      ).resolves.toFailWithDetail(
+        /link-local/,
+        expect.objectContaining({
+          kind: 'blocked-by-guard',
+          url: 'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+          hop: 1,
+          guard: 'blockPrivateNetworks'
+        })
+      );
+      // The assertion that matters: the request was never made. A failure that arrived after the
+      // connect would look identical to the caller and would still have hit the metadata service.
+      expect(requestedUrls(transport)).toEqual([START]);
+    });
+
+    test('a 302 to loopback is blocked by default and permitted only on explicit opt-in', async () => {
+      const script: ReadonlyArray<ScriptEntry> = [
+        [START, () => redirect(302, 'http://127.0.0.1:11434/v1/models')],
+        ['http://127.0.0.1:11434/v1/models', () => ok('sidecar')]
+      ];
+
+      const blocked = scripted(...script);
+      await expect(
+        saferFetchText(START, options(blocked, { addressGuard: guardResolving({}) }))
+      ).resolves.toFailWith(/127\.0\.0\.1 is loopback/);
+      expect(requestedUrls(blocked)).toEqual([START]);
+
+      const permitted = scripted(...script);
+      await expect(
+        saferFetchText(
+          START,
+          options(permitted, {
+            addressGuard: blockPrivateNetworks({
+              allowLoopback: true,
+              resolve: async (): Promise<Result<ReadonlyArray<string>>> => succeed(['93.184.216.34'])
+            })
+          })
+        )
+      ).resolves.toSucceedAndSatisfy((response: SaferFetch.ISaferFetchResponse<string>) => {
+        expect(response.value).toBe('sidecar');
+      });
+      expect(requestedUrls(permitted)).toEqual([START, 'http://127.0.0.1:11434/v1/models']);
+    });
+
+    test('a hop whose host resolves to one public and one private address is refused', async () => {
+      const transport = scripted([START, () => redirect(302, 'https://rebind.example/target')]);
+      await expect(
+        saferFetchText(
+          START,
+          options(transport, {
+            addressGuard: guardResolving({ 'rebind.example': ['93.184.216.34', '10.0.0.5'] })
+          })
+        )
+      ).resolves.toFailWith(/10\.0\.0\.5 is private/);
+      expect(requestedUrls(transport)).toEqual([START]);
+    });
+
+    test('the guard sees the whole chain, oldest first, with the producing status on each hop', async () => {
+      const observed = observingGuard();
+      const transport = scripted(
+        [START, () => redirect(302, 'https://mid.example/b')],
+        ['https://mid.example/b', () => redirect(307, 'https://end.example/c')],
+        ['https://end.example/c', () => ok('done')]
+      );
+      await expect(
+        saferFetchText(START, options(transport, { addressGuard: observed.guard }))
+      ).resolves.toSucceed();
+
+      expect(observed.chains.map((c) => c.length)).toEqual([1, 2, 3]);
+      const last = observed.chains[2];
+      expect(last.map((hop) => hop.url.toString())).toEqual([
+        START,
+        'https://mid.example/b',
+        'https://end.example/c'
+      ]);
+      expect(last.map((hop) => hop.status)).toEqual([302, 307, undefined]);
+      // Hop 0 is not a special case: the very first check already receives a chain.
+      expect(observed.chains[0][0].status).toBeUndefined();
+    });
+
+    test('records connectedAddress on earlier hops once a guard pins and the transport accepts', async () => {
+      const observed = observingGuard('93.184.216.34');
+      const transport = scripted(
+        [START, () => redirect(302, 'https://end.example/second')],
+        ['https://end.example/second', () => ok('done')]
+      );
+      await expect(
+        saferFetchText(START, options(transport, { addressGuard: observed.guard }))
+      ).resolves.toSucceed();
+
+      expect(transport.calls[0].hints.pinnedAddress).toBe('93.184.216.34');
+      expect(observed.chains[1][0].connectedAddress).toBe('93.184.216.34');
+      // The hop under consideration has not connected yet, so it has nothing to report.
+      expect(observed.chains[1][1].connectedAddress).toBeUndefined();
+    });
+  });
+
+  describe('credential stripping', () => {
+    const AUTH: Readonly<Record<string, string>> = {
+      authorization: 'Bearer secret',
+      cookie: 'session=abc',
+      'proxy-authorization': 'Basic zzz',
+      accept: 'text/plain'
+    };
+
+    test('keeps credentials on a same-origin hop', async () => {
+      const transport = scripted(
+        [START, () => redirect(302, 'https://start.example/second')],
+        ['https://start.example/second', () => ok('same origin')]
+      );
+      await expect(saferFetchText(START, options(transport, { headers: AUTH }))).resolves.toSucceed();
+      expect(headersOf(transport.calls[1]).get('authorization')).toBe('Bearer secret');
+      expect(headersOf(transport.calls[1]).get('cookie')).toBe('session=abc');
+    });
+
+    test('drops credentials on a cross-origin hop and keeps ordinary headers', async () => {
+      const transport = scripted(
+        [START, () => redirect(302, 'https://other.example/second')],
+        ['https://other.example/second', () => ok('cross origin')]
+      );
+      await expect(saferFetchText(START, options(transport, { headers: AUTH }))).resolves.toSucceed();
+      const sent = headersOf(transport.calls[1]);
+      expect(sent.get('authorization')).toBeNull();
+      expect(sent.get('cookie')).toBeNull();
+      expect(sent.get('proxy-authorization')).toBeNull();
+      expect(sent.get('accept')).toBe('text/plain');
+    });
+
+    test('a port change is a cross-origin hop', async () => {
+      const transport = scripted(
+        [START, () => redirect(302, 'https://start.example:8443/second')],
+        ['https://start.example:8443/second', () => ok('other port')]
+      );
+      await expect(saferFetchText(START, options(transport, { headers: AUTH }))).resolves.toSucceed();
+      expect(headersOf(transport.calls[1]).get('authorization')).toBeNull();
+    });
+
+    test('a scheme downgrade is a cross-origin hop', async () => {
+      const transport = scripted(
+        [START, () => redirect(302, 'http://start.example/second')],
+        ['http://start.example/second', () => ok('downgraded')]
+      );
+      await expect(saferFetchText(START, options(transport, { headers: AUTH }))).resolves.toSucceed();
+      expect(headersOf(transport.calls[1]).get('authorization')).toBeNull();
+    });
+
+    test('A → B → A does NOT re-attach credentials on the final hop', async () => {
+      // The leak this exists to catch: comparing the final hop only against the caller's original
+      // origin finds it same-origin with A and hands the token back — after B has already watched
+      // the chain go past. It reviews as correct and it is a real credential disclosure.
+      const transport = scripted(
+        [START, () => redirect(302, 'https://launder.example/hop')],
+        ['https://launder.example/hop', () => redirect(302, 'https://start.example/back')],
+        ['https://start.example/back', () => ok('returned')]
+      );
+      await expect(saferFetchText(START, options(transport, { headers: AUTH }))).resolves.toSucceed();
+
+      expect(requestedUrls(transport)).toEqual([
+        START,
+        'https://launder.example/hop',
+        'https://start.example/back'
+      ]);
+      expect(headersOf(transport.calls[0]).get('authorization')).toBe('Bearer secret');
+      expect(headersOf(transport.calls[1]).get('authorization')).toBeNull();
+      expect(headersOf(transport.calls[2]).get('authorization')).toBeNull();
+      expect(headersOf(transport.calls[2]).get('cookie')).toBeNull();
+    });
+
+    test('drops caller-declared sensitive headers too, case-insensitively', async () => {
+      const transport = scripted(
+        [START, () => redirect(302, 'https://other.example/second')],
+        ['https://other.example/second', () => ok('cross origin')]
+      );
+      await expect(
+        saferFetchText(
+          START,
+          options(transport, {
+            headers: { 'x-api-key': 'k', 'x-trace': 't' },
+            sensitiveHeaders: ['X-API-Key']
+          })
+        )
+      ).resolves.toSucceed();
+      expect(headersOf(transport.calls[1]).get('x-api-key')).toBeNull();
+      expect(headersOf(transport.calls[1]).get('x-trace')).toBe('t');
+    });
+
+    test('strips a credential a request guard added under a non-lowercase spelling', async () => {
+      // A caller's headers are lowercased at the boundary, but a request guard returns a
+      // replacement request whose header names it chose. A strip keyed on the exact string
+      // `authorization` would sail straight past `Authorization` and replay the token.
+      const adding: SaferFetch.IRequestGuard = {
+        name: 'adding',
+        check: async (
+          request: SaferFetch.ISaferFetchRequest
+        ): Promise<Result<SaferFetch.ISaferFetchRequest>> =>
+          request.url.toString() === START
+            ? succeed({ ...request, headers: { ...request.headers, Authorization: 'Bearer secret' } })
+            : succeed(request)
+      };
+      const transport = scripted(
+        [START, () => redirect(302, 'https://other.example/second')],
+        ['https://other.example/second', () => ok('done')]
+      );
+      await expect(saferFetchText(START, options(transport, { requestGuard: adding }))).resolves.toSucceed();
+      expect(headersOf(transport.calls[0]).get('authorization')).toBe('Bearer secret');
+      expect(headersOf(transport.calls[1]).get('authorization')).toBeNull();
+    });
+  });
+
+  describe('method and body rewriting', () => {
+    async function follow(
+      status: number,
+      method: SaferFetch.SaferFetchMethod,
+      body?: string
+    ): Promise<IMockTransport> {
+      const transport = scripted(
+        [START, () => redirect(status, 'https://end.example/second')],
+        ['https://end.example/second', () => ok('done')]
+      );
+      await expect(
+        saferFetchText(
+          START,
+          options(transport, {
+            method,
+            ...(body !== undefined ? { body } : {}),
+            headers: { 'content-type': 'application/json' }
+          })
+        )
+      ).resolves.toSucceed();
+      return transport;
+    }
+
+    test.each([301, 302])('%d converts a POST to a GET and drops the body', async (status: number) => {
+      const transport = await follow(status, 'POST', '{"a":1}');
+      expect(transport.calls[1].init.method).toBe('GET');
+      expect(transport.calls[1].init.body).toBeUndefined();
+      // A Content-Type describing a body that is no longer there is not a rounding error on a
+      // request the next hop's guards are about to inspect.
+      expect(headersOf(transport.calls[1]).get('content-type')).toBeNull();
+    });
+
+    test.each([301, 302])('%d leaves a non-POST method and its body alone', async (status: number) => {
+      const transport = await follow(status, 'PUT', '{"a":1}');
+      expect(transport.calls[1].init.method).toBe('PUT');
+      expect(transport.calls[1].init.body).toBe('{"a":1}');
+      expect(headersOf(transport.calls[1]).get('content-type')).toBe('application/json');
+    });
+
+    test('303 converts any non-GET/HEAD method to a GET and drops the body', async () => {
+      const transport = await follow(303, 'PUT', '{"a":1}');
+      expect(transport.calls[1].init.method).toBe('GET');
+      expect(transport.calls[1].init.body).toBeUndefined();
+    });
+
+    test('303 leaves a GET alone', async () => {
+      const transport = await follow(303, 'GET');
+      expect(transport.calls[1].init.method).toBe('GET');
+      expect(headersOf(transport.calls[1]).get('content-type')).toBe('application/json');
+    });
+
+    test.each([307, 308])('%d preserves both method and body', async (status: number) => {
+      const transport = await follow(status, 'POST', '{"a":1}');
+      expect(transport.calls[1].init.method).toBe('POST');
+      expect(transport.calls[1].init.body).toBe('{"a":1}');
+      expect(headersOf(transport.calls[1]).get('content-type')).toBe('application/json');
+    });
+  });
+
+  describe('bounding the chain', () => {
+    /** `hop-<n>` redirects to `hop-<n+1>`, forever. */
+    function endlessChain(): IMockTransport {
+      return mockTransport((call: IRecordedCall) => {
+        const n = Number(call.url.pathname.slice('/hop-'.length));
+        return succeed(redirect(302, `https://chain.example/hop-${n + 1}`));
+      });
+    }
+
+    test('fails past the default hop cap', async () => {
+      const transport = endlessChain();
+      await expect(
+        saferFetchText('https://chain.example/hop-0', options(transport))
+      ).resolves.toFailWithDetail(/exceeded the limit of 5 hops/, {
+        kind: 'too-many-redirects',
+        hops: 6,
+        limit: 5
+      });
+      expect(transport.calls).toHaveLength(6);
+    });
+
+    test('honors a lower cap', async () => {
+      const transport = endlessChain();
+      await expect(
+        saferFetchText('https://chain.example/hop-0', options(transport, { maxRedirects: 2 }))
+      ).resolves.toFailWithDetail(/exceeded the limit of 2 hops/, {
+        kind: 'too-many-redirects',
+        hops: 3,
+        limit: 2
+      });
+      expect(transport.calls).toHaveLength(3);
+    });
+
+    test('maxRedirects: 0 follows nothing', async () => {
+      const transport = endlessChain();
+      await expect(
+        saferFetchText('https://chain.example/hop-0', options(transport, { maxRedirects: 0 }))
+      ).resolves.toFailWithDetail(/exceeded the limit of 0 hops/, {
+        kind: 'too-many-redirects',
+        hops: 1,
+        limit: 0
+      });
+      expect(transport.calls).toHaveLength(1);
+    });
+
+    test('catches an A→B→A→B oscillation instead of burning the whole budget', async () => {
+      const a: string = 'https://a.example/x';
+      const b: string = 'https://b.example/y';
+      const transport = scripted([a, () => redirect(302, b)], [b, () => redirect(302, a)]);
+      await expect(saferFetchText(a, options(transport))).resolves.toFailWithDetail(/already in the chain/, {
+        kind: 'redirect-rejected',
+        url: a,
+        status: 302
+      });
+      // Two requests, not the six the cap alone would have allowed: the repeat is caught before
+      // it is issued, so the oscillation never gets a second lap.
+      expect(requestedUrls(transport)).toEqual([a, b]);
+    });
+
+    test('catches an immediate self-redirect', async () => {
+      const transport = scripted([START, () => redirect(302, START)]);
+      await expect(saferFetchText(START, options(transport))).resolves.toFailWith(/already in the chain/);
+      expect(transport.calls).toHaveLength(1);
+    });
+  });
+
+  describe('unfollowable redirects', () => {
+    test('a redirect with no Location header is refused', async () => {
+      const transport = scripted([START, () => new Response(null, { status: 302 })]);
+      await expect(saferFetchText(START, options(transport))).resolves.toFailWithDetail(
+        /no usable Location header/,
+        { kind: 'redirect-rejected', url: START, status: 302 }
+      );
+    });
+
+    test('a redirect with a blank Location header is refused', async () => {
+      const transport = scripted([START, () => redirect(302, '   ')]);
+      await expect(saferFetchText(START, options(transport))).resolves.toFailWith(
+        /no usable Location header/
+      );
+    });
+
+    test('a Location that cannot be parsed is an invalid-url failure', async () => {
+      const transport = scripted([START, () => redirect(302, 'http://[')]);
+      await expect(saferFetchText(START, options(transport))).resolves.toFailWithDetail(
+        /invalid redirect target/,
+        expect.objectContaining({ kind: 'invalid-url', url: 'http://[' })
+      );
+      expect(transport.calls).toHaveLength(1);
+    });
+
+    test('a Location naming a scheme this primitive never requests is refused', async () => {
+      const transport = scripted([START, () => redirect(302, 'ftp://files.example/secret')]);
+      await expect(saferFetchText(START, options(transport))).resolves.toFailWithDetail(
+        /scheme "ftp:" is not supported/,
+        expect.objectContaining({ kind: 'invalid-url', url: 'ftp://files.example/secret' })
+      );
+      expect(transport.calls).toHaveLength(1);
+    });
+  });
+
+  describe('interaction with the rest of the pipeline', () => {
+    test('a non-2xx on a later hop is reported as http-status, not as a redirect failure', async () => {
+      const transport = scripted(
+        [START, () => redirect(302, 'https://end.example/gone')],
+        ['https://end.example/gone', () => new Response('nope', { status: 404, statusText: 'Not Found' })]
+      );
+      await expect(saferFetchText(START, options(transport))).resolves.toFailWithDetail(/404/, {
+        kind: 'http-status',
+        status: 404,
+        statusText: 'Not Found'
+      });
+    });
+
+    test('the response-headers guard sees the full chain on the final hop', async () => {
+      const chains: number[] = [];
+      const recording: SaferFetch.IResponseHeadersGuard = {
+        name: 'recording',
+        check: async (
+          __head: SaferFetch.ISaferFetchResponseHead,
+          chain: ReadonlyArray<SaferFetch.IRequestHop>
+        ): Promise<Result<true>> => {
+          chains.push(chain.length);
+          return succeed(true as const);
+        }
+      };
+      const transport = scripted(
+        [START, () => redirect(302, 'https://end.example/second')],
+        ['https://end.example/second', () => ok('done')]
+      );
+      await expect(
+        saferFetchText(START, options(transport, { responseHeadersGuard: recording }))
+      ).resolves.toSucceed();
+      // The redirect hop never reaches the response-headers guard — its body is discarded before
+      // any policy runs — so the guard is consulted exactly once, on the response that has one.
+      expect(chains).toEqual([2]);
+    });
+
+    test('the headers deadline is per attempt, so a later hop that never answers still times out', async () => {
+      // The first hop answers immediately, which retires its headers deadline. If that retirement
+      // were for the whole call rather than for the attempt, the second host stalling would be
+      // bounded only by the 30s overall deadline — a hang, not a timeout.
+      const transport = mockTransport(async (call: IRecordedCall) => {
+        if (call.url.toString() === START) {
+          return succeed(redirect(302, 'https://silent.example/second'));
+        }
+        return new Promise<Result<Response>>((resolve) => {
+          call.init.signal?.addEventListener('abort', () => resolve(fail('aborted')));
+        });
+      });
+      await expect(
+        saferFetchText(START, options(transport, { headersTimeoutMs: 20, timeoutMs: 5_000 }))
+      ).resolves.toFailWithDetail(
+        /timed out/,
+        expect.objectContaining({ kind: 'timeout', phase: 'headers', limitMs: 20 })
+      );
+      expect(requestedUrls(transport)).toEqual([START, 'https://silent.example/second']);
+    });
+
+    test('a request guard rejecting a later hop reports that hop index', async () => {
+      const blocking: SaferFetch.IRequestGuard = {
+        name: 'blocking',
+        check: async (
+          request: SaferFetch.ISaferFetchRequest
+        ): Promise<Result<SaferFetch.ISaferFetchRequest>> =>
+          request.url.hostname === 'end.example' ? fail('not that host') : succeed(request)
+      };
+      const transport = scripted(
+        [START, () => redirect(302, 'https://end.example/second')],
+        ['https://end.example/second', () => ok('never')]
+      );
+      await expect(
+        saferFetchText(START, options(transport, { requestGuard: blocking }))
+      ).resolves.toFailWithDetail(/not that host/, {
+        kind: 'blocked-by-guard',
+        url: 'https://end.example/second',
+        hop: 1,
+        guard: 'blocking',
+        detail: 'not that host'
+      });
+      expect(requestedUrls(transport)).toEqual([START]);
+    });
+
+    test('a request guard replacing a later hop with a bad scheme is refused', async () => {
+      const retargeting: SaferFetch.IRequestGuard = {
+        name: 'retargeting',
+        check: async (
+          request: SaferFetch.ISaferFetchRequest
+        ): Promise<Result<SaferFetch.ISaferFetchRequest>> =>
+          request.url.hostname === 'end.example'
+            ? succeed({ ...request, url: new URL('ftp://files.example/secret') })
+            : succeed(request)
+      };
+      const transport = scripted(
+        [START, () => redirect(302, 'https://end.example/second')],
+        ['https://end.example/second', () => ok('never')]
+      );
+      await expect(
+        saferFetchText(START, options(transport, { requestGuard: retargeting }))
+      ).resolves.toFailWith(/scheme "ftp:" is not supported/);
+      expect(requestedUrls(transport)).toEqual([START]);
+    });
+  });
+});

--- a/libraries/ts-extras/src/test/unit/safer-fetch/saferFetchRedirect.test.ts
+++ b/libraries/ts-extras/src/test/unit/safer-fetch/saferFetchRedirect.test.ts
@@ -137,6 +137,29 @@ describe('saferFetch redirect walk', () => {
       );
       expect(transport.calls).toHaveLength(0);
     });
+
+    // These names decide which headers get stripped on a cross-origin hop, and the types are only
+    // enforced for TypeScript callers. A JavaScript caller passing the wrong shape must be told,
+    // not silently given a set that stops matching the credential it was meant to strip.
+    test.each([
+      ['a bare string instead of an array', 'authorization', /sensitiveHeaders must be an array/],
+      ['a non-string entry', ['x-token', 42], /sensitiveHeaders\[1\] must be a string header name/],
+      ['an undefined entry', ['x-token', undefined], /sensitiveHeaders\[1\] must be a string header name/]
+    ])(
+      'rejects %s for sensitiveHeaders',
+      async (__name: string, sensitiveHeaders: unknown, expected: RegExp) => {
+        const transport = scripted();
+        await expect(
+          saferFetchText(
+            START,
+            options(transport, {
+              sensitiveHeaders: sensitiveHeaders as unknown as ReadonlyArray<string>
+            })
+          )
+        ).resolves.toFailWith(expected);
+        expect(transport.calls).toHaveLength(0);
+      }
+    );
   });
 
   describe('following', () => {

--- a/libraries/ts-extras/src/test/unit/safer-fetch/saferFetchRedirect.test.ts
+++ b/libraries/ts-extras/src/test/unit/safer-fetch/saferFetchRedirect.test.ts
@@ -516,11 +516,13 @@ describe('saferFetch redirect walk', () => {
       const a: string = 'https://a.example/x';
       const b: string = 'https://b.example/y';
       const transport = scripted([a, () => redirect(302, b)], [b, () => redirect(302, a)]);
-      await expect(saferFetchText(a, options(transport))).resolves.toFailWithDetail(/already in the chain/, {
-        kind: 'redirect-rejected',
-        url: a,
-        status: 302
-      });
+      // `url` is the hop that issued the rejected redirect — b, not the repeated target a.
+      // Naming the target here would make the field mean something different than it does on
+      // the other two 'redirect-rejected' paths; the target is named in the message.
+      await expect(saferFetchText(a, options(transport))).resolves.toFailWithDetail(
+        /redirected with status 302 to https:\/\/a\.example\/x, which is already in the chain/,
+        { kind: 'redirect-rejected', url: b, status: 302 }
+      );
       // Two requests, not the six the cap alone would have allowed: the repeat is caught before
       // it is issued, so the oscillation never gets a second lap.
       expect(requestedUrls(transport)).toEqual([a, b]);


### PR DESCRIPTION
Stream **S2b** of the `safer-fetch` workstream. Joins S1's core to S2a's address classifier and makes the guard load-bearing.

Branches from and targets **`release`** — the brief said `integration/safer-fetch`, but that branch has been squashed to `release` and no longer exists. **Do not merge**; this is for review.

## What ships

**`blockPrivateNetworks()` — the DNS-resolving address guard (Node only).**
Classifies `url.hostname`, never raw URL text. Resolves only when the hostname is not already an IP literal — a `classifyAddress` failure means "not a literal, so resolve it", never "block". Delegates every resolved address to S2a's reject-if-any policy **unchanged**; no classification logic is reimplemented. The `HostResolver` seam is injectable, so no test in the suite touches the network. `node:dns` rejects on `ENOTFOUND`/`EAI_AGAIN`, so the default resolver wraps it in `captureAsyncResult` — a rejected lookup is a `Failure`, never a throw out of an API documented to always return a `Result`. Lives in its own module so the packlet's browser barrel stays free of `node:dns`.

`lookup` rather than `resolve4`/`resolve6`: `lookup` goes through the OS resolver — the same path the connect takes — so it sees `/etc/hosts`. `resolve4` would miss a hosts-file entry pointing an allowlisted name at `127.0.0.1`, which is a bypass rather than a curiosity.

**`redirectPolicy: 'validate-each-hop'` — the walk.**
`redirect: 'manual'`, the full address guard on **every** hop before any connection, `Location` resolved against the hop that sent it. The chain is passed whole; hop 0 is not a special case. `IRequestHop.status` is populated; `connectedAddress` is recorded once a guard pins and the transport accepts (sound because a transport that cannot honor a pin must fail rather than connect by hostname).

Plus: `maxRedirects` (default 5), whole-chain loop detection, Fetch-standard method/body rewriting (301/302 convert `POST`→`GET` and drop the body; 303 converts any non-`GET`/`HEAD`; 307/308 preserve both — a dropped body takes `Content-Type`/`Content-Length` with it), and monotonic credential stripping.

**Credential stripping is monotonic, and that is the load-bearing part.**
Headers carry forward from the request actually sent on the previous hop, and the origin comparison is against the hop that redirected. Deriving each hop's headers from the caller's original set and comparing to the caller's original origin finds the last hop of `A`(auth) → `B` → `A` same-origin with `A` and hands the token back, after `B` has already watched the chain go past. It reviews as correct and it is a real disclosure. Dedicated test: `A → B → A does NOT re-attach credentials on the final hop`. Matching is case-insensitive — a request guard returning a replacement request spelled `Authorization` must not slip past a set keyed on `authorization`; also tested.

`sensitiveHeaders` and `maxRedirects` are added to `ISaferFetchOptions` now, with the behaviour behind them — S1 deliberately left them off rather than ship an option that does nothing.

## Naming end state (the decision I was asked to own)

**Unsuffixed factory ⇒ `IAddressGuard`. `Policy`-suffixed factory ⇒ `IAddressPolicy`.**

- `allowAnyAddress()` / `blockPrivateNetworks()` → guards (what `saferFetch*` takes)
- `allowAnyAddressPolicy()` / `blockPrivateNetworksPolicy()` → pure synchronous policies

So the policy factory is renamed `blockPrivateNetworks` → `blockPrivateNetworksPolicy`, and the unsuffixed name moves to the guard layer. Rationale: design § 6.1 hands callers `blockPrivateNetworks()` as the thing they pass to an entry point, so the clean name belongs to the guard; and the rule now generalizes rather than being a per-symbol accident. Diagnostic `name` strings track the factory names (`'blockPrivateNetworksPolicy(allowLoopback)'`, `'blockPrivateNetworks(allowLoopback)'`). Breaking, but only on an unreleased surface within the same alpha.

## Where the design was wrong or silent once I hit the code

1. **`headersTimeoutMs` is documented "per attempt" but was retired for the whole call.** `DeadlineWatch.headersReceived()` clears the headers timer permanently. Correct with one attempt; with a walk, hop 2+ had **no headers deadline at all** — a chain whose second host simply never answers would hang for the full 30s overall budget instead of failing as `timeout.phase === 'headers'`. Added `attemptStarted()`, called at the top of each hop (before the address guard, so guard/DNS time stays inside the budget per § 3.6). This is a defect my change would have introduced, not a pre-existing one. Tested.
2. **Default `redirectPolicy` stays `'reject'`, not `'validate-each-hop'`.** § 6.2 names `'validate-each-hop'` the *Node* default, but S1 shipped one core serving both barrels and there is no runtime split to hang a per-runtime default on. `'reject'` is the only mode with identical semantics on both, and following a chain into hosts the caller never named is a posture worth spelling at the call site — same polarity as `addressGuard` having no default. Flagging it as a deliberate deviation; happy to flip it if you'd rather match § 6.2 literally.
3. **307/308 with an unreplayable body is not reachable.** § 4 step 3c says a stream body makes 307/308 unfollowable. `ISaferFetchOptions.body` is `string | Uint8Array` — always replayable — so there is no case to fail. No code, noted here so the design's line is not read as unimplemented.
4. **Loop detection fires one hop earlier than the brief's example implies.** `A→B→A→B` is caught when `B` names `A` again (2 requests), not on the fourth hop. Strictly better; the test asserts the earlier stop.

## Failure taxonomy — collapsed rather than widened (L4)

No new `FetchFailureReason` variants. Three follow-time conditions share `'redirect-rejected'`: policy is `'reject'`, no usable `Location`, or the target repeats a URL already in the chain. Splitting them would buy a caller almost nothing and would widen the scanning oracle; the two follow-time cases are facts about the chain the *redirecting server* produced, not about the network behind this process. "The chain got too long" stays a separate question as `'too-many-redirects'`, whose message names no URL. An unparseable or non-`http(s)` `Location` reuses `'invalid-url'`.

## Not in scope / unchanged

Pinned-connect: `IGuardVerdict.pinnedAddress` stays `undefined`, `platformFetchTransport` still fails rather than ignore a pin, and **DNS rebinding remains a stated open limit** — no TSDoc implies otherwise. The guard applies no host/port allowlist and no `allowInsecureHttp`; § 13 L6's example calls for those, and they are additive follow-ons (see below). Retry, the browser packlet, README guarantee tables and `LIBRARY_CAPABILITIES.md` are S3's.

## Testing

Everything through the mock `IFetchTransport`; DNS through the injected `HostResolver`. No live server and nothing that could reach `169.254.169.254`. Two `nodeHostResolver` tests do exercise the real resolver but are answered locally — `localhost` from the hosts file, and a name past the 255-octet limit rejected by `getaddrinfo` before it asks anyone.

Beyond the brief's required list: a **`302` → `169.254.169.254` blocked at the hop with `expect(requestedUrls(transport)).toEqual([START])`** — asserted on the transport, not just the returned failure, because a failure raised after the connect looks identical to the caller and would still have hit the metadata service. Also: the guard sees the whole chain with per-hop statuses; a hop resolving to one public + one private address is refused; a scheme-downgrade and a port change each count as cross-origin; a request guard rejecting or retargeting a later hop; the per-attempt headers deadline.

## Gates

- `rushx build` ✅ / `rushx lint` ✅ / `rushx test` ✅ — **100% statements, branches, functions, lines** across every safer-fetch file (and the package).
- `rushx fixlint` run before the final commit; `rush prettier` ran on the commit hook.
- `etc/ts-extras.api.md` regenerated. `ae-unresolved-link` "does not have an export" count is **84 before and 84 after** — no new warnings of that class.
- Rush change file added (`minor`, since it carries the unreleased-surface rename).

## Review-loop discipline

**No `code-reviewer` agent-spawn tool was available in this session**, so layer 1 was a **manual pass against `CODE_REVIEW_CHECKLIST.md`** rather than the agent. An independent pass may be wanted; flagging for the orchestrator to commission.

What the manual pass found and resolved:

- **P1 — none outstanding.** No `any`, no manual-type-check-plus-cast, no double casts in the diff; every fallible operation returns `Result`/`DetailedResult`; no `orThrow` in business logic. The `node:dns` rejection path was the obvious candidate for the "un-captured promise escaping as a throw" class (#594's body-read loop) and is wrapped in `captureAsyncResult`, with a test asserting it surfaces as a `Failure`.
- **P2 — the `headersTimeoutMs` per-attempt defect above**, found by walking the deadline lifecycle against its own TSDoc. Fixed with `attemptStarted()` plus a test.
- **P3 — resolved**: replaced five `expect.stringContaining(...) as unknown as string` matcher casts with `expect.objectContaining`, matching the sibling `saferFetch.test.ts` idiom; dropped a redirect-policy test that duplicated an existing one; switched the scripted-transport helper from URL-keyed object literals to entry tuples (the keys are URLs, which no identifier naming convention accepts).

Coverage closure was **not** needed — the scenario-driven tests reached 100% on their own, so no `c8 ignore` directives were added anywhere.

## For S3

- The `redirectPolicy` default is a live question (item 2 above) — worth settling before the README's guarantee table is written.
- `blockPrivateNetworks` takes no `allowHosts` / `allowPorts` / `allowInsecureHttp`. § 13 L6's Ollama reconciliation example uses all three; adding them is purely additive on `IBlockPrivateNetworksGuardOptions` and the guard is the right place. Today the loopback sidecar case works via `{ allowLoopback: true }` alone, since the core permits `http:` and nothing narrows ports.
- The browser barrel exports the widened `SaferFetchRedirectPolicy`. `'validate-each-hop'` in a browser fails as `'redirect-opaque'` — honest, but S3 should decide whether the browser entry points should refuse the mode up front instead.
- `ALWAYS_STRIPPED_HEADERS` and `DEFAULT_MAX_REDIRECTS` are exported and are the right things to cite in the README's guarantee table.

Copilot review loop not yet started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD


---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfgMLqVj4pf82wyVTg9bD)_